### PR TITLE
SF-7: feat(datafn): add python package

### DIFF
--- a/datafn/python/datafn/__init__.py
+++ b/datafn/python/datafn/__init__.py
@@ -1,0 +1,3 @@
+from .server import create_datafn_server
+
+__all__ = ["create_datafn_server"]

--- a/datafn/python/datafn/authz.py
+++ b/datafn/python/datafn/authz.py
@@ -1,0 +1,394 @@
+import json
+from typing import Any, Dict, List, Optional, Set
+from .envelope import DatafnError
+from .validation import SchemaIndex
+
+GLOBAL_PERMISSIONS_TABLE = "__datafn_permissions_global"
+PRINCIPAL_MEMBERSHIPS_TABLE = "__datafn_principal_memberships"
+PRINCIPAL_HIERARCHY_TABLE = "__datafn_principal_hierarchy"
+
+_LEVEL_RANK = {"viewer": 1, "editor": 2, "owner": 3}
+
+
+def normalize_non_empty_string(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    return trimmed if trimmed else None
+
+
+def canonicalize_principal_from_user_id(user_id: str) -> str:
+    return user_id if ":" in user_id else f"user:{user_id}"
+
+
+def canonicalize_actor_principal(actor_id: str) -> str:
+    normalized = normalize_non_empty_string(actor_id)
+    if not normalized:
+        return "user:"
+    return canonicalize_principal_from_user_id(normalized)
+
+
+def get_actor_id_from_context(ctx: Any) -> Optional[str]:
+    if not isinstance(ctx, dict):
+        return None
+    actor = (
+        ctx.get("actorId")
+        or ctx.get("actor_id")
+        or ctx.get("userId")
+        or ctx.get("user_id")
+    )
+    return normalize_non_empty_string(actor)
+
+
+def get_shareable_capability(resource_def: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    capabilities = resource_def.get("capabilities", [])
+    if not isinstance(capabilities, list):
+        return None
+    for capability in capabilities:
+        if isinstance(capability, dict) and isinstance(capability.get("shareable"), dict):
+            return capability["shareable"]
+    return None
+
+
+def is_private_shareable_resource(resource_def: Dict[str, Any]) -> bool:
+    shareable = get_shareable_capability(resource_def)
+    if not shareable:
+        return False
+    return shareable.get("default") == "private"
+
+
+def is_grant_active(row: Dict[str, Any]) -> bool:
+    return row.get("revokedAt") is None
+
+
+async def resolve_effective_principals(
+    db: Any,
+    namespace: str,
+    actor_id: str,
+) -> List[str]:
+    actor_principal = canonicalize_actor_principal(actor_id)
+    effective: Set[str] = {actor_id, actor_principal}
+
+    # Direct memberships
+    for actor_candidate in {actor_id, actor_principal}:
+        try:
+            rows = await db.find_many(
+                PRINCIPAL_MEMBERSHIPS_TABLE,
+                where=[{"field": "actorId", "operator": "eq", "value": actor_candidate}],
+                namespace=namespace,
+            )
+        except Exception:
+            rows = []
+        for row in rows:
+            principal_id = normalize_non_empty_string(row.get("principalId"))
+            if principal_id and is_grant_active(row):
+                effective.add(principal_id)
+
+    # Hierarchy expansion (best-effort; absent tables are tolerated)
+    frontier = list(effective)
+    visited: Set[str] = set()
+    max_depth = 16
+    depth = 0
+
+    while frontier and depth < max_depth:
+        depth += 1
+        next_frontier: List[str] = []
+        for principal_id in frontier:
+            if principal_id in visited:
+                continue
+            visited.add(principal_id)
+            try:
+                parent_rows = await db.find_many(
+                    PRINCIPAL_HIERARCHY_TABLE,
+                    where=[{"field": "principalId", "operator": "eq", "value": principal_id}],
+                    namespace=namespace,
+                )
+            except Exception:
+                parent_rows = []
+            for row in parent_rows:
+                parent = normalize_non_empty_string(row.get("parentPrincipalId"))
+                if not parent or not is_grant_active(row):
+                    continue
+                if parent not in effective:
+                    effective.add(parent)
+                    next_frontier.append(parent)
+        frontier = next_frontier
+
+    return sorted(effective)
+
+
+async def resolve_access_level(
+    db: Any,
+    schema_index: SchemaIndex,
+    resource_name: str,
+    record_id: str,
+    actor_id: Optional[str],
+    namespace: str = "datafn",
+) -> Optional[str]:
+    if not actor_id:
+        return None
+
+    resource_def = schema_index.resources_by_name.get(resource_name)
+    if not resource_def:
+        return None
+
+    if not is_private_shareable_resource(resource_def):
+        return "owner"
+
+    record = await db.find_one(
+        resource_name,
+        [{"field": "id", "operator": "eq", "value": record_id}],
+        namespace=namespace,
+    )
+    if not record:
+        return None
+
+    actor_principal = canonicalize_actor_principal(actor_id)
+    created_by = normalize_non_empty_string(record.get("createdBy"))
+    if created_by and (
+        created_by == actor_id
+        or canonicalize_principal_from_user_id(created_by) == actor_principal
+    ):
+        return "owner"
+
+    principals = await resolve_effective_principals(db, namespace, actor_id)
+    best_level: Optional[str] = None
+    for principal_id in principals:
+        rows = await db.find_many(
+            GLOBAL_PERMISSIONS_TABLE,
+            where=[
+                {"field": "resourceType", "operator": "eq", "value": resource_name},
+                {"field": "resourceNs", "operator": "eq", "value": namespace},
+                {"field": "principalId", "operator": "eq", "value": principal_id},
+            ],
+            namespace=namespace,
+        )
+        for row in rows:
+            if not is_grant_active(row):
+                continue
+            level = row.get("level")
+            if level not in _LEVEL_RANK:
+                continue
+            grant_resource_id = row.get("resourceId")
+            if grant_resource_id is not None and grant_resource_id != record_id:
+                continue
+            if best_level is None or _LEVEL_RANK[level] > _LEVEL_RANK[best_level]:
+                best_level = level
+
+    return best_level
+
+
+async def is_record_visible(
+    db: Any,
+    schema_index: SchemaIndex,
+    resource_name: str,
+    record: Dict[str, Any],
+    actor_id: Optional[str],
+    namespace: str = "datafn",
+) -> bool:
+    resource_def = schema_index.resources_by_name.get(resource_name)
+    if not resource_def:
+        return False
+    if not is_private_shareable_resource(resource_def):
+        return True
+    if not actor_id:
+        return False
+    record_id = normalize_non_empty_string(record.get("id"))
+    if not record_id:
+        return False
+    level = await resolve_access_level(
+        db,
+        schema_index,
+        resource_name,
+        record_id,
+        actor_id,
+        namespace=namespace,
+    )
+    return level is not None
+
+
+def validate_query_authz(
+    query: Dict[str, Any],
+    resource_name: str,
+    index: SchemaIndex,
+    allow_unknown_resources: bool = False,
+) -> Optional[DatafnError]:
+    """
+    Validate field-level read authorization on a query.
+    If the resource has permissions.read.fields defined, only those fields are readable.
+    `id` is always readable.
+    """
+    resource_def = index.resources_by_name.get(resource_name)
+    if not resource_def:
+        return None
+
+    permissions = resource_def.get("permissions")
+    if not permissions:
+        if is_private_shareable_resource(resource_def) and not allow_unknown_resources:
+            return DatafnError(
+                code="FORBIDDEN",
+                message="Access denied: resource requires explicit permissions",
+                details={"path": "python.authz"},
+            )
+        return None
+
+    read_perms = permissions.get("read")
+    if not read_perms:
+        return None
+
+    allowed_fields = read_perms.get("fields")
+    if not allowed_fields:
+        return None
+
+    allowed_set: Set[str] = set(allowed_fields)
+    allowed_set.add("id")  # id is always readable
+
+    # Check select fields
+    select = query.get("select", [])
+    for field in select:
+        base = field.split(".")[0]
+        if base not in allowed_set:
+            return DatafnError(
+                code="FORBIDDEN",
+                message=f"Access denied for field '{base}' on resource '{resource_name}'",
+                details={"path": "select"}
+            )
+
+    # Check filter fields
+    filters = query.get("filters", {})
+    err = _check_filter_fields(filters, allowed_set, resource_name)
+    if err:
+        return err
+
+    # Check sort fields
+    sort = query.get("sort", [])
+    for term in sort:
+        if isinstance(term, str):
+            field = term.lstrip("-").split(":")[0]
+            if field not in allowed_set:
+                return DatafnError(
+                    code="FORBIDDEN",
+                    message=f"Access denied for field '{field}' on resource '{resource_name}'",
+                    details={"path": "sort"}
+                )
+
+    return None
+
+
+def _check_filter_fields(
+    filters: Any,
+    allowed_set: Set[str],
+    resource_name: str,
+) -> Optional[DatafnError]:
+    """Recursively check that filter fields are allowed."""
+    if not isinstance(filters, dict):
+        return None
+
+    for key, value in filters.items():
+        if key in ("$and", "$or"):
+            if isinstance(value, list):
+                for item in value:
+                    err = _check_filter_fields(item, allowed_set, resource_name)
+                    if err:
+                        return err
+        elif not key.startswith("$"):
+            base = key.split(".")[0]
+            if base not in allowed_set:
+                return DatafnError(
+                    code="FORBIDDEN",
+                    message=f"Access denied for field '{base}' on resource '{resource_name}'",
+                    details={"path": "filters"}
+                )
+    return None
+
+
+def validate_mutation_authz(
+    mutation: Dict[str, Any],
+    resource_name: str,
+    index: SchemaIndex,
+    allow_unknown_resources: bool = False,
+) -> Optional[DatafnError]:
+    """
+    Validate field-level write authorization on a mutation.
+    If the resource has permissions.write.fields defined, only those fields are writable.
+    """
+    resource_def = index.resources_by_name.get(resource_name)
+    if not resource_def:
+        return None
+
+    permissions = resource_def.get("permissions")
+    if not permissions:
+        if is_private_shareable_resource(resource_def) and not allow_unknown_resources:
+            return DatafnError(
+                code="FORBIDDEN",
+                message="Access denied: resource requires explicit permissions",
+                details={"path": "python.authz"},
+            )
+        return None
+
+    write_perms = permissions.get("write")
+    if not write_perms:
+        return None
+
+    allowed_fields = write_perms.get("fields")
+    if not allowed_fields:
+        return None
+
+    allowed_set: Set[str] = set(allowed_fields)
+
+    # Check single record
+    record = mutation.get("record", {})
+    if record:
+        for key in record.keys():
+            if key not in allowed_set:
+                return DatafnError(
+                    code="FORBIDDEN",
+                    message=f"Access denied for field '{key}' on resource '{resource_name}'",
+                    details={"path": "record"}
+                )
+
+    # Check batch records
+    records = mutation.get("records", [])
+    if records:
+        for i, rec in enumerate(records):
+            if isinstance(rec, dict):
+                for key in rec.keys():
+                    if key not in allowed_set:
+                        return DatafnError(
+                            code="FORBIDDEN",
+                            message=f"Access denied for field '{key}' on resource '{resource_name}'",
+                            details={"path": f"records[{i}]"}
+                        )
+
+    return None
+
+
+def check_payload_size(body: Any, max_bytes: int) -> Optional[DatafnError]:
+    """
+    Check if payload body exceeds max_bytes.
+    body can be bytes, str, or have a length.
+    Returns DatafnError if exceeded, None otherwise.
+    """
+    if max_bytes <= 0:
+        return None
+
+    size = 0
+    if isinstance(body, bytes):
+        size = len(body)
+    elif isinstance(body, str):
+        size = len(body.encode("utf-8"))
+    elif hasattr(body, "__len__"):
+        try:
+            size = len(json.dumps(body).encode("utf-8"))
+        except TypeError:
+            size = len(repr(body).encode("utf-8"))
+    else:
+        return None
+
+    if size > max_bytes:
+        return DatafnError(
+            code="LIMIT_EXCEEDED",
+            message=f"Payload size ({size} bytes) exceeds maximum of {max_bytes} bytes",
+            details={"path": "$"}
+        )
+    return None

--- a/datafn/python/datafn/change_tracking.py
+++ b/datafn/python/datafn/change_tracking.py
@@ -1,0 +1,129 @@
+import uuid
+from typing import Any, Dict, List, Optional
+from .db import Adapter
+from .transaction import with_transaction
+import time
+
+# Tables
+CHANGES_TABLE = "__datafn_changes"
+SEQ_TABLE = "__datafn_server_seq"
+
+async def get_next_server_seq(db: Adapter, namespace: str = "datafn") -> int:
+    """
+    Returns the next monotonic server sequence number.
+    Uses a transaction to ensure atomicity.
+    """
+    async def _increment(tx_db: Adapter) -> int:
+        # 1. Get current seq
+        record = await tx_db.find_one(SEQ_TABLE, [{"field": "id", "operator": "eq", "value": namespace}], namespace=namespace)
+        
+        current_seq = 0
+        if record:
+            current_seq = int(record.get("seq", 0))
+            
+        next_seq = current_seq + 1
+        
+        # 2. Update or Create
+        if record:
+            await tx_db.update(
+                SEQ_TABLE,
+                [{"field": "id", "operator": "eq", "value": namespace}],
+                {"seq": next_seq},
+                namespace=namespace
+            )
+        else:
+            await tx_db.create(
+                SEQ_TABLE,
+                {"id": namespace, "seq": next_seq},
+                namespace=namespace
+            )
+            
+        return next_seq
+
+    # Use transaction for atomic read-modify-write
+    return await with_transaction(db, _increment)
+
+async def write_change(
+    db: Adapter, 
+    namespace: str, 
+    table: str, 
+    operation: str, 
+    record_id: str, 
+    server_seq: int = 0
+) -> None:
+    """
+    Writes a change record to the changelog.
+    If server_seq is 0 (default), it generates a new one.
+    """
+    if server_seq == 0:
+        server_seq = await get_next_server_seq(db, namespace)
+        
+    change_record = {
+        "namespace": namespace,
+        "table": table,
+        "operation": operation,
+        "recordId": record_id,
+        "serverSeq": server_seq,
+        "timestamp": int(time.time() * 1000)
+    }
+    
+    # We might need an ID for the change record itself for DBs that require PK
+    change_record["id"] = str(uuid.uuid4())
+    
+    await db.create(CHANGES_TABLE, change_record, namespace=namespace)
+
+async def get_changes_since(
+    db: Adapter,
+    namespace: str,
+    table: str,
+    cursor: Optional[str],
+    limit: Optional[int] = None
+) -> Dict[str, Any]:
+    """
+    Returns changes for a table since the given cursor (serverSeq).
+    When limit is provided, at most `limit` changes are returned (PY-002).
+    """
+    min_seq = int(cursor) if cursor else 0
+
+    # Find changes > min_seq
+    changes = await db.find_many(
+        CHANGES_TABLE,
+        where=[
+            {"field": "namespace", "operator": "eq", "value": namespace},
+            {"field": "table", "operator": "eq", "value": table},
+            {"field": "serverSeq", "operator": "gt", "value": min_seq}
+        ],
+        sort=["serverSeq:asc"],
+        limit=limit,
+        namespace=namespace
+    )
+    
+    # Determine new cursor
+    new_cursor = cursor
+    if changes:
+        last_seq = changes[-1]["serverSeq"]
+        new_cursor = str(last_seq)
+        
+    return {
+        "changes": changes,
+        "cursor": new_cursor
+    }
+
+async def get_latest_cursor(db: Adapter, namespace: str, table: str) -> Optional[str]:
+    """
+    Gets the latest serverSeq for a table.
+    """
+    changes = await db.find_many(
+        CHANGES_TABLE,
+        where=[
+            {"field": "namespace", "operator": "eq", "value": namespace},
+            {"field": "table", "operator": "eq", "value": table}
+        ],
+        sort=["serverSeq:desc"],
+        limit=1,
+        namespace=namespace
+    )
+    
+    if changes:
+        return str(changes[0]["serverSeq"])
+    return None # Or "0"? Spec says "return as string cursor"

--- a/datafn/python/datafn/constants.py
+++ b/datafn/python/datafn/constants.py
@@ -1,0 +1,15 @@
+"""
+DataFn shared constants.
+
+Source of truth is core/src/system-fields.ts; keep in sync with that file.
+"""
+
+# All core-managed fields present on every DataFn record.
+CORE_FIELDS: frozenset[str] = frozenset([
+    "id",
+    "createdAt",
+    "updatedAt",
+    "createdBy",
+    "updatedBy",
+    "isArchived",
+])

--- a/datafn/python/datafn/db.py
+++ b/datafn/python/datafn/db.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, List, Optional, Protocol, Union, AsyncContextManager
+
+class Adapter(Protocol):
+    async def find_many(
+        self, 
+        model: str, 
+        where: List[Dict[str, Any]], 
+        limit: Optional[int] = None,
+        sort: Optional[List[str]] = None,
+        cursor: Optional[Dict[str, Any]] = None,
+        namespace: str = "datafn"
+    ) -> List[Dict[str, Any]]:
+        ...
+        
+    async def find_one(self, model: str, where: List[Dict[str, Any]], namespace: str = "datafn") -> Optional[Dict[str, Any]]:
+        ...
+
+    async def create(self, model: str, data: Dict[str, Any], namespace: str = "datafn") -> None:
+        ...
+        
+    async def update(self, model: str, where: List[Dict[str, Any]], data: Dict[str, Any], namespace: str = "datafn") -> None:
+        ...
+        
+    async def delete(self, model: str, where: List[Dict[str, Any]], namespace: str = "datafn") -> None:
+        ...
+
+    def transaction(self) -> AsyncContextManager["Adapter"]:
+        """
+        Returns an async context manager that yields a transactional Adapter instance.
+        If the context exits without error, the transaction is committed.
+        If an error occurs, the transaction is rolled back.
+        """
+        ...

--- a/datafn/python/datafn/envelope.py
+++ b/datafn/python/datafn/envelope.py
@@ -1,0 +1,83 @@
+import re
+from typing import Any, Dict, Optional, TypedDict
+
+# Error code constants
+SCHEMA_INVALID = "SCHEMA_INVALID"
+DFQL_INVALID = "DFQL_INVALID"
+DFQL_UNKNOWN_RESOURCE = "DFQL_UNKNOWN_RESOURCE"
+DFQL_UNKNOWN_FIELD = "DFQL_UNKNOWN_FIELD"
+DFQL_UNKNOWN_RELATION = "DFQL_UNKNOWN_RELATION"
+DFQL_ABORTED = "DFQL_ABORTED"
+LIMIT_EXCEEDED = "LIMIT_EXCEEDED"
+CONFLICT = "CONFLICT"
+NOT_FOUND = "NOT_FOUND"
+FORBIDDEN = "FORBIDDEN"
+INTERNAL = "INTERNAL"
+
+# Patterns for error classification
+_DUPLICATE_PATTERNS = [
+    re.compile(r"unique constraint", re.IGNORECASE),
+    re.compile(r"duplicate key", re.IGNORECASE),
+    re.compile(r"UNIQUE constraint failed", re.IGNORECASE),
+    re.compile(r"already exists", re.IGNORECASE),
+]
+_NOT_FOUND_PATTERNS = [
+    re.compile(r"not found", re.IGNORECASE),
+    re.compile(r"no such", re.IGNORECASE),
+    re.compile(r"does not exist", re.IGNORECASE),
+]
+
+
+class DatafnError(Exception):
+    def __init__(self, code: str, message: str, details: Optional[Dict[str, Any]] = None):
+        self.code = code
+        self.message = message
+        self.details = details or {}
+        if "path" not in self.details:
+            self.details["path"] = "$"
+        super().__init__(message)
+
+    def to_envelope(self) -> Dict[str, Any]:
+        return {
+            "ok": False,
+            "error": {
+                "code": self.code,
+                "message": self.message,
+                "details": self.details
+            }
+        }
+
+
+def classify_error(exception: Exception) -> str:
+    msg = str(exception)
+    for pat in _DUPLICATE_PATTERNS:
+        if pat.search(msg):
+            return CONFLICT
+    for pat in _NOT_FOUND_PATTERNS:
+        if pat.search(msg):
+            return NOT_FOUND
+    return INTERNAL
+
+
+def ok_response(result: Any) -> Dict[str, Any]:
+    return {"ok": True, "result": result}
+
+def error_response(error: Dict[str, Any]) -> Dict[str, Any]:
+    return {"ok": False, "error": error}
+
+# Helper aliases
+def ok(result: Any) -> Dict[str, Any]:
+    return ok_response(result)
+
+def err(code: str, message: str, details: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    details = details or {}
+    if "path" not in details:
+        details["path"] = "$"
+    return {
+        "ok": False,
+        "error": {
+            "code": code,
+            "message": message,
+            "details": details
+        }
+    }

--- a/datafn/python/datafn/filters.py
+++ b/datafn/python/datafn/filters.py
@@ -1,0 +1,244 @@
+import re
+from typing import Any, Dict, List, Optional
+
+# Remap non-$-prefixed operators to $-prefixed form
+OP_REMAP = {
+    "eq": "$eq",
+    "ne": "$ne",
+    "gt": "$gt",
+    "gte": "$gte",
+    "lt": "$lt",
+    "lte": "$lte",
+    "in": "$in",
+    "not_in": "$nin",
+    "nin": "$nin",
+    "like": "$like",
+    "ilike": "$ilike",
+    "not_like": "$not_like",
+    "not_ilike": "$not_ilike",
+    "is_null": "$is_null",
+    "is_not_null": "$is_not_null",
+    "is_empty": "$is_empty",
+    "is_not_empty": "$is_not_empty",
+    "contains": "$contains",
+    "startsWith": "$startsWith",
+    "endsWith": "$endsWith",
+    "before": "$before",
+    "after": "$after",
+    "between": "$between",
+    "not_between": "$not_between",
+}
+
+
+def normalize_filter_ops(filters: Any) -> Any:
+    if isinstance(filters, dict):
+        result = {}
+        for key, value in filters.items():
+            if key in ("$and", "$or"):
+                result[key] = [normalize_filter_ops(item) for item in value] if isinstance(value, list) else value
+            elif not key.startswith("$") and key in OP_REMAP:
+                result[OP_REMAP[key]] = normalize_filter_ops(value)
+            else:
+                result[key] = normalize_filter_ops(value)
+        return result
+    if isinstance(filters, list):
+        return [normalize_filter_ops(item) for item in filters]
+    return filters
+
+
+def _like_to_regex(pattern: str, flags: int = 0) -> re.Pattern:
+    # Convert SQL LIKE pattern to regex:
+    # Process char by char to handle % and _ before escaping other chars
+    result = []
+    for ch in pattern:
+        if ch == "%":
+            result.append(".*")
+        elif ch == "_":
+            result.append(".")
+        else:
+            result.append(re.escape(ch))
+    regex_str = "".join(result)
+    return re.compile(f"^{regex_str}$", flags)
+
+
+def _get_nested_value(record: Dict[str, Any], path: str) -> Any:
+    parts = path.split(".")
+    current = record
+    for part in parts:
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+    return current
+
+
+def _evaluate_operator(value: Any, op: str, operand: Any) -> bool:
+    if op == "$eq":
+        return value == operand
+    if op == "$ne":
+        return value != operand
+    if op == "$is_null":
+        return (value is None) == bool(operand)
+    if op == "$is_not_null":
+        if operand:
+            return value is not None
+        return value is None
+    if op == "$is_empty":
+        is_empty = value is None or value == "" or value == []
+        return is_empty == bool(operand)
+    if op == "$is_not_empty":
+        is_empty = value is None or value == "" or value == []
+        if operand:
+            return not is_empty
+        return is_empty
+
+    # For remaining operators, None values return False
+    if value is None:
+        return False
+
+    if op == "$gt":
+        try:
+            return value > operand
+        except TypeError:
+            return False
+    if op == "$gte":
+        try:
+            return value >= operand
+        except TypeError:
+            return False
+    if op == "$lt":
+        try:
+            return value < operand
+        except TypeError:
+            return False
+    if op == "$lte":
+        try:
+            return value <= operand
+        except TypeError:
+            return False
+    if op == "$in":
+        if not isinstance(operand, (list, tuple, set)):
+            return False
+        return value in operand
+    if op == "$nin":
+        if not isinstance(operand, (list, tuple, set)):
+            return False
+        return value not in operand
+    if op == "$like":
+        if not isinstance(value, str) or not isinstance(operand, str):
+            return False
+        return bool(_like_to_regex(operand).match(value))
+    if op == "$ilike":
+        if not isinstance(value, str) or not isinstance(operand, str):
+            return False
+        return bool(_like_to_regex(operand, re.IGNORECASE).match(value))
+    if op == "$not_like":
+        if not isinstance(value, str) or not isinstance(operand, str):
+            return False
+        return not bool(_like_to_regex(operand).match(value))
+    if op == "$not_ilike":
+        if not isinstance(value, str) or not isinstance(operand, str):
+            return False
+        return not bool(_like_to_regex(operand, re.IGNORECASE).match(value))
+    if op == "$contains":
+        if isinstance(value, str) and isinstance(operand, str):
+            return operand in value
+        if isinstance(value, list):
+            return operand in value
+        return False
+    if op == "$startsWith":
+        if not isinstance(value, str) or not isinstance(operand, str):
+            return False
+        return value.startswith(operand)
+    if op == "$endsWith":
+        if not isinstance(value, str) or not isinstance(operand, str):
+            return False
+        return value.endswith(operand)
+    if op == "$before":
+        try:
+            return value < operand
+        except TypeError:
+            return False
+    if op == "$after":
+        try:
+            return value > operand
+        except TypeError:
+            return False
+    if op == "$between":
+        if not isinstance(operand, (list, tuple)) or len(operand) != 2:
+            return False
+        lower, upper = operand
+        try:
+            return lower <= value <= upper
+        except TypeError:
+            return False
+    if op == "$not_between":
+        if not isinstance(operand, (list, tuple)) or len(operand) != 2:
+            return False
+        lower, upper = operand
+        try:
+            return not (lower <= value <= upper)
+        except TypeError:
+            return False
+
+    # Unknown operator - reject instead of silently matching everything
+    return False
+
+
+def evaluate_filter(
+    record: Dict[str, Any],
+    filters: Dict[str, Any],
+    max_depth: int = 10,
+    _current_depth: int = 0,
+) -> bool:
+    if _current_depth > max_depth:
+        from .envelope import DatafnError
+        raise DatafnError(
+            code="LIMIT_EXCEEDED",
+            message=f"Filter depth exceeds maximum of {max_depth}",
+        )
+
+    for key, value in filters.items():
+        if key == "$and":
+            if not isinstance(value, list):
+                return False
+            if len(value) == 0:
+                continue  # Empty $and is true
+            if not all(isinstance(f, dict) for f in value):
+                return False
+            if not all(
+                evaluate_filter(record, f, max_depth, _current_depth + 1)
+                for f in value
+            ):
+                return False
+            continue
+        if key == "$or":
+            if not isinstance(value, list):
+                return False
+            if len(value) == 0:
+                return False  # Empty $or is false
+            if not all(isinstance(f, dict) for f in value):
+                return False
+            if not any(
+                evaluate_filter(record, f, max_depth, _current_depth + 1)
+                for f in value
+            ):
+                return False
+            continue
+
+        # Get record value — supports dot-path traversal
+        if "." in key:
+            record_val = _get_nested_value(record, key)
+        else:
+            record_val = record.get(key)
+
+        if isinstance(value, dict):
+            for op, op_val in value.items():
+                actual_op = OP_REMAP.get(op, op) if not op.startswith("$") else op
+                if not _evaluate_operator(record_val, actual_op, op_val):
+                    return False
+        else:
+            if record_val != value:
+                return False
+
+    return True

--- a/datafn/python/datafn/guards.py
+++ b/datafn/python/datafn/guards.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, Optional
+from .db import Adapter
+from .filters import evaluate_filter
+
+
+async def evaluate_guard(
+    db: Adapter,
+    resource: str,
+    record_id: str,
+    guard: Dict[str, Any],
+    namespace: str = "datafn",
+    tx_db: Optional[Adapter] = None,
+) -> bool:
+    """
+    Evaluate a guard condition against a record.
+    Uses tx_db if provided (for transactional guard evaluation), otherwise db.
+    """
+    try:
+        use_db = tx_db if tx_db is not None else db
+        record = await use_db.find_one(
+            model=resource,
+            where=[{"field": "id", "operator": "eq", "value": record_id}],
+            namespace=namespace
+        )
+        if not record:
+            return False  # Guard on non-existent record fails
+
+        return evaluate_filter(record, guard)
+    except Exception:
+        return False

--- a/datafn/python/datafn/handlers/mutation.py
+++ b/datafn/python/datafn/handlers/mutation.py
@@ -1,0 +1,882 @@
+import time
+import traceback
+from typing import Any, Dict, List, Optional, Tuple, Union
+from ..envelope import ok_response, error_response, DatafnError, classify_error
+from ..validation import (
+    SchemaIndex, validate_resource, validate_record_keys, validate_relation,
+    validate_fields, validate_record_types, validate_required_fields,
+    apply_defaults, validate_mutation_limits, validate_id_length,
+)
+from ..utils.validate_fields import check_prototype_pollution
+from ..idempotency import check_idempotency, store_idempotency
+from ..guards import evaluate_guard
+from ..relations import execute_relate, execute_modify_relation, execute_unrelate
+from ..hooks import run_before_hook, run_after_hook
+from ..change_tracking import write_change
+from ..authz import (
+    canonicalize_principal_from_user_id,
+    get_actor_id_from_context,
+    get_shareable_capability,
+    is_private_shareable_resource,
+    resolve_access_level,
+    validate_mutation_authz,
+)
+
+RESERVED_FIELDS = {"id", "createdAt", "createdBy", "updatedAt", "updatedBy", "version"}
+GLOBAL_PERMISSIONS_TABLE = "__datafn_permissions_global"
+
+
+def _get_namespace(ctx: Any) -> str:
+    if isinstance(ctx, dict):
+        namespace = ctx.get("namespace")
+        if isinstance(namespace, str) and namespace.strip():
+            return namespace
+    return "datafn"
+
+
+def _normalize_non_empty_string(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    return trimmed if trimmed else None
+
+
+def _principal_in_namespace(principal_id: str, namespace: str) -> bool:
+    return principal_id == namespace or principal_id.startswith(f"{namespace}:")
+
+
+def _permission_entry_id(
+    resource: str,
+    namespace: str,
+    resource_id: Optional[str],
+    principal_id: str,
+) -> str:
+    return f"{resource}:{namespace}:{resource_id if resource_id is not None else '*'}:{principal_id}"
+
+
+def _apply_audit_fields_on_insert(record: Dict[str, Any], actor_id: Optional[str]) -> Dict[str, Any]:
+    if not actor_id:
+        return record
+    if "createdBy" not in record:
+        record["createdBy"] = actor_id
+    if "updatedBy" not in record:
+        record["updatedBy"] = actor_id
+    return record
+
+
+def _resolve_share_scope(payload: Dict[str, Any]) -> str:
+    scope = payload.get("scope", "record")
+    if scope not in ("record", "resource"):
+        raise DatafnError(
+            code="DFQL_SHARE_SCOPE_INVALID",
+            message="scope must be either record or resource",
+            details={"path": "scope"},
+        )
+    if scope == "resource" and payload.get("id") is not None:
+        raise DatafnError(
+            code="DFQL_SHARE_SCOPE_INVALID",
+            message="resource scope share must omit id",
+            details={"path": "id"},
+        )
+    return scope
+
+
+def _canonicalize_share_principal(share_with: Any) -> str:
+    if not isinstance(share_with, dict):
+        raise DatafnError(
+            code="DFQL_INVALID",
+            message="Invalid DFQL: shareWith must be object",
+            details={"path": "shareWith"},
+        )
+
+    principal_id = _normalize_non_empty_string(share_with.get("principalId"))
+    user_id = _normalize_non_empty_string(share_with.get("userId"))
+
+    if share_with.get("principalId") is not None and principal_id is None:
+        raise DatafnError(
+            code="DFQL_PRINCIPAL_INVALID",
+            message="principalId must be non-empty string",
+            details={"path": "shareWith.principalId"},
+        )
+    if share_with.get("userId") is not None and user_id is None:
+        raise DatafnError(
+            code="DFQL_PRINCIPAL_INVALID",
+            message="userId must be non-empty string",
+            details={"path": "shareWith.userId"},
+        )
+    if principal_id and user_id:
+        canonical_user = canonicalize_principal_from_user_id(user_id)
+        if canonical_user != principal_id:
+            raise DatafnError(
+                code="DFQL_PRINCIPAL_INVALID",
+                message="Provide only one of shareWith.userId or shareWith.principalId",
+                details={"path": "shareWith"},
+            )
+    if not principal_id and not user_id:
+        raise DatafnError(
+            code="DFQL_PRINCIPAL_INVALID",
+            message="Either shareWith.userId or shareWith.principalId is required",
+            details={"path": "shareWith"},
+        )
+    return principal_id or canonicalize_principal_from_user_id(user_id)  # type: ignore[arg-type]
+
+
+async def _enforce_private_shareable_mutation_access(
+    db: Any,
+    index: SchemaIndex,
+    resource: str,
+    operation: str,
+    record_id: Optional[str],
+    actor_id: Optional[str],
+    namespace: str,
+    share_scope: Optional[str] = None,
+    logger: Any = None,
+) -> None:
+    resource_def = index.resources_by_name.get(resource)
+    if not resource_def or not is_private_shareable_resource(resource_def):
+        return
+
+    if operation == "insert":
+        if actor_id:
+            return
+        raise DatafnError(
+            code="FORBIDDEN",
+            message="Authorization denied",
+            details={"path": "operation"},
+        )
+
+    if operation not in {"merge", "replace", "delete", "share", "unshare"}:
+        return
+
+    if (
+        operation in {"merge", "replace", "delete", "share", "unshare"}
+        and not record_id
+        and not (operation in {"share", "unshare"} and share_scope == "resource")
+    ):
+        # Let operation-specific validation return deterministic missing-id errors.
+        return
+
+    # Scope-level share/unshare requires actor but no record ownership lookup.
+    if operation in {"share", "unshare"} and share_scope == "resource":
+        if actor_id:
+            return
+        raise DatafnError(
+            code="FORBIDDEN",
+            message="Authorization denied",
+            details={"path": "operation"},
+        )
+
+    if not record_id or not actor_id:
+        if operation in {"share", "unshare"} and logger:
+            logger.warn("Unauthorized share access", {
+                "resource": resource,
+                "recordId": record_id,
+                "actorId": actor_id,
+                "operation": operation,
+            })
+        raise DatafnError(
+            code="FORBIDDEN",
+            message="Authorization denied",
+            details={"path": "operation"},
+        )
+
+    level = await resolve_access_level(
+        db,
+        index,
+        resource,
+        record_id,
+        actor_id,
+        namespace=namespace,
+    )
+    if operation in {"delete", "share", "unshare"}:
+        allowed = level == "owner"
+    else:
+        allowed = level in {"owner", "editor"}
+
+    if not allowed:
+        if operation in {"share", "unshare"} and logger:
+            logger.warn("Unauthorized share access", {
+                "resource": resource,
+                "recordId": record_id,
+                "actorId": actor_id,
+                "operation": operation,
+            })
+        raise DatafnError(
+            code="FORBIDDEN",
+            message="Authorization denied",
+            details={"path": "operation"},
+        )
+
+
+async def _execute_share(
+    db: Any,
+    index: SchemaIndex,
+    payload: Dict[str, Any],
+    namespace: str,
+    actor_id: Optional[str],
+) -> Tuple[List[str], List[Dict[str, Any]]]:
+    resource = payload["resource"]
+    resource_def = index.resources_by_name[resource]
+    shareable = get_shareable_capability(resource_def)
+    if not shareable:
+        raise DatafnError(
+            code="DFQL_UNSUPPORTED",
+            message="Unsupported DFQL feature: mutation.operation.share",
+            details={"path": "operation"},
+        )
+
+    scope = _resolve_share_scope(payload)
+    record_id = payload.get("id") if scope == "record" else None
+    if scope == "record" and not isinstance(record_id, str):
+        raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+
+    principal_id = _canonicalize_share_principal(payload.get("shareWith"))
+    if shareable.get("crossNsShareable") is False and not _principal_in_namespace(principal_id, namespace):
+        raise DatafnError(
+            code="DFQL_CROSS_NS_SHARE_FORBIDDEN",
+            message="Cross-namespace sharing is disabled for this resource",
+            details={"path": "shareWith.principalId"},
+        )
+
+    level = payload.get("shareWith", {}).get("level", "viewer")
+    allowed_levels = shareable.get("levels", ["viewer", "editor", "owner"])
+    if not isinstance(level, str) or level not in allowed_levels:
+        raise DatafnError(
+            code="DFQL_INVALID",
+            message=f"Invalid DFQL: shareWith.level must be one of [{', '.join(allowed_levels)}]",
+            details={"path": "shareWith.level"},
+        )
+
+    permission_id = _permission_entry_id(resource, namespace, record_id, principal_id)
+    now = int(time.time() * 1000)
+    permission_record = {
+        "id": permission_id,
+        "resourceType": resource,
+        "resourceNs": namespace,
+        "resourceId": record_id,
+        "principalId": principal_id,
+        "level": level,
+        "grantKind": "scope" if scope == "resource" else "record",
+        "sourceRef": None,
+        "grantedBy": actor_id or "system",
+        "grantedAt": now,
+        "revokedAt": None,
+    }
+    existing = await db.find_one(
+        GLOBAL_PERMISSIONS_TABLE,
+        [{"field": "id", "operator": "eq", "value": permission_id}],
+        namespace=namespace,
+    )
+    if existing:
+        await db.update(
+            GLOBAL_PERMISSIONS_TABLE,
+            [{"field": "id", "operator": "eq", "value": permission_id}],
+            permission_record,
+            namespace=namespace,
+        )
+    else:
+        await db.create(GLOBAL_PERMISSIONS_TABLE, permission_record, namespace=namespace)
+
+    return (
+        [permission_id],
+        [{"table": GLOBAL_PERMISSIONS_TABLE, "operation": "upsert", "recordId": permission_id}],
+    )
+
+
+async def _execute_unshare(
+    db: Any,
+    index: SchemaIndex,
+    payload: Dict[str, Any],
+    namespace: str,
+    actor_id: Optional[str],
+) -> Tuple[List[str], List[Dict[str, Any]]]:
+    resource = payload["resource"]
+    resource_def = index.resources_by_name[resource]
+    shareable = get_shareable_capability(resource_def)
+    if not shareable:
+        raise DatafnError(
+            code="DFQL_UNSUPPORTED",
+            message="Unsupported DFQL feature: mutation.operation.unshare",
+            details={"path": "operation"},
+        )
+
+    scope = _resolve_share_scope(payload)
+    record_id = payload.get("id") if scope == "record" else None
+    if scope == "record" and not isinstance(record_id, str):
+        raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+
+    principal_id = _canonicalize_share_principal(payload.get("shareWith"))
+    permission_id = _permission_entry_id(resource, namespace, record_id, principal_id)
+
+    existing = await db.find_one(
+        GLOBAL_PERMISSIONS_TABLE,
+        [{"field": "id", "operator": "eq", "value": permission_id}],
+        namespace=namespace,
+    )
+    if not existing:
+        return [], []
+
+    await db.delete(
+        GLOBAL_PERMISSIONS_TABLE,
+        [{"field": "id", "operator": "eq", "value": permission_id}],
+        namespace=namespace,
+    )
+    return (
+        [permission_id],
+        [{"table": GLOBAL_PERMISSIONS_TABLE, "operation": "delete", "recordId": permission_id}],
+    )
+
+
+async def handle_mutation(ctx: Any, payload: Any, config: Any) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+    if isinstance(payload, list):
+        results = []
+        for p in payload:
+            results.append(await _handle_single_mutation(ctx, p, config))
+        return results
+
+    return await _handle_single_mutation(ctx, payload, config)
+
+
+async def _handle_single_mutation(ctx: Any, payload: Any, config: Any) -> Dict[str, Any]:
+    logger = getattr(config, "logger", None)
+    plugins = getattr(config, "plugins", []) or []
+    namespace = _get_namespace(ctx)
+    actor_id = get_actor_id_from_context(ctx)
+
+    try:
+        if not isinstance(payload, dict):
+            return error_response({
+                "code": "DFQL_INVALID",
+                "message": "Invalid JSON",
+                "details": {"path": "$"}
+            })
+
+        resource = payload.get("resource")
+        if logger:
+            logger.debug("Mutation request", {"resource": resource, "operation": payload.get("operation")})
+
+        # Run before_mutation hooks
+        if plugins:
+            hook_result = await run_before_hook(plugins, "server", "before_mutation", ctx, payload, logger=logger)
+            if not hook_result.get("ok"):
+                if logger:
+                    logger.error("Mutation rejected by plugin", {"error": hook_result.get("error", {}).get("message", "")})
+                return hook_result
+            payload = hook_result.get("value", payload)
+
+        # Authorize
+        if config.authorize:
+            try:
+                allowed = await config.authorize(ctx, "mutation", payload)
+                if not allowed:
+                    if logger:
+                        logger.error("Mutation authorization denied", {"resource": resource})
+                    return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+            except Exception:
+                if logger:
+                    logger.error("Mutation authorization denied", {"resource": resource})
+                return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+
+        # Idempotency Check
+        client_id = payload.get("clientId")
+        mutation_id = payload.get("mutationId")
+
+        if client_id and mutation_id:
+            cached = await check_idempotency(
+                config.db,
+                namespace,
+                client_id,
+                mutation_id,
+                logger=logger,
+            )
+            if cached:
+                cached_result = dict(cached)
+                cached_result["deduped"] = True
+                return ok_response(cached_result)
+
+        # Core Execution
+        index = SchemaIndex(config.schema)
+        limits = getattr(config, "limits", {}) or {}
+
+        # Field-level authorization
+        resource = payload.get("resource")
+        if resource:
+            authz_err = validate_mutation_authz(
+                payload,
+                resource,
+                index,
+                allow_unknown_resources=getattr(config, "allowUnknownResources", False),
+            )
+            if authz_err:
+                if logger:
+                    logger.error("Mutation field authorization denied", {"code": authz_err.code, "message": authz_err.message})
+                return authz_err.to_envelope()
+
+        affected_ids, changes = await execute_mutation_core(
+            config.db,
+            index,
+            payload,
+            limits,
+            namespace=namespace,
+            actor_id=actor_id,
+            logger=logger,
+        )
+
+        result = {
+            "ok": True,
+            "mutationId": mutation_id,
+            "affectedIds": affected_ids,
+            "deduped": False,
+            "errors": []
+        }
+
+        # Write change tracking
+        if changes:
+            for change in changes:
+                try:
+                    await _write_change(config.db, change, namespace)
+                except Exception as e:
+                    if logger:
+                        logger.warn(
+                            "Change tracking failed",
+                            {"namespace": namespace, "change": change, "error": str(e)},
+                        )
+
+        # Store Idempotency
+        if client_id and mutation_id:
+            await store_idempotency(config.db, namespace, client_id, mutation_id, result)
+
+        response = ok_response(result)
+
+        # Run after_mutation hooks
+        if plugins:
+            response = await run_after_hook(
+                plugins,
+                "server",
+                "after_mutation",
+                ctx,
+                payload,
+                response,
+                logger=logger,
+            )
+
+        if logger:
+            logger.debug("Mutation completed", {"resource": resource})
+
+        return response
+
+    except DatafnError as e:
+        if logger:
+            logger.error("Mutation failed", {"code": e.code, "message": e.message})
+        return e.to_envelope()
+    except Exception as e:
+        if logger:
+            logger.error(
+                "Mutation failed",
+                {
+                    "code": "INTERNAL",
+                    "message": str(e),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        return error_response({
+            "code": "INTERNAL",
+            "message": "Internal server error",
+            "details": {}
+        })
+
+
+async def _write_change(db: Any, change: Dict[str, Any], namespace: str) -> None:
+    await write_change(
+        db,
+        namespace=namespace,
+        table=change["table"],
+        operation=change["operation"],
+        record_id=change["recordId"],
+    )
+
+
+async def execute_mutation_core(
+    db: Any,
+    index: SchemaIndex,
+    payload: Dict[str, Any],
+    limits: Optional[Dict[str, Any]] = None,
+    namespace: str = "datafn",
+    actor_id: Optional[str] = None,
+    logger: Any = None,
+) -> tuple:
+    """
+    Executes a single mutation payload.
+    Returns (affected_ids, changes) tuple.
+    """
+    limits = limits or {}
+    resource = payload.get("resource")
+    operation = payload.get("operation")
+    record_id = payload.get("id")
+
+    if not resource:
+        raise DatafnError(code="DFQL_INVALID", message="Missing resource", details={"path": "resource"})
+
+    err = validate_resource(index, resource, "resource")
+    if err:
+        raise err
+
+    # ID length validation
+    max_id_length = limits.get("maxIdLength", 255)
+    id_err = validate_id_length(record_id, max_id_length)
+    if id_err:
+        raise id_err
+
+    await _enforce_private_shareable_mutation_access(
+        db,
+        index,
+        resource,
+        operation,
+        record_id if isinstance(record_id, str) else None,
+        actor_id,
+        namespace,
+        share_scope=payload.get("scope") if operation in {"share", "unshare"} else None,
+        logger=logger,
+    )
+
+    # Batch insert via records[]
+    records_list = payload.get("records")
+    if records_list is not None:
+        if not isinstance(records_list, list):
+            raise DatafnError(code="DFQL_INVALID", message="records must be an array", details={"path": "records"})
+
+        # Batch size limit
+        batch_err = validate_mutation_limits(payload, limits)
+        if batch_err:
+            raise batch_err
+
+        affected_ids = []
+        changes = []
+        for i, rec in enumerate(records_list):
+            if not isinstance(rec, dict):
+                raise DatafnError(
+                    code="DFQL_INVALID",
+                    message="Record must be an object",
+                    details={"path": f"records[{i}]"},
+                )
+            # Prototype pollution check
+            poisoned = check_prototype_pollution(rec)
+            if poisoned:
+                raise DatafnError(code="DFQL_INVALID", message=f"Prototype pollution detected: {poisoned}", details={"path": f"records[{i}]"})
+
+            # ID length check per record
+            rec_id = rec.get("id")
+            id_err = validate_id_length(rec_id, max_id_length)
+            if id_err:
+                raise id_err
+
+            # Field validation
+            err = validate_record_keys(index, resource, rec, f"records[{i}]")
+            if err:
+                raise err
+
+            type_errors = validate_record_types(rec, resource, index)
+            if type_errors:
+                raise DatafnError(code="DFQL_INVALID", message=type_errors[0], details={"path": f"records[{i}]"})
+
+            # Required fields + defaults for insert
+            missing = validate_required_fields(rec, resource, index)
+            if missing:
+                raise DatafnError(code="DFQL_INVALID", message=f"Required field '{missing[0]}' missing", details={"path": f"records[{i}]"})
+
+            rec = apply_defaults(rec, resource, index)
+            rec = _apply_audit_fields_on_insert(rec, actor_id)
+
+            try:
+                await db.create(resource, rec, namespace=namespace)
+            except Exception as e:
+                code = classify_error(e)
+                raise DatafnError(code=code, message=str(e), details={"path": f"records[{i}]"})
+
+            rid = rec.get("id")
+            if rid:
+                affected_ids.append(rid)
+                changes.append({"table": resource, "operation": "insert", "recordId": rid})
+
+        return affected_ids, changes
+
+    # Single record path
+    record = payload.get("record", {})
+    if not isinstance(record, dict):
+        raise DatafnError(
+            code="DFQL_INVALID",
+            message="Record must be an object",
+            details={"path": "record"},
+        )
+
+    # Prototype pollution check
+    poisoned = check_prototype_pollution(record)
+    if poisoned:
+        raise DatafnError(code="DFQL_INVALID", message=f"Prototype pollution detected: {poisoned}", details={"path": "record"})
+
+    # Guard Evaluation
+    guard = payload.get("if")
+
+    if guard:
+        if not record_id:
+            raise DatafnError(code="DFQL_INVALID", message="Guard requires id", details={"path": "id"})
+
+        # When adapter supports transactions, wrap guard+mutation atomically
+        if hasattr(db, "transaction"):
+            async with db.transaction() as tx_db:
+                match = await evaluate_guard(
+                    tx_db,
+                    resource,
+                    record_id,
+                    guard,
+                    namespace=namespace,
+                    tx_db=tx_db,
+                )
+                if not match:
+                    raise DatafnError(code="CONFLICT", message="Guard condition not met", details={"path": "if"})
+                # Execute mutation within the same transaction, guard already passed
+                payload_no_guard = {k: v for k, v in payload.items() if k != "if"}
+                return await execute_mutation_core(
+                    tx_db,
+                    index,
+                    payload_no_guard,
+                    limits,
+                    namespace=namespace,
+                    actor_id=actor_id,
+                    logger=logger,
+                )
+        else:
+            # No transaction support — sequential with TOCTOU risk
+            match = await evaluate_guard(
+                db,
+                resource,
+                record_id,
+                guard,
+                namespace=namespace,
+            )
+            if not match:
+                raise DatafnError(code="CONFLICT", message="Guard condition not met", details={"path": "if"})
+
+    affected_ids = []
+    changes = []
+
+    if operation == "insert":
+        err = validate_record_keys(index, resource, record, "record")
+        if err:
+            raise err
+
+        type_errors = validate_record_types(record, resource, index)
+        if type_errors:
+            raise DatafnError(code="DFQL_INVALID", message=type_errors[0], details={"path": "record"})
+
+        # Required fields + defaults
+        missing = validate_required_fields(record, resource, index)
+        if missing:
+            raise DatafnError(code="DFQL_INVALID", message=f"Required field '{missing[0]}' missing", details={"path": "record"})
+
+        record = apply_defaults(record, resource, index)
+        record = _apply_audit_fields_on_insert(record, actor_id)
+
+        if "id" not in record and record_id:
+            record["id"] = record_id
+
+        try:
+            await db.create(resource, record, namespace=namespace)
+        except Exception as e:
+            code = classify_error(e)
+            raise DatafnError(code=code, message=str(e), details={"path": "record"})
+
+        rid = record.get("id")
+        if rid:
+            affected_ids.append(rid)
+            changes.append({"table": resource, "operation": "insert", "recordId": rid})
+
+    elif operation == "merge":
+        if not record_id:
+            raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+
+        err = validate_record_keys(index, resource, record, "record")
+        if err:
+            raise err
+
+        type_errors = validate_record_types(record, resource, index)
+        if type_errors:
+            raise DatafnError(code="DFQL_INVALID", message=type_errors[0], details={"path": "record"})
+
+        # Merge decision: check existence
+        existing = await db.find_one(
+            resource,
+            [{"field": "id", "operator": "eq", "value": record_id}],
+            namespace=namespace,
+        )
+
+        if existing:
+            # Update path — partial merge, no required field check
+            try:
+                await db.update(
+                    resource,
+                    [{"field": "id", "operator": "eq", "value": record_id}],
+                    record,
+                    namespace=namespace,
+                )
+            except Exception as e:
+                code = classify_error(e)
+                raise DatafnError(code=code, message=str(e), details={"path": "record"})
+            changes.append({"table": resource, "operation": "update", "recordId": record_id})
+        else:
+            # Insert path — validate required fields, apply defaults
+            missing = validate_required_fields(record, resource, index)
+            if missing:
+                raise DatafnError(code="DFQL_INVALID", message=f"Required field '{missing[0]}' missing", details={"path": "record"})
+
+            record = apply_defaults(record, resource, index)
+            record = _apply_audit_fields_on_insert(record, actor_id)
+            record["id"] = record_id
+
+            try:
+                await db.create(resource, record, namespace=namespace)
+            except Exception as e:
+                code = classify_error(e)
+                raise DatafnError(code=code, message=str(e), details={"path": "record"})
+            changes.append({"table": resource, "operation": "insert", "recordId": record_id})
+
+        affected_ids.append(record_id)
+
+    elif operation == "replace":
+        if not record_id:
+            raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+
+        # Fetch existing to preserve system fields
+        existing = await db.find_one(
+            resource,
+            [{"field": "id", "operator": "eq", "value": record_id}],
+            namespace=namespace,
+        )
+
+        # Build replacement record: all schema fields set to null or default
+        all_writable = index.writable_fields_by_resource.get(resource, set())
+        defaults = index.field_defaults.get(resource, {})
+
+        replace_record = {}
+        for f in all_writable:
+            if f in RESERVED_FIELDS:
+                continue
+            replace_record[f] = defaults.get(f, None)
+
+        # Apply incoming record (strip readonly/system fields from input)
+        readonly = index.readonly_fields.get(resource, set())
+        for key, value in record.items():
+            if key in readonly or key in RESERVED_FIELDS:
+                continue
+            replace_record[key] = value
+
+        if existing:
+            for field in ("createdAt", "createdBy", "version"):
+                if field in existing:
+                    replace_record[field] = existing[field]
+
+        # Type validation on the final replacement
+        type_errors = validate_record_types(replace_record, resource, index)
+        if type_errors:
+            raise DatafnError(code="DFQL_INVALID", message=type_errors[0], details={"path": "record"})
+
+        try:
+            await db.update(
+                resource,
+                [{"field": "id", "operator": "eq", "value": record_id}],
+                replace_record,
+                namespace=namespace,
+            )
+        except Exception as e:
+            code = classify_error(e)
+            raise DatafnError(code=code, message=str(e), details={"path": "record"})
+
+        affected_ids.append(record_id)
+        changes.append({"table": resource, "operation": "update", "recordId": record_id})
+
+    elif operation == "delete":
+        if not record_id:
+            raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+
+        # Idempotent delete: check existence first
+        existing = await db.find_one(
+            resource,
+            [{"field": "id", "operator": "eq", "value": record_id}],
+            namespace=namespace,
+        )
+        if existing:
+            try:
+                await db.delete(
+                    resource,
+                    [{"field": "id", "operator": "eq", "value": record_id}],
+                    namespace=namespace,
+                )
+            except Exception as e:
+                code = classify_error(e)
+                raise DatafnError(code=code, message=str(e), details={"path": "id"})
+            affected_ids.append(record_id)
+            changes.append({"table": resource, "operation": "delete", "recordId": record_id})
+        # If not exists: return empty affectedIds, no change tracking
+
+    elif operation == "share":
+        share_affected, share_changes = await _execute_share(
+            db,
+            index,
+            payload,
+            namespace=namespace,
+            actor_id=actor_id,
+        )
+        affected_ids.extend(share_affected)
+        changes.extend(share_changes)
+        share_scope = _resolve_share_scope(payload)
+        if share_scope == "record" and isinstance(record_id, str):
+            changes.append({"table": resource, "operation": "upsert", "recordId": record_id, "reason": "grant_backfill"})
+        elif share_scope == "resource":
+            scope_rows = await db.find_many(resource, where=[], namespace=namespace)
+            for row in scope_rows:
+                row_id = row.get("id")
+                if isinstance(row_id, str):
+                    changes.append({"table": resource, "operation": "upsert", "recordId": row_id, "reason": "grant_backfill"})
+
+    elif operation == "unshare":
+        unshare_affected, unshare_changes = await _execute_unshare(
+            db,
+            index,
+            payload,
+            namespace=namespace,
+            actor_id=actor_id,
+        )
+        affected_ids.extend(unshare_affected)
+        changes.extend(unshare_changes)
+        unshare_scope = _resolve_share_scope(payload)
+        if unshare_scope == "record" and isinstance(record_id, str):
+            changes.append({"table": resource, "operation": "delete", "recordId": record_id, "reason": "revoked"})
+        elif unshare_scope == "resource":
+            scope_rows = await db.find_many(resource, where=[], namespace=namespace)
+            for row in scope_rows:
+                row_id = row.get("id")
+                if isinstance(row_id, str):
+                    changes.append({"table": resource, "operation": "delete", "recordId": row_id, "reason": "revoked"})
+
+    elif operation == "relate":
+        if not record_id:
+            raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+        await execute_relate(db, index, payload, namespace=namespace)
+        affected_ids.append(record_id)
+
+    elif operation == "modifyRelation":
+        if not record_id:
+            raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+        await execute_modify_relation(db, index, payload, namespace=namespace)
+        affected_ids.append(record_id)
+
+    elif operation == "unrelate":
+        if not record_id:
+            raise DatafnError(code="DFQL_INVALID", message="Missing id", details={"path": "id"})
+        await execute_unrelate(db, index, payload, namespace=namespace)
+        affected_ids.append(record_id)
+
+    else:
+        raise DatafnError(code="DFQL_INVALID", message=f"Unknown operation: {operation}", details={"path": "operation"})
+
+    return affected_ids, changes

--- a/datafn/python/datafn/handlers/query.py
+++ b/datafn/python/datafn/handlers/query.py
@@ -1,0 +1,304 @@
+from typing import Any, Dict, List, Optional, Union
+from ..envelope import ok_response, error_response, DatafnError
+from ..validation import SchemaIndex, validate_resource, validate_fields, validate_query_limits
+from ..filters import evaluate_filter, normalize_filter_ops, _evaluate_operator, OP_REMAP
+from ..utils.sort import parse_sort_terms, sort_records
+from ..utils.select import apply_select, apply_omit
+from ..utils.aggregate import calculate_aggregation
+from ..hooks import run_before_hook, run_after_hook
+from ..authz import (
+    get_actor_id_from_context,
+    is_private_shareable_resource,
+    is_record_visible,
+    validate_query_authz,
+)
+
+
+def _get_namespace(ctx: Any) -> str:
+    if isinstance(ctx, dict):
+        namespace = ctx.get("namespace")
+        if isinstance(namespace, str) and namespace.strip():
+            return namespace
+    return "datafn"
+
+
+async def handle_query(ctx: Any, payload: Any, config: Any) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+    if isinstance(payload, list):
+        results = []
+        for p in payload:
+            results.append(await _handle_single_query(ctx, p, config))
+        return results
+
+    return await _handle_single_query(ctx, payload, config)
+
+
+def _compare_cursor(record: Dict[str, Any], cursor: Dict[str, Any], sort_terms: List[Dict[str, str]], direction: str) -> bool:
+    for term in sort_terms:
+        field = term["field"]
+        sort_dir = term["direction"]
+        rv = record.get(field)
+        cv = cursor.get(field)
+
+        if rv is None and cv is None:
+            continue
+        if rv is None:
+            return sort_dir == "desc" if direction == "after" else sort_dir == "asc"
+        if cv is None:
+            return sort_dir == "asc" if direction == "after" else sort_dir == "desc"
+
+        if direction == "after":
+            if sort_dir == "asc":
+                if rv > cv: return True
+                if rv < cv: return False
+            else:
+                if rv < cv: return True
+                if rv > cv: return False
+        else:
+            if sort_dir == "asc":
+                if rv < cv: return True
+                if rv > cv: return False
+            else:
+                if rv > cv: return True
+                if rv < cv: return False
+
+    return False
+
+
+async def _handle_single_query(ctx: Any, payload: Any, config: Any) -> Dict[str, Any]:
+    logger = getattr(config, "logger", None)
+    plugins = getattr(config, "plugins", []) or []
+    namespace = _get_namespace(ctx)
+    actor_id = get_actor_id_from_context(ctx)
+
+    try:
+        if not isinstance(payload, dict):
+            return error_response({
+                "code": "DFQL_INVALID",
+                "message": "Invalid JSON: payload must be an object",
+                "details": {"path": "$"}
+            })
+
+        resource = payload.get("resource")
+        if logger:
+            logger.debug("Query request", {"resource": resource})
+
+        # Run before_query hooks
+        if plugins:
+            hook_result = await run_before_hook(plugins, "server", "before_query", ctx, payload, logger=logger)
+            if not hook_result.get("ok"):
+                if logger:
+                    logger.error("Query rejected by plugin", {"error": hook_result.get("error", {}).get("message", "")})
+                return hook_result
+            payload = hook_result.get("value", payload)
+
+        # Authorize
+        if config.authorize:
+            try:
+                allowed = await config.authorize(ctx, "query", payload)
+                if not allowed:
+                    if logger:
+                        logger.error("Query authorization denied", {"resource": resource})
+                    return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+            except Exception:
+                if logger:
+                    logger.error("Query authorization denied", {"resource": resource})
+                return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+
+        resource = payload.get("resource")
+        if not resource:
+            return error_response({"code": "DFQL_INVALID", "message": "Missing resource", "details": {"path": "resource"}})
+
+        index = SchemaIndex(config.schema)
+
+        err = validate_resource(index, resource, "resource")
+        if err:
+            if logger:
+                logger.error("Query failed", {"code": err.code, "message": err.message})
+            return err.to_envelope()
+
+        # Field-level authorization
+        authz_err = validate_query_authz(payload, resource, index)
+        if authz_err:
+            if logger:
+                logger.error("Query field authorization denied", {"code": authz_err.code, "message": authz_err.message})
+            return authz_err.to_envelope()
+
+        # Validate select fields
+        select = payload.get("select")
+        omit = payload.get("omit")
+        if select and omit:
+            return error_response({"code": "DFQL_INVALID", "message": "Cannot use both select and omit", "details": {"path": "$"}})
+
+        if select:
+            err = validate_fields(index, resource, select, "select")
+            if err:
+                return err.to_envelope()
+
+        # Limit enforcement
+        limits = getattr(config, "limits", {}) or {}
+        limit_err = validate_query_limits(payload, limits)
+        if limit_err:
+            return limit_err.to_envelope()
+
+        # Default sort
+        sort_raw = payload.get("sort") or ["id"]
+        sort_terms = parse_sort_terms(sort_raw)
+
+        # Cursor validation: id must be final sort field
+        cursor = payload.get("cursor")
+        if cursor:
+            if not sort_terms or sort_terms[-1]["field"] != "id":
+                sort_terms.append({"field": "id", "direction": "asc"})
+
+        # Limit clamping
+        max_limit = limits.get("maxLimit", 1000)
+        req_limit = payload.get("limit")
+        if req_limit is None:
+            limit = max_limit
+        else:
+            limit = min(req_limit, max_limit)
+
+        # Fetch all records from adapter
+        data = await config.db.find_many(model=resource, where=[], namespace=namespace)
+
+        # In-memory filter
+        filters = payload.get("filters", {})
+        if filters:
+            normalized = normalize_filter_ops(filters)
+            data = [r for r in data if evaluate_filter(r, normalized)]
+
+        resource_def = index.resources_by_name.get(resource)
+        if resource_def and is_private_shareable_resource(resource_def):
+            visible_rows = []
+            for row in data:
+                if await is_record_visible(
+                    config.db,
+                    index,
+                    resource,
+                    row,
+                    actor_id,
+                    namespace=namespace,
+                ):
+                    visible_rows.append(row)
+            data = visible_rows
+
+        # In-memory sort
+        data = sort_records(data, sort_terms)
+
+        # Count (before pagination)
+        count_requested = payload.get("count", False)
+        total_count = len(data) if count_requested else None
+
+        # Aggregation
+        group_by = payload.get("groupBy")
+        aggregations = payload.get("aggregations")
+        if aggregations:
+            result = _handle_aggregation(data, group_by, aggregations, payload.get("having"))
+            # Run after_query hooks
+            if plugins:
+                result = await run_after_hook(plugins, "server", "after_query", ctx, payload, result, logger=logger)
+            if logger:
+                logger.debug("Query completed", {"resource": resource})
+            return result
+
+        # Cursor pagination
+        next_cursor = None
+        if cursor:
+            if "after" in cursor:
+                data = [r for r in data if _compare_cursor(r, cursor["after"], sort_terms, "after")]
+            elif "before" in cursor:
+                data = [r for r in data if _compare_cursor(r, cursor["before"], sort_terms, "before")]
+                if len(data) > limit:
+                    data = data[-limit:]
+
+        # Offset pagination
+        offset = payload.get("offset", 0)
+        if offset:
+            data = data[offset:]
+
+        # Limit + nextCursor (limit+1 strategy)
+        if len(data) > limit:
+            data = data[:limit]
+            next_cursor = {t["field"]: data[-1].get(t["field"]) for t in sort_terms}
+        else:
+            data = data[:limit]
+
+        # Select/omit
+        if select:
+            data = apply_select(data, select)
+        elif omit:
+            data = apply_omit(data, omit)
+
+        result_data = {"data": data, "nextCursor": next_cursor}
+        if count_requested:
+            result_data["count"] = total_count
+
+        response = ok_response(result_data)
+
+        # Run after_query hooks
+        if plugins:
+            response = await run_after_hook(plugins, "server", "after_query", ctx, payload, response, logger=logger)
+
+        if logger:
+            logger.debug("Query completed", {"resource": resource})
+
+        return response
+
+    except DatafnError as e:
+        if logger:
+            logger.error("Query failed", {"code": e.code, "message": e.message})
+        return e.to_envelope()
+    except Exception as e:
+        if logger:
+            logger.error("Query failed", {"code": "INTERNAL", "message": str(e)})
+        return error_response({"code": "INTERNAL", "message": str(e), "details": {}})
+
+
+def _handle_aggregation(
+    data: List[Dict[str, Any]],
+    group_by: Optional[List[str]],
+    aggregations: Dict[str, Dict[str, str]],
+    having: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    if group_by:
+        groups: Dict[tuple, List[Dict[str, Any]]] = {}
+        for record in data:
+            key = tuple(record.get(f) for f in group_by)
+            groups.setdefault(key, []).append(record)
+
+        result_data = []
+        for key, records in groups.items():
+            row = {}
+            for i, field in enumerate(group_by):
+                row[field] = key[i]
+
+            for agg_name, agg_def in aggregations.items():
+                for op, field in agg_def.items():
+                    row[agg_name] = calculate_aggregation(op, field, records)
+
+            if having:
+                passes = True
+                for field, condition in having.items():
+                    if isinstance(condition, dict):
+                        for op, val in condition.items():
+                            actual_op = OP_REMAP.get(op, op) if not op.startswith("$") else op
+                            if not _evaluate_operator(row.get(field), actual_op, val):
+                                passes = False
+                                break
+                    else:
+                        if row.get(field) != condition:
+                            passes = False
+                    if not passes:
+                        break
+                if not passes:
+                    continue
+
+            result_data.append(row)
+
+        return ok_response({"data": result_data})
+    else:
+        row = {}
+        for agg_name, agg_def in aggregations.items():
+            for op, field in agg_def.items():
+                row[agg_name] = calculate_aggregation(op, field, data)
+        return ok_response({"data": [row]})

--- a/datafn/python/datafn/handlers/sync.py
+++ b/datafn/python/datafn/handlers/sync.py
@@ -1,0 +1,474 @@
+import traceback
+from typing import Any, Dict, List
+from ..envelope import ok_response, error_response, DatafnError
+from ..db import Adapter
+from ..validation import SchemaIndex
+from ..change_tracking import get_changes_since, get_latest_cursor, write_change, get_next_server_seq
+from ..idempotency import check_idempotency, store_idempotency
+from ..utils.date import coerce_date_fields_to_epoch
+from ..utils.joins import get_join_table_name, enumerate_join_store_keys
+from ..authz import (
+    get_actor_id_from_context,
+    is_private_shareable_resource,
+    is_record_visible,
+    validate_mutation_authz,
+)
+from .mutation import execute_mutation_core
+
+SEED_TABLE = "__datafn_seed"
+DEFAULT_NAMESPACE = "datafn"
+DEFAULT_MAX_PULL_LIMIT = 5000
+
+
+def _resource_is_private_shareable(index: SchemaIndex, resource: str) -> bool:
+    resource_def = index.resources_by_name.get(resource)
+    if not resource_def:
+        return False
+    return is_private_shareable_resource(resource_def)
+
+
+async def _filter_visible_records(
+    db: Any,
+    index: SchemaIndex,
+    resource: str,
+    records: List[Dict[str, Any]],
+    actor_id: str,
+    namespace: str,
+) -> List[Dict[str, Any]]:
+    if not _resource_is_private_shareable(index, resource):
+        return records
+    filtered: List[Dict[str, Any]] = []
+    for record in records:
+        if await is_record_visible(db, index, resource, record, actor_id, namespace=namespace):
+            filtered.append(record)
+    return filtered
+
+
+async def handle_seed(ctx: Any, payload: Any, config: Any) -> Dict[str, Any]:
+    logger = getattr(config, "logger", None)
+    try:
+        if logger:
+            logger.debug("Seed request", {})
+        if not isinstance(payload, dict):
+            return error_response({"code": "DFQL_INVALID", "message": "Invalid JSON", "details": {"path": "$"}})
+
+        client_id = payload.get("clientId")
+        if not client_id:
+            return error_response({"code": "DFQL_INVALID", "message": "Missing clientId", "details": {"path": "clientId"}})
+
+        if config.authorize:
+            if not await config.authorize(ctx, "seed", payload):
+                return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+
+        namespace = _get_namespace(ctx)
+        seed_rec = await config.db.find_one(SEED_TABLE, [{"field": "id", "operator": "eq", "value": client_id}], namespace=namespace)
+
+        if not seed_rec:
+            await config.db.create(SEED_TABLE, {"id": client_id, "timestamp": 0}, namespace=namespace)
+
+        return ok_response({"ok": True})
+
+    except Exception as e:
+        if logger:
+            logger.error(
+                "Seed failed",
+                {
+                    "code": "INTERNAL",
+                    "message": str(e),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        return error_response({"code": "INTERNAL", "message": str(e), "details": {}})
+
+
+async def handle_clone(ctx: Any, payload: Any, config: Any) -> Dict[str, Any]:
+    logger = getattr(config, "logger", None)
+    try:
+        if logger:
+            logger.debug("Clone request", {})
+        if not isinstance(payload, dict):
+            return error_response({"code": "DFQL_INVALID", "message": "Invalid JSON", "details": {"path": "$"}})
+
+        client_id = payload.get("clientId")
+        tables = payload.get("tables", [])
+
+        if not client_id:
+            return error_response({"code": "DFQL_INVALID", "message": "Missing clientId", "details": {"path": "clientId"}})
+
+        if config.authorize:
+            if not await config.authorize(ctx, "clone", payload):
+                return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+
+        namespace = _get_namespace(ctx)
+        actor_id = get_actor_id_from_context(ctx)
+        index = SchemaIndex(config.schema)
+        data = {}
+        cursors = {}
+
+        for table in tables:
+            res_def = index.resources_by_name.get(table)
+            if not res_def:
+                return error_response({"code": "DFQL_UNKNOWN_RESOURCE", "message": f"Unknown resource: {table}", "details": {"path": "tables"}})
+
+            if res_def.get("isRemoteOnly"):
+                return error_response({
+                    "code": "DFQL_INVALID",
+                    "message": "Table is remote-only and cannot be cloned",
+                    "details": {"path": "tables", "table": table}
+                })
+
+            records = await config.db.find_many(table, [], sort=["id:asc"], namespace=namespace)
+            if actor_id:
+                records = await _filter_visible_records(
+                    config.db,
+                    index,
+                    table,
+                    records,
+                    actor_id,
+                    namespace,
+                )
+            elif _resource_is_private_shareable(index, table):
+                records = []
+            data[table] = records
+
+            cursor = await get_latest_cursor(config.db, namespace, table)
+            if cursor:
+                cursors[table] = cursor
+
+        return ok_response({
+            "data": data,
+            "cursors": cursors
+        })
+
+    except Exception as e:
+        if logger:
+            logger.error(
+                "Clone failed",
+                {
+                    "code": "INTERNAL",
+                    "message": str(e),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        return error_response({"code": "INTERNAL", "message": str(e), "details": {}})
+
+
+async def handle_pull(ctx: Any, payload: Any, config: Any) -> Dict[str, Any]:
+    logger = getattr(config, "logger", None)
+    try:
+        if logger:
+            logger.debug("Pull request", {})
+        if not isinstance(payload, dict):
+            return error_response({"code": "DFQL_INVALID", "message": "Invalid JSON", "details": {"path": "$"}})
+
+        client_id = payload.get("clientId")
+        cursors = payload.get("cursors", {})
+
+        if not client_id:
+            return error_response({"code": "DFQL_INVALID", "message": "Missing clientId", "details": {"path": "clientId"}})
+
+        if config.authorize:
+            if not await config.authorize(ctx, "pull", payload):
+                return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+
+        # Validate cursor format
+        for table_name, cursor_val in cursors.items():
+            if cursor_val is not None:
+                err = _validate_cursor(cursor_val, table_name)
+                if err:
+                    return err
+
+        namespace = _get_namespace(ctx)
+        actor_id = get_actor_id_from_context(ctx)
+        index = SchemaIndex(config.schema)
+        limits = getattr(config, "limits", {}) or {}
+        max_pull_limit = limits.get("maxPullLimit", DEFAULT_MAX_PULL_LIMIT)
+
+        result_records = {}
+        result_deleted = {}
+        result_cursors = {}
+        has_more = False
+
+        # Collect tables to pull: all non-remote-only resources + join tables
+        tables_to_pull = []
+        for res_name, res_def in index.resources_by_name.items():
+            if res_def.get("isRemoteOnly"):
+                continue
+            tables_to_pull.append(res_name)
+
+        # Add join tables from many-many relations
+        relations = config.schema.get("relations", [])
+        join_keys = enumerate_join_store_keys(relations)
+        for jk in join_keys:
+            tables_to_pull.append(jk["joinTable"])
+
+        # Collect all changes across tables
+        all_resource_changes: Dict[str, Any] = {}
+        total_changes = 0
+
+        for table_name in tables_to_pull:
+            cursor = cursors.get(table_name)
+            # Fetch limit+1 to detect hasMore
+            fetch_limit = max_pull_limit - total_changes + 1 if max_pull_limit else None
+            if fetch_limit is not None and fetch_limit <= 0:
+                has_more = True
+                break
+
+            changes_result = await get_changes_since(config.db, namespace, table_name, cursor, limit=fetch_limit)
+            changes = changes_result["changes"]
+            new_cursor = changes_result["cursor"]
+
+            if changes:
+                # Check if we exceeded the pull limit
+                if max_pull_limit and total_changes + len(changes) > max_pull_limit:
+                    # Trim to fit within limit
+                    allowed = max_pull_limit - total_changes
+                    if allowed > 0:
+                        changes = changes[:allowed]
+                        new_cursor = str(changes[-1]["serverSeq"])
+                    else:
+                        changes = []
+                    has_more = True
+
+                if changes:
+                    all_resource_changes[table_name] = {
+                        "changes": changes,
+                        "new_cursor": new_cursor,
+                    }
+                    total_changes += len(changes)
+            elif new_cursor:
+                result_cursors[table_name] = new_cursor
+
+        # Batch-fetch records for all upserts
+        for table_name, info in all_resource_changes.items():
+            changes = info["changes"]
+            new_cursor = info["new_cursor"]
+
+            upsert_ids = list(set(
+                c["recordId"] for c in changes if c["operation"] != "delete"
+            ))
+            delete_ids = list(set(
+                c["recordId"] for c in changes if c["operation"] == "delete"
+            ))
+
+            upserts: List[Dict[str, Any]] = []
+            if upsert_ids:
+                rows = await config.db.find_many(
+                    table_name,
+                    where=[{"field": "id", "operator": "in", "value": upsert_ids}],
+                    namespace=namespace,
+                )
+                upserts = rows
+                if actor_id:
+                    upserts = await _filter_visible_records(
+                        config.db,
+                        index,
+                        table_name,
+                        upserts,
+                        actor_id,
+                        namespace,
+                    )
+                elif _resource_is_private_shareable(index, table_name):
+                    upserts = []
+
+            if not actor_id and _resource_is_private_shareable(index, table_name):
+                delete_ids = []
+
+            if upserts:
+                result_records[table_name] = upserts
+            if delete_ids:
+                result_deleted[table_name] = delete_ids
+            if new_cursor:
+                result_cursors[table_name] = new_cursor
+
+        response = {
+            "records": result_records,
+            "deleted": result_deleted,
+            "cursors": result_cursors,
+            "hasMore": has_more,
+        }
+
+        return ok_response(response)
+
+    except Exception as e:
+        if logger:
+            logger.error(
+                "Pull failed",
+                {
+                    "code": "INTERNAL",
+                    "message": str(e),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        return error_response({"code": "INTERNAL", "message": str(e), "details": {}})
+
+
+async def handle_push(ctx: Any, payload: Any, config: Any) -> Dict[str, Any]:
+    logger = getattr(config, "logger", None)
+    try:
+        if logger:
+            logger.debug("Push request", {})
+        if not isinstance(payload, dict):
+            return error_response({"code": "DFQL_INVALID", "message": "Invalid JSON", "details": {"path": "$"}})
+
+        client_id = payload.get("clientId")
+        mutations = payload.get("mutations", [])
+
+        if not client_id:
+            return error_response({"code": "DFQL_INVALID", "message": "Missing clientId", "details": {"path": "clientId"}})
+
+        if config.authorize:
+            if not await config.authorize(ctx, "push", payload):
+                return error_response({"code": "FORBIDDEN", "message": "Authorization denied", "details": {"path": "$"}})
+
+        namespace = _get_namespace(ctx)
+        actor_id = get_actor_id_from_context(ctx)
+        applied = []
+        errors = []
+        index = SchemaIndex(config.schema)
+
+        for mutation in mutations:
+            m_client_id = mutation.get("clientId")
+            m_id = mutation.get("mutationId")
+            resource = mutation.get("resource")
+
+            if m_client_id != client_id:
+                errors.append({
+                    "mutationId": m_id,
+                    "error": {"code": "DFQL_INVALID", "message": "ClientId mismatch"}
+                })
+                continue
+
+            # Idempotency
+            cached = await check_idempotency(
+                config.db,
+                namespace,
+                m_client_id,
+                m_id,
+                logger=logger,
+            )
+            if cached:
+                applied.append(m_id)
+                continue
+
+            try:
+                if isinstance(resource, str):
+                    authz_err = validate_mutation_authz(
+                        mutation,
+                        resource,
+                        index,
+                        allow_unknown_resources=getattr(config, "allowUnknownResources", False),
+                    )
+                    if authz_err:
+                        errors.append({
+                            "mutationId": m_id,
+                            "error": {"code": authz_err.code, "message": authz_err.message, "details": authz_err.details},
+                        })
+                        continue
+
+                # Date coercion on mutation record
+                date_fields = index.date_fields.get(resource or "", set())
+                if date_fields:
+                    record = mutation.get("record")
+                    if record and isinstance(record, dict):
+                        coerce_date_fields_to_epoch(record, list(date_fields))
+                    # Also coerce batch records
+                    records_list = mutation.get("records")
+                    if records_list and isinstance(records_list, list):
+                        for rec in records_list:
+                            if isinstance(rec, dict):
+                                coerce_date_fields_to_epoch(rec, list(date_fields))
+
+                # Execute
+                affected_ids, mutation_changes = await execute_mutation_core(
+                    config.db,
+                    index,
+                    mutation,
+                    namespace=namespace,
+                    actor_id=actor_id,
+                    logger=logger,
+                )
+
+                # Change Tracking
+                for change in mutation_changes:
+                    server_seq = await get_next_server_seq(config.db, namespace)
+                    await write_change(
+                        config.db,
+                        namespace,
+                        change["table"],
+                        change["operation"],
+                        change["recordId"],
+                        server_seq
+                    )
+
+                # Store idempotency
+                result = {
+                    "ok": True,
+                    "mutationId": m_id,
+                    "affectedIds": affected_ids,
+                    "deduped": False,
+                    "errors": []
+                }
+                await store_idempotency(config.db, namespace, m_client_id, m_id, result)
+
+                applied.append(m_id)
+
+            except DatafnError as e:
+                errors.append({
+                    "mutationId": m_id,
+                    "error": {"code": e.code, "message": e.message, "details": e.details}
+                })
+            except Exception as e:
+                errors.append({
+                    "mutationId": m_id,
+                    "error": {"code": "INTERNAL", "message": str(e)}
+                })
+
+        return ok_response({
+            "applied": applied,
+            "errors": errors
+        })
+
+    except Exception as e:
+        if logger:
+            logger.error(
+                "Push failed",
+                {
+                    "code": "INTERNAL",
+                    "message": str(e),
+                    "traceback": traceback.format_exc(),
+                },
+            )
+        return error_response({"code": "INTERNAL", "message": str(e), "details": {}})
+
+
+def _get_namespace(ctx: Any) -> str:
+    """Extract namespace from request context, defaulting to 'datafn'."""
+    if isinstance(ctx, dict):
+        return ctx.get("namespace", DEFAULT_NAMESPACE)
+    return DEFAULT_NAMESPACE
+
+
+def _validate_cursor(cursor_val: Any, table_name: str) -> Any:
+    """Validate cursor is a non-negative integer string. Returns error response or None."""
+    if not isinstance(cursor_val, (str, int)):
+        return error_response({
+            "code": "DFQL_INVALID",
+            "message": "Invalid cursor format",
+            "details": {"path": f"cursors.{table_name}"}
+        })
+    try:
+        val = int(cursor_val)
+        if val < 0:
+            return error_response({
+                "code": "DFQL_INVALID",
+                "message": "Invalid cursor format",
+                "details": {"path": f"cursors.{table_name}"}
+            })
+    except (ValueError, TypeError):
+        return error_response({
+            "code": "DFQL_INVALID",
+            "message": "Invalid cursor format",
+            "details": {"path": f"cursors.{table_name}"}
+        })
+    return None

--- a/datafn/python/datafn/handlers/transact.py
+++ b/datafn/python/datafn/handlers/transact.py
@@ -1,0 +1,178 @@
+from typing import Any, Dict, List
+from ..envelope import ok_response, error_response, DatafnError
+from ..transaction import with_transaction
+from ..db import Adapter
+from .query import handle_query
+from .mutation import handle_mutation
+
+DEFAULT_MAX_STEPS = 100
+
+
+async def handle_transact(ctx: Any, payload: Any, config: Any) -> Dict[str, Any]:
+    logger = getattr(config, "logger", None)
+    try:
+        if logger:
+            logger.debug("Transact request", {"atomic": payload.get("atomic", True) if isinstance(payload, dict) else None})
+        if not isinstance(payload, dict):
+            return error_response({
+                "code": "DFQL_INVALID",
+                "message": "Invalid JSON",
+                "details": {"path": "$"}
+            })
+
+        if config.authorize:
+            if not await config.authorize(ctx, "transact", payload):
+                return error_response({
+                    "code": "FORBIDDEN",
+                    "message": "Authorization denied",
+                    "details": {"path": "$"}
+                })
+
+        steps = payload.get("steps")
+        if not isinstance(steps, list):
+            return error_response({
+                "code": "DFQL_INVALID",
+                "message": "Missing steps array",
+                "details": {"path": "steps"}
+            })
+
+        limits = getattr(config, "limits", {}) or {}
+        max_steps = limits.get("maxTransactSteps", DEFAULT_MAX_STEPS)
+
+        if len(steps) > max_steps:
+            return error_response({
+                "code": "LIMIT_EXCEEDED",
+                "message": "Transaction exceeds maximum steps",
+                "details": {"path": "steps", "max": max_steps}
+            })
+
+        atomic = payload.get("atomic", True)
+
+        if atomic:
+            return await _execute_atomic(config, steps, ctx)
+        else:
+            return await _execute_non_atomic(config, steps, ctx)
+
+    except Exception as e:
+        if logger:
+            logger.error("Transact failed", {"code": "INTERNAL", "message": str(e)})
+        return error_response({
+            "code": "INTERNAL",
+            "message": str(e),
+            "details": {}
+        })
+
+
+async def _execute_atomic(config: Any, steps: List[Dict[str, Any]], ctx: Any) -> Dict[str, Any]:
+    """Execute all steps atomically. On error, roll back and annotate prior results."""
+
+    # Shared mutable state for capturing results inside the transaction callback
+    captured_results: List[Dict[str, Any]] = []
+    captured_step_types: List[str] = []  # "query" or "mutation"
+    failed_error = None
+
+    async def run_in_tx(tx_db: Adapter) -> List[Any]:
+        tx_config = _TxConfig(config, tx_db)
+        for step in steps:
+            step_type = "query" if "query" in step else "mutation"
+            res = await _execute_single_step(tx_db, tx_config, step, ctx)
+            captured_step_types.append(step_type)
+
+            if not res.get("ok"):
+                # Capture the error and prior results, then raise to trigger rollback
+                captured_results.append(res)
+                err_data = res.get("error", {})
+                raise DatafnError(
+                    code=err_data.get("code", "INTERNAL"),
+                    message=err_data.get("message", "Unknown error"),
+                    details=err_data.get("details")
+                )
+
+            captured_results.append(res)
+
+        return [_unwrap_envelope_result(r) for r in captured_results]
+
+    try:
+        results = await with_transaction(config.db, run_in_tx)
+        return ok_response({"ok": True, "results": results})
+    except DatafnError as e:
+        # Transaction rolled back. Annotate prior successful mutation results.
+        annotated = []
+        for i, res in enumerate(captured_results):
+            unwrapped = _unwrap_envelope_result(res)
+            if res.get("ok") and captured_step_types[i] == "mutation":
+                # Mutation result — mark as rolled back
+                if isinstance(unwrapped, dict):
+                    unwrapped["rolledBack"] = True
+            annotated.append(unwrapped)
+
+        # If the last captured result is the error itself, it's already in annotated.
+        # If not (error was raised before appending), add error entry.
+        last_is_error = captured_results and not captured_results[-1].get("ok")
+        if not last_is_error:
+            annotated.append({"ok": False, "error": {"code": e.code, "message": e.message, "details": e.details}})
+
+        return ok_response({"ok": False, "results": annotated})
+    except Exception as e:
+        return error_response({
+            "code": "INTERNAL",
+            "message": str(e),
+            "details": {}
+        })
+
+
+async def _execute_non_atomic(config: Any, steps: List[Dict[str, Any]], ctx: Any) -> Dict[str, Any]:
+    """Execute steps independently. On error, record it and continue."""
+    step_results = []
+    overall_ok = True
+
+    for step in steps:
+        try:
+            res = await _execute_single_step(config.db, config, step, ctx)
+            step_results.append(_unwrap_envelope_result(res))
+
+            if not res.get("ok"):
+                overall_ok = False
+        except Exception as e:
+            overall_ok = False
+            step_results.append({
+                "ok": False,
+                "error": {"code": "INTERNAL", "message": str(e)}
+            })
+
+    return ok_response({
+        "ok": overall_ok,
+        "results": step_results
+    })
+
+
+class _TxConfig:
+    """Config wrapper that substitutes the transaction-bound adapter."""
+    def __init__(self, original: Any, tx_db: Adapter):
+        self.schema = original.schema
+        self.db = tx_db
+        self.authorize = original.authorize
+        self.limits = getattr(original, "limits", {}) or {}
+        self.plugins = getattr(original, "plugins", []) or []
+        self.logger = getattr(original, "logger", None)
+        self.allowUnknownResources = getattr(original, "allowUnknownResources", False)
+
+
+async def _execute_single_step(db: Adapter, config: Any, step: Dict[str, Any], ctx: Any) -> Dict[str, Any]:
+    if "query" in step:
+        return await handle_query(ctx, step["query"], config)
+    elif "mutation" in step:
+        return await handle_mutation(ctx, step["mutation"], config)
+    else:
+        return error_response({
+            "code": "DFQL_INVALID",
+            "message": "Invalid step: must contain query or mutation",
+            "details": {"path": "steps"}
+        })
+
+
+def _unwrap_envelope_result(envelope: Dict[str, Any]) -> Any:
+    if envelope.get("ok"):
+        return envelope.get("result")
+    else:
+        return envelope

--- a/datafn/python/datafn/hooks.py
+++ b/datafn/python/datafn/hooks.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, List, Optional
+
+def _normalize_runs_on(plugin: Any) -> List[str]:
+    runs_on = getattr(plugin, "runs_on", [])
+    if isinstance(runs_on, list):
+        return runs_on
+    if isinstance(runs_on, tuple):
+        return list(runs_on)
+    return []
+
+async def run_before_hook(
+    plugins: List[Any],
+    env: str,
+    hook_name: str,
+    ctx: Any,
+    payload: Any,
+    logger: Any = None,
+) -> Dict[str, Any]:
+    current = payload
+    for plugin in plugins:
+        runs_on = _normalize_runs_on(plugin)
+        if env not in runs_on:
+            continue
+
+        hook_fn = getattr(plugin, hook_name, None)
+        if hook_fn is None:
+            continue
+
+        try:
+            result = await hook_fn(ctx, current)
+            if result is not None:
+                current = result
+        except Exception as e:
+            plugin_name = getattr(plugin, "name", "unknown")
+            if logger:
+                logger.error(
+                    f"Plugin '{plugin_name}' {hook_name} failed",
+                    {"plugin": plugin_name, "hook": hook_name, "error": str(e)},
+                )
+            return {
+                "ok": False,
+                "error": {
+                    "code": "PLUGIN_ERROR",
+                    "message": f"Plugin '{plugin_name}' {hook_name} failed",
+                    "details": {"plugin": plugin_name, "hook": hook_name},
+                },
+            }
+
+    return {"ok": True, "value": current}
+
+
+async def run_after_hook(
+    plugins: List[Any],
+    env: str,
+    hook_name: str,
+    ctx: Any,
+    payload: Any,
+    result: Any,
+    logger: Any = None,
+) -> Any:
+    current_result = result
+    for plugin in plugins:
+        runs_on = _normalize_runs_on(plugin)
+        if env not in runs_on:
+            continue
+
+        hook_fn = getattr(plugin, hook_name, None)
+        if hook_fn is None:
+            continue
+
+        try:
+            transformed = await hook_fn(ctx, payload, current_result)
+            if transformed is not None:
+                current_result = transformed
+        except Exception as e:
+            if logger:
+                logger.error(
+                    f"Plugin '{getattr(plugin, 'name', 'unknown')}' {hook_name} failed: {e}",
+                    {"plugin": getattr(plugin, "name", "unknown"), "hook": hook_name},
+                )
+
+    return current_result

--- a/datafn/python/datafn/idempotency.py
+++ b/datafn/python/datafn/idempotency.py
@@ -1,0 +1,67 @@
+from typing import Any, Dict, Optional, TypedDict
+from .db import Adapter
+from .envelope import CONFLICT, classify_error
+from .logger import DatafnLogger
+
+class MutationResult(TypedDict):
+    ok: bool
+    mutationId: str
+    affectedIds: list[str]
+    deduped: bool
+    errors: list[Dict[str, Any]]
+
+async def check_idempotency(
+    db: Adapter,
+    namespace: str,
+    client_id: str,
+    mutation_id: str,
+    logger: Optional[DatafnLogger] = None,
+) -> Optional[MutationResult]:
+    # Table: __datafn_idempotency
+    try:
+        record = await db.find_one(
+            model="__datafn_idempotency",
+            where=[
+                {"field": "clientId", "operator": "eq", "value": client_id},
+                {"field": "mutationId", "operator": "eq", "value": mutation_id}
+            ],
+            namespace=namespace
+        )
+        if record:
+            stored = record.get("result")
+            if isinstance(stored, dict):
+                result = dict(stored)
+                result["deduped"] = True
+                return result
+    except Exception as exc:
+        if logger:
+            logger.warn(
+                "Idempotency lookup failed",
+                {
+                    "namespace": namespace,
+                    "clientId": client_id,
+                    "mutationId": mutation_id,
+                    "error": str(exc),
+                },
+            )
+    return None
+
+async def store_idempotency(db: Adapter, namespace: str, client_id: str, mutation_id: str, result: MutationResult) -> None:
+    try:
+        # Clean result before storage if needed?
+        # Ensure deduped flag is not stored as True? 
+        # Actually it doesn't matter, we set it on retrieval.
+        
+        await db.create(
+            model="__datafn_idempotency",
+            data={
+                "clientId": client_id,
+                "mutationId": mutation_id,
+                "result": result
+            },
+            namespace=namespace
+        )
+    except Exception as exc:
+        # Ignore duplicate key errors if race condition
+        if classify_error(exc) != CONFLICT:
+            raise

--- a/datafn/python/datafn/logger.py
+++ b/datafn/python/datafn/logger.py
@@ -1,0 +1,55 @@
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DatafnLogger(Protocol):
+    def info(self, message: str, context: Optional[Dict[str, Any]] = None) -> None: ...
+    def warn(self, message: str, context: Optional[Dict[str, Any]] = None) -> None: ...
+    def error(self, message: str, context: Optional[Dict[str, Any]] = None) -> None: ...
+    def debug(self, message: str, context: Optional[Dict[str, Any]] = None) -> None: ...
+
+
+class NoopLogger:
+    def info(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        pass
+
+    def warn(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        pass
+
+    def error(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        pass
+
+    def debug(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        pass
+
+
+class ConsoleLogger:
+    def info(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        print(f"[INFO] {message}", end="")
+        if context:
+            print(f" {context}", end="")
+        print()
+
+    def warn(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        print(f"[WARN] {message}", end="")
+        if context:
+            print(f" {context}", end="")
+        print()
+
+    def error(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        print(f"[ERROR] {message}", end="")
+        if context:
+            print(f" {context}", end="")
+        print()
+
+    def debug(self, message: str, context: Optional[Dict[str, Any]] = None) -> None:
+        print(f"[DEBUG] {message}", end="")
+        if context:
+            print(f" {context}", end="")
+        print()
+
+
+def create_logger(logger: Any = None) -> DatafnLogger:
+    if logger is not None:
+        return logger
+    return NoopLogger()

--- a/datafn/python/datafn/relations.py
+++ b/datafn/python/datafn/relations.py
@@ -1,0 +1,179 @@
+from typing import Any, Dict, List, Optional
+from .db import Adapter
+from .validation import SchemaIndex
+
+def _resolve_one_many_inverse_fk(rel_def: Dict[str, Any]) -> str:
+    inverse_fk = rel_def.get("inverseForeignKey")
+    if inverse_fk:
+        return inverse_fk
+
+    inverse_name = rel_def.get("inverse")
+    if not inverse_name:
+        raise ValueError("one-many relation requires 'inverse' or 'inverseForeignKey'")
+    return f"{inverse_name}Id"
+
+
+def _normalize_targets(rel_type: str, target: Any) -> List[Any]:
+    if rel_type == "many-one" and isinstance(target, list):
+        raise ValueError("many-one relation must have a single target")
+    return target if isinstance(target, list) else [target]
+
+async def execute_relate(db: Adapter, index: SchemaIndex, mutation: Dict[str, Any], namespace: str = "datafn") -> None:
+    resource = mutation["resource"]
+    record_id = mutation["id"]
+    relations = mutation["relations"]
+    
+    for rel_name, target in relations.items():
+        rel_def = index.relation_defs_by_resource[resource].get(rel_name)
+        if not rel_def:
+            continue
+            
+        rel_type = rel_def.get("type", "many-one") # Default assumption?
+
+        targets = _normalize_targets(rel_type, target)
+        
+        for t in targets:
+            target_id = t if isinstance(t, str) else t.get("$ref")
+            if not isinstance(target_id, str) or not target_id.strip():
+                raise ValueError("relation target must include a non-empty $ref")
+            metadata = {k: v for k, v in t.items() if k != "$ref"} if isinstance(t, dict) else {}
+            
+            if rel_type == "many-many":
+                join_table = rel_def.get("joinTable")
+                if join_table:
+                    # Determine columns
+                    # If from=tasks, to=tags. joinTable=tasks_tags.
+                    # Usually col names are derived from resource names or explicit config.
+                    # Assuming standard: {from}_id, {to}_id
+                    from_col = f"{resource}_id" # simplified assumption
+                    to_col = f"{rel_def['to']}_id" # simplified
+                    
+                    # Or check 'fromKey', 'toKey' in rel_def
+                    if "fromKey" in rel_def:
+                        from_col = rel_def["fromKey"]
+                    if "toKey" in rel_def:
+                        to_col = rel_def["toKey"]
+                    
+                    # Insert into join table
+                    data = {
+                        from_col: record_id,
+                        to_col: target_id,
+                        **metadata
+                    }
+                    await db.create(join_table, data, namespace=namespace)
+            
+            elif rel_type == "many-one":
+                # We are 'tasks', rel is 'project' (many-one to projects).
+                # We update 'tasks' (us) to set project_id = target_id.
+                fk = rel_def.get("foreignKey", f"{rel_name}Id")
+                await db.update(
+                    resource,
+                    [{"field": "id", "operator": "eq", "value": record_id}],
+                    {fk: target_id},
+                    namespace=namespace
+                )
+            
+            elif rel_type == "one-many":
+                # We are 'projects', rel is 'tasks' (one-many to tasks).
+                # We update 'tasks' (target) to set project_id = us.
+                inverse_fk = _resolve_one_many_inverse_fk(rel_def)
+                await db.update(
+                    rel_def["to"],
+                    [{"field": "id", "operator": "eq", "value": target_id}],
+                    {inverse_fk: record_id},
+                    namespace=namespace
+                )
+
+async def execute_modify_relation(db: Adapter, index: SchemaIndex, mutation: Dict[str, Any], namespace: str = "datafn") -> None:
+    # Updates metadata in join table for many-many
+    resource = mutation["resource"]
+    record_id = mutation["id"]
+    relations = mutation["relations"]
+    
+    for rel_name, target in relations.items():
+        rel_def = index.relation_defs_by_resource[resource].get(rel_name)
+        if not rel_def or rel_def.get("type") != "many-many":
+            continue
+            
+        join_table = rel_def.get("joinTable")
+        if not join_table:
+            continue
+            
+        targets = _normalize_targets(rel_def.get("type", "many-many"), target)
+        for t in targets:
+            if not isinstance(t, dict):
+                continue # Must have metadata to modify
+            
+            target_id = t.get("$ref")
+            if not isinstance(target_id, str) or not target_id.strip():
+                raise ValueError("relation target must include a non-empty $ref")
+            metadata = {k: v for k, v in t.items() if k != "$ref"}
+            
+            if not metadata:
+                continue
+
+            from_col = rel_def.get("fromKey", f"{resource}_id")
+            to_col = rel_def.get("toKey", f"{rel_def['to']}_id")
+            
+            await db.update(
+                join_table,
+                [
+                    {"field": from_col, "operator": "eq", "value": record_id},
+                    {"field": to_col, "operator": "eq", "value": target_id}
+                ],
+                metadata,
+                namespace=namespace
+            )
+
+async def execute_unrelate(db: Adapter, index: SchemaIndex, mutation: Dict[str, Any], namespace: str = "datafn") -> None:
+    resource = mutation["resource"]
+    record_id = mutation["id"]
+    relations = mutation["relations"]
+    
+    for rel_name, target in relations.items():
+        rel_def = index.relation_defs_by_resource[resource].get(rel_name)
+        if not rel_def:
+            continue
+            
+        rel_type = rel_def.get("type", "many-one")
+        targets = _normalize_targets(rel_type, target)
+        
+        for t in targets:
+            target_id = t if isinstance(t, str) else t.get("$ref")
+            if not isinstance(target_id, str) or not target_id.strip():
+                raise ValueError("relation target must include a non-empty $ref")
+            
+            if rel_type == "many-many":
+                join_table = rel_def.get("joinTable")
+                if join_table:
+                    from_col = rel_def.get("fromKey", f"{resource}_id")
+                    to_col = rel_def.get("toKey", f"{rel_def['to']}_id")
+                    
+                    await db.delete(
+                        join_table,
+                        [
+                            {"field": from_col, "operator": "eq", "value": record_id},
+                            {"field": to_col, "operator": "eq", "value": target_id}
+                        ],
+                        namespace=namespace
+                    )
+            
+            elif rel_type == "many-one":
+                # Clear FK on self
+                fk = rel_def.get("foreignKey", f"{rel_name}Id")
+                await db.update(
+                    resource,
+                    [{"field": "id", "operator": "eq", "value": record_id}],
+                    {fk: None},
+                    namespace=namespace
+                )
+                
+            elif rel_type == "one-many":
+                # Clear FK on target
+                inverse_fk = _resolve_one_many_inverse_fk(rel_def)
+                await db.update(
+                    rel_def["to"],
+                    [{"field": "id", "operator": "eq", "value": target_id}],
+                    {inverse_fk: None},
+                    namespace=namespace
+                )

--- a/datafn/python/datafn/server.py
+++ b/datafn/python/datafn/server.py
@@ -1,0 +1,103 @@
+from typing import Any, Dict, Callable, Optional, Union
+from .envelope import DatafnError
+from .handlers.query import handle_query
+from .handlers.mutation import handle_mutation
+from .handlers.transact import handle_transact
+from .handlers.sync import handle_seed, handle_clone, handle_pull, handle_push
+from .validation import validate_schema
+from .logger import create_logger
+
+
+class DatafnServerConfig:
+    def __init__(self, schema: Any = None, db: Any = None, authorize: Any = None,
+                 plugins: Any = None, logger: Any = None, limits: Any = None, **kwargs):
+        if kwargs:
+            unknown = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unexpected config key(s): {unknown}")
+        self.schema = schema
+        self.db = db
+        self.authorize = authorize
+        self.plugins = [] if plugins is None else plugins
+        self.logger = create_logger(logger)
+        self.limits = limits
+
+
+def _validate_config(config_obj: 'DatafnServerConfig') -> None:
+    """Validate config parameters at server initialization. Raises ValueError on invalid config."""
+    if config_obj.schema is None:
+        raise ValueError("schema is required")
+    if not isinstance(config_obj.schema, dict):
+        raise ValueError("schema must be a dict")
+
+    if config_obj.db is None:
+        raise ValueError("db is required")
+
+    if config_obj.authorize is not None and not callable(config_obj.authorize):
+        raise ValueError("authorize must be callable")
+
+    if config_obj.limits is not None:
+        if not isinstance(config_obj.limits, dict):
+            raise ValueError("limits must be a dict")
+        for key, val in config_obj.limits.items():
+            if not isinstance(val, (int, float)):
+                raise ValueError(f"limits.{key} must be numeric, got {type(val).__name__}")
+            if val < 0:
+                raise ValueError(f"limits.{key} must be non-negative, got {val}")
+
+
+def create_datafn_server(config: Any) -> Dict[str, Any]:
+    # Normalize config
+    if isinstance(config, DatafnServerConfig):
+        config_obj = config
+    elif isinstance(config, dict):
+        config_obj = DatafnServerConfig(**config)
+    else:
+        config_obj = DatafnServerConfig(**vars(config))
+
+    # Validate config parameters
+    _validate_config(config_obj)
+
+    # Validate schema at init
+    validation_result = validate_schema(config_obj.schema)
+    if not validation_result["ok"]:
+        raise DatafnError(
+            code=validation_result["error"]["code"],
+            message=validation_result["error"]["message"],
+            details=validation_result["error"].get("details", {})
+        )
+
+    # Log server initialization
+    config_obj.logger.info("DataFn server initialized")
+
+    async def query_wrapper(ctx: Any, payload: Any) -> Union[Dict[str, Any], Any]:
+        return await handle_query(ctx, payload, config_obj)
+
+    async def mutation_wrapper(ctx: Any, payload: Any) -> Union[Dict[str, Any], Any]:
+        return await handle_mutation(ctx, payload, config_obj)
+
+    async def transact_wrapper(ctx: Any, payload: Any) -> Dict[str, Any]:
+        return await handle_transact(ctx, payload, config_obj)
+
+    async def seed_wrapper(ctx: Any, payload: Any) -> Dict[str, Any]:
+        return await handle_seed(ctx, payload, config_obj)
+
+    async def clone_wrapper(ctx: Any, payload: Any) -> Dict[str, Any]:
+        return await handle_clone(ctx, payload, config_obj)
+
+    async def pull_wrapper(ctx: Any, payload: Any) -> Dict[str, Any]:
+        return await handle_pull(ctx, payload, config_obj)
+
+    async def push_wrapper(ctx: Any, payload: Any) -> Dict[str, Any]:
+        return await handle_push(ctx, payload, config_obj)
+
+    return {
+        "routes": {
+            "POST /datafn/query": query_wrapper,
+            "POST /datafn/mutation": mutation_wrapper,
+            "POST /datafn/transact": transact_wrapper,
+            "POST /datafn/seed": seed_wrapper,
+            "POST /datafn/clone": clone_wrapper,
+            "POST /datafn/pull": pull_wrapper,
+            "POST /datafn/push": push_wrapper,
+        }
+    }

--- a/datafn/python/datafn/transaction.py
+++ b/datafn/python/datafn/transaction.py
@@ -1,0 +1,16 @@
+from typing import Any, Callable, TypeVar, Awaitable
+from .db import Adapter
+
+T = TypeVar("T")
+
+async def with_transaction(db: Adapter, callback: Callable[[Adapter], Awaitable[T]]) -> T:
+    """
+    Executes callback within a transaction.
+    """
+    # Runtime guard in case a custom adapter omits transaction().
+    if not hasattr(db, "transaction"):
+        # Run callback directly when transaction support is unavailable.
+        return await callback(db)
+
+    async with db.transaction() as tx_db:
+        return await callback(tx_db)

--- a/datafn/python/datafn/utils/__init__.py
+++ b/datafn/python/datafn/utils/__init__.py
@@ -1,0 +1,18 @@
+from .sort import parse_sort_terms, sort_records
+from .select import parse_select_token, apply_select, apply_omit
+from .date import to_epoch_ms, from_epoch_ms, coerce_date_fields_to_epoch
+from .aggregate import calculate_aggregation
+from .normalize import normalize_dfql, dfql_key
+from .joins import get_join_table_name, get_join_store_key, enumerate_join_store_keys
+from .ns import ns
+from .validate_fields import check_prototype_pollution, validate_field_value
+
+__all__ = [
+    "apply_omit", "apply_select",
+    "calculate_aggregation",
+    "check_prototype_pollution", "coerce_date_fields_to_epoch",
+    "dfql_key", "enumerate_join_store_keys",
+    "from_epoch_ms", "get_join_store_key", "get_join_table_name",
+    "normalize_dfql", "ns", "parse_select_token", "parse_sort_terms",
+    "sort_records", "to_epoch_ms", "validate_field_value",
+]

--- a/datafn/python/datafn/utils/aggregate.py
+++ b/datafn/python/datafn/utils/aggregate.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict, List, Optional
+
+
+def calculate_aggregation(op: str, field: str, records: List[Dict[str, Any]]) -> Any:
+    if op == "count":
+        return len(records)
+
+    values = [r.get(field) for r in records if r.get(field) is not None]
+
+    if not values:
+        return None
+
+    if op == "sum":
+        return sum(values)
+    elif op == "avg":
+        return sum(values) / len(values)
+    elif op == "min":
+        return min(values)
+    elif op == "max":
+        return max(values)
+    else:
+        raise ValueError(f"Unknown aggregation operation: {op}")

--- a/datafn/python/datafn/utils/date.py
+++ b/datafn/python/datafn/utils/date.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Union
+
+
+def to_epoch_ms(value: Any) -> int:
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int(value.timestamp() * 1000)
+    if isinstance(value, str):
+        try:
+            # Handle Z suffix for Python < 3.11
+            s = value.replace("Z", "+00:00") if value.endswith("Z") else value
+            dt = datetime.fromisoformat(s)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp() * 1000)
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"Invalid date value: {value}") from e
+    raise ValueError(f"Cannot convert {type(value).__name__} to epoch ms")
+
+
+def from_epoch_ms(value: Union[int, float, str]) -> datetime:
+    if isinstance(value, str):
+        try:
+            value = int(value)
+        except ValueError as e:
+            raise ValueError(f"Invalid epoch ms value: {value}") from e
+    return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+
+
+def coerce_date_fields_to_epoch(record: Dict[str, Any], date_fields: List[str]) -> None:
+    for field in date_fields:
+        if field in record and record[field] is not None:
+            record[field] = to_epoch_ms(record[field])

--- a/datafn/python/datafn/utils/joins.py
+++ b/datafn/python/datafn/utils/joins.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict, List, Optional
+
+
+def get_join_table_name(from_resource: str, relation_name: str, join_table: Optional[str] = None) -> str:
+    if join_table:
+        return join_table
+    return f"__datafn_join_{from_resource}_{relation_name}"
+
+
+def get_join_store_key(from_resource: str, relation_name: str, to_resource: str) -> str:
+    return f"join_{from_resource}_{relation_name}_{to_resource}"
+
+
+def enumerate_join_store_keys(
+    relations: List[Dict[str, Any]], resource_filter: Optional[str] = None
+) -> List[Dict[str, str]]:
+    keys = []
+    for rel in relations:
+        rel_type = rel.get("type", "")
+        if rel_type != "many-many":
+            continue
+
+        from_res = rel.get("from", "")
+        to_res = rel.get("to", "")
+        rel_name = rel.get("relation", "")
+
+        if isinstance(from_res, list) or isinstance(to_res, list):
+            continue
+
+        if resource_filter and from_res != resource_filter:
+            continue
+
+        join_table = rel.get("joinTable")
+        keys.append({
+            "from": from_res,
+            "relation": rel_name,
+            "to": to_res,
+            "joinTable": get_join_table_name(from_res, rel_name, join_table),
+            "storeKey": get_join_store_key(from_res, rel_name, to_res),
+        })
+    return keys

--- a/datafn/python/datafn/utils/normalize.py
+++ b/datafn/python/datafn/utils/normalize.py
@@ -1,0 +1,14 @@
+import json
+from typing import Any
+
+
+def normalize_dfql(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: normalize_dfql(v) for k, v in sorted(value.items())}
+    if isinstance(value, list):
+        return [normalize_dfql(v) for v in value]
+    return value
+
+
+def dfql_key(value: Any) -> str:
+    return json.dumps(normalize_dfql(value), separators=(",", ":"), sort_keys=True)

--- a/datafn/python/datafn/utils/ns.py
+++ b/datafn/python/datafn/utils/ns.py
@@ -1,0 +1,7 @@
+def ns(*segments: str) -> str:
+    if not segments:
+        raise ValueError("ns() requires at least one segment")
+    filtered = [s for s in segments if s]
+    if not filtered:
+        raise ValueError("ns() requires at least one non-empty segment")
+    return ":".join(filtered)

--- a/datafn/python/datafn/utils/select.py
+++ b/datafn/python/datafn/utils/select.py
@@ -1,0 +1,40 @@
+from typing import Any, Dict, List, Optional
+
+
+def parse_select_token(token: str) -> Dict[str, Any]:
+    parts = token.split(".")
+    directive = None
+    if len(parts) > 1 and parts[-1] == "*":
+        directive = "*"
+    return {
+        "path": parts,
+        "base_name": parts[0],
+        "directive": directive,
+    }
+
+
+def apply_select(records: List[Dict[str, Any]], select_tokens: List[str]) -> List[Dict[str, Any]]:
+    parsed = [parse_select_token(t) for t in select_tokens]
+    allowed = {"id"}  # id always included
+    for p in parsed:
+        allowed.add(p["base_name"])
+
+    result = []
+    for record in records:
+        filtered = {k: v for k, v in record.items() if k in allowed}
+        result.append(filtered)
+    return result
+
+
+def apply_omit(records: List[Dict[str, Any]], omit_tokens: List[str]) -> List[Dict[str, Any]]:
+    parsed = [parse_select_token(t) for t in omit_tokens]
+    excluded = set()
+    for p in parsed:
+        excluded.add(p["base_name"])
+    excluded.discard("id")  # id is always kept
+
+    result = []
+    for record in records:
+        filtered = {k: v for k, v in record.items() if k not in excluded}
+        result.append(filtered)
+    return result

--- a/datafn/python/datafn/utils/sort.py
+++ b/datafn/python/datafn/utils/sort.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, List
+import functools
+
+
+def parse_sort_terms(sort_list: List[str]) -> List[Dict[str, str]]:
+    terms = []
+    for term in sort_list:
+        if term.startswith("-"):
+            terms.append({"field": term[1:], "direction": "desc"})
+        elif ":" in term:
+            field, direction = term.split(":", 1)
+            normalized = direction.strip().lower()
+            if normalized not in {"asc", "desc"}:
+                raise ValueError(f"Invalid sort direction for {field}: {direction}")
+            terms.append({"field": field, "direction": normalized})
+        else:
+            terms.append({"field": term, "direction": "asc"})
+    return terms
+
+
+def sort_records(records: List[Dict[str, Any]], terms: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+    if not terms and not records:
+        return records
+
+    def compare(a: Dict[str, Any], b: Dict[str, Any]) -> int:
+        for term in terms:
+            field = term["field"]
+            direction = term["direction"]
+            va = a.get(field)
+            vb = b.get(field)
+
+            # Null handling: nulls sort AFTER non-nulls in asc, BEFORE in desc
+            if va is None and vb is None:
+                continue
+            if va is None:
+                return 1 if direction == "asc" else -1
+            if vb is None:
+                return -1 if direction == "asc" else 1
+
+            if va < vb:
+                return -1 if direction == "asc" else 1
+            if va > vb:
+                return 1 if direction == "asc" else -1
+
+        # Tie-break by id ascending
+        id_a = a.get("id", "")
+        id_b = b.get("id", "")
+        if id_a < id_b:
+            return -1
+        if id_a > id_b:
+            return 1
+        return 0
+
+    return sorted(records, key=functools.cmp_to_key(compare))

--- a/datafn/python/datafn/utils/validate_fields.py
+++ b/datafn/python/datafn/utils/validate_fields.py
@@ -1,0 +1,42 @@
+from typing import Any, Optional
+from datetime import datetime
+
+
+POISON_KEYS = {"__proto__", "constructor", "prototype"}
+
+
+def check_prototype_pollution(obj: Any, path: str = "$") -> Optional[str]:
+    if isinstance(obj, dict):
+        for key in obj:
+            if key in POISON_KEYS:
+                return key
+            nested = check_prototype_pollution(obj[key], f"{path}.{key}")
+            if nested is not None:
+                return nested
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            nested = check_prototype_pollution(item, f"{path}[{i}]")
+            if nested is not None:
+                return nested
+    return None
+
+
+def validate_field_value(schema_type: str, value: Any, nullable: bool = False) -> bool:
+    if value is None:
+        return nullable
+
+    type_checks = {
+        "string": lambda v: isinstance(v, str),
+        "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+        "boolean": lambda v: isinstance(v, bool),
+        "date": lambda v: isinstance(v, (int, float, str, datetime)) and not isinstance(v, bool),
+        "object": lambda v: isinstance(v, dict),
+        "array": lambda v: isinstance(v, list),
+        "file": lambda v: isinstance(v, (str, dict)),
+        "json": lambda _v: True,
+    }
+
+    checker = type_checks.get(schema_type)
+    if checker is None:
+        return True  # Unknown types pass (forward compat)
+    return checker(value)

--- a/datafn/python/datafn/validation.py
+++ b/datafn/python/datafn/validation.py
@@ -1,0 +1,349 @@
+from typing import Any, Dict, List, Optional, Set, Union
+from .envelope import DatafnError
+from .utils.validate_fields import validate_field_value
+
+
+class SchemaIndex:
+    def __init__(self, schema: Dict[str, Any]):
+        self.schema = schema
+        self.resources_by_name: Dict[str, Dict[str, Any]] = {}
+        self.fields_by_resource: Dict[str, Set[str]] = {}
+        self.writable_fields_by_resource: Dict[str, Set[str]] = {}
+        self.readonly_fields: Dict[str, Set[str]] = {}
+        self.relations_by_resource: Dict[str, Set[str]] = {}
+        self.relation_defs_by_resource: Dict[str, Dict[str, Any]] = {}
+        self.field_schemas: Dict[str, Dict[str, dict]] = {}
+        self.required_fields: Dict[str, Set[str]] = {}
+        self.field_defaults: Dict[str, Dict[str, Any]] = {}
+        self.date_fields: Dict[str, Set[str]] = {}
+
+        self._build_index()
+
+    def _build_index(self):
+        resources = self.schema.get("resources", [])
+        relations = self.schema.get("relations", [])
+
+        for resource in resources:
+            name = resource["name"]
+            self.resources_by_name[name] = resource
+
+            fields = set()
+            writable = set()
+            readonly = set()
+            field_schemas = {}
+            required = set()
+            defaults = {}
+            date_flds = set()
+
+            # System fields
+            core_fields = {"id", "createdAt", "updatedAt", "createdBy", "updatedBy", "isArchived", "version"}
+            READONLY_SYSTEM = {"createdAt", "updatedAt", "createdBy", "updatedBy"}
+
+            fields.update(core_fields)
+            readonly.add("id")
+            readonly.update(READONLY_SYSTEM)
+
+            writable.add("id")  # Writable on insert (backward compat)
+            writable.add("isArchived")
+            writable.add("version")
+
+            for field in resource.get("fields", []):
+                fname = field["name"]
+                fields.add(fname)
+                field_schemas[fname] = field
+
+                if field.get("readonly"):
+                    readonly.add(fname)
+                else:
+                    writable.add(fname)
+
+                if field.get("required") and "default" not in field:
+                    required.add(fname)
+
+                if "default" in field:
+                    defaults[fname] = field["default"]
+
+                if field.get("type") == "date":
+                    date_flds.add(fname)
+
+            self.fields_by_resource[name] = fields
+            self.writable_fields_by_resource[name] = writable
+            self.readonly_fields[name] = readonly
+            self.field_schemas[name] = field_schemas
+            self.required_fields[name] = required
+            self.field_defaults[name] = defaults
+            self.date_fields[name] = date_flds
+            self.relations_by_resource[name] = set()
+            self.relation_defs_by_resource[name] = {}
+
+        for relation in relations:
+            from_res_list = relation["from"] if isinstance(relation["from"], list) else [relation["from"]]
+            to_res_list = relation["to"] if isinstance(relation["to"], list) else [relation["to"]]
+
+            # FK injection for many-one relations
+            rel_type = relation.get("type", "")
+            if rel_type == "many-one":
+                rel_name = relation.get("relation", "")
+                fk_field = relation.get("fkField", f"{rel_name}Id") if rel_name else None
+                if fk_field:
+                    for from_res in from_res_list:
+                        if from_res in self.fields_by_resource:
+                            self.fields_by_resource[from_res].add(fk_field)
+                            self.writable_fields_by_resource[from_res].add(fk_field)
+                            self.field_schemas.setdefault(from_res, {})[fk_field] = {
+                                "name": fk_field,
+                                "type": "string",
+                                "required": False,
+                                "readonly": False,
+                            }
+
+            for from_res in from_res_list:
+                if from_res in self.relations_by_resource:
+                    if "relation" in relation:
+                        rel_name = relation["relation"]
+                        self.relations_by_resource[from_res].add(rel_name)
+                        self.relation_defs_by_resource[from_res][rel_name] = relation
+
+            for to_res in to_res_list:
+                if to_res in self.relations_by_resource:
+                    if "inverse" in relation:
+                        inv_name = relation["inverse"]
+                        self.relations_by_resource[to_res].add(inv_name)
+                        self.relation_defs_by_resource[to_res][inv_name] = relation
+
+
+def validate_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(schema, dict):
+        return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": "Schema must be a dict", "details": {"path": "$"}}}
+
+    resources = schema.get("resources")
+    if not resources or not isinstance(resources, list):
+        return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": "Schema must have a non-empty 'resources' list", "details": {"path": "$.resources"}}}
+
+    if len(resources) == 0:
+        return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": "Schema must have at least one resource", "details": {"path": "$.resources"}}}
+
+    if len(resources) > 100:
+        return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Too many resources ({len(resources)}), maximum is 100", "details": {"path": "$.resources"}}}
+
+    seen_names = set()
+    for i, resource in enumerate(resources):
+        rname = resource.get("name")
+        if not rname:
+            return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Resource at index {i} has no name", "details": {"path": f"$.resources[{i}]"}}}
+
+        if rname in seen_names:
+            return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Duplicate resource name: {rname}", "details": {"path": f"$.resources[{i}]"}}}
+        seen_names.add(rname)
+
+        res_fields = resource.get("fields", [])
+        if len(res_fields) > 200:
+            return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Resource '{rname}' has too many fields ({len(res_fields)}), maximum is 200", "details": {"path": f"$.resources[{i}].fields"}}}
+
+        seen_field_names = set()
+        for j, field in enumerate(res_fields):
+            fname = field.get("name")
+            if not fname:
+                return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Field at index {j} in resource '{rname}' has no name", "details": {"path": f"$.resources[{i}].fields[{j}]"}}}
+            if fname in seen_field_names:
+                return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Duplicate field name '{fname}' in resource '{rname}'", "details": {"path": f"$.resources[{i}].fields[{j}]"}}}
+            seen_field_names.add(fname)
+
+    # Validate relations
+    relations = schema.get("relations", [])
+    for i, rel in enumerate(relations):
+        from_res = rel.get("from")
+        to_res = rel.get("to")
+        from_list = from_res if isinstance(from_res, list) else [from_res]
+        to_list = to_res if isinstance(to_res, list) else [to_res]
+        for fr in from_list:
+            if fr not in seen_names:
+                return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Relation references unknown resource '{fr}'", "details": {"path": f"$.relations[{i}].from"}}}
+        for tr in to_list:
+            if tr not in seen_names:
+                return {"ok": False, "error": {"code": "SCHEMA_INVALID", "message": f"Relation references unknown resource '{tr}'", "details": {"path": f"$.relations[{i}].to"}}}
+
+    return {"ok": True, "result": schema}
+
+
+def validate_record_types(record: Dict[str, Any], resource_name: str, schema_index: SchemaIndex) -> List[str]:
+    errors = []
+    field_schemas = schema_index.field_schemas.get(resource_name, {})
+    for key, value in record.items():
+        if key in field_schemas:
+            fschema = field_schemas[key]
+            ftype = fschema.get("type")
+            if ftype is None:
+                continue  # No type specified, skip validation
+            nullable = fschema.get("nullable", True)
+            if not validate_field_value(ftype, value, nullable):
+                expected = ftype
+                got = type(value).__name__
+                if value is None:
+                    got = "null"
+                errors.append(f"Field '{key}' expects {expected}, got {got}")
+    return errors
+
+
+def validate_required_fields(record: Dict[str, Any], resource_name: str, schema_index: SchemaIndex) -> List[str]:
+    missing = []
+    required = schema_index.required_fields.get(resource_name, set())
+    defaults = schema_index.field_defaults.get(resource_name, {})
+    for fname in required:
+        if fname not in record and fname not in defaults:
+            missing.append(fname)
+    return missing
+
+
+def apply_defaults(record: Dict[str, Any], resource_name: str, schema_index: SchemaIndex) -> Dict[str, Any]:
+    defaults = schema_index.field_defaults.get(resource_name, {})
+    for fname, default_val in defaults.items():
+        if fname not in record:
+            record[fname] = default_val
+    return record
+
+
+def _count_filter_keys(filters: Any, depth: int = 0) -> int:
+    if not isinstance(filters, dict):
+        return 0
+    count = sum(1 for key in filters if not key.startswith("$"))
+    nested_counts = [count]
+    for key, value in filters.items():
+        if key in ("$and", "$or"):
+            if isinstance(value, list):
+                for item in value:
+                    nested_counts.append(_count_filter_keys(item, depth + 1))
+    return max(nested_counts)
+
+
+def validate_query_limits(query: Dict[str, Any], limits: Dict[str, Any]) -> Optional[DatafnError]:
+    max_select = limits.get("maxSelectTokens", 50)
+    select = query.get("select", [])
+    omit = query.get("omit", [])
+    if len(select) > max_select:
+        return DatafnError(code="LIMIT_EXCEEDED", message=f"Too many select tokens ({len(select)}), maximum is {max_select}")
+    if len(omit) > max_select:
+        return DatafnError(code="LIMIT_EXCEEDED", message=f"Too many omit tokens ({len(omit)}), maximum is {max_select}")
+
+    max_sort = limits.get("maxSortFields", 10)
+    sort = query.get("sort", [])
+    if len(sort) > max_sort:
+        return DatafnError(code="LIMIT_EXCEEDED", message=f"Too many sort fields ({len(sort)}), maximum is {max_sort}")
+
+    max_filter_keys = limits.get("maxFilterKeysPerLevel", 20)
+    filters = query.get("filters", {})
+    if isinstance(filters, dict):
+        filter_key_count = _count_filter_keys(filters)
+        if filter_key_count > max_filter_keys:
+            return DatafnError(code="LIMIT_EXCEEDED", message=f"Too many filter keys ({filter_key_count}), maximum is {max_filter_keys}")
+
+    max_agg = limits.get("maxAggregations", 10)
+    aggregations = query.get("aggregations", {})
+    if len(aggregations) > max_agg:
+        return DatafnError(code="LIMIT_EXCEEDED", message=f"Too many aggregations ({len(aggregations)}), maximum is {max_agg}")
+
+    return None
+
+
+def validate_mutation_limits(mutation: Dict[str, Any], limits: Dict[str, Any]) -> Optional[DatafnError]:
+    max_batch = limits.get("maxBatchSize", 100)
+    records = mutation.get("records", [])
+    if len(records) > max_batch:
+        return DatafnError(code="LIMIT_EXCEEDED", message=f"Batch size ({len(records)}) exceeds maximum of {max_batch}")
+    return None
+
+
+def validate_id_length(id_value: Any, max_length: int = 255) -> Optional[DatafnError]:
+    if id_value is not None and isinstance(id_value, str) and len(id_value) > max_length:
+        return DatafnError(code="DFQL_INVALID", message=f"ID exceeds maximum length of {max_length}")
+    return None
+
+
+def validate_resource(index: SchemaIndex, resource_name: str, path: str = "$") -> Optional[DatafnError]:
+    if resource_name not in index.resources_by_name:
+        return DatafnError(
+            code="DFQL_UNKNOWN_RESOURCE",
+            message=f"Unknown resource: {resource_name}",
+            details={"path": path}
+        )
+    return None
+
+
+def validate_fields(index: SchemaIndex, resource_name: str, field_names: List[str], path_prefix: str = "$") -> Optional[DatafnError]:
+    if resource_name not in index.fields_by_resource:
+        return DatafnError(
+            code="DFQL_UNKNOWN_RESOURCE",
+            message=f"Unknown resource: {resource_name}",
+            details={"path": path_prefix}
+        )
+
+    valid_fields = index.fields_by_resource[resource_name]
+    valid_relations = index.relations_by_resource[resource_name]
+
+    for i, field in enumerate(field_names):
+        parts = field.split(".")
+        base_name = parts[0]
+
+        if base_name in valid_fields:
+            if len(parts) > 1:
+                pass
+        elif base_name in valid_relations:
+            pass
+        else:
+            code = "DFQL_UNKNOWN_FIELD"
+            msg = f"Unknown field: {base_name}"
+
+            if "." in field or field.endswith(".*"):
+                return DatafnError(
+                    code="DFQL_UNKNOWN_RELATION",
+                    message=f"Unknown relation: {base_name}",
+                    details={"path": f"{path_prefix}[{i}]"}
+                )
+
+            return DatafnError(
+                code=code,
+                message=msg,
+                details={"path": f"{path_prefix}[{i}]"}
+            )
+
+    return None
+
+
+def validate_relation(index: SchemaIndex, resource_name: str, relation_name: str, path: str = "$") -> Optional[DatafnError]:
+    if resource_name not in index.resources_by_name:
+        return DatafnError(
+            code="DFQL_UNKNOWN_RESOURCE",
+            message=f"Unknown resource: {resource_name}",
+            details={"path": path}
+        )
+
+    if relation_name not in index.relations_by_resource[resource_name]:
+        return DatafnError(
+            code="DFQL_UNKNOWN_RELATION",
+            message=f"Unknown relation: {relation_name}",
+            details={"path": path}
+        )
+    return None
+
+
+def validate_record_keys(index: SchemaIndex, resource_name: str, record: Dict[str, Any], path: str = "$") -> Optional[DatafnError]:
+    if resource_name not in index.fields_by_resource:
+        return DatafnError(code="DFQL_UNKNOWN_RESOURCE", message=f"Unknown resource: {resource_name}", details={"path": path})
+
+    valid_fields = index.writable_fields_by_resource[resource_name]
+    readonly = index.readonly_fields.get(resource_name, set())
+
+    for key in record.keys():
+        if key in readonly and key != "id":
+            return DatafnError(
+                code="DFQL_INVALID",
+                message=f"Cannot write to read-only field: {key}",
+                details={"path": f"{path}.{key}"}
+            )
+        if key not in valid_fields and key not in readonly:
+            return DatafnError(
+                code="DFQL_UNKNOWN_FIELD",
+                message=f"Unknown field: {key}",
+                details={"path": f"{path}.{key}"}
+            )
+    return None

--- a/datafn/python/pyproject.toml
+++ b/datafn/python/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "datafn"
+version = "0.0.1"
+description = "Python Server SDK for DataFn"
+requires-python = ">=3.8"
+dependencies = []
+
+[tool.hatch.build.targets.wheel]
+packages = ["datafn"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "venv/",
+    ".pytest_cache/",
+    "dist/",
+    "build/",
+    "*.egg-info/",
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra -q"
+testpaths = ["tests"]

--- a/datafn/python/tests/mock_db.py
+++ b/datafn/python/tests/mock_db.py
@@ -1,0 +1,108 @@
+from typing import Any, Dict, List, Optional, AsyncContextManager
+import copy
+
+class MockTransactionContext:
+    def __init__(self, adapter):
+        self.adapter = adapter
+        self.snapshot = None
+
+    async def __aenter__(self):
+        # Create a snapshot of data
+        self.snapshot = copy.deepcopy(self.adapter.data)
+        # Return the same adapter instance (simplification) 
+        # In real life, we might return a transaction object or bound adapter.
+        # But MockAdapter stores data in memory.
+        return self.adapter
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if exc_type:
+            # Rollback: restore snapshot
+            self.adapter.data = self.snapshot
+        else:
+            # Commit: keep changes (do nothing)
+            pass
+        self.snapshot = None
+
+class MockAdapter:
+    def __init__(self):
+        self.data = {} # model -> list of records
+
+    async def find_many(
+        self, 
+        model: str, 
+        where: List[Dict[str, Any]], 
+        limit: Optional[int] = None,
+        sort: Optional[List[str]] = None,
+        cursor: Optional[Dict[str, Any]] = None,
+        namespace: str = "datafn"
+    ) -> List[Dict[str, Any]]:
+        records = self.data.get(model, [])
+        filtered = []
+        for r in records:
+            match = True
+            for w in where:
+                field = w["field"]
+                op = w.get("operator", "eq")
+                val = w.get("value")
+                
+                rv = r.get(field)
+                if op == "eq":
+                    if rv != val:
+                        match = False
+                elif op == "gt":
+                    if rv is None or val is None or not (rv > val):
+                        match = False
+                elif op == "gte":
+                    if rv is None or val is None or not (rv >= val):
+                        match = False
+                elif op == "lt":
+                    if rv is None or val is None or not (rv < val):
+                        match = False
+                elif op == "lte":
+                    if rv is None or val is None or not (rv <= val):
+                        match = False
+                elif op == "in":
+                    if val is None or not isinstance(val, (list, tuple, set)) or rv not in val:
+                        match = False
+            if match:
+                filtered.append(r)
+        
+        # Sort?
+        # Only simple sort for now if needed by tests
+        if sort:
+            # Sort by first field
+            field, _, direction = sort[0].partition(":")
+            desc = direction == "desc"
+            filtered.sort(key=lambda x: x.get(field, ""), reverse=desc)
+            
+        if limit is not None:
+            filtered = filtered[:limit]
+            
+        return filtered
+
+    async def find_one(self, model: str, where: List[Dict[str, Any]], namespace: str = "datafn") -> Optional[Dict[str, Any]]:
+        # Reuse logic?
+        res = await self.find_many(model, where, limit=1, namespace=namespace)
+        return res[0] if res else None
+
+    async def create(self, model: str, data: Dict[str, Any], namespace: str = "datafn") -> None:
+        if model not in self.data:
+            self.data[model] = []
+        # Ensure ID?
+        if "id" not in data:
+            import uuid
+            data["id"] = str(uuid.uuid4())
+        self.data[model].append(data)
+
+    async def update(self, model: str, where: List[Dict[str, Any]], data: Dict[str, Any], namespace: str = "datafn") -> None:
+        record = await self.find_one(model, where, namespace)
+        if record:
+            record.update(data)
+            
+    async def delete(self, model: str, where: List[Dict[str, Any]], namespace: str = "datafn") -> None:
+        record = await self.find_one(model, where, namespace)
+        if record:
+            self.data[model].remove(record)
+
+    def transaction(self) -> AsyncContextManager["MockAdapter"]:
+        return MockTransactionContext(self)

--- a/datafn/python/tests/test_authz.py
+++ b/datafn/python/tests/test_authz.py
@@ -1,0 +1,173 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+
+# Schema with field-level permissions
+SCHEMA_WITH_PERMISSIONS = {
+    "resources": [
+        {
+            "name": "employees",
+            "version": 1,
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "email", "type": "string"},
+                {"name": "salary", "type": "number"},
+                {"name": "ssn", "type": "string"},
+            ],
+            "permissions": {
+                "read": {
+                    "fields": ["id", "name", "email"]
+                },
+                "write": {
+                    "fields": ["name", "email"]
+                }
+            }
+        },
+        {
+            "name": "tasks",
+            "version": 1,
+            "fields": [
+                {"name": "title", "type": "string"},
+                {"name": "status", "type": "string"},
+            ]
+        },
+        {
+            "name": "__datafn_idempotency",
+            "fields": [
+                {"name": "clientId"},
+                {"name": "mutationId"},
+                {"name": "result"}
+            ]
+        },
+    ],
+    "relations": []
+}
+
+
+def _make_server():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": SCHEMA_WITH_PERMISSIONS, "db": db})
+    return server, db
+
+
+@pytest.mark.asyncio
+async def test_query_unauthorized_field_returns_forbidden():
+    """TV-AUTH-001: Query selecting unauthorized field returns FORBIDDEN."""
+    server, db = _make_server()
+    query_handler = server["routes"]["POST /datafn/query"]
+
+    res = await query_handler({}, {
+        "resource": "employees",
+        "version": 1,
+        "select": ["id", "salary"]
+    })
+    assert res["ok"] is False
+    assert res["error"]["code"] == "FORBIDDEN"
+    assert "salary" in res["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_query_authorized_fields_succeed():
+    """Query selecting only authorized fields succeeds."""
+    server, db = _make_server()
+    query_handler = server["routes"]["POST /datafn/query"]
+
+    res = await query_handler({}, {
+        "resource": "employees",
+        "version": 1,
+        "select": ["id", "name", "email"]
+    })
+    assert res["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_query_no_permissions_all_fields_accessible():
+    """When no permissions are defined, all fields are accessible."""
+    server, db = _make_server()
+    query_handler = server["routes"]["POST /datafn/query"]
+
+    res = await query_handler({}, {
+        "resource": "tasks",
+        "version": 1,
+        "select": ["id", "title", "status"]
+    })
+    assert res["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_query_id_always_readable():
+    """id is always readable even if not explicitly in permissions."""
+    server, db = _make_server()
+    query_handler = server["routes"]["POST /datafn/query"]
+
+    res = await query_handler({}, {
+        "resource": "employees",
+        "version": 1,
+        "select": ["id"]
+    })
+    assert res["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_mutation_unauthorized_field_returns_forbidden():
+    """Mutation writing unauthorized field returns FORBIDDEN."""
+    server, db = _make_server()
+    mutation_handler = server["routes"]["POST /datafn/mutation"]
+
+    res = await mutation_handler({}, {
+        "resource": "employees",
+        "version": 1,
+        "operation": "insert",
+        "id": "emp1",
+        "record": {"name": "Alice", "salary": 100000}
+    })
+    assert res["ok"] is False
+    assert res["error"]["code"] == "FORBIDDEN"
+    assert "salary" in res["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_mutation_authorized_fields_succeed():
+    """Mutation writing only authorized fields succeeds."""
+    server, db = _make_server()
+    mutation_handler = server["routes"]["POST /datafn/mutation"]
+
+    res = await mutation_handler({}, {
+        "resource": "employees",
+        "version": 1,
+        "operation": "insert",
+        "id": "emp1",
+        "record": {"name": "Alice", "email": "alice@example.com"}
+    })
+    assert res["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_query_filter_unauthorized_field_forbidden():
+    """Filtering on unauthorized field returns FORBIDDEN."""
+    server, db = _make_server()
+    query_handler = server["routes"]["POST /datafn/query"]
+
+    res = await query_handler({}, {
+        "resource": "employees",
+        "version": 1,
+        "filters": {"salary": {"$gte": 50000}}
+    })
+    assert res["ok"] is False
+    assert res["error"]["code"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_query_sort_unauthorized_field_forbidden():
+    """Sorting on unauthorized field returns FORBIDDEN."""
+    server, db = _make_server()
+    query_handler = server["routes"]["POST /datafn/query"]
+
+    res = await query_handler({}, {
+        "resource": "employees",
+        "version": 1,
+        "sort": ["salary:desc"]
+    })
+    assert res["ok"] is False
+    assert res["error"]["code"] == "FORBIDDEN"

--- a/datafn/python/tests/test_change_tracking_limit.py
+++ b/datafn/python/tests/test_change_tracking_limit.py
@@ -1,0 +1,83 @@
+"""
+Phase 09: Bounded change fetching tests (PY-002)
+Test vector: TV-PY-BOUND-001
+"""
+
+import pytest
+from datafn.change_tracking import get_changes_since, write_change, get_next_server_seq
+from .mock_db import MockAdapter
+
+
+@pytest.mark.asyncio
+async def test_get_changes_since_with_limit():
+    """TV-PY-BOUND-001: get_changes_since with limit returns bounded results."""
+    db = MockAdapter()
+    namespace = "datafn"
+    table = "task"
+
+    # Seed 50 change entries
+    for i in range(1, 51):
+        seq = await get_next_server_seq(db, namespace)
+        await write_change(db, namespace, table, "insert", f"t{i}", seq)
+
+    # Fetch with limit=10
+    result = await get_changes_since(db, namespace, table, "0", limit=10)
+    assert len(result["changes"]) == 10
+    # Should be ordered by serverSeq ASC (1-10)
+    seqs = [c["serverSeq"] for c in result["changes"]]
+    assert seqs == list(range(1, 11))
+    # Cursor should point to seq 10
+    assert result["cursor"] == "10"
+
+
+@pytest.mark.asyncio
+async def test_get_changes_since_without_limit():
+    """TV-PY-BOUND-001 (backward compat): omitting limit returns all changes."""
+    db = MockAdapter()
+    namespace = "datafn"
+    table = "task"
+
+    # Seed 20 change entries
+    for i in range(1, 21):
+        seq = await get_next_server_seq(db, namespace)
+        await write_change(db, namespace, table, "insert", f"t{i}", seq)
+
+    # Fetch without limit
+    result = await get_changes_since(db, namespace, table, "0")
+    assert len(result["changes"]) == 20
+
+
+@pytest.mark.asyncio
+async def test_get_changes_since_limit_larger_than_data():
+    """Limit larger than available changes returns all available."""
+    db = MockAdapter()
+    namespace = "datafn"
+    table = "task"
+
+    # Seed 5 entries
+    for i in range(1, 6):
+        seq = await get_next_server_seq(db, namespace)
+        await write_change(db, namespace, table, "insert", f"t{i}", seq)
+
+    result = await get_changes_since(db, namespace, table, "0", limit=100)
+    assert len(result["changes"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_get_changes_since_with_cursor_and_limit():
+    """Limit applies after cursor filtering."""
+    db = MockAdapter()
+    namespace = "datafn"
+    table = "task"
+
+    # Seed 30 entries
+    for i in range(1, 31):
+        seq = await get_next_server_seq(db, namespace)
+        await write_change(db, namespace, table, "insert", f"t{i}", seq)
+
+    # Fetch from cursor "10" with limit=5 → should get seqs 11-15
+    result = await get_changes_since(db, namespace, table, "10", limit=5)
+    assert len(result["changes"]) == 5
+    seqs = [c["serverSeq"] for c in result["changes"]]
+    assert seqs == [11, 12, 13, 14, 15]
+    assert result["cursor"] == "15"

--- a/datafn/python/tests/test_filters.py
+++ b/datafn/python/tests/test_filters.py
@@ -1,0 +1,237 @@
+import pytest
+from datafn.filters import evaluate_filter, normalize_filter_ops, OP_REMAP
+from datafn.envelope import DatafnError
+
+
+class TestFilterOperators:
+    # TV-FILT-001: $in
+    def test_in_positive(self):
+        assert evaluate_filter({"status": "active"}, {"status": {"$in": ["active", "pending"]}})
+
+    def test_in_negative(self):
+        assert not evaluate_filter({"status": "closed"}, {"status": {"$in": ["active", "pending"]}})
+
+    # TV-FILT-002: $nin
+    def test_nin_positive(self):
+        assert evaluate_filter({"status": "closed"}, {"status": {"$nin": ["active", "pending"]}})
+
+    def test_nin_negative(self):
+        assert not evaluate_filter({"status": "active"}, {"status": {"$nin": ["active", "pending"]}})
+
+    # TV-FILT-003: $like (case-sensitive)
+    def test_like_positive(self):
+        assert evaluate_filter({"name": "Hello World"}, {"name": {"$like": "Hello%"}})
+
+    def test_like_negative_case(self):
+        assert not evaluate_filter({"name": "hello world"}, {"name": {"$like": "Hello%"}})
+
+    def test_like_underscore(self):
+        assert evaluate_filter({"name": "cat"}, {"name": {"$like": "c_t"}})
+        assert not evaluate_filter({"name": "coat"}, {"name": {"$like": "c_t"}})
+
+    # TV-FILT-004: $ilike (case-insensitive)
+    def test_ilike_positive(self):
+        assert evaluate_filter({"name": "Hello World"}, {"name": {"$ilike": "hello%"}})
+
+    # $not_like / $not_ilike
+    def test_not_like(self):
+        assert evaluate_filter({"name": "hello"}, {"name": {"$not_like": "Hello%"}})
+        assert not evaluate_filter({"name": "Hello World"}, {"name": {"$not_like": "Hello%"}})
+
+    def test_not_ilike(self):
+        assert not evaluate_filter({"name": "Hello World"}, {"name": {"$not_ilike": "hello%"}})
+
+    # TV-FILT-005: $is_null
+    def test_is_null_true(self):
+        assert evaluate_filter({"email": None}, {"email": {"$is_null": True}})
+
+    def test_is_null_false(self):
+        assert not evaluate_filter({"email": "test@example.com"}, {"email": {"$is_null": True}})
+
+    def test_is_null_inverse(self):
+        assert evaluate_filter({"email": "test@example.com"}, {"email": {"$is_null": False}})
+
+    # $is_not_null
+    def test_is_not_null(self):
+        assert evaluate_filter({"email": "test@example.com"}, {"email": {"$is_not_null": True}})
+        assert not evaluate_filter({"email": None}, {"email": {"$is_not_null": True}})
+
+    # TV-FILT-006: $is_empty
+    def test_is_empty_none(self):
+        assert evaluate_filter({"tags": None}, {"tags": {"$is_empty": True}})
+
+    def test_is_empty_string(self):
+        assert evaluate_filter({"name": ""}, {"name": {"$is_empty": True}})
+
+    def test_is_empty_list(self):
+        assert evaluate_filter({"items": []}, {"items": {"$is_empty": True}})
+
+    def test_is_empty_negative(self):
+        assert not evaluate_filter({"name": "hello"}, {"name": {"$is_empty": True}})
+
+    # $is_not_empty
+    def test_is_not_empty(self):
+        assert evaluate_filter({"name": "hello"}, {"name": {"$is_not_empty": True}})
+        assert not evaluate_filter({"name": ""}, {"name": {"$is_not_empty": True}})
+
+    # TV-FILT-007: $contains / $startsWith / $endsWith
+    def test_contains(self):
+        assert evaluate_filter({"title": "Hello World"}, {"title": {"$contains": "lo Wor"}})
+
+    def test_starts_with(self):
+        assert evaluate_filter({"title": "Hello World"}, {"title": {"$startsWith": "Hello"}})
+
+    def test_ends_with(self):
+        assert evaluate_filter({"title": "Hello World"}, {"title": {"$endsWith": "World"}})
+
+    def test_starts_with_negative(self):
+        assert not evaluate_filter({"title": "Hello World"}, {"title": {"$startsWith": "World"}})
+
+    # TV-FILT-008: $before / $after
+    def test_before(self):
+        assert evaluate_filter({"createdAt": 1704067200000}, {"createdAt": {"$before": 1704153600000}})
+
+    def test_after(self):
+        assert evaluate_filter({"createdAt": 1704153600000}, {"createdAt": {"$after": 1704067200000}})
+
+    # TV-FILT-009: $between / $not_between
+    def test_between(self):
+        assert evaluate_filter({"priority": 5}, {"priority": {"$between": [3, 7]}})
+
+    def test_between_boundary(self):
+        assert evaluate_filter({"priority": 3}, {"priority": {"$between": [3, 7]}})
+        assert evaluate_filter({"priority": 7}, {"priority": {"$between": [3, 7]}})
+
+    def test_not_between(self):
+        assert not evaluate_filter({"priority": 5}, {"priority": {"$not_between": [3, 7]}})
+        assert evaluate_filter({"priority": 1}, {"priority": {"$not_between": [3, 7]}})
+
+    # TV-FILT-010: Null values with comparison operators
+    def test_null_comparison(self):
+        assert not evaluate_filter({"score": None}, {"score": {"$gt": 5}})
+        assert not evaluate_filter({"score": None}, {"score": {"$lt": 5}})
+        assert not evaluate_filter({"score": None}, {"score": {"$gte": 5}})
+        assert not evaluate_filter({"score": None}, {"score": {"$lte": 5}})
+
+    # Basic existing operators
+    def test_eq(self):
+        assert evaluate_filter({"x": 1}, {"x": {"$eq": 1}})
+        assert not evaluate_filter({"x": 2}, {"x": {"$eq": 1}})
+
+    def test_ne(self):
+        assert evaluate_filter({"x": 2}, {"x": {"$ne": 1}})
+
+    def test_gt(self):
+        assert evaluate_filter({"x": 5}, {"x": {"$gt": 3}})
+        assert not evaluate_filter({"x": 3}, {"x": {"$gt": 3}})
+
+    def test_gte(self):
+        assert evaluate_filter({"x": 3}, {"x": {"$gte": 3}})
+
+    def test_lt(self):
+        assert evaluate_filter({"x": 2}, {"x": {"$lt": 3}})
+
+    def test_lte(self):
+        assert evaluate_filter({"x": 3}, {"x": {"$lte": 3}})
+
+    # Direct equality (shorthand)
+    def test_direct_equality(self):
+        assert evaluate_filter({"status": "active"}, {"status": "active"})
+        assert not evaluate_filter({"status": "closed"}, {"status": "active"})
+
+
+class TestNormalizeFilterOps:
+    # TV-FILT-011
+    def test_remap_basic(self):
+        result = normalize_filter_ops({"status": {"eq": "active"}, "priority": {"gte": 3, "lte": 10}})
+        assert result == {"status": {"$eq": "active"}, "priority": {"$gte": 3, "$lte": 10}}
+
+    def test_already_prefixed(self):
+        result = normalize_filter_ops({"status": {"$eq": "active"}})
+        assert result == {"status": {"$eq": "active"}}
+
+    def test_nested_remap(self):
+        result = normalize_filter_ops({"$and": [{"status": {"eq": "active"}}, {"priority": {"gt": 3}}]})
+        assert result == {"$and": [{"status": {"$eq": "active"}}, {"priority": {"$gt": 3}}]}
+
+    def test_non_operator_keys_preserved(self):
+        result = normalize_filter_ops({"status": {"eq": "active"}, "name": "test"})
+        assert result == {"status": {"$eq": "active"}, "name": "test"}
+
+
+class TestLogicalOperators:
+    # TV-FILT-012: $and
+    def test_and_positive(self):
+        record = {"status": "active", "priority": 5}
+        assert evaluate_filter(record, {"$and": [{"status": {"$eq": "active"}}, {"priority": {"$gte": 3}}]})
+
+    def test_and_negative(self):
+        record = {"status": "closed", "priority": 5}
+        assert not evaluate_filter(record, {"$and": [{"status": {"$eq": "active"}}, {"priority": {"$gte": 3}}]})
+
+    def test_and_empty(self):
+        assert evaluate_filter({"x": 1}, {"$and": []})
+
+    # TV-FILT-013: $or
+    def test_or_positive(self):
+        record = {"status": "closed", "priority": 5}
+        assert evaluate_filter(record, {"$or": [{"status": {"$eq": "active"}}, {"priority": {"$gte": 3}}]})
+
+    def test_or_negative(self):
+        record = {"status": "closed", "priority": 1}
+        assert not evaluate_filter(record, {"$or": [{"status": {"$eq": "active"}}, {"priority": {"$gte": 3}}]})
+
+    def test_or_empty(self):
+        assert not evaluate_filter({"x": 1}, {"$or": []})
+
+    def test_nested_logical(self):
+        record = {"a": 1, "b": 2, "c": 3}
+        filt = {"$and": [{"$or": [{"a": {"$eq": 1}}, {"a": {"$eq": 2}}]}, {"b": {"$eq": 2}}]}
+        assert evaluate_filter(record, filt)
+
+
+class TestDotPath:
+    # TV-FILT-014
+    def test_dot_path_positive(self):
+        assert evaluate_filter({"metadata": {"priority": 5}}, {"metadata.priority": {"$eq": 5}})
+
+    def test_dot_path_missing_key(self):
+        assert not evaluate_filter({"metadata": {}}, {"metadata.priority": {"$eq": 5}})
+
+    def test_dot_path_deep(self):
+        record = {"a": {"b": {"c": 42}}}
+        assert evaluate_filter(record, {"a.b.c": {"$eq": 42}})
+
+    def test_dot_path_missing_intermediate(self):
+        assert not evaluate_filter({"x": 1}, {"a.b.c": {"$eq": 42}})
+
+
+class TestFilterDepth:
+    # TV-FILT-015
+    def test_depth_limit_exceeded(self):
+        # Build 11 levels of $and nesting
+        filt = {"x": {"$eq": 1}}
+        for _ in range(11):
+            filt = {"$and": [filt]}
+
+        with pytest.raises(DatafnError) as exc_info:
+            evaluate_filter({"x": 1}, filt)
+        assert exc_info.value.code == "LIMIT_EXCEEDED"
+        assert "depth" in exc_info.value.message.lower()
+
+    def test_within_depth_limit(self):
+        # Build 9 levels - should be fine
+        filt = {"x": {"$eq": 1}}
+        for _ in range(9):
+            filt = {"$and": [filt]}
+        assert evaluate_filter({"x": 1}, filt)
+
+
+class TestNonPrefixedOpsInEvaluate:
+    def test_legacy_operators_work(self):
+        assert evaluate_filter({"x": 1}, {"x": {"eq": 1}})
+        assert evaluate_filter({"x": 5}, {"x": {"gt": 3}})
+        assert evaluate_filter({"x": 5}, {"x": {"gte": 5}})
+        assert evaluate_filter({"x": 5}, {"x": {"lt": 10}})
+        assert evaluate_filter({"x": 5}, {"x": {"lte": 5}})
+        assert evaluate_filter({"x": 2}, {"x": {"ne": 1}})

--- a/datafn/python/tests/test_hooks.py
+++ b/datafn/python/tests/test_hooks.py
@@ -1,0 +1,168 @@
+import pytest
+from datafn.hooks import run_before_hook, run_after_hook
+
+
+# --- Test plugin classes ---
+
+class ModifyQueryPlugin:
+    name = "modify-query"
+    runs_on = ["server"]
+
+    async def before_query(self, ctx, query):
+        query = dict(query)
+        query["limit"] = 10
+        return query
+
+    async def after_query(self, ctx, query, result):
+        return {"transformed": True, "original": result}
+
+
+class FailingPlugin:
+    name = "failing-plugin"
+    runs_on = ["server"]
+
+    async def before_query(self, ctx, query):
+        raise ValueError("plugin error")
+
+    async def after_query(self, ctx, query, result):
+        raise ValueError("after hook error")
+
+
+class ClientOnlyPlugin:
+    name = "client-plugin"
+    runs_on = ["client"]
+
+    async def before_query(self, ctx, query):
+        query = dict(query)
+        query["injected"] = True
+        return query
+
+
+class PassthroughPlugin:
+    name = "passthrough"
+    runs_on = ["server"]
+
+    async def before_query(self, ctx, query):
+        return None  # No modification
+
+    async def after_query(self, ctx, query, result):
+        return None  # No modification
+
+
+# --- Before hook tests ---
+
+class TestRunBeforeHook:
+    @pytest.mark.asyncio
+    async def test_single_plugin_modifies_payload(self):
+        result = await run_before_hook(
+            [ModifyQueryPlugin()], "server", "before_query", {}, {"resource": "tasks"}
+        )
+        assert result["ok"] is True
+        assert result["value"]["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_on_error(self):
+        result = await run_before_hook(
+            [FailingPlugin()], "server", "before_query", {}, {"resource": "tasks"}
+        )
+        assert result["ok"] is False
+        assert result["error"]["code"] == "PLUGIN_ERROR"
+        assert "failing-plugin" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_filtered_by_runs_on(self):
+        result = await run_before_hook(
+            [ClientOnlyPlugin()], "server", "before_query", {}, {"resource": "tasks"}
+        )
+        assert result["ok"] is True
+        assert "injected" not in result["value"]
+
+    @pytest.mark.asyncio
+    async def test_no_plugins(self):
+        result = await run_before_hook(
+            [], "server", "before_query", {}, {"resource": "tasks"}
+        )
+        assert result["ok"] is True
+        assert result["value"] == {"resource": "tasks"}
+
+    @pytest.mark.asyncio
+    async def test_passthrough_returns_original(self):
+        result = await run_before_hook(
+            [PassthroughPlugin()], "server", "before_query", {}, {"resource": "tasks"}
+        )
+        assert result["ok"] is True
+        assert result["value"] == {"resource": "tasks"}
+
+    @pytest.mark.asyncio
+    async def test_chaining(self):
+        class AddFieldPlugin:
+            name = "add-field"
+            runs_on = ["server"]
+            async def before_query(self, ctx, query):
+                query = dict(query)
+                query["extra"] = True
+                return query
+
+        result = await run_before_hook(
+            [ModifyQueryPlugin(), AddFieldPlugin()], "server", "before_query", {}, {"resource": "tasks"}
+        )
+        assert result["ok"] is True
+        assert result["value"]["limit"] == 10
+        assert result["value"]["extra"] is True
+
+    @pytest.mark.asyncio
+    async def test_error_stops_chain(self):
+        class TrackPlugin:
+            name = "tracker"
+            runs_on = ["server"]
+            called = False
+            async def before_query(self, ctx, query):
+                TrackPlugin.called = True
+                return query
+
+        TrackPlugin.called = False
+        result = await run_before_hook(
+            [FailingPlugin(), TrackPlugin()], "server", "before_query", {}, {}
+        )
+        assert result["ok"] is False
+        assert TrackPlugin.called is False
+
+
+# --- After hook tests ---
+
+class TestRunAfterHook:
+    @pytest.mark.asyncio
+    async def test_result_transformation(self):
+        result = await run_after_hook(
+            [ModifyQueryPlugin()], "server", "after_query", {}, {}, {"data": []}
+        )
+        assert result["transformed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_error(self):
+        result = await run_after_hook(
+            [FailingPlugin()], "server", "after_query", {}, {}, {"data": []}
+        )
+        # Error swallowed, original result returned
+        assert result == {"data": []}
+
+    @pytest.mark.asyncio
+    async def test_no_plugins(self):
+        result = await run_after_hook(
+            [], "server", "after_query", {}, {}, {"data": [1, 2]}
+        )
+        assert result == {"data": [1, 2]}
+
+    @pytest.mark.asyncio
+    async def test_passthrough(self):
+        result = await run_after_hook(
+            [PassthroughPlugin()], "server", "after_query", {}, {}, {"data": []}
+        )
+        assert result == {"data": []}
+
+    @pytest.mark.asyncio
+    async def test_filtered_by_runs_on(self):
+        result = await run_after_hook(
+            [ClientOnlyPlugin()], "server", "after_query", {}, {}, {"data": []}
+        )
+        assert result == {"data": []}

--- a/datafn/python/tests/test_integration.py
+++ b/datafn/python/tests/test_integration.py
@@ -1,0 +1,488 @@
+"""
+End-to-end integration tests for datafn Python server.
+Covers: config validation, logger, plugins/hooks, field authz, limits,
+cursor pagination, aggregation, merge decision, replace, batch insert,
+transaction rollback, sync push/pull.
+"""
+import pytest
+from unittest.mock import MagicMock
+from datafn.server import create_datafn_server
+from datafn.envelope import DatafnError
+from .mock_db import MockAdapter
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers & schemas
+# ---------------------------------------------------------------------------
+FULL_SCHEMA = {
+    "resources": [
+        {
+            "name": "tasks",
+            "version": 1,
+            "fields": [
+                {"name": "title", "type": "string", "required": True},
+                {"name": "status", "type": "string", "default": "pending"},
+                {"name": "priority", "type": "number"},
+                {"name": "description", "type": "string"},
+            ],
+        },
+        {
+            "name": "tags",
+            "version": 1,
+            "fields": [
+                {"name": "label", "type": "string"},
+            ],
+        },
+        {
+            "name": "__datafn_idempotency",
+            "fields": [
+                {"name": "clientId"},
+                {"name": "mutationId"},
+                {"name": "result"},
+            ],
+        },
+        {
+            "name": "__datafn_changes",
+            "fields": [
+                {"name": "table"},
+                {"name": "operation"},
+                {"name": "recordId"},
+            ],
+        },
+        {
+            "name": "__datafn_seed",
+            "fields": [
+                {"name": "timestamp"},
+            ],
+        },
+        {
+            "name": "__datafn_seq",
+            "fields": [
+                {"name": "value"},
+            ],
+        },
+    ],
+    "relations": [],
+}
+
+
+def _make_server(schema=None, **extra):
+    db = MockAdapter()
+    cfg = {"schema": schema or FULL_SCHEMA, "db": db, **extra}
+    server = create_datafn_server(cfg)
+    return server, db
+
+
+# ---------------------------------------------------------------------------
+# 1. Config validation
+# ---------------------------------------------------------------------------
+class TestConfigValidation:
+    def test_missing_schema_raises(self):
+        """SRV-004: missing schema raises ValueError."""
+        with pytest.raises((ValueError, TypeError), match="schema"):
+            create_datafn_server({"db": MockAdapter()})
+
+    def test_missing_db_raises(self):
+        """SRV-004: missing db raises ValueError."""
+        with pytest.raises(ValueError, match="db is required"):
+            create_datafn_server({"schema": FULL_SCHEMA})
+
+    def test_invalid_limits_negative(self):
+        """SRV-004: negative limit value raises ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            create_datafn_server({"schema": FULL_SCHEMA, "db": MockAdapter(), "limits": {"maxLimit": -1}})
+
+    def test_invalid_authorize_not_callable(self):
+        """SRV-004: non-callable authorize raises ValueError."""
+        with pytest.raises(ValueError, match="callable"):
+            create_datafn_server({"schema": FULL_SCHEMA, "db": MockAdapter(), "authorize": "not-a-fn"})
+
+    def test_valid_config_succeeds(self):
+        """SRV-004: valid config creates server without error."""
+        server, _ = _make_server()
+        assert "routes" in server
+
+
+# ---------------------------------------------------------------------------
+# 2. Logger
+# ---------------------------------------------------------------------------
+class TestLogger:
+    def test_logger_called_on_init(self):
+        """SRV-001 / TV-SRV-001: logger.info called with 'DataFn server initialized'."""
+        mock_logger = MagicMock()
+        _make_server(logger=mock_logger)
+        mock_logger.info.assert_called_with("DataFn server initialized")
+
+    @pytest.mark.asyncio
+    async def test_logger_debug_on_query(self):
+        """SRV-001: logger.debug called on query request."""
+        mock_logger = MagicMock()
+        server, _ = _make_server(logger=mock_logger)
+        handler = server["routes"]["POST /datafn/query"]
+        await handler({}, {"resource": "tasks", "version": 1})
+        # Should have debug calls for request start and completion
+        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+        assert any("Query request" in c for c in debug_calls)
+        assert any("Query completed" in c for c in debug_calls)
+
+
+# ---------------------------------------------------------------------------
+# 3. Plugin / hook system
+# ---------------------------------------------------------------------------
+class TestPlugins:
+    @pytest.mark.asyncio
+    async def test_before_query_hook_modifies_query(self):
+        """SRV-002 / TV-SRV-002: Plugin adds limit to query."""
+        class LimitPlugin:
+            name = "limit-plugin"
+            runs_on = ["server"]
+            async def before_query(self, ctx, query):
+                query["limit"] = 10
+                return query
+
+        server, db = _make_server(plugins=[LimitPlugin()])
+        handler = server["routes"]["POST /datafn/query"]
+        # Insert 20 records
+        for i in range(20):
+            await db.create("tasks", {"id": f"t{i:02d}", "title": f"Task {i}", "status": "active"})
+
+        res = await handler({}, {"resource": "tasks", "version": 1, "limit": 50})
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_before_mutation_hook_rejects(self):
+        """SRV-002: Plugin rejects mutation."""
+        class RejectPlugin:
+            name = "reject-plugin"
+            runs_on = ["server"]
+            async def before_mutation(self, ctx, mutation):
+                raise Exception("Rejected by policy")
+
+        server, _db = _make_server(plugins=[RejectPlugin()])
+        handler = server["routes"]["POST /datafn/mutation"]
+        res = await handler({}, {
+            "resource": "tasks", "version": 1, "operation": "insert",
+            "id": "t1", "record": {"title": "Test"}
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "PLUGIN_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# 4. Limit enforcement
+# ---------------------------------------------------------------------------
+class TestLimits:
+    @pytest.mark.asyncio
+    async def test_max_select_tokens_exceeded(self):
+        """VAL-008 / TV-VAL-009: Query with too many select tokens rejected."""
+        server, _db = _make_server(limits={"maxSelectTokens": 2})
+        handler = server["routes"]["POST /datafn/query"]
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "select": ["id", "title", "status"]
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "LIMIT_EXCEEDED"
+
+
+# ---------------------------------------------------------------------------
+# 5. Payload size limit
+# ---------------------------------------------------------------------------
+class TestPayloadSizeLimit:
+    def test_check_payload_size_exceeds(self):
+        """SRV-003 / TV-SRV-003: Oversized payload returns LIMIT_EXCEEDED."""
+        from datafn.authz import check_payload_size
+        body = b"x" * (5 * 1024 * 1024 + 1)  # 5MB + 1 byte
+        err = check_payload_size(body, 5 * 1024 * 1024)
+        assert err is not None
+        assert err.code == "LIMIT_EXCEEDED"
+
+    def test_check_payload_size_within_limit(self):
+        """SRV-003: Payload within limit returns None."""
+        from datafn.authz import check_payload_size
+        body = b"x" * 100
+        err = check_payload_size(body, 5 * 1024 * 1024)
+        assert err is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Cursor pagination end-to-end
+# ---------------------------------------------------------------------------
+class TestCursorPagination:
+    @pytest.mark.asyncio
+    async def test_paginate_with_limit_3(self):
+        """QRY-001/003: Insert 10 records, paginate with limit 3."""
+        server, db = _make_server()
+        handler_q = server["routes"]["POST /datafn/query"]
+        handler_m = server["routes"]["POST /datafn/mutation"]
+
+        for i in range(10):
+            await handler_m({}, {
+                "resource": "tasks", "version": 1, "operation": "insert",
+                "id": f"t{i:02d}", "record": {"title": f"Task {i}"}
+            })
+
+        # Page 1
+        res1 = await handler_q({}, {
+            "resource": "tasks", "version": 1, "sort": ["id"], "limit": 3
+        })
+        assert res1["ok"] is True
+        assert len(res1["result"]["data"]) == 3
+        assert res1["result"]["data"][0]["id"] == "t00"
+        assert res1["result"]["nextCursor"] is not None
+
+        # Page 2
+        res2 = await handler_q({}, {
+            "resource": "tasks", "version": 1, "sort": ["id"], "limit": 3,
+            "cursor": {"after": res1["result"]["nextCursor"]}
+        })
+        assert res2["ok"] is True
+        assert len(res2["result"]["data"]) == 3
+        assert res2["result"]["data"][0]["id"] == "t03"
+
+
+# ---------------------------------------------------------------------------
+# 7. Aggregation end-to-end
+# ---------------------------------------------------------------------------
+class TestAggregation:
+    @pytest.mark.asyncio
+    async def test_group_by_count(self):
+        """QRY-007 / TV-QRY-007: GroupBy + count aggregation."""
+        server, _db = _make_server()
+        handler_m = server["routes"]["POST /datafn/mutation"]
+        handler_q = server["routes"]["POST /datafn/query"]
+
+        for item in [
+            {"id": "t1", "title": "A", "status": "active", "priority": 5},
+            {"id": "t2", "title": "B", "status": "active", "priority": 3},
+            {"id": "t3", "title": "C", "status": "closed", "priority": 1},
+        ]:
+            await handler_m({}, {
+                "resource": "tasks", "version": 1, "operation": "insert",
+                "id": item["id"], "record": item
+            })
+
+        res = await handler_q({}, {
+            "resource": "tasks", "version": 1,
+            "groupBy": ["status"],
+            "aggregations": {"total": {"count": "*"}, "avgPriority": {"avg": "priority"}}
+        })
+        assert res["ok"] is True
+        data = res["result"]["data"]
+        active = next(r for r in data if r["status"] == "active")
+        closed = next(r for r in data if r["status"] == "closed")
+        assert active["total"] == 2
+        assert active["avgPriority"] == 4.0
+        assert closed["total"] == 1
+        assert closed["avgPriority"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 8. Merge decision end-to-end
+# ---------------------------------------------------------------------------
+class TestMergeDecision:
+    @pytest.mark.asyncio
+    async def test_merge_nonexistent_creates(self):
+        """MUT-001 / TV-MUT-001: Merge on non-existent creates."""
+        server, db = _make_server()
+        handler = server["routes"]["POST /datafn/mutation"]
+
+        res = await handler({}, {
+            "resource": "tasks", "version": 1, "operation": "merge",
+            "id": "new_task", "record": {"title": "New Task", "status": "active"}
+        })
+        assert res["ok"] is True
+        assert "new_task" in res["result"]["affectedIds"]
+
+        # Verify record exists
+        record = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "new_task"}])
+        assert record is not None
+        assert record["title"] == "New Task"
+
+    @pytest.mark.asyncio
+    async def test_merge_existing_updates(self):
+        """MUT-001: Merge on existing updates."""
+        server, db = _make_server()
+        handler = server["routes"]["POST /datafn/mutation"]
+
+        # Create first
+        await handler({}, {
+            "resource": "tasks", "version": 1, "operation": "insert",
+            "id": "t1", "record": {"title": "Original", "status": "active"}
+        })
+
+        # Merge (update)
+        res = await handler({}, {
+            "resource": "tasks", "version": 1, "operation": "merge",
+            "id": "t1", "record": {"status": "closed"}
+        })
+        assert res["ok"] is True
+
+        record = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "t1"}])
+        assert record["status"] == "closed"
+        assert record["title"] == "Original"  # Untouched
+
+
+# ---------------------------------------------------------------------------
+# 9. Replace end-to-end
+# ---------------------------------------------------------------------------
+class TestReplace:
+    @pytest.mark.asyncio
+    async def test_replace_preserves_system_fields(self):
+        """MUT-002 / TV-MUT-002: Replace preserves system fields."""
+        server, db = _make_server()
+        handler = server["routes"]["POST /datafn/mutation"]
+
+        await handler({}, {
+            "resource": "tasks", "version": 1, "operation": "insert",
+            "id": "t1", "record": {"title": "Original", "priority": 5}
+        })
+
+        # Replace — try to overwrite createdAt (system field)
+        res = await handler({}, {
+            "resource": "tasks", "version": 1, "operation": "replace",
+            "id": "t1", "record": {"title": "Replaced"}
+        })
+        assert res["ok"] is True
+
+        record = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "t1"}])
+        assert record["title"] == "Replaced"
+
+
+# ---------------------------------------------------------------------------
+# 10. Batch insert end-to-end
+# ---------------------------------------------------------------------------
+class TestBatchInsert:
+    @pytest.mark.asyncio
+    async def test_batch_insert_5_records(self):
+        """MUT-003 / TV-MUT-003: Insert 5 records via records[]."""
+        server, _db = _make_server()
+        handler = server["routes"]["POST /datafn/mutation"]
+
+        records = [{"id": f"t{i}", "title": f"Task {i}"} for i in range(5)]
+        res = await handler({}, {
+            "resource": "tasks", "version": 1, "operation": "insert",
+            "records": records
+        })
+        assert res["ok"] is True
+        assert len(res["result"]["affectedIds"]) == 5
+
+
+# ---------------------------------------------------------------------------
+# 11. Transaction end-to-end
+# ---------------------------------------------------------------------------
+class TestTransaction:
+    @pytest.mark.asyncio
+    async def test_atomic_rollback_with_annotation(self):
+        """TXN-001/002 / TV-TXN-001/002: Atomic rollback annotates prior results."""
+        server, db = _make_server()
+        handler = server["routes"]["POST /datafn/transact"]
+
+        res = await handler({}, {
+            "atomic": True,
+            "steps": [
+                {"mutation": {"resource": "tasks", "version": 1, "operation": "insert", "id": "t1", "record": {"title": "A"}}},
+                {"mutation": {"resource": "tasks", "version": 1, "operation": "insert", "id": "t2", "record": {"title": "B"}}},
+                {"mutation": {"resource": "NONEXISTENT", "version": 1, "operation": "insert", "id": "t3", "record": {"title": "C"}}},
+            ]
+        })
+
+        assert res["ok"] is True
+        inner = res["result"]
+        assert inner["ok"] is False
+
+        # Check that rolled-back results have rolledBack: True
+        results = inner["results"]
+        # First two should have rolledBack
+        for r in results[:2]:
+            if isinstance(r, dict) and r.get("ok") is not False:
+                assert r.get("rolledBack") is True
+
+        # t1 and t2 should NOT be in db (rolled back)
+        t1 = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "t1"}])
+        assert t1 is None
+
+
+# ---------------------------------------------------------------------------
+# 12. Sync end-to-end
+# ---------------------------------------------------------------------------
+class TestSync:
+    @pytest.mark.asyncio
+    async def test_push_and_pull(self):
+        """SYN-001/003: Push with mutations, pull back."""
+        server, _db = _make_server()
+        push_handler = server["routes"]["POST /datafn/push"]
+        pull_handler = server["routes"]["POST /datafn/pull"]
+        seed_handler = server["routes"]["POST /datafn/seed"]
+
+        # Seed
+        await seed_handler({}, {"clientId": "client1"})
+
+        # Push a mutation
+        res = await push_handler({}, {
+            "clientId": "client1",
+            "mutations": [
+                {
+                    "clientId": "client1",
+                    "mutationId": "m1",
+                    "resource": "tasks",
+                    "operation": "insert",
+                    "id": "t1",
+                    "record": {"title": "Pushed Task"}
+                }
+            ]
+        })
+        assert res["ok"] is True
+        assert "m1" in res["result"]["applied"]
+
+        pull_res = await pull_handler({}, {
+            "clientId": "client1",
+            "cursors": {},
+        })
+        assert pull_res["ok"] is True
+        tasks = pull_res["result"]["records"].get("tasks", [])
+        assert any(
+            record.get("id") == "t1" and record.get("title") == "Pushed Task"
+            for record in tasks
+        )
+
+
+# ---------------------------------------------------------------------------
+# 13. Full flow: create server → query → mutation → transact
+# ---------------------------------------------------------------------------
+class TestFullFlow:
+    @pytest.mark.asyncio
+    async def test_create_query_mutate_transact(self):
+        """Full integration flow."""
+        server, _db = _make_server()
+        q = server["routes"]["POST /datafn/query"]
+        m = server["routes"]["POST /datafn/mutation"]
+        t = server["routes"]["POST /datafn/transact"]
+
+        # Insert
+        res = await m({}, {
+            "resource": "tasks", "version": 1, "operation": "insert",
+            "id": "t1", "record": {"title": "Task 1"}
+        })
+        assert res["ok"] is True
+
+        # Query
+        res = await q({}, {"resource": "tasks", "version": 1})
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 1
+
+        # Transact
+        res = await t({}, {
+            "atomic": False,
+            "steps": [
+                {"mutation": {"resource": "tasks", "version": 1, "operation": "insert", "id": "t2", "record": {"title": "Task 2"}}},
+                {"query": {"resource": "tasks", "version": 1}},
+            ]
+        })
+        assert res["ok"] is True
+        assert res["result"]["ok"] is True
+
+        # Verify final state
+        res = await q({}, {"resource": "tasks", "version": 1})
+        assert len(res["result"]["data"]) == 2

--- a/datafn/python/tests/test_logger.py
+++ b/datafn/python/tests/test_logger.py
@@ -1,0 +1,76 @@
+import pytest
+from datafn.logger import NoopLogger, ConsoleLogger, create_logger, DatafnLogger
+
+
+class TestNoopLogger:
+    def test_info_no_raise(self):
+        logger = NoopLogger()
+        logger.info("test message")
+
+    def test_warn_no_raise(self):
+        logger = NoopLogger()
+        logger.warn("test warning")
+
+    def test_error_no_raise(self):
+        logger = NoopLogger()
+        logger.error("test error")
+
+    def test_debug_no_raise(self):
+        logger = NoopLogger()
+        logger.debug("test debug")
+
+    def test_with_context(self):
+        logger = NoopLogger()
+        logger.info("test", {"key": "value"})
+
+
+class TestConsoleLogger:
+    def test_info_output(self, capsys):
+        logger = ConsoleLogger()
+        logger.info("server started")
+        captured = capsys.readouterr()
+        assert "[INFO] server started" in captured.out
+
+    def test_warn_output(self, capsys):
+        logger = ConsoleLogger()
+        logger.warn("deprecated feature")
+        captured = capsys.readouterr()
+        assert "[WARN] deprecated feature" in captured.out
+
+    def test_error_output(self, capsys):
+        logger = ConsoleLogger()
+        logger.error("something failed")
+        captured = capsys.readouterr()
+        assert "[ERROR] something failed" in captured.out
+
+    def test_debug_output(self, capsys):
+        logger = ConsoleLogger()
+        logger.debug("debug info")
+        captured = capsys.readouterr()
+        assert "[DEBUG] debug info" in captured.out
+
+    def test_with_context(self, capsys):
+        logger = ConsoleLogger()
+        logger.info("test", {"key": "value"})
+        captured = capsys.readouterr()
+        assert "[INFO] test" in captured.out
+        assert "key" in captured.out
+
+
+class TestCreateLogger:
+    def test_none_returns_noop(self):
+        logger = create_logger(None)
+        assert isinstance(logger, NoopLogger)
+
+    def test_provided_logger_returned(self):
+        custom = ConsoleLogger()
+        logger = create_logger(custom)
+        assert logger is custom
+
+    def test_noop_satisfies_protocol(self):
+        logger = NoopLogger()
+        assert isinstance(logger, DatafnLogger)
+
+    def test_console_satisfies_protocol(self):
+        logger = ConsoleLogger()
+        assert isinstance(logger, DatafnLogger)

--- a/datafn/python/tests/test_mutation.py
+++ b/datafn/python/tests/test_mutation.py
@@ -1,0 +1,63 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [{"name": "title"}]}
+    ],
+    "relations": []
+}
+
+@pytest.mark.asyncio
+async def test_mutation_valid():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/mutation"]
+    
+    res = await handler({}, {
+        "resource": "tasks",
+        "version": 1,
+        "operation": "insert",
+        "clientId": "c1",
+        "mutationId": "m1",
+        "id": "t1",
+        "record": {"title": "Task 1"}
+    })
+    
+    assert res["ok"] is True
+    assert res["result"]["ok"] is True
+    
+    # Check DB
+    tasks = await db.find_many("tasks", [])
+    assert len(tasks) == 1
+    assert tasks[0]["title"] == "Task 1"
+
+@pytest.mark.asyncio
+async def test_mutation_idempotency():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/mutation"]
+    
+    payload = {
+        "resource": "tasks",
+        "version": 1,
+        "operation": "insert",
+        "clientId": "c1",
+        "mutationId": "m1",
+        "id": "t1",
+        "record": {"title": "Task 1"}
+    }
+    
+    # First call
+    res1 = await handler({}, payload)
+    assert res1["ok"] is True
+    
+    # Second call
+    res2 = await handler({}, payload)
+    assert res2["ok"] is True
+    assert res2["result"]["deduped"] is True
+    
+    # Check DB (only 1 insert)
+    tasks = await db.find_many("tasks", [])
+    assert len(tasks) == 1

--- a/datafn/python/tests/test_mutation_enhanced.py
+++ b/datafn/python/tests/test_mutation_enhanced.py
@@ -1,0 +1,447 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [
+            {"name": "title", "type": "string", "required": True},
+            {"name": "status", "type": "string", "default": "pending"},
+            {"name": "priority", "type": "number"},
+            {"name": "description", "type": "string"},
+            {"name": "details", "type": "object"},
+        ]}
+    ],
+    "relations": [],
+}
+
+
+async def _setup(records=None, limits=None):
+    db = MockAdapter()
+    if records:
+        for r in records:
+            await db.create("tasks", r)
+    config = {"schema": schema, "db": db, "limits": limits}
+    server = create_datafn_server(config)
+    handler = server["routes"]["POST /datafn/mutation"]
+    return handler, db
+
+
+# --- Merge Decision (MUT-001 / TV-MUT-001) ---
+
+class TestMergeDecision:
+    @pytest.mark.asyncio
+    async def test_merge_creates_when_not_exists(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "new_task",
+            "record": {"title": "New Task"},
+        })
+        assert res["ok"] is True
+        assert "new_task" in res["result"]["affectedIds"]
+        # Verify record was created
+        tasks = await db.find_many("tasks", [{"field": "id", "operator": "eq", "value": "new_task"}])
+        assert len(tasks) == 1
+        assert tasks[0]["title"] == "New Task"
+
+    @pytest.mark.asyncio
+    async def test_merge_updates_when_exists(self):
+        handler, db = await _setup([
+            {"id": "task_1", "title": "Old Title", "status": "active"},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "task_1",
+            "record": {"title": "Updated Title"},
+        })
+        assert res["ok"] is True
+        assert "task_1" in res["result"]["affectedIds"]
+        # Verify only title was updated
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "task_1"}])
+        assert task["title"] == "Updated Title"
+        assert task["status"] == "active"  # unchanged
+
+
+# --- Replace (MUT-002 / TV-MUT-002) ---
+
+class TestReplace:
+    @pytest.mark.asyncio
+    async def test_replace_preserves_system_fields(self):
+        handler, db = await _setup([
+            {"id": "task_1", "title": "Old", "status": "active", "createdAt": 12345},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "replace", "id": "task_1",
+            "record": {"title": "New Title", "createdAt": 9999},
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "task_1"}])
+        assert task["title"] == "New Title"
+        assert task.get("createdAt") == 12345  # NOT overwritten
+
+    @pytest.mark.asyncio
+    async def test_replace_nulls_missing_fields(self):
+        handler, db = await _setup([
+            {"id": "task_1", "title": "Old", "status": "active", "priority": 5},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "replace", "id": "task_1",
+            "record": {"title": "New"},
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "task_1"}])
+        assert task["title"] == "New"
+        # status has a default, so gets the default value
+        assert task.get("status") == "pending"
+        # priority has no default, so null
+        assert task.get("priority") is None
+
+
+# --- Batch Insert (MUT-003 / TV-MUT-003) ---
+
+class TestBatchInsert:
+    @pytest.mark.asyncio
+    async def test_batch_insert_multiple_records(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "records": [
+                {"id": "t1", "title": "A"},
+                {"id": "t2", "title": "B"},
+            ],
+        })
+        assert res["ok"] is True
+        assert res["result"]["affectedIds"] == ["t1", "t2"]
+        tasks = await db.find_many("tasks", [])
+        assert len(tasks) == 2
+
+    @pytest.mark.asyncio
+    async def test_batch_insert_respects_batch_size_limit(self):
+        handler, _db = await _setup(limits={"maxBatchSize": 1})
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "records": [
+                {"id": "t1", "title": "A"},
+                {"id": "t2", "title": "B"},
+            ],
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "LIMIT_EXCEEDED"
+
+
+# --- Error Classification (MUT-004 / TV-MUT-004) ---
+
+class TestErrorClassification:
+    @pytest.mark.asyncio
+    async def test_duplicate_key_conflict(self):
+        handler, db = await _setup([
+            {"id": "task_1", "title": "Existing"},
+        ])
+
+        # Override create to simulate duplicate key error
+        original_create = db.create
+
+        async def failing_create(model, data, namespace="datafn"):
+            raise Exception("unique constraint violation")
+
+        db.create = failing_create
+
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_dup",
+            "record": {"title": "Dup"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "CONFLICT"
+
+
+# --- Field Type Validation (VAL-004 / TV-VAL-005) ---
+
+class TestFieldTypeValidation:
+    @pytest.mark.asyncio
+    async def test_string_field_rejects_number(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_bad",
+            "record": {"title": 123},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+        assert "title" in res["error"]["message"]
+        assert "string" in res["error"]["message"]
+
+
+# --- Required Field Validation (VAL-005 / TV-VAL-006) ---
+
+class TestRequiredFieldValidation:
+    @pytest.mark.asyncio
+    async def test_insert_without_required_field_fails(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_no_title",
+            "record": {"priority": 5},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+        assert "title" in res["error"]["message"]
+        assert "missing" in res["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_merge_update_skips_required_check(self):
+        handler, db = await _setup([
+            {"id": "task_1", "title": "Existing", "status": "active"},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "task_1",
+            "record": {"priority": 10},
+        })
+        # Should succeed — merge on existing skips required field check
+        assert res["ok"] is True
+
+
+# --- Default Value Application (VAL-006 / TV-VAL-007) ---
+
+class TestDefaultValues:
+    @pytest.mark.asyncio
+    async def test_missing_field_gets_default_on_insert(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_default",
+            "record": {"title": "Task 1"},
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "task_default"}])
+        assert task["status"] == "pending"  # default value applied
+
+    @pytest.mark.asyncio
+    async def test_defaults_applied_on_merge_create(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "new_merge",
+            "record": {"title": "Merged"},
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "new_merge"}])
+        assert task["status"] == "pending"
+
+
+# --- Prototype Pollution (VAL-007 / TV-VAL-008) ---
+
+class TestPrototypePollution:
+    @pytest.mark.asyncio
+    async def test_proto_key_rejected(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_hack",
+            "record": {"__proto__": {"isAdmin": True}, "title": "hack"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+        assert "Prototype pollution" in res["error"]["message"]
+        assert "__proto__" in res["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_nested_proto_key_rejected(self):
+        handler, _db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_hack2",
+            "record": {
+                "title": "ok",
+                "details": {"nested": {"__proto__": {"polluted": True}}},
+            },
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+        assert "Prototype pollution" in res["error"]["message"]
+        assert "__proto__" in res["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_constructor_key_rejected(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_con",
+            "record": {"constructor": {"x": 1}, "title": "hack"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+        assert "Prototype pollution" in res["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_batch_proto_pollution_rejected(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "records": [
+                {"id": "t1", "title": "ok"},
+                {"id": "t2", "__proto__": {}, "title": "bad"},
+            ],
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+
+
+# --- ID Length Validation (VAL-009 / TV-VAL-010) ---
+
+class TestIdLength:
+    @pytest.mark.asyncio
+    async def test_oversized_id_rejected(self):
+        handler, db = await _setup(limits={"maxIdLength": 10})
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "a" * 20,
+            "record": {"title": "Task"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+        assert "ID exceeds" in res["error"]["message"]
+
+
+# --- Change Tracking (MUT-005 / TV-MUT-005) ---
+
+class TestChangeTracking:
+    @pytest.mark.asyncio
+    async def test_insert_writes_change_record(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "id": "task_ct",
+            "record": {"title": "Tracked"},
+        })
+        assert res["ok"] is True
+        changes = await db.find_many("__datafn_changes", [])
+        assert len(changes) == 1
+        assert changes[0]["table"] == "tasks"
+        assert changes[0]["operation"] == "insert"
+        assert changes[0]["recordId"] == "task_ct"
+
+    @pytest.mark.asyncio
+    async def test_merge_update_writes_change(self):
+        handler, db = await _setup([
+            {"id": "task_1", "title": "Old"},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "task_1",
+            "record": {"title": "New"},
+        })
+        assert res["ok"] is True
+        changes = await db.find_many("__datafn_changes", [])
+        assert len(changes) == 1
+        assert changes[0]["operation"] == "update"
+
+    @pytest.mark.asyncio
+    async def test_delete_writes_change(self):
+        handler, db = await _setup([
+            {"id": "task_1", "title": "To Delete"},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "delete", "id": "task_1",
+        })
+        assert res["ok"] is True
+        changes = await db.find_many("__datafn_changes", [])
+        assert len(changes) == 1
+        assert changes[0]["operation"] == "delete"
+
+    @pytest.mark.asyncio
+    async def test_batch_insert_writes_changes(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "records": [
+                {"id": "t1", "title": "A"},
+                {"id": "t2", "title": "B"},
+            ],
+        })
+        assert res["ok"] is True
+        changes = await db.find_many("__datafn_changes", [])
+        assert len(changes) == 2
+
+
+# --- Idempotent Delete (MUT-006 / TV-MUT-006) ---
+
+class TestIdempotentDelete:
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_succeeds(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "delete", "id": "nonexistent_id",
+        })
+        assert res["ok"] is True
+        assert res["result"]["affectedIds"] == []
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_no_change_tracking(self):
+        handler, db = await _setup()
+        await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "delete", "id": "nonexistent_id",
+        })
+        changes = await db.find_many("__datafn_changes", [])
+        assert len(changes) == 0
+
+
+# --- Result Structure (MUT-008 / TV-MUT-008) ---
+
+class TestResultStructure:
+    @pytest.mark.asyncio
+    async def test_result_has_all_fields(self):
+        handler, db = await _setup()
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "clientId": "c1",
+            "mutationId": "mut_xyz",
+            "id": "task_1",
+            "record": {"title": "Task 1"},
+        })
+        assert res["ok"] is True
+        result = res["result"]
+        assert result["ok"] is True
+        assert result["mutationId"] == "mut_xyz"
+        assert result["affectedIds"] == ["task_1"]
+        assert result["deduped"] is False
+        assert result["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_deduped_true_on_cache_hit(self):
+        handler, db = await _setup()
+        payload = {
+            "resource": "tasks", "version": 1,
+            "operation": "insert",
+            "clientId": "c1",
+            "mutationId": "m1",
+            "id": "task_1",
+            "record": {"title": "Task 1"},
+        }
+        # First call
+        await handler({}, payload)
+        # Second call (cache hit)
+        res2 = await handler({}, payload)
+        assert res2["ok"] is True
+        assert res2["result"]["deduped"] is True

--- a/datafn/python/tests/test_parity.py
+++ b/datafn/python/tests/test_parity.py
@@ -1,0 +1,166 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+# Schema for parity tests
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [{"name": "title"}, {"name": "status"}]},
+        {"name": "__datafn_idempotency", "fields": [{"name": "clientId"}, {"name": "mutationId"}, {"name": "result"}]}
+    ],
+    "relations": []
+}
+
+@pytest.mark.asyncio
+async def test_parity_response_format():
+    """
+    Ensure response format matches TS: { ok: bool, result?: ..., error?: ... }
+    """
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/query"]
+    
+    # Valid query
+    res = await handler({}, {"resource": "tasks", "version": 1})
+    assert "ok" in res
+    assert res["ok"] is True
+    assert "result" in res
+    assert "data" in res["result"]
+    assert "nextCursor" in res["result"]
+
+@pytest.mark.asyncio
+async def test_parity_error_format():
+    """
+    Ensure error format matches TS: { ok: False, error: { code, message, details: { path } } }
+    """
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/query"]
+    
+    # Invalid resource
+    res = await handler({}, {"resource": "unknown", "version": 1})
+    assert res["ok"] is False
+    assert "error" in res
+    assert "code" in res["error"]
+    assert res["error"]["code"] == "DFQL_UNKNOWN_RESOURCE"
+    assert "details" in res["error"]
+    assert "path" in res["error"]["details"]
+
+@pytest.mark.asyncio
+async def test_parity_idempotency_persistence():
+    """
+    TV-PY-IDEMP-PERSIST-001: Idempotency is persisted to DB.
+    """
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/mutation"]
+    
+    payload = {
+        "resource": "tasks",
+        "version": 1,
+        "operation": "insert",
+        "clientId": "client-parity",
+        "mutationId": "mut-parity-1",
+        "id": "t1",
+        "record": {"title": "Task 1"}
+    }
+    
+    # 1. Execute
+    await handler({}, payload)
+    
+    # 2. Check DB directly
+    # __datafn_idempotency table should have record
+    recs = await db.find_many("__datafn_idempotency", [])
+    assert len(recs) == 1
+    assert recs[0]["clientId"] == "client-parity"
+    assert recs[0]["mutationId"] == "mut-parity-1"
+    
+    # 3. Replay
+    res2 = await handler({}, payload)
+    assert res2["result"]["deduped"] is True
+
+@pytest.mark.asyncio
+async def test_transact_parity():
+    """
+    Contract test for Transact.
+    Ensures output structure matches expected TS format.
+    """
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/transact"]
+    
+    payload = {
+        "atomic": True,
+        "steps": [
+            {
+                "mutation": {
+                    "resource": "tasks",
+                    "operation": "insert",
+                    "clientId": "c1",
+                    "mutationId": "m1",
+                    "id": "t1",
+                    "record": {"title": "Task 1"}
+                }
+            }
+        ]
+    }
+    
+    res = await handler({}, payload)
+    assert res["ok"] is True
+    assert "result" in res
+    assert res["result"]["ok"] is True
+    assert isinstance(res["result"]["results"], list)
+    assert len(res["result"]["results"]) == 1
+    
+    # Inner result check
+    inner = res["result"]["results"][0]
+    assert inner["ok"] is True
+    assert inner["mutationId"] == "m1"
+
+@pytest.mark.asyncio
+async def test_sync_parity():
+    """
+    Contract test for Sync endpoints (seed, clone, pull, push).
+    """
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    
+    # Seed
+    seed_handler = server["routes"]["POST /datafn/seed"]
+    res_seed = await seed_handler({}, {"clientId": "c1"})
+    assert res_seed["ok"] is True
+    
+    # Push
+    push_handler = server["routes"]["POST /datafn/push"]
+    res_push = await push_handler({}, {
+        "clientId": "c1",
+        "mutations": [{
+            "resource": "tasks", 
+            "version": "1", 
+            "clientId": "c1", 
+            "mutationId": "m1", 
+            "operation": "insert", 
+            "id": "t1", 
+            "record": {"title": "T1"}
+        }]
+    })
+    assert res_push["ok"] is True
+    assert "result" in res_push
+    assert "applied" in res_push["result"]
+    assert "errors" in res_push["result"]
+    
+    # Clone
+    clone_handler = server["routes"]["POST /datafn/clone"]
+    res_clone = await clone_handler({}, {"clientId": "c2", "tables": ["tasks"]})
+    assert res_clone["ok"] is True
+    assert "data" in res_clone["result"]
+    assert "cursors" in res_clone["result"]
+    assert isinstance(res_clone["result"]["data"], dict)
+    
+    # Pull
+    pull_handler = server["routes"]["POST /datafn/pull"]
+    res_pull = await pull_handler({}, {"clientId": "c2", "cursors": {}})
+    assert res_pull["ok"] is True
+    assert "records" in res_pull["result"]
+    assert "deleted" in res_pull["result"]
+    assert "cursors" in res_pull["result"]

--- a/datafn/python/tests/test_query.py
+++ b/datafn/python/tests/test_query.py
@@ -1,0 +1,43 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [{"name": "title"}, {"name": "status"}]}
+    ],
+    "relations": []
+}
+
+@pytest.mark.asyncio
+async def test_query_valid():
+    db = MockAdapter()
+    await db.create("tasks", {"id": "1", "title": "Task 1"})
+    
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/query"]
+    
+    res = await handler({}, {"resource": "tasks", "version": 1, "select": ["title"]})
+    
+    assert res["ok"] is True
+    assert len(res["result"]["data"]) == 1
+    assert res["result"]["data"][0]["title"] == "Task 1"
+
+@pytest.mark.asyncio
+async def test_query_invalid_json():
+    # Caller should parse JSON. If passed not dict:
+    server = create_datafn_server({"schema": schema, "db": MockAdapter()})
+    handler = server["routes"]["POST /datafn/query"]
+    
+    res = await handler({}, "invalid")
+    assert res["ok"] is False
+    assert res["error"]["code"] == "DFQL_INVALID"
+
+@pytest.mark.asyncio
+async def test_query_unknown_resource():
+    server = create_datafn_server({"schema": schema, "db": MockAdapter()})
+    handler = server["routes"]["POST /datafn/query"]
+    
+    res = await handler({}, {"resource": "unknown", "version": 1})
+    assert res["ok"] is False
+    assert res["error"]["code"] == "DFQL_UNKNOWN_RESOURCE"

--- a/datafn/python/tests/test_query_enhanced.py
+++ b/datafn/python/tests/test_query_enhanced.py
@@ -1,0 +1,381 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "status", "type": "string"},
+            {"name": "priority", "type": "number"},
+            {"name": "description", "type": "string"},
+        ]}
+    ],
+    "relations": [],
+}
+
+
+async def _setup(records=None, limits=None):
+    db = MockAdapter()
+    if records:
+        for r in records:
+            await db.create("tasks", r)
+    config = {"schema": schema, "db": db}
+    if limits:
+        config["limits"] = limits
+    server = create_datafn_server(config)
+    return server["routes"]["POST /datafn/query"]
+
+
+# --- Default Sort (SORT-003 / TV-SORT-004) ---
+
+class TestDefaultSort:
+    @pytest.mark.asyncio
+    async def test_no_sort_defaults_to_id_asc(self):
+        handler = await _setup([
+            {"id": "c", "title": "C"},
+            {"id": "a", "title": "A"},
+            {"id": "b", "title": "B"},
+        ])
+        res = await handler({}, {"resource": "tasks", "version": 1})
+        assert res["ok"] is True
+        ids = [r["id"] for r in res["result"]["data"]]
+        assert ids == ["a", "b", "c"]
+
+
+# --- Forward Cursor (QRY-001 / TV-QRY-001) ---
+
+class TestForwardCursor:
+    @pytest.mark.asyncio
+    async def test_cursor_after(self):
+        handler = await _setup([
+            {"id": "task_1", "title": "T1", "priority": 8},
+            {"id": "task_2", "title": "T2", "priority": 5},
+            {"id": "task_3", "title": "T3", "priority": 5},
+            {"id": "task_4", "title": "T4", "priority": 3},
+            {"id": "task_5", "title": "T5", "priority": 1},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "sort": ["priority:desc", "id"],
+            "limit": 2,
+            "cursor": {"after": {"priority": 5, "id": "task_3"}},
+        })
+        assert res["ok"] is True
+        ids = [r["id"] for r in res["result"]["data"]]
+        assert ids == ["task_4", "task_5"]
+        assert res["result"]["nextCursor"] is None
+
+    @pytest.mark.asyncio
+    async def test_cursor_after_with_more(self):
+        handler = await _setup([
+            {"id": f"t{i}", "title": f"Task {i}", "priority": i}
+            for i in range(1, 6)
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "sort": ["id"],
+            "limit": 2,
+            "cursor": {"after": {"id": "t1"}},
+        })
+        assert res["ok"] is True
+        ids = [r["id"] for r in res["result"]["data"]]
+        assert ids == ["t2", "t3"]
+        assert res["result"]["nextCursor"] is not None
+
+
+# --- Backward Cursor (QRY-002 / TV-QRY-002) ---
+
+class TestBackwardCursor:
+    @pytest.mark.asyncio
+    async def test_cursor_before(self):
+        handler = await _setup([
+            {"id": "task_1", "title": "T1"},
+            {"id": "task_2", "title": "T2"},
+            {"id": "task_3", "title": "T3"},
+            {"id": "task_4", "title": "T4"},
+            {"id": "task_5", "title": "T5"},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "sort": ["id"],
+            "limit": 2,
+            "cursor": {"before": {"id": "task_4"}},
+        })
+        assert res["ok"] is True
+        ids = [r["id"] for r in res["result"]["data"]]
+        assert ids == ["task_2", "task_3"]
+
+
+# --- nextCursor (QRY-003 / TV-QRY-003) ---
+
+class TestNextCursor:
+    @pytest.mark.asyncio
+    async def test_next_cursor_present(self):
+        handler = await _setup([
+            {"id": f"task_{i}", "title": f"T{i}"}
+            for i in range(1, 6)
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "limit": 2,
+        })
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 2
+        assert res["result"]["nextCursor"] is not None
+        assert res["result"]["nextCursor"]["id"] == "task_2"
+
+    @pytest.mark.asyncio
+    async def test_next_cursor_null_at_end(self):
+        handler = await _setup([
+            {"id": "task_1", "title": "T1"},
+            {"id": "task_2", "title": "T2"},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "limit": 5,
+        })
+        assert res["ok"] is True
+        assert res["result"]["nextCursor"] is None
+
+
+# --- Offset (QRY-004 / TV-QRY-004) ---
+
+class TestOffset:
+    @pytest.mark.asyncio
+    async def test_offset_pagination(self):
+        handler = await _setup([
+            {"id": f"task_{i}", "title": f"T{i}"}
+            for i in range(1, 6)
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "limit": 2, "offset": 2,
+        })
+        assert res["ok"] is True
+        ids = [r["id"] for r in res["result"]["data"]]
+        assert ids == ["task_3", "task_4"]
+
+
+# --- Limit Clamping (QRY-005 / TV-QRY-005) ---
+
+class TestLimitClamping:
+    @pytest.mark.asyncio
+    async def test_limit_clamped_to_max(self):
+        handler = await _setup(
+            [{"id": f"t{i}", "title": f"T{i}"} for i in range(1, 11)],
+            limits={"maxLimit": 3},
+        )
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "limit": 100,
+        })
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_no_limit_uses_max(self):
+        handler = await _setup(
+            [{"id": f"t{i}", "title": f"T{i}"} for i in range(1, 11)],
+            limits={"maxLimit": 5},
+        )
+        res = await handler({}, {"resource": "tasks", "version": 1})
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 5
+
+
+# --- Count (QRY-006 / TV-QRY-006) ---
+
+class TestCount:
+    @pytest.mark.asyncio
+    async def test_count_with_limit(self):
+        handler = await _setup([
+            {"id": f"t{i}", "title": f"T{i}"}
+            for i in range(1, 11)
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "count": True, "limit": 2,
+        })
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 2
+        assert res["result"]["count"] == 10
+
+    @pytest.mark.asyncio
+    async def test_count_not_present_when_false(self):
+        handler = await _setup([{"id": "t1", "title": "T1"}])
+        res = await handler({}, {"resource": "tasks", "version": 1})
+        assert "count" not in res["result"]
+
+
+# --- Aggregation (QRY-007 / TV-QRY-007) ---
+
+class TestAggregation:
+    @pytest.mark.asyncio
+    async def test_group_by_with_aggregation(self):
+        handler = await _setup([
+            {"id": "1", "title": "T1", "status": "active", "priority": 5},
+            {"id": "2", "title": "T2", "status": "active", "priority": 3},
+            {"id": "3", "title": "T3", "status": "closed", "priority": 1},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "groupBy": ["status"],
+            "aggregations": {"total": {"count": "*"}, "avgPriority": {"avg": "priority"}},
+        })
+        assert res["ok"] is True
+        data = res["result"]["data"]
+        active = next(r for r in data if r["status"] == "active")
+        closed = next(r for r in data if r["status"] == "closed")
+        assert active["total"] == 2
+        assert active["avgPriority"] == 4.0
+        assert closed["total"] == 1
+        assert closed["avgPriority"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_aggregation_without_group_by(self):
+        handler = await _setup([
+            {"id": "1", "title": "T1", "priority": 10},
+            {"id": "2", "title": "T2", "priority": 20},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "aggregations": {"total": {"count": "*"}, "sumPriority": {"sum": "priority"}},
+        })
+        assert res["ok"] is True
+        row = res["result"]["data"][0]
+        assert row["total"] == 2
+        assert row["sumPriority"] == 30
+
+    @pytest.mark.asyncio
+    async def test_having_filter(self):
+        handler = await _setup([
+            {"id": "1", "title": "T1", "status": "active", "priority": 5},
+            {"id": "2", "title": "T2", "status": "active", "priority": 3},
+            {"id": "3", "title": "T3", "status": "closed", "priority": 1},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "groupBy": ["status"],
+            "aggregations": {"total": {"count": "*"}},
+            "having": {"total": {"$gte": 2}},
+        })
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 1
+        assert res["result"]["data"][0]["status"] == "active"
+
+
+# --- Select/Omit (QRY-008, SEL-002 / TV-SEL-002, TV-SEL-003) ---
+
+class TestSelectOmit:
+    @pytest.mark.asyncio
+    async def test_select_whitelist(self):
+        handler = await _setup([
+            {"id": "1", "title": "Task 1", "description": "desc", "priority": 5},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "select": ["id", "title"],
+        })
+        assert res["ok"] is True
+        record = res["result"]["data"][0]
+        assert set(record.keys()) == {"id", "title"}
+
+    @pytest.mark.asyncio
+    async def test_omit_blacklist(self):
+        handler = await _setup([
+            {"id": "1", "title": "Task 1", "description": "desc", "priority": 5},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "omit": ["description"],
+        })
+        assert res["ok"] is True
+        record = res["result"]["data"][0]
+        assert "description" not in record
+        assert "title" in record
+
+    @pytest.mark.asyncio
+    async def test_select_and_omit_together_error(self):
+        handler = await _setup([{"id": "1", "title": "T1"}])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "select": ["title"],
+            "omit": ["description"],
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+
+
+# --- Cursor Sort Validation (QRY-009 / TV-QRY-008) ---
+
+class TestCursorSortValidation:
+    @pytest.mark.asyncio
+    async def test_cursor_auto_appends_id(self):
+        handler = await _setup([
+            {"id": "1", "title": "T1", "priority": 5},
+            {"id": "2", "title": "T2", "priority": 3},
+        ])
+        # Sort without id — should auto-append
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "sort": ["priority"],
+            "cursor": {"after": {"priority": 5, "id": "1"}},
+            "limit": 10,
+        })
+        assert res["ok"] is True
+
+
+# --- Query Limits (VAL-008 / TV-VAL-009) ---
+
+class TestQueryLimits:
+    @pytest.mark.asyncio
+    async def test_max_select_tokens(self):
+        handler = await _setup([], limits={"maxSelectTokens": 3})
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "select": ["id", "title", "status", "priority"],
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "LIMIT_EXCEEDED"
+
+    @pytest.mark.asyncio
+    async def test_max_sort_fields(self):
+        handler = await _setup([], limits={"maxSortFields": 1})
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "sort": ["title", "priority"],
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "LIMIT_EXCEEDED"
+
+
+# --- Filtering ---
+
+class TestFiltering:
+    @pytest.mark.asyncio
+    async def test_filter_eq(self):
+        handler = await _setup([
+            {"id": "1", "title": "T1", "status": "active"},
+            {"id": "2", "title": "T2", "status": "closed"},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "filters": {"status": {"$eq": "active"}},
+        })
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 1
+        assert res["result"]["data"][0]["id"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_filter_with_non_prefixed_ops(self):
+        handler = await _setup([
+            {"id": "1", "title": "T1", "priority": 5},
+            {"id": "2", "title": "T2", "priority": 3},
+        ])
+        res = await handler({}, {
+            "resource": "tasks", "version": 1,
+            "filters": {"priority": {"gte": 5}},
+        })
+        assert res["ok"] is True
+        assert len(res["result"]["data"]) == 1

--- a/datafn/python/tests/test_server.py
+++ b/datafn/python/tests/test_server.py
@@ -1,0 +1,40 @@
+import pytest
+from datafn.server import create_datafn_server, DatafnError
+from .mock_db import MockAdapter
+
+def test_tv_py_001_routes_exposed():
+    """
+    TV-PY-001: Python server SDK exposes /datafn/* routes.
+    """
+    schema = {
+        "resources": [
+            {"name": "task", "version": 1, "fields": []}
+        ],
+        "relations": []
+    }
+
+    # Pass config dict
+    result = create_datafn_server({"schema": schema, "db": MockAdapter()})
+    
+    routes = result["routes"].keys()
+    
+    # Map "POST /datafn/query" -> "/datafn/query" for checking
+    route_paths = [r.split(" ")[1] for r in routes]
+    
+    expected_routes = [
+        # "/datafn/status", # Status not implemented yet?
+        "/datafn/query", 
+        "/datafn/mutation", 
+        "/datafn/transact", 
+        "/datafn/seed", 
+        "/datafn/clone", 
+        "/datafn/pull", 
+        "/datafn/push"
+    ]
+    
+    for route in expected_routes:
+        assert route in route_paths
+
+# Schema validation on creation not implemented yet.
+# def test_tv_py_002_invalid_schema_rejection():
+#     ...

--- a/datafn/python/tests/test_spv2_parity.py
+++ b/datafn/python/tests/test_spv2_parity.py
@@ -1,0 +1,281 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+
+class LogCollector:
+    def __init__(self):
+        self.events = []
+
+    def _push(self, level, message, context=None):
+        self.events.append({"level": level, "message": message, "context": context or {}})
+
+    def info(self, message, context=None):
+        self._push("info", message, context)
+
+    def warn(self, message, context=None):
+        self._push("warn", message, context)
+
+    def error(self, message, context=None):
+        self._push("error", message, context)
+
+    def debug(self, message, context=None):
+        self._push("debug", message, context)
+
+
+SCHEMA = {
+    "resources": [
+        {
+            "name": "notes",
+            "version": 1,
+            "capabilities": [
+                {"shareable": {"levels": ["viewer", "editor", "owner"], "default": "private"}}
+            ],
+            "permissions": {
+                "read": {"fields": ["id", "title"]},
+                "write": {"fields": ["title"]},
+            },
+            "fields": [{"name": "title", "type": "string", "required": True}],
+        },
+        {
+            "name": "privateNotes",
+            "version": 1,
+            "capabilities": [
+                {"shareable": {"levels": ["viewer", "editor", "owner"], "default": "private"}}
+            ],
+            "fields": [{"name": "title", "type": "string", "required": True}],
+        },
+        {
+            "name": "cycleLogs",
+            "version": 1,
+            "fields": [
+                {"name": "symptoms", "type": "string"},
+                {"name": "mood", "type": "string"},
+            ],
+        },
+    ],
+    "relations": [],
+}
+
+
+def _ctx(actor):
+    return {"namespace": "user:owner", "actorId": actor}
+
+
+@pytest.mark.asyncio
+async def test_tv_py_001_p_owner_allow_viewer_deny_for_share():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": SCHEMA, "db": db})
+    mutation = server["routes"]["POST /datafn/mutation"]
+
+    seed = await mutation(_ctx("owner"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "insert",
+        "clientId": "c-py-1",
+        "mutationId": "m-seed",
+        "id": "n1",
+        "record": {"title": "Owner note"},
+    })
+    assert seed["ok"] is True
+
+    owner_share = await mutation(_ctx("owner"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "share",
+        "clientId": "c-py-1",
+        "mutationId": "m-owner-share",
+        "id": "n1",
+        "shareWith": {"principalId": "user:viewer", "level": "viewer"},
+    })
+    assert owner_share["ok"] is True
+
+    viewer_share = await mutation(_ctx("viewer"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "share",
+        "clientId": "c-py-1",
+        "mutationId": "m-viewer-share",
+        "id": "n1",
+        "shareWith": {"principalId": "user:eve", "level": "viewer"},
+    })
+    assert viewer_share["ok"] is False
+    assert viewer_share["error"]["code"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_tv_py_001_n_private_shareable_missing_permissions_denied_by_default():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": SCHEMA, "db": db})
+    mutation = server["routes"]["POST /datafn/mutation"]
+
+    res = await mutation(_ctx("eve"), {
+        "resource": "privateNotes",
+        "version": 1,
+        "operation": "merge",
+        "clientId": "c-py-1n",
+        "mutationId": "m-py-1n",
+        "id": "pn1",
+        "record": {"title": "Should not allow"},
+    })
+
+    assert res["ok"] is False
+    assert res["error"]["code"] == "FORBIDDEN"
+    assert res["error"]["message"] == "Access denied: resource requires explicit permissions"
+    assert res["error"]["details"]["path"] == "python.authz"
+
+
+@pytest.mark.asyncio
+async def test_sync_actor_visible_filtering_and_backfill_revoke():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": SCHEMA, "db": db})
+    mutation = server["routes"]["POST /datafn/mutation"]
+    clone = server["routes"]["POST /datafn/clone"]
+    pull = server["routes"]["POST /datafn/pull"]
+    push = server["routes"]["POST /datafn/push"]
+
+    await mutation(_ctx("owner"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "insert",
+        "clientId": "c-sync",
+        "mutationId": "m-sync-seed",
+        "id": "n-historical",
+        "record": {"title": "Historical"},
+    })
+
+    baseline_pull = await pull(_ctx("viewer"), {"clientId": "viewer-client", "cursors": {"notes": "0"}})
+    assert baseline_pull["ok"] is True
+    assert baseline_pull["result"].get("records", {}).get("notes", []) == []
+    baseline_cursor = baseline_pull["result"].get("cursors", {}).get("notes", "0")
+
+    share = await mutation(_ctx("owner"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "share",
+        "clientId": "c-sync",
+        "mutationId": "m-sync-share",
+        "id": "n-historical",
+        "shareWith": {"principalId": "user:viewer", "level": "viewer"},
+    })
+    assert share["ok"] is True
+
+    clone_res = await clone(_ctx("viewer"), {"clientId": "viewer-client", "tables": ["notes"]})
+    assert clone_res["ok"] is True
+    assert [row["id"] for row in clone_res["result"]["data"].get("notes", [])] == ["n-historical"]
+
+    backfill_pull = await pull(
+        _ctx("viewer"),
+        {"clientId": "viewer-client", "cursors": {"notes": baseline_cursor}},
+    )
+    assert backfill_pull["ok"] is True
+    assert [row["id"] for row in backfill_pull["result"].get("records", {}).get("notes", [])] == ["n-historical"]
+    post_share_cursor = backfill_pull["result"].get("cursors", {}).get("notes", baseline_cursor)
+
+    # viewer cannot mutate non-editor private record via push
+    viewer_push = await push(_ctx("viewer"), {
+        "clientId": "viewer-client",
+        "mutations": [
+            {
+                "resource": "notes",
+                "version": 1,
+                "operation": "merge",
+                "clientId": "viewer-client",
+                "mutationId": "m-viewer-merge",
+                "id": "n-historical",
+                "record": {"title": "Viewer edit"},
+            }
+        ],
+    })
+    assert viewer_push["ok"] is True
+    assert viewer_push["result"]["errors"][0]["error"]["code"] == "FORBIDDEN"
+
+    unshare = await mutation(_ctx("owner"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "unshare",
+        "clientId": "c-sync",
+        "mutationId": "m-sync-unshare",
+        "id": "n-historical",
+        "shareWith": {"principalId": "user:viewer"},
+    })
+    assert unshare["ok"] is True
+
+    revoke_pull = await pull(
+        _ctx("viewer"),
+        {"clientId": "viewer-client", "cursors": {"notes": post_share_cursor}},
+    )
+    assert revoke_pull["ok"] is True
+    assert "n-historical" in revoke_pull["result"].get("deleted", {}).get("notes", [])
+
+
+@pytest.mark.asyncio
+async def test_tv_sec_001_p_n_logs_redact_sensitive_payload_and_log_unauthorized_share_context():
+    logger = LogCollector()
+    db = MockAdapter()
+    server = create_datafn_server({"schema": SCHEMA, "db": db, "logger": logger})
+    mutation = server["routes"]["POST /datafn/mutation"]
+
+    insert = await mutation(_ctx("owner"), {
+        "resource": "cycleLogs",
+        "version": 1,
+        "operation": "insert",
+        "clientId": "c-sec",
+        "mutationId": "m-sec-insert",
+        "id": "cl1",
+        "record": {"symptoms": "private", "mood": "private"},
+    })
+    assert insert["ok"] is True
+
+    contexts_blob = "\n".join(str(event.get("context", {})) for event in logger.events)
+    assert "private detail" not in contexts_blob
+    assert "'symptoms': 'private'" not in contexts_blob
+    assert "'mood': 'private'" not in contexts_blob
+
+    request_events = [
+        event for event in logger.events
+        if event["message"] == "Mutation request" and event["context"].get("resource") == "cycleLogs"
+    ]
+    assert request_events
+    assert all("record" not in event["context"] for event in request_events)
+
+    # Seed a private note and share viewer access.
+    await mutation(_ctx("owner"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "insert",
+        "clientId": "c-sec",
+        "mutationId": "m-sec-note",
+        "id": "n-sec",
+        "record": {"title": "Sec note"},
+    })
+    await mutation(_ctx("owner"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "share",
+        "clientId": "c-sec",
+        "mutationId": "m-sec-share",
+        "id": "n-sec",
+        "shareWith": {"principalId": "user:viewer", "level": "viewer"},
+    })
+
+    # Unauthorized share attempt should emit security context log.
+    denied_share = await mutation(_ctx("viewer"), {
+        "resource": "notes",
+        "version": 1,
+        "operation": "share",
+        "clientId": "c-sec",
+        "mutationId": "m-sec-denied",
+        "id": "n-sec",
+        "shareWith": {"principalId": "user:eve", "level": "viewer"},
+    })
+    assert denied_share["ok"] is False
+
+    security_logs = [event for event in logger.events if event["message"] == "Unauthorized share access"]
+    assert security_logs
+    assert any(
+        event["context"].get("actorId") == "viewer"
+        and event["context"].get("resource") == "notes"
+        and event["context"].get("recordId") == "n-sec"
+        for event in security_logs
+    )

--- a/datafn/python/tests/test_sync.py
+++ b/datafn/python/tests/test_sync.py
@@ -1,0 +1,139 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [{"name": "title"}, {"name": "status"}]},
+        # Tables for sync (implicit or explicit in schema?)
+        # datafn code doesn't check schema for __datafn tables unless we call validate_resource on them?
+        # Handlers access them directly via DB.
+        # But if we use validate_resource on user tables, they must be in schema.
+    ],
+    "relations": []
+}
+
+@pytest.mark.asyncio
+async def test_seed():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/seed"]
+    
+    # 1. First Seed
+    res = await handler({}, {"clientId": "c1"})
+    assert res["ok"] is True
+    
+    # Check DB
+    seeds = await db.find_many("__datafn_seed", [])
+    assert len(seeds) == 1
+    assert seeds[0]["id"] == "c1"
+    
+    # 2. Repeated Seed
+    res2 = await handler({}, {"clientId": "c1"})
+    assert res2["ok"] is True
+    
+    # DB still has 1
+    seeds = await db.find_many("__datafn_seed", [])
+    assert len(seeds) == 1
+
+@pytest.mark.asyncio
+async def test_push_and_change_tracking():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    push_handler = server["routes"]["POST /datafn/push"]
+    
+    # Push a mutation
+    payload = {
+        "clientId": "c1",
+        "mutations": [
+            {
+                "resource": "tasks",
+                "version": "1",
+                "clientId": "c1",
+                "mutationId": "m1",
+                "operation": "insert",
+                "id": "t1",
+                "record": {"title": "Task 1"}
+            }
+        ]
+    }
+    
+    res = await push_handler({}, payload)
+    assert res["ok"] is True
+    assert res["result"]["applied"] == ["m1"]
+    
+    # Verify Data
+    tasks = await db.find_many("tasks", [])
+    assert len(tasks) == 1
+    assert tasks[0]["title"] == "Task 1"
+    
+    # Verify Change Tracking
+    changes = await db.find_many("__datafn_changes", [])
+    assert len(changes) == 1
+    assert changes[0]["table"] == "tasks"
+    assert changes[0]["operation"] == "insert"
+    assert changes[0]["recordId"] == "t1"
+    assert changes[0]["serverSeq"] > 0
+    
+    # Verify Server Seq Table
+    seqs = await db.find_many("__datafn_server_seq", [])
+    assert len(seqs) == 1
+    assert seqs[0]["seq"] >= 1
+
+@pytest.mark.asyncio
+async def test_pull():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    push_handler = server["routes"]["POST /datafn/push"]
+    pull_handler = server["routes"]["POST /datafn/pull"]
+    
+    # 1. Push data
+    await push_handler({}, {
+        "clientId": "c1",
+        "mutations": [
+            {"resource": "tasks", "version": "1", "clientId": "c1", "mutationId": "m1", "operation": "insert", "id": "t1", "record": {"title": "T1"}},
+            {"resource": "tasks", "version": "1", "clientId": "c1", "mutationId": "m2", "operation": "insert", "id": "t2", "record": {"title": "T2"}}
+        ]
+    })
+    
+    # 2. Pull from beginning
+    res = await pull_handler({}, {"clientId": "c2", "cursors": {}})
+    assert res["ok"] is True
+    data = res["result"]
+    
+    assert len(data["records"]["tasks"]) == 2
+    assert "t1" in [r["id"] for r in data["records"]["tasks"]]
+    assert "t2" in [r["id"] for r in data["records"]["tasks"]]
+    
+    cursor = data["cursors"]["tasks"]
+    assert int(cursor) >= 2
+    
+    # 3. Pull from cursor
+    res2 = await pull_handler({}, {"clientId": "c2", "cursors": {"tasks": cursor}})
+    assert res2["ok"] is True
+    # Should be empty
+    if "tasks" in res2["result"]["records"]:
+         assert len(res2["result"]["records"]["tasks"]) == 0
+
+@pytest.mark.asyncio
+async def test_clone():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    push_handler = server["routes"]["POST /datafn/push"]
+    clone_handler = server["routes"]["POST /datafn/clone"]
+    
+    # 1. Push data
+    await push_handler({}, {
+        "clientId": "c1",
+        "mutations": [
+            {"resource": "tasks", "version": "1", "clientId": "c1", "mutationId": "m1", "operation": "insert", "id": "t1", "record": {"title": "T1"}}
+        ]
+    })
+    
+    # 2. Clone
+    res = await clone_handler({}, {"clientId": "c2", "tables": ["tasks"]})
+    assert res["ok"] is True
+    
+    assert len(res["result"]["data"]["tasks"]) == 1
+    assert res["result"]["data"]["tasks"][0]["title"] == "T1"
+    assert "tasks" in res["result"]["cursors"]

--- a/datafn/python/tests/test_sync_batch.py
+++ b/datafn/python/tests/test_sync_batch.py
@@ -1,0 +1,152 @@
+"""
+Phase 09: Batch record fetching tests (PY-001)
+Test vector: TV-PY-BATCH-001
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+
+schema = {
+    "resources": [
+        {"name": "task", "fields": [{"name": "title"}, {"name": "status"}]},
+    ],
+    "relations": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_pull_uses_batch_fetch():
+    """
+    TV-PY-BATCH-001: handle_pull fetches records with a single batch find_many
+    using IN filter instead of N individual find_one calls.
+    """
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    push_handler = server["routes"]["POST /datafn/push"]
+    pull_handler = server["routes"]["POST /datafn/pull"]
+
+    # Push 5 mutations to create records and change log entries
+    mutations = []
+    for i in range(1, 6):
+        mutations.append({
+            "clientId": "c1",
+            "mutationId": f"m{i}",
+            "operation": "insert",
+            "resource": "task",
+            "id": f"task-{i}",
+            "record": {"title": f"Task {i}", "status": "active"},
+        })
+
+    push_res = await push_handler({}, {
+        "clientId": "c1",
+        "mutations": mutations,
+    })
+    assert push_res["ok"] is True
+
+    # Wrap find_many to track calls
+    original_find_many = db.find_many
+    find_many_calls = []
+
+    async def tracked_find_many(model, where, **kwargs):
+        find_many_calls.append({"model": model, "where": where, "kwargs": kwargs})
+        return await original_find_many(model, where, **kwargs)
+
+    db.find_many = tracked_find_many
+
+    # Now pull
+    pull_res = await pull_handler({}, {
+        "clientId": "c2",
+        "cursors": {},
+    })
+
+    assert pull_res["ok"] is True
+    result = pull_res["result"]
+    records = result.get("records", {})
+
+    # Should have task records
+    assert "task" in records
+    assert len(records["task"]) == 5
+
+    # Verify batch fetch: there should be a find_many call to "task" with an IN filter
+    task_find_many_calls = [
+        c for c in find_many_calls
+        if c["model"] == "task"
+    ]
+    assert len(task_find_many_calls) == 1, (
+        f"Expected exactly 1 find_many call to 'task', got {len(task_find_many_calls)}. "
+        f"N+1 pattern not eliminated."
+    )
+
+    # Verify the call used IN operator
+    where_clauses = task_find_many_calls[0]["where"]
+    assert any(
+        w.get("operator") == "in" and w.get("field") == "id"
+        for w in where_clauses
+    ), "Expected find_many to use 'in' operator on 'id' field"
+
+
+@pytest.mark.asyncio
+async def test_pull_batch_fetch_returns_correct_records():
+    """Batch fetch returns the same records as N+1 would."""
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    push_handler = server["routes"]["POST /datafn/push"]
+    pull_handler = server["routes"]["POST /datafn/pull"]
+
+    # Push 3 records
+    await push_handler({}, {
+        "clientId": "c1",
+        "mutations": [
+            {"clientId": "c1", "mutationId": "m1", "operation": "insert",
+             "resource": "task", "id": "t1", "record": {"title": "A", "status": "active"}},
+            {"clientId": "c1", "mutationId": "m2", "operation": "insert",
+             "resource": "task", "id": "t2", "record": {"title": "B", "status": "done"}},
+            {"clientId": "c1", "mutationId": "m3", "operation": "insert",
+             "resource": "task", "id": "t3", "record": {"title": "C", "status": "active"}},
+        ],
+    })
+
+    pull_res = await pull_handler({}, {
+        "clientId": "c2",
+        "cursors": {},
+    })
+
+    assert pull_res["ok"] is True
+    records = pull_res["result"]["records"]["task"]
+    ids = {r["id"] for r in records}
+    assert ids == {"t1", "t2", "t3"}
+
+
+@pytest.mark.asyncio
+async def test_pull_handles_deletes_correctly():
+    """Deleted records appear in deleted, not records."""
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    push_handler = server["routes"]["POST /datafn/push"]
+    pull_handler = server["routes"]["POST /datafn/pull"]
+
+    # Insert then delete
+    await push_handler({}, {
+        "clientId": "c1",
+        "mutations": [
+            {"clientId": "c1", "mutationId": "m1", "operation": "insert",
+             "resource": "task", "id": "t1", "record": {"title": "A", "status": "active"}},
+            {"clientId": "c1", "mutationId": "m2", "operation": "delete",
+             "resource": "task", "id": "t1", "record": {}},
+        ],
+    })
+
+    pull_res = await pull_handler({}, {
+        "clientId": "c2",
+        "cursors": {},
+    })
+
+    assert pull_res["ok"] is True
+    result = pull_res["result"]
+    deleted = result.get("deleted", {})
+    # t1 was deleted, so it should appear in deleted
+    assert "task" in deleted
+    assert "t1" in deleted["task"]

--- a/datafn/python/tests/test_sync_enhanced.py
+++ b/datafn/python/tests/test_sync_enhanced.py
@@ -1,0 +1,285 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "status", "type": "string"},
+            {"name": "dueDate", "type": "date"},
+        ]}
+    ],
+    "relations": [],
+}
+
+schema_with_join = {
+    "resources": [
+        {"name": "tasks", "fields": [
+            {"name": "title", "type": "string"},
+        ]},
+        {"name": "tags", "fields": [
+            {"name": "name", "type": "string"},
+        ]},
+    ],
+    "relations": [
+        {
+            "from": "tasks",
+            "to": "tags",
+            "type": "many-many",
+            "relation": "tags",
+            "inverse": "tasks",
+        }
+    ],
+}
+
+
+async def _setup(schema_override=None, limits=None):
+    db = MockAdapter()
+    s = schema_override or schema
+    config = {"schema": s, "db": db}
+    if limits:
+        config["limits"] = limits
+    server = create_datafn_server(config)
+    return server, db
+
+
+# --- SYN-001: Push date coercion ---
+
+class TestPushDateCoercion:
+    @pytest.mark.asyncio
+    async def test_iso_string_coerced_to_epoch_ms(self):
+        server, db = await _setup()
+        push = server["routes"]["POST /datafn/push"]
+        res = await push({}, {
+            "clientId": "c1",
+            "mutations": [{
+                "clientId": "c1",
+                "mutationId": "m1",
+                "operation": "insert",
+                "resource": "tasks",
+                "id": "t1",
+                "record": {"title": "Task", "dueDate": "2024-01-01T00:00:00Z"},
+            }],
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "t1"}])
+        assert task["dueDate"] == 1704067200000
+
+    @pytest.mark.asyncio
+    async def test_epoch_number_unchanged(self):
+        server, db = await _setup()
+        push = server["routes"]["POST /datafn/push"]
+        res = await push({}, {
+            "clientId": "c1",
+            "mutations": [{
+                "clientId": "c1",
+                "mutationId": "m1",
+                "operation": "insert",
+                "resource": "tasks",
+                "id": "t1",
+                "record": {"title": "Task", "dueDate": 1704067200000},
+            }],
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "t1"}])
+        assert task["dueDate"] == 1704067200000
+
+    @pytest.mark.asyncio
+    async def test_non_date_fields_not_modified(self):
+        server, db = await _setup()
+        push = server["routes"]["POST /datafn/push"]
+        res = await push({}, {
+            "clientId": "c1",
+            "mutations": [{
+                "clientId": "c1",
+                "mutationId": "m1",
+                "operation": "insert",
+                "resource": "tasks",
+                "id": "t1",
+                "record": {"title": "Task", "status": "active"},
+            }],
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "t1"}])
+        assert task["title"] == "Task"
+        assert task["status"] == "active"
+
+
+# --- SYN-002: Pull cursor validation ---
+
+class TestPullCursorValidation:
+    @pytest.mark.asyncio
+    async def test_valid_cursor_accepted(self):
+        server, db = await _setup()
+        pull = server["routes"]["POST /datafn/pull"]
+        res = await pull({}, {
+            "clientId": "c1",
+            "cursors": {"tasks": "0"},
+        })
+        assert res["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_cursor_rejected(self):
+        server, db = await _setup()
+        pull = server["routes"]["POST /datafn/pull"]
+        res = await pull({}, {
+            "clientId": "c1",
+            "cursors": {"tasks": "abc"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+        assert "cursor" in res["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_negative_cursor_rejected(self):
+        server, db = await _setup()
+        pull = server["routes"]["POST /datafn/pull"]
+        res = await pull({}, {
+            "clientId": "c1",
+            "cursors": {"tasks": "-1"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "DFQL_INVALID"
+
+
+# --- SYN-003: Pull limit enforcement ---
+
+class TestPullLimit:
+    @pytest.mark.asyncio
+    async def test_pull_limits_changes_with_has_more(self):
+        server, db = await _setup(limits={"maxPullLimit": 2})
+        push = server["routes"]["POST /datafn/push"]
+        pull = server["routes"]["POST /datafn/pull"]
+
+        # Push 5 mutations
+        mutations = []
+        for i in range(1, 6):
+            mutations.append({
+                "clientId": "c1",
+                "mutationId": f"m{i}",
+                "operation": "insert",
+                "resource": "tasks",
+                "id": f"t{i}",
+                "record": {"title": f"Task {i}"},
+            })
+        await push({}, {"clientId": "c1", "mutations": mutations})
+
+        # Pull with limit 2
+        res = await pull({}, {"clientId": "c2", "cursors": {}})
+        assert res["ok"] is True
+        assert res["result"]["hasMore"] is True
+
+    @pytest.mark.asyncio
+    async def test_pull_no_has_more_when_all_fit(self):
+        server, db = await _setup(limits={"maxPullLimit": 100})
+        push = server["routes"]["POST /datafn/push"]
+        pull = server["routes"]["POST /datafn/pull"]
+
+        # Push 2 mutations
+        await push({}, {
+            "clientId": "c1",
+            "mutations": [
+                {"clientId": "c1", "mutationId": "m1", "operation": "insert",
+                 "resource": "tasks", "id": "t1", "record": {"title": "A"}},
+                {"clientId": "c1", "mutationId": "m2", "operation": "insert",
+                 "resource": "tasks", "id": "t2", "record": {"title": "B"}},
+            ],
+        })
+
+        res = await pull({}, {"clientId": "c2", "cursors": {}})
+        assert res["ok"] is True
+        assert res["result"]["hasMore"] is False
+
+
+# --- SYN-004: Join table sync ---
+
+class TestJoinTableSync:
+    @pytest.mark.asyncio
+    async def test_pull_includes_join_table_in_tables(self):
+        server, db = await _setup(schema_override=schema_with_join)
+        pull = server["routes"]["POST /datafn/pull"]
+
+        # Manually create a join table change entry
+        from datafn.change_tracking import write_change
+        await write_change(db, "datafn", "__datafn_join_tasks_tags", "insert", "jt1", 1)
+
+        # Create the actual join record
+        await db.create("__datafn_join_tasks_tags", {"id": "jt1", "taskId": "t1", "tagId": "tag1"})
+
+        res = await pull({}, {"clientId": "c2", "cursors": {}})
+        assert res["ok"] is True
+        # Join table should be in records or cursors
+        result = res["result"]
+        join_table = "__datafn_join_tasks_tags"
+        has_join_data = (
+            join_table in result.get("records", {}) or
+            join_table in result.get("cursors", {})
+        )
+        assert has_join_data
+
+
+# --- SYN-005: Namespace consistency ---
+
+class TestNamespaceConsistency:
+    @pytest.mark.asyncio
+    async def test_namespace_passed_to_adapter(self):
+        server, db = await _setup()
+        push = server["routes"]["POST /datafn/push"]
+
+        # Track adapter calls
+        original_create = db.create
+        create_calls = []
+
+        async def tracked_create(model, data, namespace="datafn"):
+            create_calls.append({"model": model, "namespace": namespace})
+            return await original_create(model, data, namespace=namespace)
+
+        db.create = tracked_create
+
+        await push({}, {
+            "clientId": "c1",
+            "mutations": [{
+                "clientId": "c1",
+                "mutationId": "m1",
+                "operation": "insert",
+                "resource": "tasks",
+                "id": "t1",
+                "record": {"title": "Task"},
+            }],
+        })
+
+        # All create calls should have namespace
+        for call in create_calls:
+            assert "namespace" in call
+
+    @pytest.mark.asyncio
+    async def test_custom_namespace_from_context(self):
+        server, db = await _setup()
+        push = server["routes"]["POST /datafn/push"]
+
+        original_create = db.create
+        create_namespaces = []
+
+        async def tracked_create(model, data, namespace="datafn"):
+            create_namespaces.append(namespace)
+            return await original_create(model, data, namespace=namespace)
+
+        db.create = tracked_create
+
+        # Pass namespace in context
+        ctx = {"namespace": "org-acme:user-1"}
+        await push(ctx, {
+            "clientId": "c1",
+            "mutations": [{
+                "clientId": "c1",
+                "mutationId": "m1",
+                "operation": "insert",
+                "resource": "tasks",
+                "id": "t1",
+                "record": {"title": "Task"},
+            }],
+        })
+
+        # Change tracking calls should use custom namespace
+        assert any(ns == "org-acme:user-1" for ns in create_namespaces)

--- a/datafn/python/tests/test_transact.py
+++ b/datafn/python/tests/test_transact.py
@@ -1,0 +1,145 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [{"name": "title"}, {"name": "status"}]}
+    ],
+    "relations": []
+}
+
+@pytest.mark.asyncio
+async def test_transact_atomic_commit():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/transact"]
+    
+    payload = {
+        "atomic": True,
+        "steps": [
+            {
+                "mutation": {
+                    "resource": "tasks",
+                    "operation": "insert",
+                    "clientId": "c1",
+                    "mutationId": "m1",
+                    "id": "t1",
+                    "record": {"title": "Task 1"}
+                }
+            },
+            {
+                "mutation": {
+                    "resource": "tasks",
+                    "operation": "insert",
+                    "clientId": "c1",
+                    "mutationId": "m2",
+                    "id": "t2",
+                    "record": {"title": "Task 2"}
+                }
+            }
+        ]
+    }
+    
+    res = await handler({}, payload)
+    assert res["ok"] is True
+    assert len(res["result"]["results"]) == 2
+    
+    # Verify DB
+    tasks = await db.find_many("tasks", [])
+    assert len(tasks) == 2
+
+@pytest.mark.asyncio
+async def test_transact_atomic_rollback():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/transact"]
+    
+    payload = {
+        "atomic": True,
+        "steps": [
+            {
+                "mutation": {
+                    "resource": "tasks",
+                    "operation": "insert",
+                    "clientId": "c1",
+                    "mutationId": "m1",
+                    "id": "t1",
+                    "record": {"title": "Task 1"}
+                }
+            },
+            {
+                "mutation": {
+                    "resource": "tasks",
+                    "clientId": "c1",
+                    "mutationId": "m2",
+                    "operation": "invalid_op",
+                    "record": {}
+                }
+            }
+        ]
+    }
+    
+    res = await handler({}, payload)
+
+    # Envelope is ok (carries transaction result), inner result signals failure
+    assert res["ok"] is True
+    assert res["result"]["ok"] is False
+
+    # Verify DB (Rollback)
+    tasks = await db.find_many("tasks", [])
+    assert len(tasks) == 0
+
+@pytest.mark.asyncio
+async def test_transact_read_your_writes():
+    db = MockAdapter()
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/transact"]
+    
+    payload = {
+        "atomic": True,
+        "steps": [
+            {
+                "mutation": {
+                    "resource": "tasks",
+                    "operation": "insert",
+                    "clientId": "c1",
+                    "mutationId": "m1",
+                    "id": "t1",
+                    "record": {"title": "RYW Task"}
+                }
+            },
+            {
+                "query": {
+                    "resource": "tasks",
+                    "filters": {"title": "RYW Task"}
+                }
+            }
+        ]
+    }
+    
+    res = await handler({}, payload)
+    assert res["ok"] is True
+    results = res["result"]["results"]
+    
+    # Mutation result
+    assert results[0]["mutationId"] == "m1"
+    
+    # Query result should see the task
+    assert len(results[1]["data"]) == 1
+    assert results[1]["data"][0]["title"] == "RYW Task"
+
+@pytest.mark.asyncio
+async def test_transact_step_limit():
+    db = MockAdapter()
+    config = {"schema": schema, "db": db, "limits": {"maxTransactSteps": 2}}
+    server = create_datafn_server(config)
+    handler = server["routes"]["POST /datafn/transact"]
+    
+    payload = {
+        "steps": [{}, {}, {}] # 3 steps
+    }
+    
+    res = await handler({}, payload)
+    assert res["ok"] is False
+    assert res["error"]["code"] == "LIMIT_EXCEEDED"

--- a/datafn/python/tests/test_transact_enhanced.py
+++ b/datafn/python/tests/test_transact_enhanced.py
@@ -1,0 +1,207 @@
+import pytest
+from datafn.server import create_datafn_server
+from .mock_db import MockAdapter
+
+schema = {
+    "resources": [
+        {"name": "tasks", "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "status", "type": "string"},
+        ]}
+    ],
+    "relations": [],
+}
+
+
+async def _setup(records=None):
+    db = MockAdapter()
+    if records:
+        for r in records:
+            await db.create("tasks", r)
+    server = create_datafn_server({"schema": schema, "db": db})
+    handler = server["routes"]["POST /datafn/transact"]
+    mutation_handler = server["routes"]["POST /datafn/mutation"]
+    return handler, mutation_handler, db
+
+
+# --- TXN-001: Atomic commit ---
+
+class TestAtomicCommit:
+    @pytest.mark.asyncio
+    async def test_atomic_all_succeed(self):
+        handler, _, db = await _setup()
+        res = await handler({}, {
+            "atomic": True,
+            "steps": [
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t1", "record": {"title": "A"}}},
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t2", "record": {"title": "B"}}},
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t3", "record": {"title": "C"}}},
+            ],
+        })
+        assert res["ok"] is True
+        assert res["result"]["ok"] is True
+        assert len(res["result"]["results"]) == 3
+        tasks = await db.find_many("tasks", [])
+        assert len(tasks) == 3
+
+
+# --- TXN-001: Atomic rollback ---
+
+class TestAtomicRollback:
+    @pytest.mark.asyncio
+    async def test_atomic_rollback_on_error(self):
+        handler, _, db = await _setup()
+        res = await handler({}, {
+            "atomic": True,
+            "steps": [
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t1", "record": {"title": "A"}}},
+                {"mutation": {"resource": "tasks", "operation": "invalid_op", "record": {}}},
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t3", "record": {"title": "C"}}},
+            ],
+        })
+        assert res["ok"] is True  # Envelope ok
+        assert res["result"]["ok"] is False  # Transaction failed
+        # All prior data rolled back
+        tasks = await db.find_many("tasks", [])
+        assert len(tasks) == 0
+
+
+# --- TXN-002: Rollback annotation ---
+
+class TestRollbackAnnotation:
+    @pytest.mark.asyncio
+    async def test_prior_mutations_marked_rolled_back(self):
+        handler, _, db = await _setup()
+        res = await handler({}, {
+            "atomic": True,
+            "steps": [
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t1", "record": {"title": "A"}}},
+                {"mutation": {"resource": "tasks", "operation": "invalid_op", "record": {}}},
+            ],
+        })
+        assert res["ok"] is True
+        result = res["result"]
+        assert result["ok"] is False
+        results = result["results"]
+        assert len(results) == 2
+        # First mutation result should be marked as rolled back
+        assert results[0].get("rolledBack") is True
+        # Second result is the error
+        assert results[1].get("ok") is False
+
+    @pytest.mark.asyncio
+    async def test_query_results_not_marked_rolled_back(self):
+        handler, _, db = await _setup([
+            {"id": "t0", "title": "Existing"},
+        ])
+        res = await handler({}, {
+            "atomic": True,
+            "steps": [
+                {"query": {"resource": "tasks", "version": 1}},
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t1", "record": {"title": "A"}}},
+                {"mutation": {"resource": "tasks", "operation": "invalid_op", "record": {}}},
+            ],
+        })
+        assert res["ok"] is True
+        result = res["result"]
+        assert result["ok"] is False
+        results = result["results"]
+        assert len(results) == 3
+        # Query result should NOT have rolledBack
+        assert "rolledBack" not in results[0]
+        # Mutation result should be rolled back
+        assert results[1].get("rolledBack") is True
+        # Error result
+        assert results[2].get("ok") is False
+
+
+# --- Non-atomic mode ---
+
+class TestNonAtomic:
+    @pytest.mark.asyncio
+    async def test_non_atomic_continues_on_error(self):
+        handler, _, db = await _setup()
+        res = await handler({}, {
+            "atomic": False,
+            "steps": [
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t1", "record": {"title": "A"}}},
+                {"mutation": {"resource": "tasks", "operation": "invalid_op", "record": {}}},
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t3", "record": {"title": "C"}}},
+            ],
+        })
+        assert res["ok"] is True
+        result = res["result"]
+        assert result["ok"] is False  # At least one error
+        # All 3 steps should have results
+        assert len(result["results"]) == 3
+        # First succeeded
+        assert result["results"][0]["ok"] is True
+        # Second failed
+        assert result["results"][1]["ok"] is False
+        # Third succeeded (continued past error)
+        assert result["results"][2]["ok"] is True
+        # t1 and t3 committed, t2 errored
+        tasks = await db.find_many("tasks", [])
+        assert len(tasks) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_atomic_no_rollback_annotations(self):
+        handler, _, db = await _setup()
+        res = await handler({}, {
+            "atomic": False,
+            "steps": [
+                {"mutation": {"resource": "tasks", "operation": "insert", "id": "t1", "record": {"title": "A"}}},
+                {"mutation": {"resource": "tasks", "operation": "invalid_op", "record": {}}},
+            ],
+        })
+        result = res["result"]
+        # First result should NOT have rolledBack
+        assert "rolledBack" not in result["results"][0]
+
+
+# --- MUT-007: Guard with transaction ---
+
+class TestGuardTransaction:
+    @pytest.mark.asyncio
+    async def test_guard_fails_mutation_not_executed(self):
+        _, mutation_handler, db = await _setup([
+            {"id": "task_1", "title": "Task", "status": "closed"},
+        ])
+        res = await mutation_handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "task_1",
+            "if": {"status": {"$eq": "active"}},
+            "record": {"title": "Updated"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "CONFLICT"
+        # Record unchanged
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "task_1"}])
+        assert task["title"] == "Task"
+
+    @pytest.mark.asyncio
+    async def test_guard_passes_mutation_executed(self):
+        _, mutation_handler, db = await _setup([
+            {"id": "task_1", "title": "Task", "status": "active"},
+        ])
+        res = await mutation_handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "task_1",
+            "if": {"status": {"$eq": "active"}},
+            "record": {"title": "Updated"},
+        })
+        assert res["ok"] is True
+        task = await db.find_one("tasks", [{"field": "id", "operator": "eq", "value": "task_1"}])
+        assert task["title"] == "Updated"
+
+    @pytest.mark.asyncio
+    async def test_guard_on_nonexistent_record_fails(self):
+        _, mutation_handler, db = await _setup()
+        res = await mutation_handler({}, {
+            "resource": "tasks", "version": 1,
+            "operation": "merge", "id": "nonexistent",
+            "if": {"status": {"$eq": "active"}},
+            "record": {"title": "Updated"},
+        })
+        assert res["ok"] is False
+        assert res["error"]["code"] == "CONFLICT"

--- a/datafn/python/tests/test_utils.py
+++ b/datafn/python/tests/test_utils.py
@@ -1,0 +1,349 @@
+import pytest
+from datetime import datetime, timezone
+
+from datafn.utils.sort import parse_sort_terms, sort_records
+from datafn.utils.select import parse_select_token, apply_select, apply_omit
+from datafn.utils.date import to_epoch_ms, from_epoch_ms, coerce_date_fields_to_epoch
+from datafn.utils.aggregate import calculate_aggregation
+from datafn.utils.normalize import normalize_dfql, dfql_key
+from datafn.utils.joins import get_join_table_name, get_join_store_key, enumerate_join_store_keys
+from datafn.utils.ns import ns
+from datafn.utils.validate_fields import check_prototype_pollution, validate_field_value
+
+
+# --- Sort ---
+
+class TestParseSortTerms:
+    # TV-SORT-001
+    def test_parse_all_formats(self):
+        result = parse_sort_terms(["name", "priority:desc", "-createdAt", "id:asc"])
+        assert result == [
+            {"field": "name", "direction": "asc"},
+            {"field": "priority", "direction": "desc"},
+            {"field": "createdAt", "direction": "desc"},
+            {"field": "id", "direction": "asc"},
+        ]
+
+    def test_single_field(self):
+        assert parse_sort_terms(["id"]) == [{"field": "id", "direction": "asc"}]
+
+    def test_empty(self):
+        assert parse_sort_terms([]) == []
+
+
+class TestSortRecords:
+    # TV-SORT-002: Null handling
+    def test_sort_with_nulls_asc(self):
+        records = [
+            {"id": "3", "name": None},
+            {"id": "1", "name": "Alice"},
+            {"id": "2", "name": "Bob"},
+        ]
+        result = sort_records(records, [{"field": "name", "direction": "asc"}])
+        assert [r["id"] for r in result] == ["1", "2", "3"]
+
+    def test_sort_with_nulls_desc(self):
+        records = [
+            {"id": "3", "name": None},
+            {"id": "1", "name": "Alice"},
+            {"id": "2", "name": "Bob"},
+        ]
+        result = sort_records(records, [{"field": "name", "direction": "desc"}])
+        assert [r["id"] for r in result] == ["3", "2", "1"]
+
+    # TV-SORT-003: Tie-breaking
+    def test_tie_breaking_by_id(self):
+        records = [
+            {"id": "c", "priority": 1},
+            {"id": "a", "priority": 1},
+            {"id": "b", "priority": 1},
+        ]
+        result = sort_records(records, [{"field": "priority", "direction": "asc"}])
+        assert [r["id"] for r in result] == ["a", "b", "c"]
+
+    def test_multi_field_sort(self):
+        records = [
+            {"id": "1", "status": "b", "priority": 2},
+            {"id": "2", "status": "a", "priority": 1},
+            {"id": "3", "status": "a", "priority": 2},
+        ]
+        result = sort_records(records, [
+            {"field": "status", "direction": "asc"},
+            {"field": "priority", "direction": "desc"},
+        ])
+        assert [r["id"] for r in result] == ["3", "2", "1"]
+
+
+# --- Select ---
+
+class TestParseSelectToken:
+    # TV-SEL-001
+    def test_simple(self):
+        result = parse_select_token("id")
+        assert result == {"path": ["id"], "base_name": "id", "directive": None}
+
+    def test_wildcard(self):
+        result = parse_select_token("tags.*")
+        assert result == {"path": ["tags", "*"], "base_name": "tags", "directive": "*"}
+
+    def test_nested(self):
+        result = parse_select_token("metadata.name")
+        assert result == {"path": ["metadata", "name"], "base_name": "metadata", "directive": None}
+
+
+class TestApplySelect:
+    # TV-SEL-002
+    def test_select_whitelist(self):
+        records = [{"id": "1", "title": "Task 1", "description": "desc", "priority": 5}]
+        result = apply_select(records, ["id", "title"])
+        assert result == [{"id": "1", "title": "Task 1"}]
+
+    def test_id_always_included(self):
+        records = [{"id": "1", "title": "Task 1", "priority": 5}]
+        result = apply_select(records, ["title"])
+        assert result == [{"id": "1", "title": "Task 1"}]
+
+
+class TestApplyOmit:
+    # TV-SEL-003
+    def test_omit_blacklist(self):
+        records = [{"id": "1", "title": "Task 1", "description": "desc", "priority": 5}]
+        result = apply_omit(records, ["description"])
+        assert result == [{"id": "1", "title": "Task 1", "priority": 5}]
+
+    def test_id_never_omitted(self):
+        records = [{"id": "1", "title": "Task 1"}]
+        result = apply_omit(records, ["id"])
+        assert result == [{"id": "1", "title": "Task 1"}]
+
+
+# --- Date ---
+
+class TestDateUtils:
+    # TV-DATE-001
+    def test_iso_string(self):
+        assert to_epoch_ms("2024-01-01T00:00:00Z") == 1704067200000
+
+    def test_epoch_int(self):
+        assert to_epoch_ms(1704067200000) == 1704067200000
+
+    def test_datetime_object(self):
+        dt = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        assert to_epoch_ms(dt) == 1704067200000
+
+    def test_invalid_date(self):
+        with pytest.raises(ValueError):
+            to_epoch_ms("not-a-date")
+
+    def test_from_epoch_ms(self):
+        dt = from_epoch_ms(1704067200000)
+        assert dt.year == 2024
+        assert dt.month == 1
+        assert dt.day == 1
+        assert dt.tzinfo == timezone.utc
+
+    def test_coerce_date_fields(self):
+        record = {"createdAt": "2024-01-01T00:00:00Z", "name": "test"}
+        coerce_date_fields_to_epoch(record, ["createdAt"])
+        assert record["createdAt"] == 1704067200000
+        assert record["name"] == "test"
+
+    def test_coerce_skips_none(self):
+        record = {"createdAt": None}
+        coerce_date_fields_to_epoch(record, ["createdAt"])
+        assert record["createdAt"] is None
+
+    def test_coerce_skips_missing(self):
+        record = {"name": "test"}
+        coerce_date_fields_to_epoch(record, ["createdAt"])
+        assert "createdAt" not in record
+
+
+# --- Aggregation ---
+
+class TestAggregation:
+    # TV-AGG-001
+    records = [
+        {"id": "1", "score": 10},
+        {"id": "2", "score": 20},
+        {"id": "3", "score": None},
+        {"id": "4", "score": 30},
+    ]
+
+    def test_count(self):
+        assert calculate_aggregation("count", "score", self.records) == 4
+
+    def test_sum(self):
+        assert calculate_aggregation("sum", "score", self.records) == 60
+
+    def test_avg(self):
+        assert calculate_aggregation("avg", "score", self.records) == 20.0
+
+    def test_min(self):
+        assert calculate_aggregation("min", "score", self.records) == 10
+
+    def test_max(self):
+        assert calculate_aggregation("max", "score", self.records) == 30
+
+    def test_empty_set_count(self):
+        assert calculate_aggregation("count", "score", []) == 0
+
+    def test_empty_set_sum(self):
+        assert calculate_aggregation("sum", "score", []) is None
+
+    def test_empty_set_avg(self):
+        assert calculate_aggregation("avg", "score", []) is None
+
+    def test_empty_set_min(self):
+        assert calculate_aggregation("min", "score", []) is None
+
+    def test_empty_set_max(self):
+        assert calculate_aggregation("max", "score", []) is None
+
+    def test_all_nulls_sum(self):
+        records = [{"id": "1", "score": None}, {"id": "2", "score": None}]
+        assert calculate_aggregation("sum", "score", records) is None
+
+
+# --- Normalize ---
+
+class TestNormalize:
+    # TV-NORM-001
+    def test_normalize_sorts_keys(self):
+        result = normalize_dfql({"b": 2, "a": 1, "c": {"z": 3, "y": 2}})
+        assert list(result.keys()) == ["a", "b", "c"]
+        assert list(result["c"].keys()) == ["y", "z"]
+
+    def test_dfql_key(self):
+        result = dfql_key({"b": 2, "a": 1, "c": {"z": 3, "y": 2}})
+        assert result == '{"a":1,"b":2,"c":{"y":2,"z":3}}'
+
+    def test_preserves_none(self):
+        result = normalize_dfql({"a": None, "b": 1})
+        assert result == {"a": None, "b": 1}
+
+    def test_normalizes_lists(self):
+        result = normalize_dfql({"a": [{"b": 2, "a": 1}]})
+        assert list(result["a"][0].keys()) == ["a", "b"]
+
+
+# --- Joins ---
+
+class TestJoinUtils:
+    # TV-JOIN-001
+    def test_join_table_name(self):
+        assert get_join_table_name("tasks", "tags") == "__datafn_join_tasks_tags"
+
+    def test_join_table_name_custom(self):
+        assert get_join_table_name("tasks", "tags", join_table="custom_join") == "custom_join"
+
+    def test_join_store_key(self):
+        assert get_join_store_key("tasks", "tags", "tags") == "join_tasks_tags_tags"
+
+    def test_enumerate_join_store_keys(self):
+        relations = [
+            {"from": "tasks", "to": "tags", "type": "many-many", "relation": "tags"},
+            {"from": "tasks", "to": "projects", "type": "many-one", "relation": "project"},
+        ]
+        keys = enumerate_join_store_keys(relations)
+        assert len(keys) == 1
+        assert keys[0]["joinTable"] == "__datafn_join_tasks_tags"
+        assert keys[0]["storeKey"] == "join_tasks_tags_tags"
+
+    def test_enumerate_with_filter(self):
+        relations = [
+            {"from": "tasks", "to": "tags", "type": "many-many", "relation": "tags"},
+            {"from": "users", "to": "roles", "type": "many-many", "relation": "roles"},
+        ]
+        keys = enumerate_join_store_keys(relations, resource_filter="tasks")
+        assert len(keys) == 1
+        assert keys[0]["from"] == "tasks"
+
+
+# --- Namespace ---
+
+class TestNs:
+    # TV-NS-001
+    def test_basic(self):
+        assert ns("org-acme", "user-123") == "org-acme:user-123"
+
+    def test_empty_segments_skipped(self):
+        assert ns("org", "", "user") == "org:user"
+
+    def test_single(self):
+        assert ns("org") == "org"
+
+    def test_no_args_raises(self):
+        with pytest.raises(ValueError):
+            ns()
+
+    def test_all_empty_raises(self):
+        with pytest.raises(ValueError):
+            ns("", "")
+
+
+# --- Validate Fields ---
+
+class TestPrototypePollution:
+    # TV-VAL-008
+    def test_proto_detected(self):
+        assert check_prototype_pollution({"__proto__": {"isAdmin": True}, "title": "hack"}) == "__proto__"
+
+    def test_constructor_detected(self):
+        assert check_prototype_pollution({"constructor": {}}) == "constructor"
+
+    def test_prototype_detected(self):
+        assert check_prototype_pollution({"prototype": {}}) == "prototype"
+
+    def test_nested_detection(self):
+        assert check_prototype_pollution({"data": {"__proto__": {}}}) == "__proto__"
+
+    def test_clean_record(self):
+        assert check_prototype_pollution({"title": "safe", "data": {"nested": True}}) is None
+
+    def test_array_detection(self):
+        assert check_prototype_pollution([{"__proto__": {}}]) == "__proto__"
+
+
+class TestValidateFieldValue:
+    # TV-VAL-005 (partial - the type validation utility)
+    def test_string(self):
+        assert validate_field_value("string", "hello")
+        assert not validate_field_value("string", 123)
+
+    def test_number(self):
+        assert validate_field_value("number", 42)
+        assert validate_field_value("number", 3.14)
+        assert not validate_field_value("number", "42")
+        assert not validate_field_value("number", True)
+
+    def test_boolean(self):
+        assert validate_field_value("boolean", True)
+        assert validate_field_value("boolean", False)
+        assert not validate_field_value("boolean", 1)
+
+    def test_date(self):
+        assert validate_field_value("date", 1704067200000)
+        assert validate_field_value("date", "2024-01-01T00:00:00Z")
+        assert validate_field_value("date", datetime(2024, 1, 1, tzinfo=timezone.utc))
+        assert not validate_field_value("date", [])
+
+    def test_object(self):
+        assert validate_field_value("object", {"key": "value"})
+        assert not validate_field_value("object", "string")
+
+    def test_array(self):
+        assert validate_field_value("array", [1, 2, 3])
+        assert not validate_field_value("array", "string")
+
+    def test_json(self):
+        assert validate_field_value("json", "anything")
+        assert validate_field_value("json", 42)
+        assert validate_field_value("json", {"key": "value"})
+
+    def test_nullable(self):
+        assert validate_field_value("string", None, nullable=True)
+        assert not validate_field_value("string", None, nullable=False)
+
+    def test_unknown_type(self):
+        assert validate_field_value("custom_type", "anything")

--- a/datafn/python/tests/test_validation_enhanced.py
+++ b/datafn/python/tests/test_validation_enhanced.py
@@ -1,0 +1,337 @@
+import pytest
+from datafn.validation import (
+    SchemaIndex, validate_schema, validate_record_types,
+    validate_required_fields, apply_defaults,
+    validate_query_limits, validate_mutation_limits,
+    validate_id_length, validate_record_keys,
+)
+from datafn.envelope import classify_error, DatafnError, CONFLICT, NOT_FOUND, INTERNAL
+from datafn.server import create_datafn_server
+
+
+# --- Helpers ---
+
+def make_schema(resources=None, relations=None):
+    return {
+        "resources": resources or [
+            {"name": "tasks", "version": 1, "fields": [
+                {"name": "title", "type": "string", "required": True},
+                {"name": "status", "type": "string", "default": "pending"},
+                {"name": "priority", "type": "number"},
+                {"name": "done", "type": "boolean"},
+                {"name": "dueDate", "type": "date"},
+                {"name": "metadata", "type": "object"},
+                {"name": "tags", "type": "array"},
+                {"name": "config", "type": "json"},
+                {"name": "readonlyField", "type": "string", "readonly": True},
+            ]}
+        ],
+        "relations": relations or [],
+    }
+
+
+# --- Schema Validation (VAL-001) ---
+
+class TestValidateSchema:
+    # TV-VAL-001
+    def test_valid_schema(self):
+        result = validate_schema(make_schema())
+        assert result["ok"] is True
+
+    # TV-VAL-002
+    def test_duplicate_resource(self):
+        schema = {
+            "resources": [
+                {"name": "tasks", "version": 1, "fields": []},
+                {"name": "tasks", "version": 1, "fields": []},
+            ],
+            "relations": [],
+        }
+        result = validate_schema(schema)
+        assert result["ok"] is False
+        assert result["error"]["code"] == "SCHEMA_INVALID"
+
+    def test_missing_resources(self):
+        result = validate_schema({})
+        assert result["ok"] is False
+
+    def test_empty_resources(self):
+        result = validate_schema({"resources": []})
+        assert result["ok"] is False
+
+    def test_too_many_resources(self):
+        resources = [{"name": f"r{i}", "fields": []} for i in range(101)]
+        result = validate_schema({"resources": resources})
+        assert result["ok"] is False
+        assert "maximum is 100" in result["error"]["message"]
+
+    def test_duplicate_field_names(self):
+        schema = {
+            "resources": [
+                {"name": "tasks", "fields": [
+                    {"name": "title"},
+                    {"name": "title"},
+                ]}
+            ],
+            "relations": [],
+        }
+        result = validate_schema(schema)
+        assert result["ok"] is False
+        assert "Duplicate field" in result["error"]["message"]
+
+    def test_too_many_fields(self):
+        fields = [{"name": f"f{i}"} for i in range(201)]
+        schema = {"resources": [{"name": "tasks", "fields": fields}], "relations": []}
+        result = validate_schema(schema)
+        assert result["ok"] is False
+
+    def test_invalid_relation_reference(self):
+        schema = {
+            "resources": [{"name": "tasks", "fields": []}],
+            "relations": [{"from": "tasks", "to": "nonexistent", "type": "many-one", "relation": "parent"}],
+        }
+        result = validate_schema(schema)
+        assert result["ok"] is False
+        assert "nonexistent" in result["error"]["message"]
+
+    def test_server_raises_on_invalid_schema(self):
+        from tests.mock_db import MockAdapter
+        with pytest.raises(DatafnError) as exc_info:
+            create_datafn_server({"schema": {}, "db": MockAdapter()})
+        assert exc_info.value.code == "SCHEMA_INVALID"
+
+
+# --- FK Field Injection (VAL-002) ---
+
+class TestFKInjection:
+    # TV-VAL-003
+    def test_fk_field_injected(self):
+        schema = {
+            "resources": [
+                {"name": "tasks", "fields": [{"name": "title", "type": "string"}]},
+                {"name": "projects", "fields": [{"name": "name", "type": "string"}]},
+            ],
+            "relations": [
+                {"from": "tasks", "to": "projects", "type": "many-one", "relation": "project"},
+            ],
+        }
+        index = SchemaIndex(schema)
+        assert "projectId" in index.writable_fields_by_resource["tasks"]
+        assert "projectId" in index.fields_by_resource["tasks"]
+
+    def test_custom_fk_field(self):
+        schema = {
+            "resources": [
+                {"name": "tasks", "fields": []},
+                {"name": "projects", "fields": []},
+            ],
+            "relations": [
+                {"from": "tasks", "to": "projects", "type": "many-one", "relation": "project", "fkField": "proj_id"},
+            ],
+        }
+        index = SchemaIndex(schema)
+        assert "proj_id" in index.writable_fields_by_resource["tasks"]
+
+    def test_fk_schema_has_correct_type(self):
+        schema = {
+            "resources": [
+                {"name": "tasks", "fields": []},
+                {"name": "projects", "fields": []},
+            ],
+            "relations": [
+                {"from": "tasks", "to": "projects", "type": "many-one", "relation": "project"},
+            ],
+        }
+        index = SchemaIndex(schema)
+        fk_schema = index.field_schemas["tasks"]["projectId"]
+        assert fk_schema["type"] == "string"
+        assert fk_schema["required"] is False
+
+
+# --- Read-only Fields (VAL-003) ---
+
+class TestReadonlyFields:
+    # TV-VAL-004
+    def test_readonly_tracked(self):
+        index = SchemaIndex(make_schema())
+        assert "id" in index.readonly_fields["tasks"]
+        assert "createdAt" in index.readonly_fields["tasks"]
+        assert "readonlyField" in index.readonly_fields["tasks"]
+        assert "title" not in index.readonly_fields["tasks"]
+
+    def test_readonly_field_rejected_in_record(self):
+        index = SchemaIndex(make_schema())
+        err = validate_record_keys(index, "tasks", {"createdAt": 12345}, "record")
+        assert err is not None
+        assert err.code == "DFQL_INVALID"
+        assert "read-only" in err.message
+
+    def test_id_allowed_in_record(self):
+        index = SchemaIndex(make_schema())
+        err = validate_record_keys(index, "tasks", {"id": "t1", "title": "test"}, "record")
+        assert err is None
+
+
+# --- Field Type Validation (VAL-004) ---
+
+class TestRecordTypeValidation:
+    # TV-VAL-005
+    def test_valid_types(self):
+        index = SchemaIndex(make_schema())
+        errors = validate_record_types(
+            {"title": "test", "priority": 5, "done": True, "dueDate": 1704067200000},
+            "tasks", index
+        )
+        assert errors == []
+
+    def test_wrong_type(self):
+        index = SchemaIndex(make_schema())
+        errors = validate_record_types({"title": 123}, "tasks", index)
+        assert len(errors) == 1
+        assert "title" in errors[0]
+        assert "string" in errors[0]
+
+    def test_no_type_spec_passes(self):
+        schema = {"resources": [{"name": "items", "fields": [{"name": "data"}]}], "relations": []}
+        index = SchemaIndex(schema)
+        errors = validate_record_types({"data": 42}, "items", index)
+        assert errors == []
+
+
+# --- Required Fields (VAL-005) ---
+
+class TestRequiredFields:
+    # TV-VAL-006
+    def test_missing_required(self):
+        index = SchemaIndex(make_schema())
+        missing = validate_required_fields({}, "tasks", index)
+        assert "title" in missing
+
+    def test_required_with_value(self):
+        index = SchemaIndex(make_schema())
+        missing = validate_required_fields({"title": "test"}, "tasks", index)
+        assert missing == []
+
+    def test_required_with_default_not_required(self):
+        # status has default, so it's not required even though it could be
+        index = SchemaIndex(make_schema())
+        missing = validate_required_fields({}, "tasks", index)
+        assert "status" not in missing
+
+
+# --- Default Values (VAL-006) ---
+
+class TestDefaults:
+    # TV-VAL-007
+    def test_apply_default(self):
+        index = SchemaIndex(make_schema())
+        record = {"title": "Task 1"}
+        apply_defaults(record, "tasks", index)
+        assert record["status"] == "pending"
+
+    def test_default_not_overwritten(self):
+        index = SchemaIndex(make_schema())
+        record = {"title": "Task 1", "status": "active"}
+        apply_defaults(record, "tasks", index)
+        assert record["status"] == "active"
+
+
+# --- Limit Enforcement (VAL-008) ---
+
+class TestLimitEnforcement:
+    # TV-VAL-009
+    def test_select_limit(self):
+        query = {"select": [f"f{i}" for i in range(51)]}
+        err = validate_query_limits(query, {"maxSelectTokens": 50})
+        assert err is not None
+        assert err.code == "LIMIT_EXCEEDED"
+
+    def test_sort_limit(self):
+        query = {"sort": [f"f{i}" for i in range(11)]}
+        err = validate_query_limits(query, {"maxSortFields": 10})
+        assert err is not None
+        assert err.code == "LIMIT_EXCEEDED"
+
+    def test_filter_keys_limit(self):
+        filters = {f"field{i}": {"$eq": i} for i in range(21)}
+        query = {"filters": filters}
+        err = validate_query_limits(query, {"maxFilterKeysPerLevel": 20})
+        assert err is not None
+        assert err.code == "LIMIT_EXCEEDED"
+
+    def test_aggregation_limit(self):
+        aggs = {f"agg{i}": {"count": "*"} for i in range(11)}
+        query = {"aggregations": aggs}
+        err = validate_query_limits(query, {"maxAggregations": 10})
+        assert err is not None
+        assert err.code == "LIMIT_EXCEEDED"
+
+    def test_batch_limit(self):
+        mutation = {"records": [{"id": f"r{i}"} for i in range(101)]}
+        err = validate_mutation_limits(mutation, {"maxBatchSize": 100})
+        assert err is not None
+        assert err.code == "LIMIT_EXCEEDED"
+
+    def test_within_limits(self):
+        query = {"select": ["a", "b"], "sort": ["id"], "filters": {"x": {"$eq": 1}}, "aggregations": {}}
+        err = validate_query_limits(query, {})
+        assert err is None
+
+
+# --- ID Length Validation (VAL-009) ---
+
+class TestIdLength:
+    # TV-VAL-010
+    def test_valid_id(self):
+        err = validate_id_length("short_id", 255)
+        assert err is None
+
+    def test_oversized_id(self):
+        err = validate_id_length("x" * 300, 255)
+        assert err is not None
+        assert err.code == "DFQL_INVALID"
+        assert "255" in err.message
+
+    def test_none_id(self):
+        err = validate_id_length(None, 255)
+        assert err is None
+
+
+# --- Error Classification (MUT-004) ---
+
+class TestErrorClassification:
+    # TV-MUT-004
+    def test_duplicate_key(self):
+        assert classify_error(Exception("UNIQUE constraint failed: tasks.id")) == CONFLICT
+
+    def test_duplicate_key_postgres(self):
+        assert classify_error(Exception("duplicate key value violates unique constraint")) == CONFLICT
+
+    def test_not_found(self):
+        assert classify_error(Exception("Record not found")) == NOT_FOUND
+
+    def test_unknown(self):
+        assert classify_error(Exception("Something random")) == INTERNAL
+
+
+# --- SchemaIndex Tracking ---
+
+class TestSchemaIndexTracking:
+    def test_date_fields_tracked(self):
+        index = SchemaIndex(make_schema())
+        assert "dueDate" in index.date_fields["tasks"]
+
+    def test_field_schemas_stored(self):
+        index = SchemaIndex(make_schema())
+        assert "title" in index.field_schemas["tasks"]
+        assert index.field_schemas["tasks"]["title"]["type"] == "string"
+
+    def test_required_fields_tracked(self):
+        index = SchemaIndex(make_schema())
+        assert "title" in index.required_fields["tasks"]
+        # status has default, so not in required
+        assert "status" not in index.required_fields["tasks"]
+
+    def test_defaults_tracked(self):
+        index = SchemaIndex(make_schema())
+        assert index.field_defaults["tasks"]["status"] == "pending"


### PR DESCRIPTION
## Summary
- add the Python `datafn` package from `next`
- include the runtime modules, helpers, and parity/integration test suite

## Validation
- `cd datafn/python && python3 -m pytest`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Python `datafn` server SDK with query, mutation, transact, and sync endpoints. Implements SF-7 with strict schema/config checks, fine-grained authz, change tracking, idempotent mutations, and batched pull to cut DB calls.

- **New Features**
  - Server factory `create_datafn_server` exposing /datafn/query, /mutation, /transact, /seed, /clone, /pull, /push
  - Strict schema/config validation (limits, types, defaults, required fields, unknown-key errors)
  - Authz: shareable capabilities, field-level permissions, visibility checks, per-record guards
  - Change tracking (monotonic server seq, bounded fetch), idempotent mutations, plugin hooks, and batched pull using IN filters
  - Query/mutation tools: filters, sort, select/omit, aggregation, relations (incl. many‑many), and a logger factory (`NoopLogger`, `ConsoleLogger`)

- **Migration**
  - Run tests: cd datafn/python && python3 -m pytest
  - Import `create_datafn_server` from `datafn` and pass your schema, DB adapter, and optional `authorize`/plugins

<sup>Written for commit e248e41abed552181344ca288d22fcb515b20204. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Python server SDK: query, mutation, transact, and sync (seed/clone/pull/push); server factory and config validation
  * Field-level authorization, payload-size guarding, idempotent mutations, change-tracking, guards, hooks, and pluggable logging
  * Advanced query capabilities: filters, sorting, select/omit, aggregation, pagination, date coercion, relation mutations, and join helpers
  * Utilities: error envelopes, schema validation/indexing, DB adapter protocol, transaction helper, and helper utils

* **Tests**
  * Extensive unit & integration suite covering authz, filters, mutation/transact, sync, utils, and end-to-end flows

* **Chores**
  * Python packaging metadata (pyproject.toml) and test mock DB added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->