### PR TITLE
SF-27: feat(searchfn): add adapter packages

### DIFF
--- a/searchfn/adapter-contracts/__tests__/contracts.test.ts
+++ b/searchfn/adapter-contracts/__tests__/contracts.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { SEARCH_ADAPTER_DISPOSED, SearchAdapterError } from "../src/index";
+
+describe("adapter contracts scaffolding", () => {
+  it("exports constants and errors", () => {
+    expect(SEARCH_ADAPTER_DISPOSED).toBe("SEARCH_ADAPTER_DISPOSED");
+    const err = new SearchAdapterError("X", "msg");
+    expect(err.code).toBe("X");
+  });
+});

--- a/searchfn/adapter-contracts/package.json
+++ b/searchfn/adapter-contracts/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@searchfn/adapter-contracts",
+  "version": "0.1.0",
+  "description": "Shared adapter interfaces and error primitives for SearchFn adapters.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@searchfn/core": "^0.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/adapter-contracts/src/index.ts
+++ b/searchfn/adapter-contracts/src/index.ts
@@ -1,0 +1,99 @@
+export interface SearchDocument {
+  id: string | number;
+  fields: Record<string, string>;
+}
+
+export interface IndexParams {
+  resource: string;
+  documents: SearchDocument[];
+  signal?: AbortSignal;
+}
+
+export interface SearchParams {
+  resource: string;
+  query: string;
+  fields?: string[];
+  limit?: number;
+  fuzzy?: boolean | number;
+  prefix?: boolean;
+  fieldBoosts?: Record<string, number>;
+  signal?: AbortSignal;
+}
+
+export interface SearchAllParams {
+  query: string;
+  resources?: string[];
+  fields?: string[];
+  limit?: number;
+  limitPerResource?: number;
+  fuzzy?: boolean | number;
+  prefix?: boolean;
+  fieldBoosts?: Record<string, number>;
+  signal?: AbortSignal;
+}
+
+export interface SearchAllResult {
+  resource: string;
+  id: string | number;
+  score: number;
+}
+
+export interface RemoveParams {
+  resource: string;
+  ids: Array<string | number>;
+  signal?: AbortSignal;
+}
+
+export interface InitializeResourceConfig {
+  name: string;
+  searchFields: string[];
+}
+
+export interface InitializeParams {
+  resources: InitializeResourceConfig[];
+}
+
+export interface SearchAdapterCapabilities {
+  persistent?: boolean;
+  searchAll?: boolean;
+  fuzzy?: boolean;
+  prefix?: boolean;
+  fieldBoosts?: boolean;
+  maxBatchSize?: number;
+}
+
+export interface SearchAdapter {
+  readonly name: string;
+  readonly capabilities?: SearchAdapterCapabilities;
+
+  initialize?(params: InitializeParams): Promise<void>;
+  index(params: IndexParams): Promise<void>;
+  search(params: SearchParams): Promise<Array<string | number>>;
+  searchAll?(params: SearchAllParams): Promise<SearchAllResult[]>;
+  remove(params: RemoveParams): Promise<void>;
+  clear(resource: string, signal?: AbortSignal): Promise<void>;
+  dispose?(): Promise<void>;
+}
+
+export interface SearchDefaults {
+  fuzzy?: boolean | number;
+  prefix?: boolean;
+  fieldBoosts?: Record<string, number>;
+}
+
+export interface SearchAdapterConfig {
+  pipeline?: import("@searchfn/core").PipelineOptions;
+  defaults?: SearchDefaults;
+}
+
+export const SEARCH_ADAPTER_DISPOSED = "SEARCH_ADAPTER_DISPOSED";
+
+export class SearchAdapterError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "SearchAdapterError";
+    this.code = code;
+  }
+}

--- a/searchfn/adapter-contracts/tsconfig.json
+++ b/searchfn/adapter-contracts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapter-contracts/tsup.config.ts
+++ b/searchfn/adapter-contracts/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist"
+});

--- a/searchfn/adapter-contracts/vitest.config.ts
+++ b/searchfn/adapter-contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"]
+  }
+});

--- a/searchfn/adapter-elasticsearch/__tests__/conformance/shared.ts
+++ b/searchfn/adapter-elasticsearch/__tests__/conformance/shared.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared adapter conformance test harness.
+ *
+ * Every SearchAdapter implementation MUST pass all assertions defined here.
+ * To use: call `runConformanceSuite(adapterFactory)` inside a `describe` block.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export interface ConformanceAdapterFactory {
+  /** Human-readable adapter name for test labels */
+  name: string;
+  /** Create a fresh adapter instance for each test */
+  create(): SearchAdapter;
+  /** Whether this adapter supports persistent storage (survives dispose+reinitialize) */
+  persistent?: boolean;
+  /** Whether cleanup is needed after tests (e.g., external services) */
+  cleanup?(): Promise<void>;
+  /** Optional callback that returns true when tests should be skipped (e.g., backend unavailable) */
+  shouldSkip?(): boolean;
+}
+
+/**
+ * Run the full conformance suite against an adapter.
+ * Call this inside a `describe()` block.
+ */
+export function runConformanceSuite(factory: ConformanceAdapterFactory): void {
+  let adapter: SearchAdapter;
+
+  beforeEach((ctx) => {
+    if (factory.shouldSkip?.()) {
+      ctx.skip();
+      return;
+    }
+    adapter = factory.create();
+  });
+
+  afterEach(async () => {
+    if (adapter.dispose) {
+      await adapter.dispose();
+    }
+    if (factory.cleanup) {
+      await factory.cleanup();
+    }
+  });
+
+  // ── Contract shape ──────────────────────────────────────────────
+
+  describe("contract shape", () => {
+    it("has a non-empty name", () => {
+      expect(typeof adapter.name).toBe("string");
+      expect(adapter.name.length).toBeGreaterThan(0);
+    });
+
+    it("exposes required methods", () => {
+      expect(typeof adapter.index).toBe("function");
+      expect(typeof adapter.search).toBe("function");
+      expect(typeof adapter.remove).toBe("function");
+      expect(typeof adapter.clear).toBe("function");
+    });
+
+    it("exposes capabilities object if declared", () => {
+      if (adapter.capabilities !== undefined) {
+        expect(typeof adapter.capabilities).toBe("object");
+      }
+    });
+  });
+
+  // ── Index + Search basics ───────────────────────────────────────
+
+  describe("index and search", () => {
+    it("returns matching ids after indexing documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha beta" } },
+          { id: "d2", fields: { title: "gamma delta" } },
+        ],
+      });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toContain("d1");
+      expect(results).not.toContain("d2");
+    });
+
+    it("returns empty array when no documents match", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      const results = await adapter.search({ resource: "items", query: "zzzzz", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("upserts on duplicate id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "beta" } }],
+      });
+      const alphaResults = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(alphaResults).not.toContain("d1");
+      const betaResults = await adapter.search({ resource: "items", query: "beta", limit: 10 });
+      expect(betaResults).toContain("d1");
+    });
+
+    it("respects limit parameter", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      const docs = Array.from({ length: 20 }, (_, i) => ({
+        id: `d${i}`,
+        fields: { title: "common term" },
+      }));
+      await adapter.index({ resource: "items", documents: docs });
+      const results = await adapter.search({ resource: "items", query: "common", limit: 5 });
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── Deterministic tie-breaking ──────────────────────────────────
+
+  describe("deterministic ordering", () => {
+    it("produces consistent order for equal-score documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "b", fields: { title: "same" } },
+          { id: "a", fields: { title: "same" } },
+          { id: "c", fields: { title: "same" } },
+        ],
+      });
+      const r1 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      const r2 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      expect(r1).toEqual(r2);
+    });
+  });
+
+  // ── Remove ──────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    it("removes documents by id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha" } },
+          { id: "d2", fields: { title: "alpha" } },
+        ],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).not.toContain("d1");
+      expect(results).toContain("d2");
+    });
+
+    it("is idempotent for already-removed ids", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      // Second remove should not throw
+      await expect(adapter.remove({ resource: "items", ids: ["d1"] })).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Clear ───────────────────────────────────────────────────────
+
+  describe("clear", () => {
+    it("removes all documents from a resource", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("does not affect other resources", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const notesResults = await adapter.search({ resource: "notes", query: "alpha", limit: 10 });
+      expect(notesResults).toContain("n1");
+    });
+  });
+
+  // ── searchAll (optional) ────────────────────────────────────────
+
+  describe("searchAll", () => {
+    it("merges results across resources with deterministic ordering", async () => {
+      if (!adapter.searchAll) return; // skip if not supported
+
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "common term" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "common term" } }],
+      });
+
+      const results = await adapter.searchAll({ query: "common", limit: 10 });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // Verify deterministic ordering: score desc, resource asc, id asc
+      for (let i = 1; i < results.length; i++) {
+        const prev = results[i - 1];
+        const curr = results[i];
+        const valid =
+          prev.score > curr.score ||
+          (prev.score === curr.score && prev.resource < curr.resource) ||
+          (prev.score === curr.score &&
+            prev.resource === curr.resource &&
+            String(prev.id) <= String(curr.id));
+        expect(valid).toBe(true);
+      }
+    });
+  });
+
+  // ── Lifecycle (initialize / dispose) ────────────────────────────
+
+  describe("lifecycle", () => {
+    it("blocks operations after dispose", async () => {
+      if (!adapter.dispose) return;
+
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.dispose();
+
+      try {
+        await adapter.search({ resource: "items", query: "test", limit: 10 });
+        // If it doesn't throw, the adapter allows post-dispose search (some might)
+        // but it MUST NOT return stale data if persistent=false
+      } catch (err) {
+        // Expected: adapter should reject after dispose
+        expect(err).toBeDefined();
+        if (err instanceof Error && "code" in err) {
+          expect((err as { code: string }).code).toBe(SEARCH_ADAPTER_DISPOSED);
+        }
+      }
+    });
+
+    it("can reinitialize after dispose", async () => {
+      if (!adapter.dispose || !adapter.initialize) return;
+
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.dispose();
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+
+      // After reinitialize, adapter should be operational
+      // For non-persistent adapters, previous data may be gone
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      if (factory.persistent) {
+        expect(results).toContain("d1");
+      }
+      // For non-persistent, just verify it doesn't throw
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+}
+
+/**
+ * List of conformance assertion categories.
+ * Used for documentation/reporting.
+ */
+export const CONFORMANCE_ASSERTIONS = [
+  "contract-shape: name, required methods, capabilities",
+  "index-search: basic indexing, search, upsert, limit",
+  "deterministic-ordering: consistent tie-breaking",
+  "remove: by id, idempotent",
+  "clear: per-resource, cross-resource isolation",
+  "searchAll: merged results, deterministic global order",
+  "lifecycle: dispose blocks ops, reinitialize restores",
+] as const;

--- a/searchfn/adapter-elasticsearch/__tests__/elasticsearch.test.ts
+++ b/searchfn/adapter-elasticsearch/__tests__/elasticsearch.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from "vitest";
+import { ElasticsearchAdapter } from "../src/index";
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+import { redactSensitive as redactElasticSensitive } from "../src/internal/redaction";
+
+const ES_URL = process.env.SEARCHFN_ES_URL ?? "http://localhost:9200";
+
+let testCounter = 0;
+
+async function canConnect(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: "GET" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+describe("ElasticsearchAdapter integration", () => {
+  let available = false;
+  let adapter: ElasticsearchAdapter;
+
+  beforeAll(async () => {
+    available = await canConnect(ES_URL);
+    if (!available) {
+      console.warn("Elasticsearch not available, skipping integration tests");
+    }
+  });
+
+  beforeEach(async () => {
+    if (!available) return;
+
+    adapter = new ElasticsearchAdapter({
+      node: ES_URL,
+      engine: "elasticsearch",
+      indexPrefix: `searchfn_es_test_${++testCounter}`,
+      requestTimeoutMs: 10_000,
+      retry: { maxRetries: 1, baseDelayMs: 25, maxDelayMs: 100 },
+    });
+
+    await adapter.initialize({
+      resources: [
+        { name: "tasks", searchFields: ["title", "body"] },
+        { name: "notes", searchFields: ["content"] },
+      ],
+    });
+  });
+
+  afterEach(async () => {
+    await adapter?.dispose();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    if (adapter) {
+      await adapter.dispose();
+    }
+  });
+
+  it("supports index/search/remove/clear with deterministic ordering", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "b", fields: { title: "incident report", body: "urgent" } },
+        { id: "a", fields: { title: "incident report", body: "urgent" } },
+      ],
+    });
+
+    const first = await adapter.search({ resource: "tasks", query: "incident", limit: 10 });
+    const second = await adapter.search({ resource: "tasks", query: "incident", limit: 10 });
+    expect(first).toEqual(second);
+    expect(first).toEqual(["a", "b"]);
+
+    await adapter.remove({ resource: "tasks", ids: ["a"] });
+    const afterRemove = await adapter.search({ resource: "tasks", query: "incident", limit: 10 });
+    expect(afterRemove).toEqual(["b"]);
+
+    await adapter.clear("tasks");
+    const afterClear = await adapter.search({ resource: "tasks", query: "incident", limit: 10 });
+    expect(afterClear).toEqual([]);
+  });
+
+  it("supports searchAll with canonical global ordering", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "2", fields: { title: "incident" } }],
+    });
+
+    await adapter.index({
+      resource: "notes",
+      documents: [{ id: "1", fields: { content: "incident" } }],
+    });
+
+    const results = await adapter.searchAll({ query: "incident", limit: 10 });
+    expect(results.length).toBeGreaterThan(0);
+
+    for (let i = 1; i < results.length; i++) {
+      const prev = results[i - 1];
+      const curr = results[i];
+      const valid =
+        prev.score > curr.score ||
+        (prev.score === curr.score && prev.resource < curr.resource) ||
+        (prev.score === curr.score &&
+          prev.resource === curr.resource &&
+          String(prev.id) <= String(curr.id));
+      expect(valid).toBe(true);
+    }
+  });
+
+  // TV-ES-001: prefix: true matches partial terms (requires live ES)
+  it("TV-ES-001: prefix: true returns partial term matches, prefix: false does not", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "todo item" } }],
+    });
+
+    const withPrefix = await adapter.search({ resource: "tasks", query: "tod", prefix: true, limit: 10 });
+    expect(withPrefix).toContain("1");
+
+    const withoutPrefix = await adapter.search({ resource: "tasks", query: "tod", prefix: false, limit: 10 });
+    expect(withoutPrefix).not.toContain("1");
+  });
+});
+
+describe("ElasticsearchAdapter resilience and validation", () => {
+  it("redacts plain connection keys without over-redacting connectionTimeout", () => {
+    expect(
+      redactElasticSensitive({
+        connection: "http://user:pass@example.test",
+        connectionTimeout: 5000,
+      }),
+    ).toEqual({
+      connection: "[REDACTED]",
+      connectionTimeout: 5000,
+    });
+  });
+
+  it("fails unsupported dialect with DFQL_UNSUPPORTED", () => {
+    expect(
+      () => new ElasticsearchAdapter({ node: "http://localhost:9200", engine: "invalid" as never }),
+    ).toThrowError(SearchAdapterError);
+
+    try {
+      new ElasticsearchAdapter({ node: "http://localhost:9200", engine: "invalid" as never });
+      expect.fail("should throw");
+    } catch (err) {
+      expect((err as SearchAdapterError).code).toBe("DFQL_UNSUPPORTED");
+      expect((err as Error).message).toContain("Unsupported elastic dialect");
+    }
+  });
+
+  it("enforces bounded retry budget", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        async () =>
+          new Response("{}", {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+
+    const adapter = new ElasticsearchAdapter({
+      node: "http://localhost:9200",
+      engine: "elasticsearch",
+      retry: { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 2 },
+      requestTimeoutMs: 100,
+    });
+
+    try {
+      await adapter.search({ resource: "tasks", query: "incident", limit: 5 });
+      expect.fail("expected retry exhaustion");
+    } catch (err) {
+      expect((err as SearchAdapterError).code).toBe("INTERNAL");
+      expect((err as Error).message).toContain("Retry budget exhausted");
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves digit-only ids as strings in search results", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      makeHitsResponse([{ _id: "00123" }, { _id: "9007199254740993" }]),
+    );
+
+    try {
+      const adapter = new ElasticsearchAdapter({
+        node: "http://localhost:9200",
+        engine: "elasticsearch",
+      });
+
+      const results = await adapter.search({ resource: "tasks", query: "incident", limit: 10 });
+      expect(results).toEqual(["00123", "9007199254740993"]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("preserves canonical safe integers as numbers in search results", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      makeHitsResponse([{ _id: "123" }, { _id: "0" }]),
+    );
+
+    try {
+      const adapter = new ElasticsearchAdapter({
+        node: "http://localhost:9200",
+        engine: "elasticsearch",
+      });
+
+      const results = await adapter.search({ resource: "tasks", query: "incident", limit: 10 });
+      expect(results).toEqual([123, 0]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("requests filtered bulk error payloads for write operations", async () => {
+    const urls: string[] = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+      urls.push(String(url));
+      if (init?.method === "POST") {
+        return new Response(JSON.stringify({ errors: false, items: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const adapter = new ElasticsearchAdapter({
+      node: "http://localhost:9200",
+      engine: "elasticsearch",
+    });
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "a", fields: { title: "incident" } }],
+    });
+    await adapter.remove({
+      resource: "tasks",
+      ids: ["a"],
+    });
+
+    expect(urls).toContain(
+      "http://localhost:9200/_bulk?refresh=wait_for&filter_path=errors,items.*._id,items.*._index,items.*.status,items.*.error",
+    );
+    expect(
+      urls.filter((url) =>
+        url === "http://localhost:9200/_bulk?refresh=wait_for&filter_path=errors,items.*._id,items.*._index,items.*.status,items.*.error",
+      ),
+    ).toHaveLength(2);
+
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves configured base paths when building backend URLs", async () => {
+    const urls: string[] = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      urls.push(String(url));
+      return makeHitsResponse([{ _id: "123" }]);
+    });
+
+    try {
+      const adapter = new ElasticsearchAdapter({
+        node: "http://localhost:9200/custom-base",
+        engine: "elasticsearch",
+      });
+
+      await adapter.search({ resource: "tasks", query: "incident", limit: 10 });
+      expect(urls[0]).toBe("http://localhost:9200/custom-base/searchfn_tasks/_search");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query construction unit tests (TV-ES-002 through TV-ES-006)
+// These tests do NOT require a live Elasticsearch instance.
+// ---------------------------------------------------------------------------
+
+function makeHitsResponse(hits: Array<{ _id: string; _score?: number }> = []) {
+  return new Response(
+    JSON.stringify({ hits: { hits } }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+async function captureSearchQuery(
+  adapterOptions: Omit<ConstructorParameters<typeof ElasticsearchAdapter>[0], "node">,
+  searchParams: Parameters<ElasticsearchAdapter["search"]>[0],
+): Promise<unknown> {
+  let capturedQuery: unknown;
+
+  const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+    const body = JSON.parse(init?.body as string) as { query: unknown };
+    capturedQuery = body.query;
+    return makeHitsResponse();
+  });
+
+  const adapter = new ElasticsearchAdapter({
+    node: "http://localhost:9200",
+    retry: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0 },
+    ...adapterOptions,
+  });
+
+  await adapter.search(searchParams);
+  fetchSpy.mockRestore();
+  return capturedQuery;
+}
+
+describe("ElasticsearchAdapter query construction", () => {
+  // TV-ES-002: prefix: true → bool.should with phrase_prefix
+  it("TV-ES-002: prefix: true emits bool.should with multi_match + phrase_prefix", async () => {
+    const query = await captureSearchQuery(
+      {},
+      { resource: "todos", query: "to", prefix: true },
+    );
+
+    const q = query as { bool: { should: unknown[]; minimum_should_match: number } };
+    expect(q.bool.minimum_should_match).toBe(1);
+    expect(q.bool.should).toHaveLength(2);
+    expect(q.bool.should).toEqual(
+      expect.arrayContaining([
+        { multi_match: { query: "to", fields: ["*"] } },
+        { multi_match: { query: "to", fields: ["*"], type: "phrase_prefix" } },
+      ]),
+    );
+  });
+
+  // TV-ES-003: prefix omitted or false → single multi_match (unchanged behaviour)
+  it("TV-ES-003: prefix omitted → single multi_match", async () => {
+    const queryOmitted = await captureSearchQuery(
+      {},
+      { resource: "todos", query: "todo" },
+    );
+    expect(queryOmitted).toEqual({ multi_match: { query: "todo", fields: ["*"] } });
+  });
+
+  it("TV-ES-003: prefix: false → single multi_match", async () => {
+    const queryFalse = await captureSearchQuery(
+      {},
+      { resource: "todos", query: "todo", prefix: false },
+    );
+    expect(queryFalse).toEqual({ multi_match: { query: "todo", fields: ["*"] } });
+  });
+
+  // TV-ES-004: prefix: true + fuzzy: true → three should clauses
+  it("TV-ES-004: prefix + fuzzy emits three bool.should clauses", async () => {
+    const query = await captureSearchQuery(
+      {},
+      { resource: "todos", query: "to", prefix: true, fuzzy: true },
+    );
+
+    const q = query as { bool: { should: unknown[]; minimum_should_match: number } };
+    expect(q.bool.minimum_should_match).toBe(1);
+    expect(q.bool.should).toHaveLength(3);
+    expect(q.bool.should).toEqual(
+      expect.arrayContaining([
+        { multi_match: { query: "to", fields: ["*"] } },
+        { multi_match: { query: "to", fields: ["*"], type: "phrase_prefix" } },
+        { multi_match: { query: "to", fields: ["*"], fuzziness: "AUTO" } },
+      ]),
+    );
+  });
+
+  // TV-ES-005: construct-time defaults applied when query params omit options
+  it("TV-ES-005: construct-time defaults.prefix + defaults.fuzzy are applied when params omit them", async () => {
+    const query = await captureSearchQuery(
+      { defaults: { prefix: true, fuzzy: true } },
+      { resource: "todos", query: "to" }, // no prefix/fuzzy in params
+    );
+
+    const q = query as { bool: { should: unknown[] } };
+    expect(q.bool.should).toHaveLength(3);
+    expect(q.bool.should).toEqual(
+      expect.arrayContaining([
+        { multi_match: { query: "to", fields: ["*"] } },
+        { multi_match: { query: "to", fields: ["*"], type: "phrase_prefix" } },
+        { multi_match: { query: "to", fields: ["*"], fuzziness: "AUTO" } },
+      ]),
+    );
+  });
+
+  // TV-ES-006: query-time prefix: false overrides construct-time prefix: true default
+  it("TV-ES-006: query-time prefix: false overrides construct-time default prefix: true", async () => {
+    const query = await captureSearchQuery(
+      { defaults: { prefix: true } },
+      { resource: "todos", query: "todo", prefix: false },
+    );
+
+    // Explicit prefix: false wins — plain multi_match, no bool.should
+    expect(query).toEqual({ multi_match: { query: "todo", fields: ["*"] } });
+  });
+
+  // TV-CAP-001 (ES part): capabilities.prefix is true
+  it("TV-CAP-001: capabilities.prefix is true", () => {
+    const adapter = new ElasticsearchAdapter({ node: "http://localhost:9200" });
+    expect(adapter.capabilities?.prefix).toBe(true);
+  });
+
+  // Additional: fuzzy-only still produces single multi_match with fuzziness (no regression)
+  it("fuzzy: true without prefix → single multi_match with fuzziness: AUTO", async () => {
+    const query = await captureSearchQuery(
+      {},
+      { resource: "todos", query: "tdo", fuzzy: true },
+    );
+    expect(query).toEqual({ multi_match: { query: "tdo", fields: ["*"], fuzziness: "AUTO" } });
+  });
+});

--- a/searchfn/adapter-elasticsearch/docker-compose.elastic.yml
+++ b/searchfn/adapter-elasticsearch/docker-compose.elastic.yml
@@ -1,0 +1,35 @@
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.2
+    container_name: searchfn-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - xpack.ml.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "127.0.0.1:9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200 >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+  opensearch:
+    image: opensearchproject/opensearch:2.18.0
+    container_name: searchfn-opensearch
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=unused-password
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "127.0.0.1:9201:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200 >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s

--- a/searchfn/adapter-elasticsearch/package.json
+++ b/searchfn/adapter-elasticsearch/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@searchfn/adapter-elasticsearch",
+  "version": "0.1.0",
+  "description": "Elasticsearch adapter for SearchFn.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@searchfn/adapter-contracts": "file:../adapter-contracts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/adapter-elasticsearch/src/elastic-client.ts
+++ b/searchfn/adapter-elasticsearch/src/elastic-client.ts
@@ -1,0 +1,221 @@
+import {
+  abortedError,
+  forbiddenError,
+  retryBudgetExhaustedError,
+  withRedactedErrorMessage,
+} from "./internal/errors";
+import { redactSensitive } from "./internal/redaction";
+import { runWithRetry, type RetryPolicy } from "./internal/retry";
+
+export type ElasticDialect = "elasticsearch" | "opensearch";
+
+export type ElasticRetryPolicy = RetryPolicy;
+
+export interface AdapterLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface ElasticClientOptions {
+  node: string;
+  dialect: ElasticDialect;
+  auth?: { username: string; password: string } | { apiKey: string };
+  requestTimeoutMs?: number;
+  retry?: ElasticRetryPolicy;
+  logger?: AdapterLogger;
+}
+
+export interface ElasticRequestOptions {
+  method: string;
+  path: string;
+  body?: unknown;
+  contentType?: string;
+  signal?: AbortSignal;
+  ignoreStatuses?: number[];
+}
+
+export interface ElasticResponse<T = unknown> {
+  status: number;
+  body?: T;
+}
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function isRetryableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return (
+    err.name === "AbortError" ||
+    err.message.includes("ECONNREFUSED") ||
+    err.message.includes("ETIMEDOUT") ||
+    err.message.includes("fetch failed")
+  );
+}
+
+function mergeSignals(
+  ...signals: Array<AbortSignal | undefined>
+): { signal?: AbortSignal; cleanup(): void } {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+  if (activeSignals.length === 0) {
+    return {
+      signal: undefined,
+      cleanup() {},
+    };
+  }
+  const controller = new AbortController();
+  const listeners: Array<{ signal: AbortSignal; listener: () => void }> = [];
+  const cleanup = () => {
+    for (const { signal, listener } of listeners) {
+      signal.removeEventListener("abort", listener);
+    }
+    listeners.length = 0;
+  };
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      controller.abort();
+      cleanup();
+      return { signal: controller.signal, cleanup };
+    }
+    const listener = () => {
+      cleanup();
+      controller.abort();
+    };
+    signal.addEventListener("abort", listener, { once: true });
+    listeners.push({ signal, listener });
+  }
+  return { signal: controller.signal, cleanup };
+}
+
+function parseResponseBody<T>(
+  text: string,
+  options: { strictJson: boolean },
+): T | string | undefined {
+  if (text.length === 0) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    if (options.strictJson) {
+      const invalidJsonError = new Error("Elastic backend returned invalid JSON");
+      (invalidJsonError as Error & { cause?: unknown }).cause = error;
+      throw invalidJsonError;
+    }
+    return text;
+  }
+}
+
+function buildRequestUrl(base: string, path: string): URL {
+  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+  const normalizedPath = path.replace(/^\/+/, "");
+  return new URL(normalizedPath, normalizedBase);
+}
+
+export class ElasticClient {
+  private readonly requestTimeoutMs: number;
+
+  constructor(private readonly options: ElasticClientOptions) {
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+  }
+
+  async request<T = unknown>(opts: ElasticRequestOptions): Promise<ElasticResponse<T>> {
+    const ignoreStatuses = new Set(opts.ignoreStatuses ?? []);
+    const startedAt = Date.now();
+
+    const response = await runWithRetry(
+      () => this.execute<T>(opts),
+      {
+        policy: this.options.retry,
+        isRetryableResult: (result) => {
+          return RETRYABLE_STATUS.has((result as ElasticResponse).status) && !ignoreStatuses.has((result as ElasticResponse).status);
+        },
+        isRetryableError,
+        exhaustedError: retryBudgetExhaustedError(),
+        onRetry: ({ attempt, delayMs, reason }) => {
+          this.options.logger?.warn("adapter.retry", redactSensitive({
+            backend: this.options.dialect,
+            operation: `${opts.method} ${opts.path}`,
+            attempt,
+            delayMs,
+            reason,
+          }));
+        },
+      },
+    );
+
+    if ((response.status === 401 || response.status === 403) && !ignoreStatuses.has(response.status)) {
+      throw forbiddenError("Backend authorization failed");
+    }
+    if (response.status >= 400 && !ignoreStatuses.has(response.status)) {
+      throw withRedactedErrorMessage(
+        `Elastic backend request failed with status ${response.status}`,
+        typeof response.body === "string" ? response.body : JSON.stringify(response.body),
+      );
+    }
+
+    this.options.logger?.debug("adapter.request", redactSensitive({
+      backend: this.options.dialect,
+      operation: `${opts.method} ${opts.path}`,
+      status: response.status,
+      durationMs: Date.now() - startedAt,
+    }));
+
+    return response;
+  }
+
+  private async execute<T>(opts: ElasticRequestOptions): Promise<ElasticResponse<T>> {
+    const timeoutController = new AbortController();
+    const timeoutId = setTimeout(() => timeoutController.abort(), this.requestTimeoutMs);
+    const merged = mergeSignals(timeoutController.signal, opts.signal);
+
+    const headers: Record<string, string> = { accept: "application/json" };
+    if (this.options.auth) {
+      if ("apiKey" in this.options.auth) {
+        headers.authorization = `ApiKey ${this.options.auth.apiKey}`;
+      } else {
+        const token = Buffer.from(`${this.options.auth.username}:${this.options.auth.password}`).toString(
+          "base64",
+        );
+        headers.authorization = `Basic ${token}`;
+      }
+    }
+
+    let body: string | undefined;
+    if (opts.body !== undefined) {
+      if (typeof opts.body === "string") {
+        body = opts.body;
+      } else {
+        body = JSON.stringify(opts.body);
+      }
+      headers["content-type"] = opts.contentType ?? "application/json";
+    }
+
+    try {
+      const url = buildRequestUrl(this.options.node, opts.path);
+      const response = await fetch(url, {
+        method: opts.method,
+        headers,
+        body,
+        signal: merged.signal,
+      });
+
+      const text = await response.text();
+      const parsed = parseResponseBody<T>(text, {
+        strictJson: response.ok,
+      });
+
+      return {
+        status: response.status,
+        body: parsed as T | undefined,
+      };
+    } catch (error) {
+      if (opts.signal?.aborted) {
+        throw abortedError();
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      merged.cleanup();
+    }
+  }
+}

--- a/searchfn/adapter-elasticsearch/src/elasticsearch.ts
+++ b/searchfn/adapter-elasticsearch/src/elasticsearch.ts
@@ -1,0 +1,366 @@
+import type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchAllResult,
+  IndexParams,
+  SearchParams,
+  SearchAllParams,
+  RemoveParams,
+  InitializeParams,
+  SearchDefaults,
+} from "@searchfn/adapter-contracts";
+import { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+import {
+  ElasticClient,
+  type ElasticDialect,
+  type ElasticRetryPolicy,
+  type AdapterLogger,
+} from "./elastic-client";
+
+export interface ElasticsearchAdapterOptions {
+  node: string;
+  auth?: { username: string; password: string } | { apiKey: string };
+  engine?: ElasticDialect;
+  indexPrefix?: string;
+  requestTimeoutMs?: number;
+  retry?: ElasticRetryPolicy;
+  logger?: AdapterLogger;
+  defaults?: SearchDefaults;
+}
+
+interface ElasticHit {
+  _id: string;
+  _score?: number | null;
+}
+
+const SUPPORTED_DIALECTS = new Set<ElasticDialect>(["elasticsearch", "opensearch"]);
+
+function sanitizeResourceName(resource: string): string {
+  return resource.replace(/[^a-z0-9_]/gi, "_").toLowerCase();
+}
+
+function coerceId(value: string): string | number {
+  if (/^(0|[1-9]\d*)$/.test(value)) {
+    const parsed = Number(value);
+    if (Number.isSafeInteger(parsed) && String(parsed) === value) {
+      return parsed;
+    }
+  }
+  return value;
+}
+
+interface ElasticBulkResponseItem {
+  index?: { _id?: string; _index?: string; status?: number; error?: unknown };
+  delete?: { _id?: string; _index?: string; status?: number; error?: unknown };
+}
+
+interface ElasticBulkResponse {
+  errors?: boolean;
+  items?: ElasticBulkResponseItem[];
+}
+
+function getBulkFailureMessage(response: ElasticBulkResponse | undefined): string {
+  const failedItem = response?.items?.find((item) => item.index?.error ?? item.delete?.error);
+  const failure = failedItem?.index ?? failedItem?.delete;
+  if (!failure?.error) {
+    return "Bulk operation failed";
+  }
+
+  return `Bulk operation failed for ${failure._index ?? "unknown-index"}/${failure._id ?? "unknown-id"}: ${JSON.stringify(failure.error)}`;
+}
+
+export class ElasticsearchAdapter implements SearchAdapter {
+  readonly name: string = "elastic-compatible";
+  readonly capabilities: SearchAdapterCapabilities = {
+    persistent: true,
+    searchAll: true,
+    fuzzy: true,
+    prefix: true,
+    fieldBoosts: true,
+  };
+
+  private readonly dialect: ElasticDialect;
+  private readonly indexPrefix: string;
+  private readonly client: ElasticClient;
+  private readonly defaults?: SearchDefaults;
+  private disposed = false;
+  private readonly resources = new Map<string, string[]>();
+
+  constructor(public readonly options: ElasticsearchAdapterOptions) {
+    const dialect = options.engine ?? "elasticsearch";
+    if (!SUPPORTED_DIALECTS.has(dialect)) {
+      throw new SearchAdapterError("DFQL_UNSUPPORTED", "Unsupported elastic dialect");
+    }
+    this.dialect = dialect;
+    this.indexPrefix = options.indexPrefix ?? "searchfn";
+    this.defaults = options.defaults;
+    this.client = new ElasticClient({
+      node: options.node,
+      dialect,
+      auth: options.auth,
+      requestTimeoutMs: options.requestTimeoutMs,
+      retry: options.retry,
+      logger: options.logger,
+    });
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) {
+      throw new SearchAdapterError(
+        SEARCH_ADAPTER_DISPOSED,
+        "Search adapter is disposed. Call initialize() before use.",
+      );
+    }
+  }
+
+  private indexName(resource: string): string {
+    return `${this.indexPrefix}_${sanitizeResourceName(resource)}`;
+  }
+
+  /**
+   * Resolves per-call options using resolution order:
+   *   query param ?? construct-time default ?? off
+   */
+  private resolveOptions(params: SearchParams | SearchAllParams): {
+    fuzzy: boolean | number | undefined;
+    prefix: boolean | undefined;
+    fieldBoosts: Record<string, number> | undefined;
+  } {
+    return {
+      fuzzy: params.fuzzy ?? this.defaults?.fuzzy,
+      prefix: params.prefix ?? this.defaults?.prefix,
+      fieldBoosts: params.fieldBoosts ?? this.defaults?.fieldBoosts,
+    };
+  }
+
+  /**
+   * Builds the Elasticsearch/OpenSearch query object based on the resolved
+   * fuzzy and prefix options.
+   *
+   * - No prefix, no fuzzy  → single multi_match (unchanged behaviour)
+   * - Fuzzy only           → single multi_match with fuzziness: "AUTO"
+   * - Prefix only          → bool.should [multi_match, phrase_prefix]
+   * - Both                 → bool.should [multi_match, phrase_prefix, fuzzy multi_match]
+   */
+  private buildElasticQuery(
+    query: string,
+    fields: string[],
+    fuzzy: boolean | number | undefined,
+    prefix: boolean | undefined,
+  ): unknown {
+    const useFuzzy = !!fuzzy;
+    const usePrefix = !!prefix;
+
+    if (!usePrefix && !useFuzzy) {
+      return { multi_match: { query, fields } };
+    }
+
+    if (useFuzzy && !usePrefix) {
+      return { multi_match: { query, fields, fuzziness: "AUTO" } };
+    }
+
+    const should: unknown[] = [
+      { multi_match: { query, fields } },
+      { multi_match: { query, fields, type: "phrase_prefix" } },
+    ];
+
+    if (useFuzzy) {
+      should.push({ multi_match: { query, fields, fuzziness: "AUTO" } });
+    }
+
+    return { bool: { should, minimum_should_match: 1 } };
+  }
+
+  async initialize(params: InitializeParams): Promise<void> {
+    if (this.disposed) {
+      this.disposed = false;
+    }
+    for (const resource of params.resources) {
+      const indexName = this.indexName(resource.name);
+      const fields = resource.searchFields.length > 0 ? resource.searchFields : ["content"];
+      this.resources.set(resource.name, fields);
+
+      const exists = await this.client.request({
+        method: "HEAD",
+        path: `/${indexName}`,
+        ignoreStatuses: [404],
+      });
+
+      if (exists.status === 404) {
+        await this.client.request({
+          method: "PUT",
+          path: `/${indexName}`,
+          body: {
+            settings: {
+              number_of_shards: 1,
+              number_of_replicas: 0,
+              refresh_interval: "1s",
+            },
+            mappings: {
+              dynamic: true,
+              properties: {
+                ...Object.fromEntries(fields.map((field) => [field, { type: "text" }])),
+              },
+            },
+          },
+          ignoreStatuses: [400],
+        });
+      } else {
+        await this.client.request({
+          method: "PUT",
+          path: `/${indexName}/_mapping`,
+          body: {
+            properties: {
+              ...Object.fromEntries(fields.map((field) => [field, { type: "text" }])),
+            },
+          },
+        });
+      }
+    }
+  }
+
+  async index({ resource, documents, signal }: IndexParams): Promise<void> {
+    this.assertNotDisposed();
+    if (documents.length === 0) return;
+
+    const indexName = this.indexName(resource);
+    const payload: string[] = [];
+    for (const document of documents) {
+      if (signal?.aborted) {
+        throw new SearchAdapterError("DFQL_ABORTED", "Index operation aborted");
+      }
+      payload.push(JSON.stringify({ index: { _index: indexName, _id: String(document.id) } }));
+      payload.push(JSON.stringify(document.fields));
+    }
+
+    const response = await this.client.request<ElasticBulkResponse>({
+      method: "POST",
+      path: "/_bulk?refresh=wait_for&filter_path=errors,items.*._id,items.*._index,items.*.status,items.*.error",
+      body: `${payload.join("\n")}\n`,
+      contentType: "application/x-ndjson",
+      signal,
+    });
+    if (response.body?.errors) {
+      throw new SearchAdapterError("INTERNAL", getBulkFailureMessage(response.body));
+    }
+  }
+
+  async search(params: SearchParams): Promise<Array<string | number>> {
+    this.assertNotDisposed();
+
+    const { fuzzy, prefix, fieldBoosts } = this.resolveOptions(params);
+    const indexName = this.indexName(params.resource);
+    const fields = params.fields?.length
+      ? params.fields
+      : this.resources.get(params.resource) ?? ["*"];
+    const boostedFields = fields.map((field) =>
+      fieldBoosts?.[field] ? `${field}^${fieldBoosts[field]}` : field,
+    );
+
+    const response = await this.client.request<{ hits?: { hits?: ElasticHit[] } }>({
+      method: "POST",
+      path: `/${indexName}/_search`,
+      body: {
+        size: Math.max(1, params.limit ?? 10),
+        track_total_hits: false,
+        query: this.buildElasticQuery(params.query, boostedFields, fuzzy, prefix),
+        sort: [{ _score: { order: "desc" } }, { _id: { order: "asc" } }],
+      },
+      signal: params.signal,
+      ignoreStatuses: [404],
+    });
+
+    if (response.status === 404) {
+      return [];
+    }
+
+    return (response.body?.hits?.hits ?? []).map((hit) => coerceId(hit._id));
+  }
+
+  async searchAll(params: SearchAllParams): Promise<SearchAllResult[]> {
+    this.assertNotDisposed();
+
+    const { fuzzy, prefix, fieldBoosts } = this.resolveOptions(params);
+    const resources = params.resources?.length ? params.resources : Array.from(this.resources.keys());
+    const limit = Math.max(1, params.limit ?? 10);
+    const limitPerResource = Math.max(1, params.limitPerResource ?? limit);
+
+    const allResults: SearchAllResult[] = [];
+    for (const resource of resources) {
+      const indexName = this.indexName(resource);
+      const fields = params.fields?.length ? params.fields : this.resources.get(resource) ?? ["*"];
+      const boostedFields = fields.map((field) =>
+        fieldBoosts?.[field] ? `${field}^${fieldBoosts[field]}` : field,
+      );
+
+      const response = await this.client.request<{ hits?: { hits?: ElasticHit[] } }>({
+        method: "POST",
+        path: `/${indexName}/_search`,
+        body: {
+          size: limitPerResource,
+          track_total_hits: false,
+          query: this.buildElasticQuery(params.query, boostedFields, fuzzy, prefix),
+          sort: [{ _score: { order: "desc" } }, { _id: { order: "asc" } }],
+        },
+        signal: params.signal,
+        ignoreStatuses: [404],
+      });
+
+      if (response.status === 404) continue;
+
+      for (const hit of response.body?.hits?.hits ?? []) {
+        allResults.push({
+          resource,
+          id: coerceId(hit._id),
+          score: hit._score ?? 0,
+        });
+      }
+    }
+
+    allResults.sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      if (a.resource !== b.resource) return a.resource.localeCompare(b.resource);
+      return String(a.id).localeCompare(String(b.id));
+    });
+    return allResults.slice(0, limit);
+  }
+
+  async remove({ resource, ids, signal }: RemoveParams): Promise<void> {
+    this.assertNotDisposed();
+    if (ids.length === 0) return;
+
+    const indexName = this.indexName(resource);
+    const payload: string[] = [];
+    for (const id of ids) {
+      payload.push(JSON.stringify({ delete: { _index: indexName, _id: String(id) } }));
+    }
+
+    const response = await this.client.request<ElasticBulkResponse>({
+      method: "POST",
+      path: "/_bulk?refresh=wait_for&filter_path=errors,items.*._id,items.*._index,items.*.status,items.*.error",
+      body: `${payload.join("\n")}\n`,
+      contentType: "application/x-ndjson",
+      signal,
+      ignoreStatuses: [404],
+    });
+    if (response.body?.errors) {
+      throw new SearchAdapterError("INTERNAL", getBulkFailureMessage(response.body));
+    }
+  }
+
+  async clear(resource: string, signal?: AbortSignal): Promise<void> {
+    this.assertNotDisposed();
+    const indexName = this.indexName(resource);
+    await this.client.request({
+      method: "POST",
+      path: `/${indexName}/_delete_by_query?refresh=true&conflicts=proceed`,
+      body: { query: { match_all: {} } },
+      signal,
+      ignoreStatuses: [404],
+    });
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+  }
+}

--- a/searchfn/adapter-elasticsearch/src/index.ts
+++ b/searchfn/adapter-elasticsearch/src/index.ts
@@ -1,0 +1,16 @@
+export { ElasticsearchAdapter } from "./elasticsearch";
+export type { ElasticsearchAdapterOptions } from "./elasticsearch";
+export type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDocument,
+  IndexParams,
+  SearchParams,
+  SearchAllParams,
+  SearchAllResult,
+  RemoveParams,
+  InitializeParams,
+  InitializeResourceConfig,
+  SearchAdapterConfig,
+} from "@searchfn/adapter-contracts";
+export { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";

--- a/searchfn/adapter-elasticsearch/src/internal/errors.ts
+++ b/searchfn/adapter-elasticsearch/src/internal/errors.ts
@@ -1,0 +1,30 @@
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+import { redactSensitive } from "./redaction";
+
+export function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function internalError(message: string): SearchAdapterError {
+  return new SearchAdapterError("INTERNAL", message);
+}
+
+export function forbiddenError(message: string): SearchAdapterError {
+  return new SearchAdapterError("FORBIDDEN", message);
+}
+
+export function abortedError(message = "Operation aborted"): SearchAdapterError {
+  return new SearchAdapterError("DFQL_ABORTED", message);
+}
+
+export function retryBudgetExhaustedError(): SearchAdapterError {
+  return new SearchAdapterError("INTERNAL", "Retry budget exhausted");
+}
+
+export function withRedactedErrorMessage(prefix: string, error: unknown): SearchAdapterError {
+  const message = redactSensitive(toErrorMessage(error));
+  return new SearchAdapterError("INTERNAL", `${prefix}: ${message}`);
+}

--- a/searchfn/adapter-elasticsearch/src/internal/redaction.ts
+++ b/searchfn/adapter-elasticsearch/src/internal/redaction.ts
@@ -1,0 +1,62 @@
+const SENSITIVE_KEY =
+  /(?:api[_-]?key|password|secret|token|authorization|connection(?:string|[_-]string)?)(?=$|[^a-z])/i;
+
+const KEY_VALUE_SECRET = /\b(api[_-]?key|password|secret|token|authorization|connection[_-]?string)\s*[:=]\s*([^\s,;]+)/gi;
+const URL_CREDENTIALS = /(https?:\/\/)([^\s/@]+)@/gi;
+const POSTGRES_CREDENTIALS = /(postgres(?:ql)?:\/\/)([^\s/@]+)@/gi;
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function redactSensitiveInternal(value: unknown, seen: WeakSet<object>): any {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return redactSensitiveString(value);
+  }
+
+  if (typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((entry) => redactSensitiveInternal(entry, seen));
+      }
+
+      const entries = Object.entries(value);
+      if (!isPlainObject(value) && entries.length === 0) {
+        return value;
+      }
+
+      const output: Record<string, unknown> = {};
+      for (const [key, entry] of entries) {
+        if (SENSITIVE_KEY.test(key)) {
+          output[key] = "[REDACTED]";
+        } else {
+          output[key] = redactSensitiveInternal(entry, seen);
+        }
+      }
+      return output;
+    } finally {
+      seen.delete(value);
+    }
+  }
+
+  return value;
+}
+export function redactSensitive(value: unknown): any {
+  return redactSensitiveInternal(value, new WeakSet<object>());
+}
+
+export function redactSensitiveString(input: string): string {
+  return input
+    .replace(KEY_VALUE_SECRET, (_match, key) => `${key}=[REDACTED]`)
+    .replace(URL_CREDENTIALS, "$1[REDACTED]@")
+    .replace(POSTGRES_CREDENTIALS, "$1[REDACTED]@");
+}

--- a/searchfn/adapter-elasticsearch/src/internal/retry.ts
+++ b/searchfn/adapter-elasticsearch/src/internal/retry.ts
@@ -1,0 +1,115 @@
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+
+export interface RetryPolicy {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface NormalizedRetryPolicy {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface RetryAttemptContext {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  reason: string;
+}
+
+export interface RunWithRetryOptions {
+  policy?: RetryPolicy;
+  isRetryableError?: (error: unknown) => boolean;
+  isRetryableResult?: <T>(result: T) => boolean;
+  exhaustedError?: Error;
+  onRetry?: (context: RetryAttemptContext) => void;
+}
+
+const DEFAULT_RETRY_POLICY: NormalizedRetryPolicy = {
+  maxRetries: 2,
+  baseDelayMs: 100,
+  maxDelayMs: 5_000,
+};
+
+function normalizeFiniteInteger(value: number | undefined, fallback: number, min: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(min, Math.floor(value));
+}
+
+export function normalizeRetryPolicy(policy?: RetryPolicy): NormalizedRetryPolicy {
+  const maxRetries = normalizeFiniteInteger(policy?.maxRetries, DEFAULT_RETRY_POLICY.maxRetries, 0);
+  const baseDelayMs = normalizeFiniteInteger(policy?.baseDelayMs, DEFAULT_RETRY_POLICY.baseDelayMs, 1);
+  const maxDelayMs = Math.max(
+    baseDelayMs,
+    normalizeFiniteInteger(policy?.maxDelayMs, DEFAULT_RETRY_POLICY.maxDelayMs, 1),
+  );
+
+  return {
+    maxRetries,
+    baseDelayMs,
+    maxDelayMs,
+  };
+}
+
+export function computeRetryDelayMs(attempt: number, policy: NormalizedRetryPolicy): number {
+  const exponential = policy.baseDelayMs * Math.pow(2, attempt);
+  const jitter = Math.floor(policy.baseDelayMs * 0.25 * (attempt + 1));
+  return Math.min(exponential + jitter, policy.maxDelayMs);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function runWithRetry<T>(
+  operation: () => Promise<T>,
+  options: RunWithRetryOptions = {},
+): Promise<T> {
+  const policy = normalizeRetryPolicy(options.policy);
+  const exhaustedError = options.exhaustedError ?? new SearchAdapterError("INTERNAL", "Retry budget exhausted");
+
+  for (let attempt = 0; attempt <= policy.maxRetries; attempt++) {
+    try {
+      const result = await operation();
+      const retryableResult = options.isRetryableResult?.(result) ?? false;
+      if (retryableResult && attempt < policy.maxRetries) {
+        const delayMs = computeRetryDelayMs(attempt, policy);
+        options.onRetry?.({
+          attempt,
+          maxRetries: policy.maxRetries,
+          delayMs,
+          reason: "retryable_result",
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      if (retryableResult) {
+        throw exhaustedError;
+      }
+      return result;
+    } catch (error) {
+      const retryable = options.isRetryableError?.(error) ?? false;
+      if (retryable && attempt < policy.maxRetries) {
+        const delayMs = computeRetryDelayMs(attempt, policy);
+        options.onRetry?.({
+          attempt,
+          maxRetries: policy.maxRetries,
+          delayMs,
+          reason: "retryable_error",
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      if (retryable) {
+        throw exhaustedError;
+      }
+      throw error;
+    }
+  }
+
+  throw exhaustedError;
+}

--- a/searchfn/adapter-elasticsearch/tsconfig.json
+++ b/searchfn/adapter-elasticsearch/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@searchfn/adapter-contracts": ["../adapter-contracts/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapter-elasticsearch/tsup.config.ts
+++ b/searchfn/adapter-elasticsearch/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist"
+});

--- a/searchfn/adapter-elasticsearch/vitest.config.ts
+++ b/searchfn/adapter-elasticsearch/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"]
+  }
+});

--- a/searchfn/adapter-indexeddb/__tests__/adapter-contract.ts
+++ b/searchfn/adapter-indexeddb/__tests__/adapter-contract.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export function runAdapterContractTests(
+  adapterName: string,
+  createAdapter: () => SearchAdapter
+): void {
+  describe(`${adapterName} — contract tests`, () => {
+    let adapter: SearchAdapter;
+
+    beforeEach(() => {
+      adapter = createAdapter();
+    });
+
+    afterEach(async () => {
+      if (adapter.dispose) {
+        await adapter.dispose();
+      }
+    });
+
+    it("indexes documents and returns matching DocIds on search", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [
+          { id: "task:1", fields: { title: "Buy groceries", description: "Get milk and bread" } },
+          { id: "task:2", fields: { title: "Review pull request", description: "Check auth changes" } }
+        ]
+      });
+      const result = await adapter.search({ resource: "tasks", query: "groceries", limit: 10 });
+      expect(result).toEqual(["task:1"]);
+    });
+
+    it("returns empty array when query matches nothing", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "task:1", fields: { title: "Buy groceries" } }]
+      });
+      const result = await adapter.search({ resource: "tasks", query: "xyznonexistent", limit: 10 });
+      expect(result).toEqual([]);
+    });
+
+    it("remove makes document invisible to search", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "task:1", fields: { title: "Buy groceries" } }]
+      });
+      await adapter.remove({ resource: "tasks", ids: ["task:1"] });
+      const result = await adapter.search({ resource: "tasks", query: "groceries" });
+      expect(result).toEqual([]);
+    });
+
+    it("clear removes all documents from a resource", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [
+          { id: "1", fields: { title: "Buy groceries" } },
+          { id: "2", fields: { title: "Review request" } },
+          { id: "3", fields: { title: "Write tests" } }
+        ]
+      });
+      await adapter.clear("tasks");
+      const result = await adapter.search({ resource: "tasks", query: "groceries" });
+      expect(result).toEqual([]);
+    });
+
+    it("works without calling initialize first", async () => {
+      await adapter.index({ resource: "x", documents: [{ id: "1", fields: { a: "hello" } }] });
+      const result = await adapter.search({ resource: "x", query: "hello" });
+      expect(result).toContain("1");
+    });
+
+    if (createAdapter().dispose) {
+      it("throws SEARCH_ADAPTER_DISPOSED after dispose", async () => {
+        const freshAdapter = createAdapter();
+        await freshAdapter.index({ resource: "x", documents: [{ id: "1", fields: { a: "hello" } }] });
+        await freshAdapter.dispose!();
+        await expect(freshAdapter.search({ resource: "x", query: "hello" })).rejects.toMatchObject({
+          code: SEARCH_ADAPTER_DISPOSED,
+          message: "Search adapter is disposed. Call initialize() before use."
+        });
+      });
+    }
+  });
+}

--- a/searchfn/adapter-indexeddb/__tests__/conformance/indexeddb.conformance.test.ts
+++ b/searchfn/adapter-indexeddb/__tests__/conformance/indexeddb.conformance.test.ts
@@ -1,0 +1,13 @@
+import { describe, afterAll } from "vitest";
+import { IndexedDbAdapter } from "../../src/index";
+import { runConformanceSuite } from "./shared";
+
+let testCounter = 0;
+
+describe("IndexedDbAdapter conformance", () => {
+  runConformanceSuite({
+    name: "indexeddb",
+    create: () => new IndexedDbAdapter({ dbName: `conformance-idb-${++testCounter}` }),
+    persistent: true,
+  });
+});

--- a/searchfn/adapter-indexeddb/__tests__/conformance/shared.ts
+++ b/searchfn/adapter-indexeddb/__tests__/conformance/shared.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared adapter conformance test harness.
+ *
+ * Every SearchAdapter implementation MUST pass all assertions defined here.
+ * To use: call `runConformanceSuite(adapterFactory)` inside a `describe` block.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export interface ConformanceAdapterFactory {
+  /** Human-readable adapter name for test labels */
+  name: string;
+  /** Create a fresh adapter instance for each test */
+  create(): SearchAdapter;
+  /** Whether this adapter supports persistent storage (survives dispose+reinitialize) */
+  persistent?: boolean;
+  /** Whether cleanup is needed after tests (e.g., external services) */
+  cleanup?(): Promise<void>;
+  /** Optional callback that returns true when tests should be skipped (e.g., backend unavailable) */
+  shouldSkip?(): boolean;
+}
+
+/**
+ * Run the full conformance suite against an adapter.
+ * Call this inside a `describe()` block.
+ */
+export function runConformanceSuite(factory: ConformanceAdapterFactory): void {
+  let adapter: SearchAdapter;
+
+  beforeEach((ctx) => {
+    if (factory.shouldSkip?.()) {
+      ctx.skip();
+      return;
+    }
+    adapter = factory.create();
+  });
+
+  afterEach(async () => {
+    if (adapter.dispose) {
+      await adapter.dispose();
+    }
+    if (factory.cleanup) {
+      await factory.cleanup();
+    }
+  });
+
+  // ── Contract shape ──────────────────────────────────────────────
+
+  describe("contract shape", () => {
+    it("has a non-empty name", () => {
+      expect(typeof adapter.name).toBe("string");
+      expect(adapter.name.length).toBeGreaterThan(0);
+    });
+
+    it("exposes required methods", () => {
+      expect(typeof adapter.index).toBe("function");
+      expect(typeof adapter.search).toBe("function");
+      expect(typeof adapter.remove).toBe("function");
+      expect(typeof adapter.clear).toBe("function");
+    });
+
+    it("exposes capabilities object if declared", () => {
+      if (adapter.capabilities !== undefined) {
+        expect(typeof adapter.capabilities).toBe("object");
+      }
+    });
+  });
+
+  // ── Index + Search basics ───────────────────────────────────────
+
+  describe("index and search", () => {
+    it("returns matching ids after indexing documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha beta" } },
+          { id: "d2", fields: { title: "gamma delta" } },
+        ],
+      });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toContain("d1");
+      expect(results).not.toContain("d2");
+    });
+
+    it("returns empty array when no documents match", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      const results = await adapter.search({ resource: "items", query: "zzzzz", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("upserts on duplicate id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "beta" } }],
+      });
+      const alphaResults = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(alphaResults).not.toContain("d1");
+      const betaResults = await adapter.search({ resource: "items", query: "beta", limit: 10 });
+      expect(betaResults).toContain("d1");
+    });
+
+    it("respects limit parameter", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      const docs = Array.from({ length: 20 }, (_, i) => ({
+        id: `d${i}`,
+        fields: { title: "common term" },
+      }));
+      await adapter.index({ resource: "items", documents: docs });
+      const results = await adapter.search({ resource: "items", query: "common", limit: 5 });
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── Deterministic tie-breaking ──────────────────────────────────
+
+  describe("deterministic ordering", () => {
+    it("produces consistent order for equal-score documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "b", fields: { title: "same" } },
+          { id: "a", fields: { title: "same" } },
+          { id: "c", fields: { title: "same" } },
+        ],
+      });
+      const r1 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      const r2 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      expect(r1).toEqual(r2);
+    });
+  });
+
+  // ── Remove ──────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    it("removes documents by id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha" } },
+          { id: "d2", fields: { title: "alpha" } },
+        ],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).not.toContain("d1");
+      expect(results).toContain("d2");
+    });
+
+    it("is idempotent for already-removed ids", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      // Second remove should not throw
+      await expect(adapter.remove({ resource: "items", ids: ["d1"] })).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Clear ───────────────────────────────────────────────────────
+
+  describe("clear", () => {
+    it("removes all documents from a resource", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("does not affect other resources", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const notesResults = await adapter.search({ resource: "notes", query: "alpha", limit: 10 });
+      expect(notesResults).toContain("n1");
+    });
+  });
+
+  // ── searchAll (optional) ────────────────────────────────────────
+
+  describe("searchAll", () => {
+    it("merges results across resources with deterministic ordering", async () => {
+      if (!adapter.searchAll) return; // skip if not supported
+
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "common term" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "common term" } }],
+      });
+
+      const results = await adapter.searchAll({ query: "common", limit: 10 });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // Verify deterministic ordering: score desc, resource asc, id asc
+      for (let i = 1; i < results.length; i++) {
+        const prev = results[i - 1];
+        const curr = results[i];
+        const valid =
+          prev.score > curr.score ||
+          (prev.score === curr.score && prev.resource < curr.resource) ||
+          (prev.score === curr.score &&
+            prev.resource === curr.resource &&
+            String(prev.id) <= String(curr.id));
+        expect(valid).toBe(true);
+      }
+    });
+  });
+
+  // ── Lifecycle (initialize / dispose) ────────────────────────────
+
+  describe("lifecycle", () => {
+    it("blocks operations after dispose", async () => {
+      if (!adapter.dispose) return;
+
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.dispose();
+
+      try {
+        await adapter.search({ resource: "items", query: "test", limit: 10 });
+        // If it doesn't throw, the adapter allows post-dispose search (some might)
+        // but it MUST NOT return stale data if persistent=false
+      } catch (err) {
+        // Expected: adapter should reject after dispose
+        expect(err).toBeDefined();
+        if (err instanceof Error && "code" in err) {
+          expect((err as { code: string }).code).toBe(SEARCH_ADAPTER_DISPOSED);
+        }
+      }
+    });
+
+    it("can reinitialize after dispose", async () => {
+      if (!adapter.dispose || !adapter.initialize) return;
+
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.dispose();
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+
+      // After reinitialize, adapter should be operational
+      // For non-persistent adapters, previous data may be gone
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      if (factory.persistent) {
+        expect(results).toContain("d1");
+      }
+      // For non-persistent, just verify it doesn't throw
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+}
+
+/**
+ * List of conformance assertion categories.
+ * Used for documentation/reporting.
+ */
+export const CONFORMANCE_ASSERTIONS = [
+  "contract-shape: name, required methods, capabilities",
+  "index-search: basic indexing, search, upsert, limit",
+  "deterministic-ordering: consistent tie-breaking",
+  "remove: by id, idempotent",
+  "clear: per-resource, cross-resource isolation",
+  "searchAll: merged results, deterministic global order",
+  "lifecycle: dispose blocks ops, reinitialize restores",
+] as const;

--- a/searchfn/adapter-indexeddb/__tests__/indexeddb.test.ts
+++ b/searchfn/adapter-indexeddb/__tests__/indexeddb.test.ts
@@ -1,0 +1,488 @@
+import { describe, it, expect } from "vitest";
+import { runAdapterContractTests } from "./adapter-contract";
+import { IndexedDbAdapter } from "../src/index";
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+
+let testCounter = 0;
+function freshDbName(): string {
+  return `test-idb-${++testCounter}`;
+}
+
+runAdapterContractTests("IndexedDbAdapter", () => new IndexedDbAdapter({ dbName: freshDbName() }));
+
+describe("IndexedDbAdapter — IDB-specific tests", () => {
+  // TV-IDB-002: persistence across dispose/reinitialize
+  it("persists indexed data across dispose and reinitialize", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [
+        { id: "task:1", fields: { title: "Buy groceries", description: "Get milk and bread" } },
+        { id: "task:2", fields: { title: "Review pull request", description: "Check auth changes" } },
+      ],
+    });
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    try {
+      const result = await adapter2.search({ resource: "tasks", query: "groceries" });
+      expect(result).toEqual(["task:1"]);
+    } finally {
+      await adapter2.dispose();
+    }
+  });
+
+  it("persists remove operations across dispose and reinitialize", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [
+        { id: "task:1", fields: { title: "Buy groceries" } },
+        { id: "task:2", fields: { title: "Review pull request" } },
+      ],
+    });
+    await adapter1.remove({ resource: "tasks", ids: ["task:1"] });
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    try {
+      const result = await adapter2.search({ resource: "tasks", query: "groceries", fields: ["title"] });
+      expect(result).toEqual([]);
+      const result2 = await adapter2.search({ resource: "tasks", query: "review", fields: ["title"] });
+      expect(result2).toContain("task:2");
+    } finally {
+      await adapter2.dispose();
+    }
+  });
+
+  // TV-IDB-003: clear removes data from IDB permanently
+  it("clear removes IndexedDB data so a new adapter session finds nothing", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [
+        { id: "1", fields: { title: "Buy groceries" } },
+        { id: "2", fields: { title: "Review request" } },
+      ],
+    });
+    await adapter1.clear("tasks");
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    try {
+      const result = await adapter2.search({
+        resource: "tasks",
+        query: "groceries",
+        fields: ["title"],
+      });
+      expect(result).toEqual([]);
+    } finally {
+      await adapter2.dispose();
+    }
+  });
+
+  // TV-IDB-004: multiple resources in same adapter use separate IDBs
+  it("isolates multiple resources — each resource uses a separate database", async () => {
+    const dbName = freshDbName();
+    const adapter = new IndexedDbAdapter({ dbName });
+
+    try {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "Task A" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "1", fields: { title: "Note A" } }],
+      });
+
+      const taskResult = await adapter.search({ resource: "tasks", query: "Note" });
+      expect(taskResult).toEqual([]);
+
+      const noteResult = await adapter.search({ resource: "notes", query: "Task" });
+      expect(noteResult).toEqual([]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it("upsert correctly updates persisted data on cold restart", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "old title" } }],
+    });
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    await adapter2.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "new title" } }],
+    });
+    await adapter2.dispose();
+
+    const adapter3 = new IndexedDbAdapter({ dbName });
+    try {
+      const oldResult = await adapter3.search({ resource: "tasks", query: "old", fields: ["title"] });
+      expect(oldResult).toEqual([]);
+
+      const newResult = await adapter3.search({ resource: "tasks", query: "new", fields: ["title"] });
+      expect(newResult).toContain("1");
+    } finally {
+      await adapter3.dispose();
+    }
+  });
+
+  it("supports fuzzy search on persisted index", async () => {
+    const dbName = freshDbName();
+    const adapter = new IndexedDbAdapter({ dbName });
+    try {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "groceries" } }],
+      });
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "groceris",
+        fuzzy: true,
+      });
+      expect(result).toContain("1");
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it("keeps legacy doc-term snapshots from polluting fuzzy vocabulary with prefix terms", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "testing" } }],
+    });
+
+    const engine1 = (adapter1 as any).getOrCreateEngine("tasks");
+    await (adapter1 as any).ensureOpen(engine1);
+    const docTermsBuffer = await engine1.storage.getCacheState("doc-terms");
+    expect(docTermsBuffer).toBeTruthy();
+
+    const legacySnapshot = JSON.parse(
+      new TextDecoder().decode(docTermsBuffer),
+    ) as Record<string, Array<{ field: string; term: string; isPrefix?: boolean }>>;
+
+    for (const entries of Object.values(legacySnapshot)) {
+      for (const entry of entries) {
+        delete entry.isPrefix;
+      }
+    }
+
+    await engine1.storage.putCacheState(
+      "doc-terms",
+      new TextEncoder().encode(JSON.stringify(legacySnapshot)).buffer,
+    );
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    try {
+      await adapter2.index({
+        resource: "tasks",
+        documents: [{ id: "2", fields: { title: "alpha" } }],
+      });
+
+      const result = await adapter2.search({
+        resource: "tasks",
+        query: "test",
+        fuzzy: true,
+      });
+
+      expect(result).toEqual([]);
+    } finally {
+      await adapter2.dispose();
+    }
+  });
+
+  it("removes stale legacy vocabulary entries after deleting the last legacy document", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "testing" } }],
+    });
+
+    const engine1 = (adapter1 as any).getOrCreateEngine("tasks");
+    await (adapter1 as any).ensureOpen(engine1);
+    const docTermsBuffer = await engine1.storage.getCacheState("doc-terms");
+    expect(docTermsBuffer).toBeTruthy();
+
+    const legacySnapshot = JSON.parse(
+      new TextDecoder().decode(docTermsBuffer),
+    ) as Record<string, Array<{ field: string; term: string; isPrefix?: boolean }>>;
+
+    for (const entries of Object.values(legacySnapshot)) {
+      for (const entry of entries) {
+        delete entry.isPrefix;
+      }
+    }
+
+    await engine1.storage.putCacheState(
+      "doc-terms",
+      new TextEncoder().encode(JSON.stringify(legacySnapshot)).buffer,
+    );
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    try {
+      await adapter2.remove({ resource: "tasks", ids: ["1"] });
+
+      const engine2 = (adapter2 as any).getOrCreateEngine("tasks");
+      await (adapter2 as any).ensureOpen(engine2);
+
+      expect(Array.from(engine2.vocabulary)).not.toContain("testing");
+    } finally {
+      await adapter2.dispose();
+    }
+  });
+
+  it("supports remove after cold restart without explicit initialize", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "cold restart removal" } }],
+    });
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    try {
+      await adapter2.remove({ resource: "tasks", ids: ["1"] });
+
+      const result = await adapter2.search({
+        resource: "tasks",
+        query: "cold",
+        fields: ["title"],
+      });
+      expect(result).toEqual([]);
+    } finally {
+      await adapter2.dispose();
+    }
+  });
+
+  it("supports explicit-resource searchAll after cold restart", async () => {
+    const dbName = freshDbName();
+
+    const adapter1 = new IndexedDbAdapter({ dbName });
+    await adapter1.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "cold restart search all" } }],
+    });
+    await adapter1.dispose();
+
+    const adapter2 = new IndexedDbAdapter({ dbName });
+    try {
+      const result = await adapter2.searchAll({
+        resources: ["tasks"],
+        query: "cold",
+        limit: 10,
+      });
+
+      expect(result).toEqual([
+        expect.objectContaining({ resource: "tasks", id: "1" }),
+      ]);
+    } finally {
+      await adapter2.dispose();
+    }
+  });
+
+  it("honors configured searchFields when params.fields is omitted", async () => {
+    const adapter = new IndexedDbAdapter({ dbName: freshDbName() });
+    try {
+      await adapter.initialize({
+        resources: [{ name: "tasks", searchFields: ["title"] }],
+      });
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "visible", body: "hidden-body-term" } }],
+      });
+
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "hidden-body-term",
+      });
+
+      expect(result).toEqual([]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it("drops removed resources from implicit searchAll after reinitialize", async () => {
+    const adapter = new IndexedDbAdapter({ dbName: freshDbName() });
+    try {
+      await adapter.initialize({
+        resources: [
+          { name: "tasks", searchFields: ["title"] },
+          { name: "notes", searchFields: ["title"] },
+        ],
+      });
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "task alpha" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { title: "note beta" } }],
+      });
+
+      await adapter.initialize({
+        resources: [{ name: "tasks", searchFields: ["title"] }],
+      });
+
+      const result = await adapter.searchAll({
+        query: "note",
+        limit: 10,
+      });
+
+      expect(result).toEqual([]);
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it("supports fieldBoosts for ranking", async () => {
+    const dbName = freshDbName();
+    const adapter = new IndexedDbAdapter({ dbName });
+    try {
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "A", fields: { title: "report", body: "quarterly data" } },
+          { id: "B", fields: { title: "quarterly data", body: "report" } },
+        ],
+      });
+      const result = await adapter.search({
+        resource: "items",
+        query: "report",
+        fieldBoosts: { title: 5, body: 1 },
+        limit: 10,
+      });
+      expect(result[0]).toBe("A");
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it("indexes >10k documents via deterministic chunking", async () => {
+    const dbName = freshDbName();
+    const adapter = new IndexedDbAdapter({ dbName });
+    try {
+      const documents = Array.from({ length: 12000 }, (_, i) => ({
+        id: `d${i}`,
+        fields: { title: `doc ${i}` },
+      }));
+      await adapter.index({ resource: "bulk", documents });
+      const result = await adapter.search({
+        resource: "bulk",
+        query: "doc 11999",
+        fields: ["title"],
+      });
+      expect(result).toContain("d11999");
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it("throws DFQL_ABORTED when indexing with an aborted signal", async () => {
+    const adapter = new IndexedDbAdapter({ dbName: freshDbName() });
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "hello" } }],
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(SearchAdapterError);
+    await expect(
+      adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "hello" } }],
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ code: "DFQL_ABORTED" });
+    await adapter.dispose();
+  });
+
+  it("throws DFQL_ABORTED when searchAll signal is aborted", async () => {
+    const adapter = new IndexedDbAdapter({ dbName: freshDbName() });
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "hello report" } }],
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      adapter.searchAll({
+        query: "report",
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ code: "DFQL_ABORTED" });
+
+    await adapter.dispose();
+  });
+});
+
+describe("IndexedDbAdapter — prefix search", () => {
+  // TV-IDB-001: prefix: true matches partial terms
+  it("TV-IDB-001: prefix: true finds documents matching partial query", async () => {
+    const adapter = new IndexedDbAdapter({ dbName: freshDbName() });
+    try {
+      await adapter.index({
+        resource: "r",
+        documents: [{ id: "1", fields: { text: "testing" } }],
+      });
+      const result = await adapter.search({
+        resource: "r",
+        query: "test",
+        prefix: true,
+      });
+      expect(result).toContain("1");
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  // TV-IDB-002: construct-time defaults.prefix applied
+  it("TV-IDB-002: construct-time defaults.prefix applied when param omitted", async () => {
+    const adapter = new IndexedDbAdapter({ dbName: freshDbName(), defaults: { prefix: true } });
+    try {
+      await adapter.index({
+        resource: "r",
+        documents: [{ id: "1", fields: { text: "hello world" } }],
+      });
+      const result = await adapter.search({
+        resource: "r",
+        query: "hel",
+      });
+      expect(result).toContain("1");
+    } finally {
+      await adapter.dispose();
+    }
+  });
+
+  it("TV-IDB-CAP: capabilities include prefix: true", () => {
+    const adapter = new IndexedDbAdapter();
+    expect(adapter.capabilities.prefix).toBe(true);
+  });
+});

--- a/searchfn/adapter-indexeddb/__tests__/setup.ts
+++ b/searchfn/adapter-indexeddb/__tests__/setup.ts
@@ -1,0 +1,9 @@
+import { IDBKeyRange, indexedDB } from "fake-indexeddb";
+
+const globalObject = globalThis as unknown as {
+  indexedDB: typeof indexedDB;
+  IDBKeyRange: typeof IDBKeyRange;
+};
+
+globalObject.indexedDB = indexedDB;
+globalObject.IDBKeyRange = IDBKeyRange;

--- a/searchfn/adapter-indexeddb/package.json
+++ b/searchfn/adapter-indexeddb/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@searchfn/adapter-indexeddb",
+  "version": "0.1.0",
+  "description": "IndexedDB adapter for SearchFn.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@searchfn/adapter-contracts": "file:../adapter-contracts",
+    "@searchfn/core": "file:../core"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "fake-indexeddb": "^6.2.4",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/adapter-indexeddb/src/index.ts
+++ b/searchfn/adapter-indexeddb/src/index.ts
@@ -1,0 +1,738 @@
+import {
+  PipelineEngine,
+  Indexer,
+  DocumentStatsManager,
+  IndexedDbManager,
+  QueryEngine,
+  LruCache,
+  encodePostings,
+  fuzzyExpand,
+} from "@searchfn/core";
+import type {
+  PipelineOptions,
+  StoredPostingChunk,
+  TermCacheValue,
+  VectorCacheValue,
+  QueryToken,
+  TermPosting,
+} from "@searchfn/core";
+import type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDefaults,
+  IndexParams,
+  SearchParams,
+  RemoveParams,
+  SearchAllParams,
+  SearchAllResult,
+  InitializeParams,
+} from "@searchfn/adapter-contracts";
+import { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export interface IndexedDbAdapterOptions {
+  dbName?: string;
+  pipeline?: PipelineOptions;
+  cache?: { terms?: number; vectors?: number };
+  defaults?: SearchDefaults;
+}
+
+interface PostingInfo {
+  frequency: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface DocTermEntry {
+  field: string;
+  term: string;
+  isPrefix?: boolean;
+}
+
+interface ResourceEngine {
+  storage: IndexedDbManager;
+  pipeline: PipelineEngine;
+  indexer: Indexer;
+  statsManager: DocumentStatsManager;
+  termCache: LruCache<TermCacheValue>;
+  vectorCache: LruCache<VectorCacheValue>;
+  queryEngine: QueryEngine;
+  postings: Map<string, Map<string, Map<string, PostingInfo>>>;
+  dirtyPostings: Map<string, Set<string>>;
+  fieldNames: Set<string>;
+  searchFields: string[] | null;
+  docTerms: Map<string, DocTermEntry[]>;
+  openPromise: Promise<void> | null;
+  mutationQueue: Promise<void>;
+  vocabulary: Set<string>;
+  fuzzyCache: Map<string, string[]>;
+}
+
+const DEFAULT_TERM_CACHE_SIZE = 2048;
+const DEFAULT_VECTOR_CACHE_SIZE = 512;
+
+type DocId = string | number;
+
+export class IndexedDbAdapter implements SearchAdapter {
+  readonly name = "indexeddb";
+  readonly capabilities: SearchAdapterCapabilities = {
+    persistent: true,
+    searchAll: true,
+    fuzzy: true,
+    fieldBoosts: true,
+    prefix: true,
+  };
+  private static readonly MAX_INDEX_BATCH_SIZE = 10_000;
+
+  private readonly options: IndexedDbAdapterOptions;
+  private readonly defaults: SearchDefaults;
+  private readonly engines = new Map<string, ResourceEngine>();
+  private disposed = false;
+
+  constructor(options?: IndexedDbAdapterOptions) {
+    this.options = options ?? {};
+    this.defaults = options?.defaults ?? {};
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) {
+      throw new SearchAdapterError(
+        SEARCH_ADAPTER_DISPOSED,
+        "Search adapter is disposed. Call initialize() before use."
+      );
+    }
+  }
+
+  private getOrCreateEngine(resource: string): ResourceEngine {
+    let engine = this.engines.get(resource);
+    if (!engine) {
+      const dbName = `${this.options.dbName ?? "searchfn-adapter"}-${resource}`;
+      const storage = new IndexedDbManager({ dbName, version: 1 });
+      const pipeline = new PipelineEngine(this.options.pipeline);
+      const termCache = new LruCache<TermCacheValue>({
+        maxEntries: this.options.cache?.terms ?? DEFAULT_TERM_CACHE_SIZE,
+      });
+      const vectorCache = new LruCache<VectorCacheValue>({
+        maxEntries: this.options.cache?.vectors ?? DEFAULT_VECTOR_CACHE_SIZE,
+      });
+      const statsManager = new DocumentStatsManager();
+      const queryEngine = new QueryEngine({
+        storage,
+        termCache,
+        vectorCache,
+        stats: statsManager,
+      });
+      engine = {
+        storage,
+        pipeline,
+        indexer: new Indexer(pipeline),
+        statsManager,
+        termCache,
+        vectorCache,
+        queryEngine,
+        postings: new Map(),
+        dirtyPostings: new Map(),
+        fieldNames: new Set(),
+        searchFields: null,
+        docTerms: new Map(),
+        openPromise: null,
+        mutationQueue: Promise.resolve(),
+        vocabulary: new Set(),
+        fuzzyCache: new Map(),
+      };
+      this.engines.set(resource, engine);
+    }
+    return engine;
+  }
+
+  private getFuzzyDistance(fuzzy?: number | boolean): number | undefined {
+    if (fuzzy === true) return 2;
+    if (typeof fuzzy === "number" && fuzzy > 0) return fuzzy;
+    return undefined;
+  }
+
+  private assertNotAborted(signal?: AbortSignal, operation = "Operation"): void {
+    if (signal?.aborted) {
+      throw new SearchAdapterError("DFQL_ABORTED", `${operation} aborted`);
+    }
+  }
+
+  private getCachedFuzzyExpansion(
+    engine: ResourceEngine,
+    term: string,
+    distance: number,
+  ): string[] {
+    const cacheKey = `${term}:${distance}`;
+    let expansion: string[] | undefined = engine.fuzzyCache.get(cacheKey);
+    if (!expansion) {
+      expansion = fuzzyExpand(term, distance, engine.vocabulary);
+      engine.fuzzyCache.set(cacheKey, expansion);
+      if (engine.fuzzyCache.size > 1000) {
+        const firstKey = engine.fuzzyCache.keys().next().value;
+        if (firstKey !== undefined) {
+          engine.fuzzyCache.delete(firstKey);
+        }
+      }
+    }
+    return expansion ?? [];
+  }
+
+  private async ensureOpen(engine: ResourceEngine): Promise<void> {
+    if (!engine.openPromise) {
+      engine.openPromise = (async () => {
+        await engine.storage.open();
+        await this.loadStats(engine);
+        await this.loadDocTerms(engine);
+        await this.loadFieldNames(engine);
+        await this.loadVocabulary(engine);
+      })();
+    }
+    await engine.openPromise;
+  }
+
+  private async loadStats(engine: ResourceEngine): Promise<void> {
+    const buffer = await engine.storage.getCacheState("document-stats");
+    if (buffer) {
+      const json = new TextDecoder().decode(buffer);
+      const stats = JSON.parse(json) as Array<{ docId: string; length: number }>;
+      engine.statsManager.load(stats);
+    }
+  }
+
+  private async loadDocTerms(engine: ResourceEngine): Promise<void> {
+    const buffer = await engine.storage.getCacheState("doc-terms");
+    if (buffer) {
+      const json = new TextDecoder().decode(buffer);
+      const snapshot = JSON.parse(json) as Record<string, DocTermEntry[]>;
+      for (const [docId, terms] of Object.entries(snapshot)) {
+        engine.docTerms.set(docId, terms);
+      }
+    }
+  }
+
+  private async loadFieldNames(engine: ResourceEngine): Promise<void> {
+    const buffer = await engine.storage.getCacheState("field-names");
+    if (buffer) {
+      const json = new TextDecoder().decode(buffer);
+      const names = JSON.parse(json) as string[];
+      for (const name of names) {
+        engine.fieldNames.add(name);
+      }
+    }
+  }
+
+  private async loadVocabulary(engine: ResourceEngine): Promise<void> {
+    const buffer = await engine.storage.getCacheState("vocabulary");
+    if (!buffer) {
+      return;
+    }
+    const json = new TextDecoder().decode(buffer);
+    const terms = JSON.parse(json) as string[];
+    engine.vocabulary.clear();
+    for (const term of terms) {
+      engine.vocabulary.add(term);
+    }
+    engine.fuzzyCache.clear();
+  }
+
+  private async persistStats(engine: ResourceEngine): Promise<void> {
+    const encoded = new TextEncoder().encode(JSON.stringify(engine.statsManager.snapshot()));
+    await engine.storage.putCacheState("document-stats", encoded.buffer);
+  }
+
+  private async persistDocTerms(engine: ResourceEngine): Promise<void> {
+    const snapshot: Record<string, DocTermEntry[]> = {};
+    for (const [docId, terms] of engine.docTerms.entries()) {
+      snapshot[docId] = terms;
+    }
+    const encoded = new TextEncoder().encode(JSON.stringify(snapshot));
+    await engine.storage.putCacheState("doc-terms", encoded.buffer);
+  }
+
+  private async persistFieldNames(engine: ResourceEngine): Promise<void> {
+    const encoded = new TextEncoder().encode(JSON.stringify(Array.from(engine.fieldNames)));
+    await engine.storage.putCacheState("field-names", encoded.buffer);
+  }
+
+  private async persistVocabulary(engine: ResourceEngine): Promise<void> {
+    this.refreshVocabulary(engine);
+    const encoded = new TextEncoder().encode(JSON.stringify(Array.from(engine.vocabulary)));
+    await engine.storage.putCacheState("vocabulary", encoded.buffer);
+  }
+
+  private refreshVocabulary(engine: ResourceEngine): void {
+    const previousVocabulary = new Set(engine.vocabulary);
+    const nextVocabulary = new Set<string>();
+    for (const terms of engine.docTerms.values()) {
+      for (const entry of terms) {
+        if (entry.isPrefix === false) {
+          nextVocabulary.add(entry.term);
+          continue;
+        }
+        // Legacy snapshots omitted `isPrefix`; only keep terms that were
+        // already known as searchable vocabulary before this refresh.
+        if (entry.isPrefix === undefined && previousVocabulary.has(entry.term)) {
+          nextVocabulary.add(entry.term);
+        }
+      }
+    }
+    const changed =
+      nextVocabulary.size !== previousVocabulary.size ||
+      Array.from(nextVocabulary).some((term) => !previousVocabulary.has(term));
+    engine.vocabulary.clear();
+    for (const term of nextVocabulary) {
+      engine.vocabulary.add(term);
+    }
+    if (changed || engine.fuzzyCache.size > 0) {
+      engine.fuzzyCache.clear();
+    }
+  }
+
+  private async withMutationLock<T>(
+    engine: ResourceEngine,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const previous = engine.mutationQueue;
+    let release!: () => void;
+    engine.mutationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  private async loadTermFromDb(
+    engine: ResourceEngine,
+    field: string,
+    term: string
+  ): Promise<void> {
+    let fieldMap = engine.postings.get(field);
+    if (!fieldMap) {
+      fieldMap = new Map();
+      engine.postings.set(field, fieldMap);
+    }
+    if (fieldMap.has(term)) return;
+    const chunk = await engine.storage.getTermChunk({ field, term, chunk: 0 });
+    const termMap = new Map<string, PostingInfo>();
+    if (chunk) {
+      const { postings } = engine.storage.decodeChunkPayload(chunk);
+      for (const raw of postings) {
+        const entry = parseRawPosting(raw);
+        if (entry) {
+          termMap.set(entry.docId, { frequency: entry.termFrequency, metadata: entry.metadata });
+        }
+      }
+    }
+    fieldMap.set(term, termMap);
+  }
+
+  private async removeDocById(engine: ResourceEngine, docId: string): Promise<void> {
+    const terms = engine.docTerms.get(docId);
+    if (!terms) return;
+    for (const { field, term } of terms) {
+      await this.loadTermFromDb(engine, field, term);
+      const termMap = engine.postings.get(field)?.get(term);
+      if (termMap) {
+        termMap.delete(docId);
+        let dirtyTerms = engine.dirtyPostings.get(field);
+        if (!dirtyTerms) {
+          dirtyTerms = new Set();
+          engine.dirtyPostings.set(field, dirtyTerms);
+        }
+        dirtyTerms.add(term);
+      }
+    }
+    engine.statsManager.removeDocument(docId);
+    engine.docTerms.delete(docId);
+  }
+
+  private upsertPosting(
+    engine: ResourceEngine,
+    field: string,
+    term: string,
+    docId: string,
+    frequency: number,
+    metadata?: Record<string, unknown>
+  ): void {
+    let fieldMap = engine.postings.get(field);
+    if (!fieldMap) {
+      fieldMap = new Map();
+      engine.postings.set(field, fieldMap);
+    }
+    let termMap = fieldMap.get(term);
+    if (!termMap) {
+      termMap = new Map();
+      fieldMap.set(term, termMap);
+    }
+    termMap.set(docId, { frequency, metadata });
+    let dirtyTerms = engine.dirtyPostings.get(field);
+    if (!dirtyTerms) {
+      dirtyTerms = new Set();
+      engine.dirtyPostings.set(field, dirtyTerms);
+    }
+    dirtyTerms.add(term);
+  }
+
+  private updateTermCache(engine: ResourceEngine): void {
+    for (const [field, dirtyTerms] of engine.dirtyPostings.entries()) {
+      const fieldMap = engine.postings.get(field);
+      if (!fieldMap) continue;
+      for (const term of dirtyTerms) {
+        const termMap = fieldMap.get(term);
+        const cacheKey = `${field}:${term}`;
+        if (!termMap || termMap.size === 0) {
+          engine.termCache.delete(cacheKey);
+          continue;
+        }
+        const postingsArray: TermPosting[] = Array.from(termMap.entries()).map(([did, info]) => ({
+          docId: did,
+          termFrequency: info.frequency,
+          metadata: info.metadata,
+        }));
+        engine.termCache.set(cacheKey, {
+          field,
+          term,
+          chunk: 0,
+          postings: postingsArray,
+          docFrequency: postingsArray.length,
+          inverseDocumentFrequency: undefined,
+        });
+      }
+    }
+  }
+
+  private async persistPostings(engine: ResourceEngine): Promise<void> {
+    const chunksToWrite: StoredPostingChunk[] = [];
+    const deletions: Array<{ field: string; term: string }> = [];
+
+    for (const [field, dirtyTerms] of engine.dirtyPostings.entries()) {
+      const fieldMap = engine.postings.get(field);
+      if (!fieldMap) continue;
+      for (const term of dirtyTerms) {
+        const termMap = fieldMap.get(term);
+        if (!termMap || termMap.size === 0) {
+          deletions.push({ field, term });
+          fieldMap.delete(term);
+          continue;
+        }
+        const postingsArray: TermPosting[] = Array.from(termMap.entries()).map(([did, info]) => ({
+          docId: did,
+          termFrequency: info.frequency,
+          metadata: info.metadata,
+        }));
+        const serialized = postingsArray.map((e) => JSON.stringify(e));
+        const { buffer, encoding } = encodePostings(serialized);
+        const payload = buffer.buffer as ArrayBuffer;
+        chunksToWrite.push({
+          key: { field, term, chunk: 0 },
+          payload,
+          docFrequency: postingsArray.length,
+          inverseDocumentFrequency: undefined,
+          encoding,
+        });
+      }
+    }
+
+    if (deletions.length > 0) {
+      await Promise.all(
+        deletions.map(({ field, term }) => engine.storage.deleteTermChunksForTerm(field, term))
+      );
+    }
+    if (chunksToWrite.length > 0) {
+      await engine.storage.putTermChunksBatch(chunksToWrite);
+    }
+    engine.dirtyPostings.clear();
+  }
+
+  private async persistAll(engine: ResourceEngine): Promise<void> {
+    await Promise.all([
+      this.persistPostings(engine),
+      this.persistStats(engine),
+      this.persistDocTerms(engine),
+      this.persistFieldNames(engine),
+      this.persistVocabulary(engine),
+    ]);
+  }
+
+  private buildQueryTokens(
+    engine: ResourceEngine,
+    query: string,
+    fields: string[],
+    fuzzyDistance?: number,
+    fieldBoosts?: Record<string, number>,
+    prefix?: boolean,
+  ): QueryToken[] {
+    const tokenMap = new Map<string, QueryToken>();
+    for (const field of fields) {
+      const rawTokens = engine.pipeline.run(field, query);
+      // Always filter out isPrefix-flagged pipeline tokens (edge-ngram artefacts at index time)
+      const filtered = rawTokens.filter(
+        (t: { metadata?: Record<string, unknown>; value: string }) => !t.metadata?.isPrefix,
+      );
+      const fieldBoost = fieldBoosts?.[field] ?? 1.0;
+      for (const token of filtered) {
+        if (prefix) {
+          // Prefix mode: vocabulary scan — find all indexed terms that start with this token value
+          for (const vocabTerm of engine.vocabulary) {
+            if (vocabTerm.startsWith(token.value)) {
+              const key = `${field}:${vocabTerm}`;
+              if (!tokenMap.has(key)) {
+                const termBoost = vocabTerm === token.value ? 1.0 : 0.9;
+                tokenMap.set(key, { field, term: vocabTerm, boost: termBoost * fieldBoost });
+              }
+            }
+          }
+        } else {
+          const terms = fuzzyDistance
+            ? this.getCachedFuzzyExpansion(engine, token.value, fuzzyDistance)
+            : [token.value];
+          for (const term of terms) {
+            const key = `${field}:${term}`;
+            if (!tokenMap.has(key)) {
+              const termBoost = term === token.value ? 1.0 : 0.8;
+              tokenMap.set(key, { field, term, boost: termBoost * fieldBoost });
+            }
+          }
+        }
+      }
+    }
+    return Array.from(tokenMap.values());
+  }
+
+  async index({ resource, documents, signal }: IndexParams): Promise<void> {
+    this.assertNotDisposed();
+    this.assertNotAborted(signal, "Index operation");
+    const engine = this.getOrCreateEngine(resource);
+    await this.withMutationLock(engine, async () => {
+      await this.ensureOpen(engine);
+
+      for (
+        let offset = 0;
+        offset < documents.length;
+        offset += IndexedDbAdapter.MAX_INDEX_BATCH_SIZE
+      ) {
+        this.assertNotAborted(signal, "Index operation");
+        const chunk = documents.slice(
+          offset,
+          offset + IndexedDbAdapter.MAX_INDEX_BATCH_SIZE,
+        );
+        for (const doc of chunk) {
+          this.assertNotAborted(signal, "Index operation");
+          const docId = String(doc.id);
+          if (engine.docTerms.has(docId)) {
+            await this.removeDocById(engine, docId);
+          }
+
+          const ingest = engine.indexer.ingest({ docId, fields: doc.fields });
+          if (ingest.totalLength === 0) continue;
+
+          engine.statsManager.addDocument(docId, ingest.totalLength);
+
+          const docTermEntries: DocTermEntry[] = [];
+          for (const [field, termFrequencies] of ingest.fieldFrequencies.entries()) {
+            engine.fieldNames.add(field);
+            const metadata =
+              ingest.fieldMetadata.get(field) ?? new Map<string, Record<string, unknown>>();
+            for (const [term, frequency] of termFrequencies.entries()) {
+              const termMetadata = metadata.get(term);
+              this.upsertPosting(engine, field, term, docId, frequency, termMetadata);
+              const isPrefix =
+                termMetadata !== undefined && termMetadata["isPrefix"] === true;
+              if (!isPrefix) {
+                engine.vocabulary.add(term);
+                engine.fuzzyCache.clear();
+              }
+              docTermEntries.push({ field, term, isPrefix });
+            }
+          }
+
+          engine.docTerms.set(docId, docTermEntries);
+        }
+      }
+
+      this.updateTermCache(engine);
+      await this.persistAll(engine);
+    });
+  }
+
+  async search(params: SearchParams): Promise<DocId[]> {
+    this.assertNotDisposed();
+    this.assertNotAborted(params.signal, "Search operation");
+    const engine = this.getOrCreateEngine(params.resource);
+    await this.ensureOpen(engine);
+
+    const fields = params.fields ?? engine.searchFields ?? Array.from(engine.fieldNames);
+    if (fields.length === 0) return [];
+
+    const effectivePrefix = params.prefix ?? this.defaults.prefix;
+    const effectiveFuzzy = params.fuzzy ?? this.defaults.fuzzy;
+    const effectiveFieldBoosts = params.fieldBoosts ?? this.defaults.fieldBoosts;
+    const fuzzyDistance = this.getFuzzyDistance(effectiveFuzzy);
+    const tokens = this.buildQueryTokens(
+      engine,
+      params.query,
+      fields,
+      fuzzyDistance,
+      effectiveFieldBoosts,
+      effectivePrefix,
+    );
+    if (tokens.length === 0) return [];
+
+    const limit = Math.max(1, params.limit ?? 10);
+    const result = await engine.queryEngine.execute(tokens, { limit });
+    return result.documents.map((d: { docId: DocId }) => d.docId);
+  }
+
+  async remove({ resource, ids, signal }: RemoveParams): Promise<void> {
+    this.assertNotDisposed();
+    this.assertNotAborted(signal, "Remove operation");
+    const engine = this.getOrCreateEngine(resource);
+    await this.withMutationLock(engine, async () => {
+      await this.ensureOpen(engine);
+
+      for (const id of ids) {
+        this.assertNotAborted(signal, "Remove operation");
+        await this.removeDocById(engine, String(id));
+      }
+
+      engine.termCache.clear();
+      await this.persistAll(engine);
+    });
+  }
+
+  async clear(resource: string, signal?: AbortSignal): Promise<void> {
+    this.assertNotDisposed();
+    this.assertNotAborted(signal, "Clear operation");
+    const engine = this.getOrCreateEngine(resource);
+    await this.withMutationLock(engine, async () => {
+      await this.ensureOpen(engine);
+
+      engine.postings.clear();
+      engine.dirtyPostings.clear();
+      engine.termCache.clear();
+      engine.statsManager.load([]);
+      engine.docTerms.clear();
+      engine.fieldNames.clear();
+      engine.vocabulary.clear();
+      engine.fuzzyCache.clear();
+
+      await engine.storage.clearStore("terms");
+      await engine.storage.clearStore("cacheState");
+    });
+  }
+
+  async searchAll(params: SearchAllParams): Promise<SearchAllResult[]> {
+    this.assertNotDisposed();
+    this.assertNotAborted(params.signal, "SearchAll operation");
+    const resourceNames = params.resources ?? Array.from(this.engines.keys());
+    const limit = params.limit ?? 10;
+    const limitPerResource = params.limitPerResource ?? limit;
+
+    const allResults: SearchAllResult[] = [];
+
+    for (const resourceName of resourceNames) {
+      this.assertNotAborted(params.signal, "SearchAll operation");
+      const engine = params.resources ? this.getOrCreateEngine(resourceName) : this.engines.get(resourceName);
+      if (!engine) continue;
+      await this.ensureOpen(engine);
+
+      const fields = params.fields ?? engine.searchFields ?? Array.from(engine.fieldNames);
+      if (fields.length === 0) continue;
+
+      const effectivePrefix = params.prefix ?? this.defaults.prefix;
+      const effectiveFuzzy = params.fuzzy ?? this.defaults.fuzzy;
+      const effectiveFieldBoosts = params.fieldBoosts ?? this.defaults.fieldBoosts;
+      const fuzzyDistance = this.getFuzzyDistance(effectiveFuzzy);
+      const tokens = this.buildQueryTokens(
+        engine,
+        params.query,
+        fields,
+        fuzzyDistance,
+        effectiveFieldBoosts,
+        effectivePrefix,
+      );
+      if (tokens.length === 0) continue;
+
+      const result = await engine.queryEngine.execute(tokens, { limit: limitPerResource });
+      for (const doc of result.documents) {
+        allResults.push({ resource: resourceName, id: doc.docId, score: doc.score });
+      }
+    }
+
+    allResults.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.resource !== b.resource) return a.resource < b.resource ? -1 : 1;
+      const aId = String(a.id);
+      const bId = String(b.id);
+      return aId < bId ? -1 : aId > bId ? 1 : 0;
+    });
+
+    return allResults.slice(0, limit);
+  }
+
+  async initialize({ resources }: InitializeParams): Promise<void> {
+    if (this.disposed) {
+      this.disposed = false;
+    }
+    const requested = new Set(resources.map((resource) => resource.name));
+    for (const [name, engine] of this.engines.entries()) {
+      if (requested.has(name)) {
+        continue;
+      }
+      await engine.mutationQueue.catch(() => undefined);
+      await engine.storage.close();
+      this.engines.delete(name);
+    }
+    const engines = resources.map(({ name }) => this.getOrCreateEngine(name));
+    for (const resource of resources) {
+      const engine = this.engines.get(resource.name);
+      if (engine) {
+        engine.searchFields = [...resource.searchFields];
+      }
+    }
+    await Promise.all(engines.map((engine) => this.ensureOpen(engine)));
+  }
+
+  async dispose(): Promise<void> {
+    for (const engine of this.engines.values()) {
+      await engine.storage.close();
+    }
+    this.engines.clear();
+    this.disposed = true;
+  }
+}
+
+function parseRawPosting(
+  raw: unknown
+): { docId: string; termFrequency: number; metadata?: Record<string, unknown> } | null {
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const docIdValue = parsed["docId"];
+      if (typeof docIdValue === "string" || typeof docIdValue === "number") {
+        return {
+          docId: String(docIdValue),
+          termFrequency: Number(parsed["termFrequency"] ?? 1),
+          metadata: parsed["metadata"] as Record<string, unknown> | undefined,
+        };
+      }
+    } catch {
+      return { docId: raw, termFrequency: 1 };
+    }
+  }
+  if (typeof raw === "number") return { docId: String(raw), termFrequency: 1 };
+  if (raw && typeof raw === "object") {
+    const r = raw as Record<string, unknown>;
+    const docIdValue = r["docId"];
+    if (typeof docIdValue === "string" || typeof docIdValue === "number") {
+      return {
+        docId: String(docIdValue),
+        termFrequency: Number(r["termFrequency"] ?? 1),
+        metadata: r["metadata"] as Record<string, unknown> | undefined,
+      };
+    }
+  }
+  return null;
+}

--- a/searchfn/adapter-indexeddb/tsconfig.json
+++ b/searchfn/adapter-indexeddb/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@searchfn/adapter-contracts": ["../adapter-contracts/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapter-indexeddb/tsup.config.ts
+++ b/searchfn/adapter-indexeddb/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist"
+});

--- a/searchfn/adapter-indexeddb/vitest.config.ts
+++ b/searchfn/adapter-indexeddb/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: ["__tests__/setup.ts"],
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"],
+  }
+});

--- a/searchfn/adapter-meilisearch/__tests__/conformance/meilisearch.conformance.test.ts
+++ b/searchfn/adapter-meilisearch/__tests__/conformance/meilisearch.conformance.test.ts
@@ -1,0 +1,41 @@
+import { describe, beforeAll } from "vitest";
+import { MeilisearchAdapter } from "../../src/index";
+import { runConformanceSuite } from "./shared";
+
+const MEILI_URL = process.env.SEARCHFN_MEILI_URL ?? "http://localhost:7700";
+const MEILI_API_KEY = process.env.SEARCHFN_MEILI_API_KEY;
+
+let available = false;
+let testCounter = 0;
+
+async function canConnect(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(new URL("/health", url), { method: "GET" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+describe("MeilisearchAdapter conformance", () => {
+  beforeAll(async () => {
+    available = await canConnect(MEILI_URL);
+    if (!available) {
+      console.warn("Meilisearch not available, skipping conformance tests");
+    }
+  });
+
+  runConformanceSuite({
+    name: "meilisearch",
+    persistent: true,
+    shouldSkip: () => !available,
+    create: () =>
+      new MeilisearchAdapter({
+        host: MEILI_URL,
+        apiKey: MEILI_API_KEY,
+        indexPrefix: `conf_meili_${++testCounter}`,
+        requestTimeoutMs: 10_000,
+        retry: { maxRetries: 1, baseDelayMs: 25, maxDelayMs: 100 },
+      }),
+  });
+});

--- a/searchfn/adapter-meilisearch/__tests__/conformance/shared.ts
+++ b/searchfn/adapter-meilisearch/__tests__/conformance/shared.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared adapter conformance test harness.
+ *
+ * Every SearchAdapter implementation MUST pass all assertions defined here.
+ * To use: call `runConformanceSuite(adapterFactory)` inside a `describe` block.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export interface ConformanceAdapterFactory {
+  /** Human-readable adapter name for test labels */
+  name: string;
+  /** Create a fresh adapter instance for each test */
+  create(): SearchAdapter;
+  /** Whether this adapter supports persistent storage (survives dispose+reinitialize) */
+  persistent?: boolean;
+  /** Whether cleanup is needed after tests (e.g., external services) */
+  cleanup?(): Promise<void>;
+  /** Optional callback that returns true when tests should be skipped (e.g., backend unavailable) */
+  shouldSkip?(): boolean;
+}
+
+/**
+ * Run the full conformance suite against an adapter.
+ * Call this inside a `describe()` block.
+ */
+export function runConformanceSuite(factory: ConformanceAdapterFactory): void {
+  let adapter: SearchAdapter;
+
+  beforeEach((ctx) => {
+    if (factory.shouldSkip?.()) {
+      ctx.skip();
+      return;
+    }
+    adapter = factory.create();
+  });
+
+  afterEach(async () => {
+    if (adapter.dispose) {
+      await adapter.dispose();
+    }
+    if (factory.cleanup) {
+      await factory.cleanup();
+    }
+  });
+
+  // ── Contract shape ──────────────────────────────────────────────
+
+  describe("contract shape", () => {
+    it("has a non-empty name", () => {
+      expect(typeof adapter.name).toBe("string");
+      expect(adapter.name.length).toBeGreaterThan(0);
+    });
+
+    it("exposes required methods", () => {
+      expect(typeof adapter.index).toBe("function");
+      expect(typeof adapter.search).toBe("function");
+      expect(typeof adapter.remove).toBe("function");
+      expect(typeof adapter.clear).toBe("function");
+    });
+
+    it("exposes capabilities object if declared", () => {
+      if (adapter.capabilities !== undefined) {
+        expect(typeof adapter.capabilities).toBe("object");
+      }
+    });
+  });
+
+  // ── Index + Search basics ───────────────────────────────────────
+
+  describe("index and search", () => {
+    it("returns matching ids after indexing documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha beta" } },
+          { id: "d2", fields: { title: "gamma delta" } },
+        ],
+      });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toContain("d1");
+      expect(results).not.toContain("d2");
+    });
+
+    it("returns empty array when no documents match", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      const results = await adapter.search({ resource: "items", query: "zzzzz", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("upserts on duplicate id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "beta" } }],
+      });
+      const alphaResults = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(alphaResults).not.toContain("d1");
+      const betaResults = await adapter.search({ resource: "items", query: "beta", limit: 10 });
+      expect(betaResults).toContain("d1");
+    });
+
+    it("respects limit parameter", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      const docs = Array.from({ length: 20 }, (_, i) => ({
+        id: `d${i}`,
+        fields: { title: "common term" },
+      }));
+      await adapter.index({ resource: "items", documents: docs });
+      const results = await adapter.search({ resource: "items", query: "common", limit: 5 });
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── Deterministic tie-breaking ──────────────────────────────────
+
+  describe("deterministic ordering", () => {
+    it("produces consistent order for equal-score documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "b", fields: { title: "same" } },
+          { id: "a", fields: { title: "same" } },
+          { id: "c", fields: { title: "same" } },
+        ],
+      });
+      const r1 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      const r2 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      expect(r1).toEqual(r2);
+    });
+  });
+
+  // ── Remove ──────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    it("removes documents by id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha" } },
+          { id: "d2", fields: { title: "alpha" } },
+        ],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).not.toContain("d1");
+      expect(results).toContain("d2");
+    });
+
+    it("is idempotent for already-removed ids", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      // Second remove should not throw
+      await expect(adapter.remove({ resource: "items", ids: ["d1"] })).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Clear ───────────────────────────────────────────────────────
+
+  describe("clear", () => {
+    it("removes all documents from a resource", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("does not affect other resources", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const notesResults = await adapter.search({ resource: "notes", query: "alpha", limit: 10 });
+      expect(notesResults).toContain("n1");
+    });
+  });
+
+  // ── searchAll (optional) ────────────────────────────────────────
+
+  describe("searchAll", () => {
+    it("merges results across resources with deterministic ordering", async () => {
+      if (!adapter.searchAll) return; // skip if not supported
+
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "common term" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "common term" } }],
+      });
+
+      const results = await adapter.searchAll({ query: "common", limit: 10 });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // Verify deterministic ordering: score desc, resource asc, id asc
+      for (let i = 1; i < results.length; i++) {
+        const prev = results[i - 1];
+        const curr = results[i];
+        const valid =
+          prev.score > curr.score ||
+          (prev.score === curr.score && prev.resource < curr.resource) ||
+          (prev.score === curr.score &&
+            prev.resource === curr.resource &&
+            String(prev.id) <= String(curr.id));
+        expect(valid).toBe(true);
+      }
+    });
+  });
+
+  // ── Lifecycle (initialize / dispose) ────────────────────────────
+
+  describe("lifecycle", () => {
+    it("blocks operations after dispose", async () => {
+      if (!adapter.dispose) return;
+
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.dispose();
+
+      try {
+        await adapter.search({ resource: "items", query: "test", limit: 10 });
+        // If it doesn't throw, the adapter allows post-dispose search (some might)
+        // but it MUST NOT return stale data if persistent=false
+      } catch (err) {
+        // Expected: adapter should reject after dispose
+        expect(err).toBeDefined();
+        if (err instanceof Error && "code" in err) {
+          expect((err as { code: string }).code).toBe(SEARCH_ADAPTER_DISPOSED);
+        }
+      }
+    });
+
+    it("can reinitialize after dispose", async () => {
+      if (!adapter.dispose || !adapter.initialize) return;
+
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.dispose();
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+
+      // After reinitialize, adapter should be operational
+      // For non-persistent adapters, previous data may be gone
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      if (factory.persistent) {
+        expect(results).toContain("d1");
+      }
+      // For non-persistent, just verify it doesn't throw
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+}
+
+/**
+ * List of conformance assertion categories.
+ * Used for documentation/reporting.
+ */
+export const CONFORMANCE_ASSERTIONS = [
+  "contract-shape: name, required methods, capabilities",
+  "index-search: basic indexing, search, upsert, limit",
+  "deterministic-ordering: consistent tie-breaking",
+  "remove: by id, idempotent",
+  "clear: per-resource, cross-resource isolation",
+  "searchAll: merged results, deterministic global order",
+  "lifecycle: dispose blocks ops, reinitialize restores",
+] as const;

--- a/searchfn/adapter-meilisearch/__tests__/meilisearch.test.ts
+++ b/searchfn/adapter-meilisearch/__tests__/meilisearch.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import { MeilisearchAdapter } from "../src/index";
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+import { redactSensitive as redactMeiliSensitive } from "../src/internal/redaction";
+
+const MEILI_URL = process.env.SEARCHFN_MEILI_URL ?? "http://localhost:7700";
+const MEILI_API_KEY = process.env.SEARCHFN_MEILI_API_KEY;
+
+let testCounter = 0;
+
+async function canConnect(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(new URL("/health", url), { method: "GET" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+describe("MeilisearchAdapter integration", () => {
+  let available = false;
+  let adapter: MeilisearchAdapter;
+
+  beforeAll(async () => {
+    available = await canConnect(MEILI_URL);
+    if (!available) {
+      console.warn("Meilisearch not available, skipping integration tests");
+    }
+  });
+
+  beforeEach(async () => {
+    if (!available) return;
+
+    adapter = new MeilisearchAdapter({
+      host: MEILI_URL,
+      apiKey: MEILI_API_KEY,
+      indexPrefix: `searchfn_meili_test_${++testCounter}`,
+      requestTimeoutMs: 10_000,
+      retry: { maxRetries: 1, baseDelayMs: 25, maxDelayMs: 100 },
+    });
+
+    await adapter.initialize({
+      resources: [
+        { name: "docs", searchFields: ["title", "body"] },
+        { name: "notes", searchFields: ["content"] },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    if (adapter) {
+      await adapter.dispose();
+    }
+  });
+
+  it("implements initialize/index/search/remove/clear", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "docs",
+      documents: [{ id: "d1", fields: { title: "Hello World", body: "incident" } }],
+    });
+
+    const first = await adapter.search({ resource: "docs", query: "hello", limit: 10 });
+    expect(first).toEqual(["d1"]);
+
+    await adapter.remove({ resource: "docs", ids: ["d1"] });
+    const afterRemove = await adapter.search({ resource: "docs", query: "hello", limit: 10 });
+    expect(afterRemove).toEqual([]);
+
+    await adapter.index({
+      resource: "docs",
+      documents: [{ id: "d2", fields: { title: "Hello Again", body: "incident" } }],
+    });
+    await adapter.clear("docs");
+    const afterClear = await adapter.search({ resource: "docs", query: "hello", limit: 10 });
+    expect(afterClear).toEqual([]);
+  });
+
+  it("supports searchAll deterministic ordering and field filter", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "docs",
+      documents: [{ id: "d1", fields: { title: "incident title", body: "body only" } }],
+    });
+    await adapter.index({
+      resource: "notes",
+      documents: [{ id: "n1", fields: { content: "incident title" } }],
+    });
+
+    const bodyFiltered = await adapter.search({
+      resource: "docs",
+      query: "body",
+      fields: ["title"],
+      limit: 10,
+    });
+    expect(bodyFiltered).toEqual([]);
+
+    const all = await adapter.searchAll({ query: "incident", limit: 10 });
+    for (let i = 1; i < all.length; i++) {
+      const prev = all[i - 1];
+      const curr = all[i];
+      const valid =
+        prev.score > curr.score ||
+        (prev.score === curr.score && prev.resource < curr.resource) ||
+        (prev.score === curr.score && prev.resource === curr.resource && String(prev.id) <= String(curr.id));
+      expect(valid).toBe(true);
+    }
+  });
+
+  it("remove and clear are idempotent", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "docs",
+      documents: [{ id: "d3", fields: { title: "idempotent" } }],
+    });
+
+    await adapter.remove({ resource: "docs", ids: ["d3"] });
+    await expect(adapter.remove({ resource: "docs", ids: ["d3"] })).resolves.toBeUndefined();
+
+    await adapter.clear("docs");
+    await expect(adapter.clear("docs")).resolves.toBeUndefined();
+  });
+});
+
+describe("MeilisearchAdapter resilience", () => {
+  it("redacts plain connection keys without over-redacting connectionTimeout", () => {
+    expect(
+      redactMeiliSensitive({
+        connection: "http://user:pass@example.test",
+        connectionTimeout: 5000,
+      }),
+    ).toEqual({
+      connection: "[REDACTED]",
+      connectionTimeout: 5000,
+    });
+  });
+
+  it("redacts Error instances instead of returning them unchanged", () => {
+    const error = Object.assign(new Error("apiKey=secret"), {
+      connection: "http://user:pass@example.test",
+    });
+
+    expect(redactMeiliSensitive(error)).toMatchObject({
+      name: "Error",
+      message: "apiKey=[REDACTED]",
+      connection: "[REDACTED]",
+    });
+  });
+
+  it("maps auth failures to FORBIDDEN", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response("{}", { status: 401, headers: { "content-type": "application/json" } });
+    });
+
+    try {
+      const adapter = new MeilisearchAdapter({ host: "http://localhost:7700", apiKey: "bad-key" });
+      await adapter.search({ resource: "docs", query: "hello", limit: 5 });
+      expect.fail("expected auth failure");
+    } catch (err) {
+      expect((err as SearchAdapterError).code).toBe("FORBIDDEN");
+      expect((err as Error).message).toContain("Meilisearch authorization failed");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("enforces bounded retry budget on retryable failures", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response("{}", { status: 503, headers: { "content-type": "application/json" } });
+    });
+
+    try {
+      const adapter = new MeilisearchAdapter({
+        host: "http://localhost:7700",
+        retry: { maxRetries: 2, baseDelayMs: 1, maxDelayMs: 2 },
+        requestTimeoutMs: 100,
+      });
+      await adapter.search({ resource: "docs", query: "hello", limit: 5 });
+      expect.fail("expected retry exhaustion");
+    } catch (err) {
+      expect((err as SearchAdapterError).code).toBe("INTERNAL");
+      expect((err as Error).message).toContain("Retry budget exhausted");
+    } finally {
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("normalizes searchAll scores across resources", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      const pathname = new URL(String(url)).pathname;
+      if (pathname.startsWith("/indexes/searchfn_docs_") && pathname.endsWith("/search")) {
+        return new Response(
+          JSON.stringify({ hits: [{ id: "d1" }, { id: "d2" }, { id: "d3" }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({ hits: [{ id: "n1" }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    try {
+      const adapter = new MeilisearchAdapter({ host: "http://localhost:7700" });
+      const results = await adapter.searchAll({
+        resources: ["docs", "notes"],
+        query: "incident",
+        limit: 10,
+      });
+
+      expect(results.slice(0, 4)).toEqual([
+        { resource: "docs", id: "d1", score: 1 },
+        { resource: "notes", id: "n1", score: 1 },
+        { resource: "docs", id: "d2", score: 2 / 3 },
+        { resource: "docs", id: "d3", score: 1 / 3 },
+      ]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("preserves non-canonical numeric string ids", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({ hits: [{ id: "0123" }, { id: "9007199254740993" }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    try {
+      const adapter = new MeilisearchAdapter({ host: "http://localhost:7700" });
+      const results = await adapter.search({ resource: "docs", query: "hello", limit: 10 });
+      expect(results).toEqual(["0123", "9007199254740993"]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("resets tracked resources on reinitialize", async () => {
+    const urls: string[] = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      urls.push(String(url));
+      const pathname = new URL(String(url)).pathname;
+      if (pathname.startsWith("/tasks/")) {
+        return new Response(JSON.stringify({ status: "succeeded" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (pathname.endsWith("/search")) {
+        return new Response(JSON.stringify({ hits: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ taskUid: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    try {
+      const adapter = new MeilisearchAdapter({ host: "http://localhost:7700" });
+      await adapter.initialize({
+        resources: [{ name: "docs", searchFields: ["title"] }],
+      });
+      await adapter.initialize({
+        resources: [{ name: "notes", searchFields: ["title"] }],
+      });
+
+      urls.length = 0;
+      await adapter.searchAll({ query: "hello", limit: 10 });
+
+      expect(urls.some((url) => url.includes("/indexes/searchfn_docs_"))).toBe(false);
+      expect(urls.some((url) => url.includes("/indexes/searchfn_notes_"))).toBe(true);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("returns no results for explicit empty field or resource allow-lists", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    try {
+      const adapter = new MeilisearchAdapter({ host: "http://localhost:7700" });
+
+      await expect(
+        adapter.search({ resource: "docs", query: "hello", fields: [], limit: 10 }),
+      ).resolves.toEqual([]);
+      await expect(
+        adapter.searchAll({ query: "hello", fields: [], limit: 10 }),
+      ).resolves.toEqual([]);
+      await expect(
+        adapter.searchAll({ query: "hello", resources: [], limit: 10 }),
+      ).resolves.toEqual([]);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+// ── TV-MS-001/002: prefix capability and defaults ────────────────────────────
+
+describe("MeilisearchAdapter — prefix capability and defaults", () => {
+  // TV-MS-001: capabilities do not advertise unsupported prefix toggling
+  it("TV-MS-001: capabilities include prefix: false", () => {
+    const adapter = new MeilisearchAdapter({ host: "http://localhost:7700" });
+    expect(adapter.capabilities.prefix).toBe(false);
+  });
+
+  // TV-MS-002: construct with defaults does not throw
+  it("TV-MS-002: accepts defaults option without error", () => {
+    expect(() => {
+      const adapter = new MeilisearchAdapter({
+        host: "http://localhost:7700",
+        defaults: { prefix: true, fuzzy: true },
+      });
+      // Verify the adapter was created and has the right name
+      expect(adapter.name).toBe("meilisearch");
+    }).not.toThrow();
+  });
+
+  it("TV-MS-FUZZY-DEFAULT: defaults.fuzzy is applied to search requests", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({ hits: [] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const adapter = new MeilisearchAdapter({
+      host: "http://localhost:7700",
+      defaults: { fuzzy: true },
+    });
+
+    try {
+      await adapter.search({ resource: "docs", query: "test", limit: 5 });
+      // When fuzzy default is true, typoTolerance should be undefined (not "min")
+      const callBody = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+      expect(callBody.typoTolerance).toBeUndefined();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/searchfn/adapter-meilisearch/docker-compose.meili.yml
+++ b/searchfn/adapter-meilisearch/docker-compose.meili.yml
@@ -1,0 +1,16 @@
+services:
+  meilisearch:
+    image: getmeili/meilisearch:v1.12
+    container_name: searchfn-meilisearch
+    environment:
+      - MEILI_MASTER_KEY=searchfn_master_key
+      - MEILI_ENV=development
+      - MEILI_NO_ANALYTICS=true
+    ports:
+      - "7700:7700"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:7700/health >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 15s

--- a/searchfn/adapter-meilisearch/package.json
+++ b/searchfn/adapter-meilisearch/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@searchfn/adapter-meilisearch",
+  "version": "0.1.0",
+  "description": "Meilisearch adapter for SearchFn.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@searchfn/adapter-contracts": "file:../adapter-contracts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/adapter-meilisearch/src/index.ts
+++ b/searchfn/adapter-meilisearch/src/index.ts
@@ -1,0 +1,16 @@
+export { MeilisearchAdapter } from "./meilisearch";
+export type { MeilisearchAdapterOptions } from "./meilisearch";
+export type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDocument,
+  IndexParams,
+  SearchParams,
+  SearchAllParams,
+  SearchAllResult,
+  RemoveParams,
+  InitializeParams,
+  InitializeResourceConfig,
+  SearchAdapterConfig,
+} from "@searchfn/adapter-contracts";
+export { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";

--- a/searchfn/adapter-meilisearch/src/internal/errors.ts
+++ b/searchfn/adapter-meilisearch/src/internal/errors.ts
@@ -1,0 +1,30 @@
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+import { redactSensitive } from "./redaction";
+
+export function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function internalError(message: string): SearchAdapterError {
+  return new SearchAdapterError("INTERNAL", message);
+}
+
+export function forbiddenError(message: string): SearchAdapterError {
+  return new SearchAdapterError("FORBIDDEN", message);
+}
+
+export function abortedError(message = "Operation aborted"): SearchAdapterError {
+  return new SearchAdapterError("DFQL_ABORTED", message);
+}
+
+export function retryBudgetExhaustedError(): SearchAdapterError {
+  return new SearchAdapterError("INTERNAL", "Retry budget exhausted");
+}
+
+export function withRedactedErrorMessage(prefix: string, error: unknown): SearchAdapterError {
+  const message = redactSensitive(toErrorMessage(error));
+  return new SearchAdapterError("INTERNAL", `${prefix}: ${message}`);
+}

--- a/searchfn/adapter-meilisearch/src/internal/redaction.ts
+++ b/searchfn/adapter-meilisearch/src/internal/redaction.ts
@@ -1,0 +1,85 @@
+const SENSITIVE_KEY =
+  /(?:api[_-]?key|password|secret|token|authorization|connection(?:string|[_-]string)?)(?=$|[^a-z])/i;
+
+const KEY_VALUE_SECRET = /\b(api[_-]?key|password|secret|token|authorization|connection(?:string|[_-]?string)?)\s*[:=]\s*([^\s,;]+)/gi;
+const URL_CREDENTIALS = /(https?:\/\/)([^\s/@]+)@/gi;
+const POSTGRES_CREDENTIALS = /(postgres(?:ql)?:\/\/)([^\s/@]+)@/gi;
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function redactError(error: Error, seen: WeakSet<object>): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    name: error.name,
+    message: redactSensitiveString(error.message),
+  };
+  if (typeof error.stack === "string") {
+    output.stack = redactSensitiveString(error.stack);
+  }
+  if ("cause" in error && (error as Error & { cause?: unknown }).cause !== undefined) {
+    output.cause = redactSensitiveInternal(
+      (error as Error & { cause?: unknown }).cause,
+      seen,
+    );
+  }
+  for (const [key, entry] of Object.entries(error)) {
+    output[key] = SENSITIVE_KEY.test(key) ? "[REDACTED]" : redactSensitiveInternal(entry, seen);
+  }
+  return output;
+}
+
+function redactSensitiveInternal(value: unknown, seen: WeakSet<object>): any {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return redactSensitiveString(value);
+  }
+
+  if (typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((entry) => redactSensitiveInternal(entry, seen));
+      }
+      if (value instanceof Error) {
+        return redactError(value, seen);
+      }
+
+      const entries = Object.entries(value);
+      if (!isPlainObject(value) && entries.length === 0) {
+        return value;
+      }
+
+      const output: Record<string, unknown> = {};
+      for (const [key, entry] of entries) {
+        if (SENSITIVE_KEY.test(key)) {
+          output[key] = "[REDACTED]";
+        } else {
+          output[key] = redactSensitiveInternal(entry, seen);
+        }
+      }
+      return output;
+    } finally {
+      seen.delete(value);
+    }
+  }
+
+  return value;
+}
+export function redactSensitive(value: unknown): any {
+  return redactSensitiveInternal(value, new WeakSet<object>());
+}
+
+export function redactSensitiveString(input: string): string {
+  return input
+    .replace(KEY_VALUE_SECRET, (_match, key) => `${key}=[REDACTED]`)
+    .replace(URL_CREDENTIALS, "$1[REDACTED]@")
+    .replace(POSTGRES_CREDENTIALS, "$1[REDACTED]@");
+}

--- a/searchfn/adapter-meilisearch/src/internal/retry.ts
+++ b/searchfn/adapter-meilisearch/src/internal/retry.ts
@@ -1,0 +1,115 @@
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+
+export interface RetryPolicy {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface NormalizedRetryPolicy {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface RetryAttemptContext {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  reason: string;
+}
+
+export interface RunWithRetryOptions {
+  policy?: RetryPolicy;
+  isRetryableError?: (error: unknown) => boolean;
+  isRetryableResult?: <T>(result: T) => boolean;
+  exhaustedError?: Error;
+  onRetry?: (context: RetryAttemptContext) => void;
+}
+
+const DEFAULT_RETRY_POLICY: NormalizedRetryPolicy = {
+  maxRetries: 2,
+  baseDelayMs: 100,
+  maxDelayMs: 5_000,
+};
+
+function normalizeFiniteInteger(value: number | undefined, fallback: number, min: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(min, Math.floor(value));
+}
+
+export function normalizeRetryPolicy(policy?: RetryPolicy): NormalizedRetryPolicy {
+  const maxRetries = normalizeFiniteInteger(policy?.maxRetries, DEFAULT_RETRY_POLICY.maxRetries, 0);
+  const baseDelayMs = normalizeFiniteInteger(policy?.baseDelayMs, DEFAULT_RETRY_POLICY.baseDelayMs, 1);
+  const maxDelayMs = Math.max(
+    baseDelayMs,
+    normalizeFiniteInteger(policy?.maxDelayMs, DEFAULT_RETRY_POLICY.maxDelayMs, 1),
+  );
+
+  return {
+    maxRetries,
+    baseDelayMs,
+    maxDelayMs,
+  };
+}
+
+export function computeRetryDelayMs(attempt: number, policy: NormalizedRetryPolicy): number {
+  const exponential = policy.baseDelayMs * Math.pow(2, attempt);
+  const jitter = Math.floor(policy.baseDelayMs * 0.25 * (attempt + 1));
+  return Math.min(exponential + jitter, policy.maxDelayMs);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function runWithRetry<T>(
+  operation: () => Promise<T>,
+  options: RunWithRetryOptions = {},
+): Promise<T> {
+  const policy = normalizeRetryPolicy(options.policy);
+  const exhaustedError = options.exhaustedError ?? new SearchAdapterError("INTERNAL", "Retry budget exhausted");
+
+  for (let attempt = 0; attempt <= policy.maxRetries; attempt++) {
+    try {
+      const result = await operation();
+      const retryableResult = options.isRetryableResult?.(result) ?? false;
+      if (retryableResult && attempt < policy.maxRetries) {
+        const delayMs = computeRetryDelayMs(attempt, policy);
+        options.onRetry?.({
+          attempt,
+          maxRetries: policy.maxRetries,
+          delayMs,
+          reason: "retryable_result",
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      if (retryableResult) {
+        throw exhaustedError;
+      }
+      return result;
+    } catch (error) {
+      const retryable = options.isRetryableError?.(error) ?? false;
+      if (retryable && attempt < policy.maxRetries) {
+        const delayMs = computeRetryDelayMs(attempt, policy);
+        options.onRetry?.({
+          attempt,
+          maxRetries: policy.maxRetries,
+          delayMs,
+          reason: "retryable_error",
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      if (retryable) {
+        throw exhaustedError;
+      }
+      throw error;
+    }
+  }
+
+  throw exhaustedError;
+}

--- a/searchfn/adapter-meilisearch/src/meili-client.ts
+++ b/searchfn/adapter-meilisearch/src/meili-client.ts
@@ -1,0 +1,240 @@
+import {
+  abortedError,
+  forbiddenError,
+  retryBudgetExhaustedError,
+  withRedactedErrorMessage,
+} from "./internal/errors";
+import { redactSensitive } from "./internal/redaction";
+import { runWithRetry, type RetryPolicy } from "./internal/retry";
+
+export type MeiliRetryPolicy = RetryPolicy;
+
+export interface AdapterLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface MeiliClientOptions {
+  host: string;
+  apiKey?: string;
+  requestTimeoutMs?: number;
+  taskTimeoutMs?: number;
+  retry?: MeiliRetryPolicy;
+  logger?: AdapterLogger;
+}
+
+export interface MeiliRequestOptions {
+  method: string;
+  path: string;
+  body?: unknown;
+  signal?: AbortSignal;
+  ignoreStatuses?: number[];
+}
+
+export interface MeiliResponse<T = unknown> {
+  status: number;
+  body?: T;
+}
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function isRetryableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return (
+    err.name === "AbortError" ||
+    err.message.includes("ECONNREFUSED") ||
+    err.message.includes("ETIMEDOUT") ||
+    err.message.includes("fetch failed")
+  );
+}
+
+function safePath(path: string): string {
+  return redactSensitive(path);
+}
+
+function mergeSignals(
+  ...signals: Array<AbortSignal | undefined>
+): { signal?: AbortSignal; cleanup(): void } {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+  if (activeSignals.length === 0) {
+    return {
+      signal: undefined,
+      cleanup() {},
+    };
+  }
+  const controller = new AbortController();
+  const listeners: Array<{ signal: AbortSignal; listener: () => void }> = [];
+  const cleanup = () => {
+    for (const { signal, listener } of listeners) {
+      signal.removeEventListener("abort", listener);
+    }
+    listeners.length = 0;
+  };
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      controller.abort();
+      cleanup();
+      return { signal: controller.signal, cleanup };
+    }
+    const listener = () => {
+      cleanup();
+      controller.abort();
+    };
+    signal.addEventListener("abort", listener, { once: true });
+    listeners.push({ signal, listener });
+  }
+  return { signal: controller.signal, cleanup };
+}
+
+function parseResponseBody<T>(text: string): T | string | undefined {
+  if (text.length === 0) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return text;
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(abortedError());
+  }
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", onAbort);
+      reject(abortedError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export class MeiliClient {
+  private readonly requestTimeoutMs: number;
+  private readonly taskTimeoutMs: number;
+
+  constructor(private readonly options: MeiliClientOptions) {
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+    this.taskTimeoutMs = options.taskTimeoutMs ?? Math.max(this.requestTimeoutMs * 10, 120_000);
+  }
+
+  async request<T = unknown>(opts: MeiliRequestOptions): Promise<MeiliResponse<T>> {
+    const ignoreStatuses = new Set(opts.ignoreStatuses ?? []);
+    const startedAt = Date.now();
+
+    const response = await runWithRetry(
+      () => this.execute<T>(opts),
+      {
+        policy: this.options.retry,
+        isRetryableResult: (result) => {
+          return RETRYABLE_STATUS.has((result as MeiliResponse).status) && !ignoreStatuses.has((result as MeiliResponse).status);
+        },
+        isRetryableError,
+        exhaustedError: retryBudgetExhaustedError(),
+        onRetry: ({ attempt, delayMs, reason }) => {
+          this.options.logger?.warn("adapter.retry", redactSensitive({
+            backend: "meilisearch",
+            operation: `${opts.method} ${safePath(opts.path)}`,
+            attempt,
+            delayMs,
+            reason,
+          }));
+        },
+      },
+    );
+
+    if ((response.status === 401 || response.status === 403) && !ignoreStatuses.has(response.status)) {
+      throw forbiddenError("Meilisearch authorization failed");
+    }
+    if (response.status >= 400 && !ignoreStatuses.has(response.status)) {
+      throw withRedactedErrorMessage(
+        `Meilisearch request failed with status ${response.status}`,
+        response.body,
+      );
+    }
+
+    this.options.logger?.debug("adapter.request", redactSensitive({
+      backend: "meilisearch",
+      operation: `${opts.method} ${safePath(opts.path)}`,
+      status: response.status,
+      durationMs: Date.now() - startedAt,
+    }));
+
+    return response;
+  }
+
+  async waitForTask(taskUid: number, signal?: AbortSignal): Promise<void> {
+    const started = Date.now();
+    while (Date.now() - started < this.taskTimeoutMs) {
+      if (signal?.aborted) {
+        throw abortedError();
+      }
+      const response = await this.request<{ status: string; error?: { message?: string } }>({
+        method: "GET",
+        path: `/tasks/${taskUid}`,
+        signal,
+      });
+
+      const status = response.body?.status;
+      if (status === "succeeded") return;
+      if (status === "failed") {
+        throw withRedactedErrorMessage("Meilisearch task failed", response.body?.error?.message ?? "unknown");
+      }
+      if (signal?.aborted) {
+        throw abortedError();
+      }
+      await delay(50, signal);
+    }
+    throw retryBudgetExhaustedError();
+  }
+
+  private async execute<T>(opts: MeiliRequestOptions): Promise<MeiliResponse<T>> {
+    const timeoutController = new AbortController();
+    const timeoutId = setTimeout(() => timeoutController.abort(), this.requestTimeoutMs);
+    const merged = mergeSignals(timeoutController.signal, opts.signal);
+
+    const headers: Record<string, string> = { accept: "application/json" };
+    if (this.options.apiKey) {
+      headers.authorization = `Bearer ${this.options.apiKey}`;
+    }
+
+    let body: string | undefined;
+    if (opts.body !== undefined) {
+      body = typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
+      headers["content-type"] = "application/json";
+    }
+
+    try {
+      const url = new URL(opts.path, this.options.host.endsWith("/") ? this.options.host : `${this.options.host}/`);
+      const response = await fetch(url, {
+        method: opts.method,
+        headers,
+        body,
+        signal: merged.signal,
+      });
+
+      const text = await response.text();
+      const parsed = parseResponseBody<T>(text);
+
+      return {
+        status: response.status,
+        body: parsed as T | undefined,
+      };
+    } catch (error) {
+      if (opts.signal?.aborted) {
+        throw abortedError();
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      merged.cleanup();
+    }
+  }
+}

--- a/searchfn/adapter-meilisearch/src/meilisearch.ts
+++ b/searchfn/adapter-meilisearch/src/meilisearch.ts
@@ -1,0 +1,253 @@
+import type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDefaults,
+  SearchAllResult,
+  IndexParams,
+  SearchParams,
+  SearchAllParams,
+  RemoveParams,
+  InitializeParams,
+} from "@searchfn/adapter-contracts";
+import { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+import { MeiliClient, type MeiliRetryPolicy, type AdapterLogger } from "./meili-client";
+import { createHash } from "node:crypto";
+
+export interface MeilisearchAdapterOptions {
+  host: string;
+  apiKey?: string;
+  indexPrefix?: string;
+  requestTimeoutMs?: number;
+  taskTimeoutMs?: number;
+  retry?: MeiliRetryPolicy;
+  logger?: AdapterLogger;
+  /** Construct-time defaults applied when query params are omitted. */
+  defaults?: SearchDefaults;
+}
+
+interface MeiliTaskResult {
+  taskUid: number;
+}
+
+interface MeiliSearchResponse {
+  hits: Array<Record<string, unknown>>;
+}
+
+function sanitizeResourceName(resource: string): string {
+  const base = resource.replace(/[^a-z0-9_]/gi, "_").toLowerCase() || "resource";
+  const hash = createHash("sha1").update(resource).digest("hex").slice(0, 8);
+  return `${base}_${hash}`;
+}
+
+function coerceId(value: unknown): string | number {
+  const asString = String(value);
+  if (/^(0|[1-9]\d*)$/.test(asString)) {
+    const asNumber = Number(asString);
+    if (Number.isSafeInteger(asNumber) && String(asNumber) === asString) {
+      return asNumber;
+    }
+  }
+  return asString;
+}
+
+export class MeilisearchAdapter implements SearchAdapter {
+  readonly name = "meilisearch";
+  readonly capabilities: SearchAdapterCapabilities = {
+    persistent: true,
+    searchAll: true,
+    fuzzy: true,
+    fieldBoosts: false,
+    prefix: false,
+  };
+
+  private readonly client: MeiliClient;
+  private readonly indexPrefix: string;
+  private readonly defaults: SearchDefaults;
+  private disposed = false;
+  private readonly resources = new Map<string, string[]>();
+
+  constructor(public readonly options: MeilisearchAdapterOptions) {
+    this.client = new MeiliClient({
+      host: options.host,
+      apiKey: options.apiKey,
+      requestTimeoutMs: options.requestTimeoutMs,
+      taskTimeoutMs: options.taskTimeoutMs,
+      retry: options.retry,
+      logger: options.logger,
+    });
+    this.indexPrefix = options.indexPrefix ?? "searchfn";
+    this.defaults = options.defaults ?? {};
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) {
+      throw new SearchAdapterError(
+        SEARCH_ADAPTER_DISPOSED,
+        "Search adapter is disposed. Call initialize() before use.",
+      );
+    }
+  }
+
+  private indexName(resource: string): string {
+    return `${this.indexPrefix}_${sanitizeResourceName(resource)}`;
+  }
+
+  async initialize(params: InitializeParams): Promise<void> {
+    if (this.disposed) {
+      this.disposed = false;
+    }
+    this.resources.clear();
+
+    for (const resource of params.resources) {
+      const indexName = this.indexName(resource.name);
+      this.resources.set(resource.name, resource.searchFields);
+
+      const create = await this.client.request<MeiliTaskResult>({
+        method: "POST",
+        path: "/indexes",
+        body: { uid: indexName, primaryKey: "id" },
+        ignoreStatuses: [400],
+      });
+      if (create.body?.taskUid !== undefined) {
+        await this.client.waitForTask(create.body.taskUid);
+      }
+
+      const searchable = await this.client.request<MeiliTaskResult>({
+        method: "PUT",
+        path: `/indexes/${indexName}/settings/searchable-attributes`,
+        body: resource.searchFields,
+      });
+      if (searchable.body?.taskUid !== undefined) {
+        await this.client.waitForTask(searchable.body.taskUid);
+      }
+    }
+  }
+
+  async index({ resource, documents, signal }: IndexParams): Promise<void> {
+    this.assertNotDisposed();
+    if (documents.length === 0) return;
+
+    const indexName = this.indexName(resource);
+    const payload = documents.map((doc) => ({ ...doc.fields, id: String(doc.id) }));
+    const add = await this.client.request<MeiliTaskResult>({
+      method: "POST",
+      path: `/indexes/${indexName}/documents`,
+      body: payload,
+      signal,
+    });
+    if (add.body?.taskUid !== undefined) {
+      await this.client.waitForTask(add.body.taskUid, signal);
+    }
+  }
+
+  async search(params: SearchParams): Promise<Array<string | number>> {
+    this.assertNotDisposed();
+    if (params.fields !== undefined && params.fields.length === 0) {
+      return [];
+    }
+
+    const effectiveFuzzy = params.fuzzy ?? this.defaults.fuzzy;
+    const indexName = this.indexName(params.resource);
+    const response = await this.client.request<MeiliSearchResponse>({
+      method: "POST",
+      path: `/indexes/${indexName}/search`,
+      body: {
+        q: params.query,
+        limit: Math.max(1, params.limit ?? 10),
+        attributesToSearchOn: params.fields !== undefined ? params.fields : undefined,
+        typoTolerance: effectiveFuzzy ? undefined : "min",
+      },
+      signal: params.signal,
+      ignoreStatuses: [404],
+    });
+
+    if (response.status === 404) return [];
+
+    return (response.body?.hits ?? []).map((hit) => coerceId(hit.id));
+  }
+
+  async searchAll(params: SearchAllParams): Promise<SearchAllResult[]> {
+    this.assertNotDisposed();
+    if (params.fields !== undefined && params.fields.length === 0) {
+      return [];
+    }
+
+    const effectiveFuzzy = params.fuzzy ?? this.defaults.fuzzy;
+    const resources = params.resources ?? Array.from(this.resources.keys());
+    if (resources.length === 0) {
+      return [];
+    }
+    const limit = Math.max(1, params.limit ?? 10);
+    const limitPerResource = Math.max(1, params.limitPerResource ?? limit);
+    const merged: SearchAllResult[] = [];
+
+    for (const resource of resources) {
+      const indexName = this.indexName(resource);
+      const response = await this.client.request<MeiliSearchResponse>({
+        method: "POST",
+        path: `/indexes/${indexName}/search`,
+        body: {
+          q: params.query,
+          limit: limitPerResource,
+          attributesToSearchOn: params.fields !== undefined ? params.fields : undefined,
+          typoTolerance: effectiveFuzzy ? undefined : "min",
+        },
+        signal: params.signal,
+        ignoreStatuses: [404],
+      });
+      if (response.status === 404) continue;
+
+      const hits = response.body?.hits ?? [];
+      for (let i = 0; i < hits.length; i++) {
+        merged.push({
+          resource,
+          id: coerceId(hits[i].id),
+          score: hits.length > 1 ? (hits.length - i) / hits.length : 1,
+        });
+      }
+    }
+
+    merged.sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      if (a.resource !== b.resource) return a.resource.localeCompare(b.resource);
+      return String(a.id).localeCompare(String(b.id));
+    });
+
+    return merged.slice(0, limit);
+  }
+
+  async remove({ resource, ids, signal }: RemoveParams): Promise<void> {
+    this.assertNotDisposed();
+    if (ids.length === 0) return;
+
+    const indexName = this.indexName(resource);
+    const remove = await this.client.request<MeiliTaskResult>({
+      method: "POST",
+      path: `/indexes/${indexName}/documents/delete-batch`,
+      body: ids.map((id) => String(id)),
+      signal,
+      ignoreStatuses: [404],
+    });
+    if (remove.body?.taskUid !== undefined) {
+      await this.client.waitForTask(remove.body.taskUid, signal);
+    }
+  }
+
+  async clear(resource: string, signal?: AbortSignal): Promise<void> {
+    this.assertNotDisposed();
+    const indexName = this.indexName(resource);
+    const clear = await this.client.request<MeiliTaskResult>({
+      method: "DELETE",
+      path: `/indexes/${indexName}/documents`,
+      signal,
+      ignoreStatuses: [404],
+    });
+    if (clear.body?.taskUid !== undefined) {
+      await this.client.waitForTask(clear.body.taskUid, signal);
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+  }
+}

--- a/searchfn/adapter-meilisearch/tsconfig.json
+++ b/searchfn/adapter-meilisearch/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@searchfn/adapter-contracts": ["../adapter-contracts/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapter-meilisearch/tsup.config.ts
+++ b/searchfn/adapter-meilisearch/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist"
+});

--- a/searchfn/adapter-meilisearch/vitest.config.ts
+++ b/searchfn/adapter-meilisearch/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"]
+  }
+});

--- a/searchfn/adapter-memory/__tests__/adapter-contract.test.ts
+++ b/searchfn/adapter-memory/__tests__/adapter-contract.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+import { MemoryAdapter } from "../src/index";
+
+export function runAdapterContractTests(
+  adapterName: string,
+  createAdapter: () => SearchAdapter
+): void {
+  describe(`${adapterName} — contract tests`, () => {
+    let adapter: SearchAdapter;
+
+    beforeEach(() => {
+      adapter = createAdapter();
+    });
+
+    afterEach(async () => {
+      if (adapter.dispose) {
+        await adapter.dispose();
+      }
+    });
+
+    // TV-MEM-001
+    it("indexes documents and returns matching DocIds on search", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [
+          {
+            id: "task:1",
+            fields: { title: "Buy groceries", description: "Get milk and bread" }
+          },
+          {
+            id: "task:2",
+            fields: {
+              title: "Review pull request",
+              description: "Check auth changes"
+            }
+          }
+        ]
+      });
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "groceries",
+        limit: 10
+      });
+      expect(result).toEqual(["task:1"]);
+    });
+
+    // TV-MEM-002
+    it("returns empty array when query matches nothing", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [
+          {
+            id: "task:1",
+            fields: { title: "Buy groceries" }
+          }
+        ]
+      });
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "xyznonexistent",
+        limit: 10
+      });
+      expect(result).toEqual([]);
+    });
+
+    // TV-MEM-003
+    it("remove makes document invisible to search", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "task:1", fields: { title: "Buy groceries" } }]
+      });
+      await adapter.remove({ resource: "tasks", ids: ["task:1"] });
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "groceries"
+      });
+      expect(result).toEqual([]);
+    });
+
+    // TV-MEM-004
+    it("clear removes all documents from a resource", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [
+          { id: "1", fields: { title: "Buy groceries" } },
+          { id: "2", fields: { title: "Review request" } },
+          { id: "3", fields: { title: "Write tests" } }
+        ]
+      });
+      await adapter.clear("tasks");
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "groceries"
+      });
+      expect(result).toEqual([]);
+    });
+
+    // TV-MEM-005
+    it("field restriction limits search to specified fields", async () => {
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "1", fields: { title: "Alpha", description: "Beta" } }
+        ]
+      });
+      const result = await adapter.search({
+        resource: "items",
+        query: "Beta",
+        fields: ["title"]
+      });
+      expect(result).toEqual([]);
+    });
+
+    // TV-UPS-001
+    it("upsert replaces old document — old content not searchable", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "old title" } }]
+      });
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "new title" } }]
+      });
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "old"
+      });
+      expect(result).toEqual([]);
+    });
+
+    // TV-UPS-002
+    it("upsert replaces old document — new content is searchable", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "old title" } }]
+      });
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "new title" } }]
+      });
+      const result = await adapter.search({
+        resource: "tasks",
+        query: "new"
+      });
+      expect(result).toContain("1");
+    });
+
+    // TV-ISO-001
+    it("resource A documents are not visible in resource B search", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "Secret task" } }]
+      });
+      const result = await adapter.search({
+        resource: "notes",
+        query: "Secret"
+      });
+      expect(result).toEqual([]);
+    });
+
+    // TV-ISO-002
+    it("clearing resource A does not affect resource B", async () => {
+      await adapter.index({
+        resource: "tasks",
+        documents: [{ id: "t1", fields: { title: "Task item" } }]
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { title: "Note item" } }]
+      });
+      await adapter.clear("tasks");
+      const result = await adapter.search({
+        resource: "notes",
+        query: "Note"
+      });
+      expect(result).toContain("n1");
+    });
+
+    // TV-LIFE-001
+    it("works without calling initialize first", async () => {
+      await adapter.index({
+        resource: "x",
+        documents: [{ id: "1", fields: { a: "hello" } }]
+      });
+      const result = await adapter.search({ resource: "x", query: "hello" });
+      expect(result).toContain("1");
+    });
+
+    // TV-LIFE-002 — only meaningful for adapters with dispose
+    if (createAdapter().dispose) {
+      it("throws SEARCH_ADAPTER_DISPOSED after dispose", async () => {
+        const freshAdapter = createAdapter();
+        await freshAdapter.index({
+          resource: "x",
+          documents: [{ id: "1", fields: { a: "hello" } }]
+        });
+        await freshAdapter.dispose!();
+        await expect(
+          freshAdapter.search({ resource: "x", query: "hello" })
+        ).rejects.toMatchObject({
+          code: SEARCH_ADAPTER_DISPOSED,
+          message: "Search adapter is disposed. Call initialize() before use."
+        });
+      });
+
+      if (createAdapter().initialize) {
+        it("allows explicit reinitialize after dispose", async () => {
+          const freshAdapter = createAdapter();
+          await freshAdapter.dispose!();
+          await freshAdapter.initialize!({ resources: [{ name: "x", searchFields: ["a"] }] });
+          await freshAdapter.index({
+            resource: "x",
+            documents: [{ id: "1", fields: { a: "hello" } }],
+          });
+          await expect(
+            freshAdapter.search({ resource: "x", query: "hello" }),
+          ).resolves.toContain("1");
+        });
+      }
+    }
+  });
+}
+
+runAdapterContractTests("MemoryAdapter", () => new MemoryAdapter());

--- a/searchfn/adapter-memory/__tests__/conformance/memory.conformance.test.ts
+++ b/searchfn/adapter-memory/__tests__/conformance/memory.conformance.test.ts
@@ -1,0 +1,11 @@
+import { describe } from "vitest";
+import { MemoryAdapter } from "../../src/index";
+import { runConformanceSuite } from "./shared";
+
+describe("MemoryAdapter conformance", () => {
+  runConformanceSuite({
+    name: "memory",
+    create: () => new MemoryAdapter(),
+    persistent: false,
+  });
+});

--- a/searchfn/adapter-memory/__tests__/conformance/shared.ts
+++ b/searchfn/adapter-memory/__tests__/conformance/shared.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared adapter conformance test harness.
+ *
+ * Every SearchAdapter implementation MUST pass all assertions defined here.
+ * To use: call `runConformanceSuite(adapterFactory)` inside a `describe` block.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export interface ConformanceAdapterFactory {
+  /** Human-readable adapter name for test labels */
+  name: string;
+  /** Create a fresh adapter instance for each test */
+  create(): SearchAdapter;
+  /** Whether this adapter supports persistent storage (survives dispose+reinitialize) */
+  persistent?: boolean;
+  /** Whether cleanup is needed after tests (e.g., external services) */
+  cleanup?(): Promise<void>;
+  /** Optional callback that returns true when tests should be skipped (e.g., backend unavailable) */
+  shouldSkip?(): boolean;
+}
+
+/**
+ * Run the full conformance suite against an adapter.
+ * Call this inside a `describe()` block.
+ */
+export function runConformanceSuite(factory: ConformanceAdapterFactory): void {
+  let adapter: SearchAdapter;
+
+  beforeEach((ctx) => {
+    if (factory.shouldSkip?.()) {
+      ctx.skip();
+      return;
+    }
+    adapter = factory.create();
+  });
+
+  afterEach(async () => {
+    if (adapter.dispose) {
+      await adapter.dispose();
+    }
+    if (factory.cleanup) {
+      await factory.cleanup();
+    }
+  });
+
+  // ── Contract shape ──────────────────────────────────────────────
+
+  describe("contract shape", () => {
+    it("has a non-empty name", () => {
+      expect(typeof adapter.name).toBe("string");
+      expect(adapter.name.length).toBeGreaterThan(0);
+    });
+
+    it("exposes required methods", () => {
+      expect(typeof adapter.index).toBe("function");
+      expect(typeof adapter.search).toBe("function");
+      expect(typeof adapter.remove).toBe("function");
+      expect(typeof adapter.clear).toBe("function");
+    });
+
+    it("exposes capabilities object if declared", () => {
+      if (adapter.capabilities !== undefined) {
+        expect(typeof adapter.capabilities).toBe("object");
+      }
+    });
+  });
+
+  // ── Index + Search basics ───────────────────────────────────────
+
+  describe("index and search", () => {
+    it("returns matching ids after indexing documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha beta" } },
+          { id: "d2", fields: { title: "gamma delta" } },
+        ],
+      });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toContain("d1");
+      expect(results).not.toContain("d2");
+    });
+
+    it("returns empty array when no documents match", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      const results = await adapter.search({ resource: "items", query: "zzzzz", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("upserts on duplicate id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "beta" } }],
+      });
+      const alphaResults = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(alphaResults).not.toContain("d1");
+      const betaResults = await adapter.search({ resource: "items", query: "beta", limit: 10 });
+      expect(betaResults).toContain("d1");
+    });
+
+    it("respects limit parameter", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      const docs = Array.from({ length: 20 }, (_, i) => ({
+        id: `d${i}`,
+        fields: { title: "common term" },
+      }));
+      await adapter.index({ resource: "items", documents: docs });
+      const results = await adapter.search({ resource: "items", query: "common", limit: 5 });
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── Deterministic tie-breaking ──────────────────────────────────
+
+  describe("deterministic ordering", () => {
+    it("produces consistent order for equal-score documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "b", fields: { title: "same" } },
+          { id: "a", fields: { title: "same" } },
+          { id: "c", fields: { title: "same" } },
+        ],
+      });
+      const r1 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      const r2 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      expect(r1).toEqual(r2);
+    });
+  });
+
+  // ── Remove ──────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    it("removes documents by id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha" } },
+          { id: "d2", fields: { title: "alpha" } },
+        ],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).not.toContain("d1");
+      expect(results).toContain("d2");
+    });
+
+    it("is idempotent for already-removed ids", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      // Second remove should not throw
+      await expect(adapter.remove({ resource: "items", ids: ["d1"] })).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Clear ───────────────────────────────────────────────────────
+
+  describe("clear", () => {
+    it("removes all documents from a resource", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("does not affect other resources", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const notesResults = await adapter.search({ resource: "notes", query: "alpha", limit: 10 });
+      expect(notesResults).toContain("n1");
+    });
+  });
+
+  // ── searchAll (optional) ────────────────────────────────────────
+
+  describe("searchAll", () => {
+    it("merges results across resources with deterministic ordering", async () => {
+      if (!adapter.searchAll) return; // skip if not supported
+
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "common term" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "common term" } }],
+      });
+
+      const results = await adapter.searchAll({ query: "common", limit: 10 });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // Verify deterministic ordering: score desc, resource asc, id asc
+      for (let i = 1; i < results.length; i++) {
+        const prev = results[i - 1];
+        const curr = results[i];
+        const valid =
+          prev.score > curr.score ||
+          (prev.score === curr.score && prev.resource < curr.resource) ||
+          (prev.score === curr.score &&
+            prev.resource === curr.resource &&
+            String(prev.id) <= String(curr.id));
+        expect(valid).toBe(true);
+      }
+    });
+  });
+
+  // ── Lifecycle (initialize / dispose) ────────────────────────────
+
+  describe("lifecycle", () => {
+    it("blocks operations after dispose", async () => {
+      if (!adapter.dispose) return;
+
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.dispose();
+
+      try {
+        await adapter.search({ resource: "items", query: "test", limit: 10 });
+        // If it doesn't throw, the adapter allows post-dispose search (some might)
+        // but it MUST NOT return stale data if persistent=false
+      } catch (err) {
+        // Expected: adapter should reject after dispose
+        expect(err).toBeDefined();
+        if (err instanceof Error && "code" in err) {
+          expect((err as { code: string }).code).toBe(SEARCH_ADAPTER_DISPOSED);
+        }
+      }
+    });
+
+    it("can reinitialize after dispose", async () => {
+      if (!adapter.dispose || !adapter.initialize) return;
+
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.dispose();
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+
+      // After reinitialize, adapter should be operational
+      // For non-persistent adapters, previous data may be gone
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      if (factory.persistent) {
+        expect(results).toContain("d1");
+      }
+      // For non-persistent, just verify it doesn't throw
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+}
+
+/**
+ * List of conformance assertion categories.
+ * Used for documentation/reporting.
+ */
+export const CONFORMANCE_ASSERTIONS = [
+  "contract-shape: name, required methods, capabilities",
+  "index-search: basic indexing, search, upsert, limit",
+  "deterministic-ordering: consistent tie-breaking",
+  "remove: by id, idempotent",
+  "clear: per-resource, cross-resource isolation",
+  "searchAll: merged results, deterministic global order",
+  "lifecycle: dispose blocks ops, reinitialize restores",
+] as const;

--- a/searchfn/adapter-memory/__tests__/memory.test.ts
+++ b/searchfn/adapter-memory/__tests__/memory.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemoryAdapter } from "../src/index";
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+
+describe("MemoryAdapter — fuzzy search", () => {
+  let adapter: MemoryAdapter;
+
+  beforeEach(() => {
+    adapter = new MemoryAdapter();
+  });
+
+  // TV-FUZZ-001
+  it("fuzzy=true finds documents with misspelled query terms", async () => {
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "groceries" } }]
+    });
+    const result = await adapter.search({
+      resource: "tasks",
+      query: "groceris",
+      fuzzy: true
+    });
+    expect(result).toContain("1");
+  });
+
+  // TV-FUZZ-002
+  it("fuzzy disabled by default — misspelling returns empty", async () => {
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "groceries" } }]
+    });
+    const result = await adapter.search({
+      resource: "tasks",
+      query: "groceris"
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("fuzzy=1 respects distance threshold", async () => {
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "hello" } }]
+    });
+    const withinDistance = await adapter.search({
+      resource: "tasks",
+      query: "hellu",
+      fuzzy: 1
+    });
+    expect(withinDistance).toContain("1");
+
+    const beyondDistance = await adapter.search({
+      resource: "tasks",
+      query: "hxllu",
+      fuzzy: 1
+    });
+    expect(beyondDistance).toEqual([]);
+  });
+
+  it("fuzzy matches score lower than exact matches", async () => {
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "exact", fields: { title: "groceries" } },
+        { id: "fuzzy-match", fields: { title: "groceris" } }
+      ]
+    });
+    const exactResult = await adapter.search({
+      resource: "tasks",
+      query: "groceries",
+      limit: 10
+    });
+    const fuzzyResult = await adapter.search({
+      resource: "tasks",
+      query: "groceris",
+      fuzzy: true,
+      limit: 10
+    });
+    expect(exactResult[0]).toBe("exact");
+    expect(fuzzyResult).toContain("fuzzy-match");
+  });
+
+  it("keeps shared vocabulary entries when removing one field bucket", async () => {
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "1", fields: { title: "report" } },
+        { id: "2", fields: { body: "report" } },
+      ],
+    });
+
+    await adapter.remove({ resource: "tasks", ids: ["1"] });
+
+    const result = await adapter.search({
+      resource: "tasks",
+      query: "report",
+      fuzzy: true,
+    });
+
+    expect(result).toEqual(["2"]);
+  });
+});
+
+describe("MemoryAdapter — field boosts", () => {
+  let adapter: MemoryAdapter;
+
+  beforeEach(() => {
+    adapter = new MemoryAdapter();
+  });
+
+  // TV-BOOST-001 / TV-MEM-007
+  it("fieldBoosts causes matches in boosted field to rank higher", async () => {
+    await adapter.index({
+      resource: "items",
+      documents: [
+        { id: "A", fields: { title: "report", body: "quarterly data" } },
+        { id: "B", fields: { title: "quarterly data", body: "report" } }
+      ]
+    });
+    const result = await adapter.search({
+      resource: "items",
+      query: "report",
+      fieldBoosts: { title: 5.0, body: 1.0 },
+      limit: 10
+    });
+    expect(result[0]).toBe("A");
+    expect(result).toContain("B");
+  });
+
+  it("default boost of 1.0 for unspecified fields", async () => {
+    await adapter.index({
+      resource: "items",
+      documents: [
+        { id: "1", fields: { title: "report", description: "quarterly data" } }
+      ]
+    });
+    const withBoosts = await adapter.search({
+      resource: "items",
+      query: "report",
+      fieldBoosts: { title: 1.0 }
+    });
+    const withoutBoosts = await adapter.search({
+      resource: "items",
+      query: "report"
+    });
+    expect(withBoosts).toContain("1");
+    expect(withoutBoosts).toContain("1");
+  });
+});
+
+describe("MemoryAdapter — searchAll", () => {
+  let adapter: MemoryAdapter;
+
+  beforeEach(async () => {
+    adapter = new MemoryAdapter();
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "t1", fields: { title: "Quarterly report analysis" } },
+        { id: "t2", fields: { title: "Monthly review" } }
+      ]
+    });
+    await adapter.index({
+      resource: "notes",
+      documents: [
+        { id: "n1", fields: { title: "Report summary" } },
+        { id: "n2", fields: { title: "Meeting notes" } }
+      ]
+    });
+  });
+
+  // TV-XSRC-001
+  it("searchAll returns results from all resources sorted by score", async () => {
+    const results = await adapter.searchAll({
+      query: "report",
+      limit: 10
+    });
+
+    const resourceIds = results.map((r) => ({ resource: r.resource, id: r.id }));
+    expect(resourceIds).toEqual(
+      expect.arrayContaining([
+        { resource: "tasks", id: "t1" },
+        { resource: "notes", id: "n1" }
+      ])
+    );
+
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].score).toBeLessThanOrEqual(results[i - 1].score);
+    }
+  });
+
+  // TV-XSRC-002
+  it("searchAll with resources filter scopes to specified resources only", async () => {
+    const results = await adapter.searchAll({
+      query: "report",
+      resources: ["tasks"],
+      limit: 10
+    });
+    expect(results.every((r) => r.resource === "tasks")).toBe(true);
+    expect(results.some((r) => r.id === "t1")).toBe(true);
+  });
+
+  // TV-XSRC-003
+  it("searchAll respects limitPerResource cap", async () => {
+    await adapter.index({
+      resource: "files",
+      documents: Array.from({ length: 10 }, (_, i) => ({
+        id: `f${i}`,
+        fields: { title: `report document ${i}` }
+      }))
+    });
+    await adapter.index({
+      resource: "pages",
+      documents: Array.from({ length: 10 }, (_, i) => ({
+        id: `p${i}`,
+        fields: { title: `report page ${i}` }
+      }))
+    });
+
+    const results = await adapter.searchAll({
+      query: "report",
+      resources: ["files", "pages"],
+      limitPerResource: 3,
+      limit: 100
+    });
+
+    const filesCount = results.filter((r) => r.resource === "files").length;
+    const pagesCount = results.filter((r) => r.resource === "pages").length;
+    expect(filesCount).toBeLessThanOrEqual(3);
+    expect(pagesCount).toBeLessThanOrEqual(3);
+  });
+
+  it("searchAll with fuzzy finds misspelled terms across resources", async () => {
+    const results = await adapter.searchAll({
+      query: "reprot",
+      fuzzy: true,
+      limit: 10
+    });
+    expect(results.length).toBeGreaterThan(0);
+    const ids = results.map((r) => r.id);
+    expect(ids.some((id) => id === "t1" || id === "n1")).toBe(true);
+  });
+
+  it("searchAll global limit caps total results", async () => {
+    const results = await adapter.searchAll({
+      query: "report",
+      limit: 1
+    });
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it("searchAll returns results with score property", async () => {
+    const results = await adapter.searchAll({ query: "report", limit: 10 });
+    for (const r of results) {
+      expect(typeof r.score).toBe("number");
+      expect(r.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("searchAll returns empty array when no resources match query", async () => {
+    const results = await adapter.searchAll({
+      query: "zzznomatch",
+      limit: 10
+    });
+    expect(results).toEqual([]);
+  });
+
+  it("searchAll deterministic tie-break: resource ASC then id ASC", async () => {
+    const fresh = new MemoryAdapter();
+    await fresh.index({
+      resource: "alpha",
+      documents: [{ id: "2", fields: { title: "unique" } }]
+    });
+    await fresh.index({
+      resource: "alpha",
+      documents: [{ id: "1", fields: { title: "unique" } }]
+    });
+    await fresh.index({
+      resource: "beta",
+      documents: [{ id: "1", fields: { title: "unique" } }]
+    });
+
+    const results = await fresh.searchAll({ query: "unique", limit: 10 });
+    const alphaResults = results.filter((r) => r.resource === "alpha");
+    const betaResults = results.filter((r) => r.resource === "beta");
+
+    if (alphaResults.length >= 2) {
+      expect(String(alphaResults[0].id) <= String(alphaResults[1].id)).toBe(
+        true
+      );
+    }
+
+    const alphaScore = alphaResults[0]?.score ?? 0;
+    const betaScore = betaResults[0]?.score ?? 0;
+    if (alphaScore === betaScore) {
+      const alphaIdx = results.findIndex((r) => r.resource === "alpha");
+      const betaIdx = results.findIndex((r) => r.resource === "beta");
+      expect(alphaIdx).toBeLessThan(betaIdx);
+    }
+
+    await fresh.dispose();
+  });
+});
+
+describe("MemoryAdapter — initialize and name", () => {
+  it("name is 'memory'", () => {
+    expect(new MemoryAdapter().name).toBe("memory");
+  });
+
+  it("initialize pre-creates resource engines", async () => {
+    const adapter = new MemoryAdapter();
+    await adapter.initialize({
+      resources: [
+        { name: "tasks", searchFields: ["title", "description"] },
+        { name: "notes", searchFields: ["title"] }
+      ]
+    });
+    const result = await adapter.search({ resource: "tasks", query: "anything" });
+    expect(result).toEqual([]);
+    await adapter.dispose();
+  });
+
+  it("indexes >10k documents via deterministic chunking", async () => {
+    const adapter = new MemoryAdapter();
+    const documents = Array.from({ length: 15000 }, (_, i) => ({
+      id: `d${i}`,
+      fields: { title: `document ${i}` },
+    }));
+    await adapter.index({ resource: "bulk", documents });
+
+    const result = await adapter.search({
+      resource: "bulk",
+      query: "document 14999",
+      fields: ["title"],
+      limit: 5,
+    });
+    expect(result).toContain("d14999");
+    await adapter.dispose();
+  });
+});
+
+describe("MemoryAdapter — prefix search", () => {
+  // TV-MEM-001
+  it("TV-MEM-001: prefix: true finds documents matching partial query", async () => {
+    const adapter = new MemoryAdapter();
+    await adapter.index({
+      resource: "r",
+      documents: [{ id: "1", fields: { text: "testing" } }],
+    });
+    const result = await adapter.search({
+      resource: "r",
+      query: "test",
+      prefix: true,
+    });
+    expect(result).toContain("1");
+    await adapter.dispose();
+  });
+
+  // TV-MEM-002
+  it("TV-MEM-002: prefix: false (default) does not match prefix-only tokens", async () => {
+    const adapter = new MemoryAdapter();
+    await adapter.index({
+      resource: "r",
+      documents: [{ id: "1", fields: { text: "hello world" } }],
+    });
+    const result = await adapter.search({
+      resource: "r",
+      query: "hel",
+    });
+    expect(result).toEqual([]);
+    await adapter.dispose();
+  });
+
+  // TV-MEM-003
+  it("TV-MEM-003: construct-time defaults.prefix applied when param omitted", async () => {
+    const adapter = new MemoryAdapter({ defaults: { prefix: true } });
+    await adapter.index({
+      resource: "r",
+      documents: [{ id: "1", fields: { text: "hello world" } }],
+    });
+    const result = await adapter.search({
+      resource: "r",
+      query: "hel",
+    });
+    expect(result).toContain("1");
+    await adapter.dispose();
+  });
+
+  it("TV-MEM-CAP: capabilities include prefix: true", () => {
+    const adapter = new MemoryAdapter();
+    expect(adapter.capabilities.prefix).toBe(true);
+  });
+});
+
+describe("MemoryAdapter — abort signal support", () => {
+  it("index throws DFQL_ABORTED when signal is already aborted", async () => {
+    const adapter = new MemoryAdapter();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "hello" } }],
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(SearchAdapterError);
+
+    await expect(
+      adapter.index({
+        resource: "tasks",
+        documents: [{ id: "1", fields: { title: "hello" } }],
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ code: "DFQL_ABORTED" });
+  });
+
+  it("searchAll throws DFQL_ABORTED when signal is aborted", async () => {
+    const adapter = new MemoryAdapter();
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "hello report" } }],
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      adapter.searchAll({
+        query: "report",
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ code: "DFQL_ABORTED" });
+
+    await adapter.dispose();
+  });
+});

--- a/searchfn/adapter-memory/package.json
+++ b/searchfn/adapter-memory/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@searchfn/adapter-memory",
+  "version": "0.1.0",
+  "description": "Memory adapter for SearchFn.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@searchfn/adapter-contracts": "file:../adapter-contracts",
+    "@searchfn/core": "file:../core"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/adapter-memory/src/index.ts
+++ b/searchfn/adapter-memory/src/index.ts
@@ -1,0 +1,489 @@
+import {
+  PipelineEngine,
+  Indexer,
+  DocumentStatsManager,
+  scorePostings,
+  fuzzyExpand
+} from "@searchfn/core";
+import type { TermPosting, RetrievedPostingChunk } from "@searchfn/core";
+import type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchAdapterConfig,
+  IndexParams,
+  SearchParams,
+  RemoveParams,
+  SearchAllParams,
+  SearchAllResult,
+  InitializeParams
+} from "@searchfn/adapter-contracts";
+import { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+type DocId = string | number;
+
+interface PostingInfo {
+  docId: DocId;
+  frequency: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface ResourceEngine {
+  pipeline: PipelineEngine;
+  indexer: Indexer;
+  statsManager: DocumentStatsManager;
+  postings: Map<string, Map<string, PostingInfo>>;
+  docIds: Map<string, DocId>;
+  fieldNames: Set<string>;
+  vocabulary: Set<string>;
+  vocabularyRefs: Map<string, number>;
+  fuzzyCache: Map<string, string[]>;
+}
+
+export class MemoryAdapter implements SearchAdapter {
+  readonly name = "memory";
+  readonly capabilities: SearchAdapterCapabilities = {
+    persistent: false,
+    searchAll: true,
+    fuzzy: true,
+    fieldBoosts: true,
+    prefix: true,
+  };
+  private static readonly MAX_INDEX_BATCH_SIZE = 10_000;
+
+  private readonly config: SearchAdapterConfig;
+  private readonly resources = new Map<string, ResourceEngine>();
+  private disposed = false;
+
+  constructor(config?: SearchAdapterConfig) {
+    this.config = config ?? {};
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) {
+      throw new SearchAdapterError(
+        SEARCH_ADAPTER_DISPOSED,
+        "Search adapter is disposed. Call initialize() before use."
+      );
+    }
+  }
+
+  private createEngine(): ResourceEngine {
+    const pipeline = new PipelineEngine(this.config.pipeline);
+    return {
+      pipeline,
+      indexer: new Indexer(pipeline),
+      statsManager: new DocumentStatsManager(),
+      postings: new Map(),
+      docIds: new Map(),
+      fieldNames: new Set(),
+      vocabulary: new Set(),
+      vocabularyRefs: new Map(),
+      fuzzyCache: new Map()
+    };
+  }
+
+  private getOrCreateResource(resource: string): ResourceEngine {
+    let engine = this.resources.get(resource);
+    if (!engine) {
+      engine = this.createEngine();
+      this.resources.set(resource, engine);
+    }
+    return engine;
+  }
+
+  private addDocToEngine(
+    engine: ResourceEngine,
+    docId: DocId,
+    fields: Record<string, string>
+  ): void {
+    const ingest = engine.indexer.ingest({ docId, fields });
+    if (ingest.totalLength === 0) return;
+
+    const docKey = this.toKey(docId);
+    engine.statsManager.addDocument(docKey, ingest.totalLength);
+    engine.docIds.set(docKey, docId);
+
+    for (const [field, termFrequencies] of ingest.fieldFrequencies.entries()) {
+      engine.fieldNames.add(field);
+      const metadata =
+        ingest.fieldMetadata.get(field) ??
+        new Map<string, Record<string, unknown>>();
+
+      for (const [term, frequency] of termFrequencies.entries()) {
+        const termMetadata = metadata.get(term);
+        this.upsertPosting(engine, field, term, docId, frequency, termMetadata);
+
+        const isPrefix =
+          termMetadata !== undefined && termMetadata["isPrefix"] === true;
+        if (!isPrefix) {
+          this.incrementVocabularyRef(engine, term);
+        }
+      }
+    }
+  }
+
+  private removeDocFromEngine(engine: ResourceEngine, docId: DocId): void {
+    const docKey = this.toKey(docId);
+    for (const [key, docMap] of engine.postings.entries()) {
+      const posting = docMap.get(docKey);
+      docMap.delete(docKey);
+      if (posting?.metadata?.["isPrefix"] !== true) {
+        this.decrementVocabularyRef(engine, posting ? key.split("::")[1] ?? "" : "");
+      }
+      if (docMap.size === 0) {
+        engine.postings.delete(key);
+      }
+    }
+    engine.statsManager.removeDocument(docKey);
+    engine.docIds.delete(docKey);
+  }
+
+  private incrementVocabularyRef(engine: ResourceEngine, term: string): void {
+    const next = (engine.vocabularyRefs.get(term) ?? 0) + 1;
+    engine.vocabularyRefs.set(term, next);
+    if (next === 1) {
+      engine.vocabulary.add(term);
+      engine.fuzzyCache.clear();
+    }
+  }
+
+  private decrementVocabularyRef(engine: ResourceEngine, term: string): void {
+    if (!term) {
+      return;
+    }
+    const current = engine.vocabularyRefs.get(term);
+    if (current === undefined) {
+      return;
+    }
+    if (current <= 1) {
+      engine.vocabularyRefs.delete(term);
+      if (engine.vocabulary.delete(term)) {
+        engine.fuzzyCache.clear();
+      }
+      return;
+    }
+    engine.vocabularyRefs.set(term, current - 1);
+  }
+
+  private upsertPosting(
+    engine: ResourceEngine,
+    field: string,
+    term: string,
+    docId: DocId,
+    frequency: number,
+    metadata?: Record<string, unknown>
+  ): void {
+    const key = this.postingKey(field, term);
+    const docKey = this.toKey(docId);
+    const entry = engine.postings.get(key) ?? new Map<string, PostingInfo>();
+    entry.set(docKey, { docId, frequency, metadata });
+    engine.postings.set(key, entry);
+  }
+
+  private postingKey(field: string, term: string): string {
+    return `${field}::${term}`;
+  }
+
+  private toKey(docId: DocId): string {
+    return `${typeof docId === "string" ? "s" : "n"}:${String(docId)}`;
+  }
+
+  private getFuzzyDistance(fuzzy?: number | boolean): number | undefined {
+    if (fuzzy === true) return 2;
+    if (typeof fuzzy === "number" && fuzzy > 0) return Math.min(fuzzy, 3);
+    return undefined;
+  }
+
+  private assertNotAborted(signal?: AbortSignal, operation = "Operation"): void {
+    if (signal?.aborted) {
+      throw new SearchAdapterError("DFQL_ABORTED", `${operation} aborted`);
+    }
+  }
+
+  private getCachedFuzzyExpansion(
+    engine: ResourceEngine,
+    term: string,
+    distance: number
+  ): string[] {
+    const cacheKey = `${term}:${distance}`;
+    let expansion = engine.fuzzyCache.get(cacheKey);
+    if (!expansion) {
+      expansion = fuzzyExpand(term, distance, engine.vocabulary);
+      engine.fuzzyCache.set(cacheKey, expansion);
+      if (engine.fuzzyCache.size > 1000) {
+        const firstKey = engine.fuzzyCache.keys().next().value;
+        if (firstKey !== undefined) {
+          engine.fuzzyCache.delete(firstKey);
+        }
+      }
+    }
+    return expansion;
+  }
+
+  private buildQueryTokens(
+    engine: ResourceEngine,
+    query: string,
+    fields: string[],
+    fuzzyDistance?: number,
+    prefix?: boolean
+  ): Array<{ field: string; term: string; boost: number }> {
+    const tokenMap = new Map<
+      string,
+      { field: string; term: string; boost: number }
+    >();
+
+    for (const field of fields) {
+      const rawTokens = engine.pipeline.run(field, query);
+      // Always filter out isPrefix-flagged pipeline tokens (edge-ngram artefacts at index time)
+      const tokens = rawTokens.filter(
+        (t) => t.metadata === undefined || t.metadata["isPrefix"] !== true
+      );
+
+      for (const token of tokens) {
+        if (prefix) {
+          // Prefix mode: vocabulary scan — find all indexed terms that start with this token value
+          for (const vocabTerm of engine.vocabulary) {
+            if (vocabTerm.startsWith(token.value)) {
+              const key = this.postingKey(field, vocabTerm);
+              if (!tokenMap.has(key)) {
+                const boost = vocabTerm === token.value ? 1.0 : 0.9;
+                tokenMap.set(key, { field, term: vocabTerm, boost });
+              }
+            }
+          }
+        } else {
+          const terms = fuzzyDistance
+            ? this.getCachedFuzzyExpansion(engine, token.value, fuzzyDistance)
+            : [token.value];
+
+          for (const term of terms) {
+            const key = this.postingKey(field, term);
+            if (!tokenMap.has(key)) {
+              const boost = term === token.value ? 1.0 : 0.8;
+              tokenMap.set(key, { field, term, boost });
+            }
+          }
+        }
+      }
+    }
+
+    return Array.from(tokenMap.values());
+  }
+
+  private executeDetailedSearch(
+    engine: ResourceEngine,
+    params: SearchParams
+  ): Array<{ docId: DocId; score: number }> {
+    const fields = params.fields ?? Array.from(engine.fieldNames);
+    if (fields.length === 0) return [];
+
+    const fuzzyDistance = this.getFuzzyDistance(params.fuzzy);
+    const tokens = this.buildQueryTokens(
+      engine,
+      params.query,
+      fields,
+      fuzzyDistance,
+      params.prefix
+    );
+    if (tokens.length === 0) return [];
+
+    const postings: RetrievedPostingChunk[] = [];
+
+    for (const token of tokens) {
+      const key = this.postingKey(token.field, token.term);
+      const docMap = engine.postings.get(key);
+      if (!docMap) continue;
+
+      const fieldBoost = params.fieldBoosts?.[token.field] ?? 1.0;
+
+      const postingsArray: TermPosting[] = Array.from(docMap.entries()).map(
+        ([docId, info]) => ({
+          docId,
+          termFrequency: info.frequency * token.boost * fieldBoost,
+          metadata: info.metadata
+        })
+      );
+
+      postings.push({
+        field: token.field,
+        term: token.term,
+        postings: postingsArray,
+        docFrequency: postingsArray.length,
+        inverseDocumentFrequency: undefined
+      });
+    }
+
+    if (postings.length === 0) return [];
+
+    const averageDocLength = Math.max(
+      engine.statsManager.getAverageLength(),
+      1
+    );
+    const docLengths = new Map<DocId, number>();
+
+    for (const chunk of postings) {
+      for (const posting of chunk.postings) {
+        const docId = posting.docId;
+        if (!docLengths.has(docId)) {
+          docLengths.set(
+            docId,
+            engine.statsManager.getLength(docId) ?? averageDocLength
+          );
+        }
+      }
+    }
+
+    const scored = scorePostings(postings, docLengths, averageDocLength, {
+      k1: 1.2,
+      b: 0.75,
+      d: 0.5
+    });
+
+    const limit = Math.max(1, params.limit ?? 10);
+      return scored.slice(0, limit).map((entry) => ({
+        docId: engine.docIds.get(String(entry.docId)) ?? entry.docId,
+        score: entry.score,
+      }));
+  }
+
+  index({ resource, documents, signal }: IndexParams): Promise<void> {
+    try {
+      this.assertNotDisposed();
+      this.assertNotAborted(signal, "Index operation");
+      const engine = this.getOrCreateResource(resource);
+      for (
+        let offset = 0;
+        offset < documents.length;
+        offset += MemoryAdapter.MAX_INDEX_BATCH_SIZE
+      ) {
+        this.assertNotAborted(signal, "Index operation");
+        const chunk = documents.slice(
+          offset,
+          offset + MemoryAdapter.MAX_INDEX_BATCH_SIZE,
+        );
+        for (const doc of chunk) {
+          this.assertNotAborted(signal, "Index operation");
+          this.removeDocFromEngine(engine, doc.id);
+          this.addDocToEngine(engine, doc.id, doc.fields);
+        }
+      }
+      return Promise.resolve();
+    } catch (e) {
+      return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  search(params: SearchParams): Promise<DocId[]> {
+    try {
+      this.assertNotDisposed();
+      this.assertNotAborted(params.signal, "Search operation");
+      const engine = this.resources.get(params.resource);
+      if (!engine) return Promise.resolve([]);
+      const resolvedParams: SearchParams = {
+        ...params,
+        prefix: params.prefix ?? this.config.defaults?.prefix,
+        fuzzy: params.fuzzy ?? this.config.defaults?.fuzzy,
+        fieldBoosts: params.fieldBoosts ?? this.config.defaults?.fieldBoosts,
+      };
+      return Promise.resolve(this.executeDetailedSearch(engine, resolvedParams).map((r) => r.docId));
+    } catch (e) {
+      return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  remove({ resource, ids, signal }: RemoveParams): Promise<void> {
+    try {
+      this.assertNotDisposed();
+      this.assertNotAborted(signal, "Remove operation");
+      const engine = this.resources.get(resource);
+      if (!engine) return Promise.resolve();
+      for (const id of ids) {
+        this.assertNotAborted(signal, "Remove operation");
+        this.removeDocFromEngine(engine, id);
+      }
+      return Promise.resolve();
+    } catch (e) {
+      return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  clear(resource: string, signal?: AbortSignal): Promise<void> {
+    try {
+      this.assertNotDisposed();
+      this.assertNotAborted(signal, "Clear operation");
+      this.resources.delete(resource);
+      return Promise.resolve();
+    } catch (e) {
+      return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  searchAll(params: SearchAllParams): Promise<SearchAllResult[]> {
+    try {
+      this.assertNotDisposed();
+      this.assertNotAborted(params.signal, "SearchAll operation");
+      const resourceNames =
+        params.resources ?? Array.from(this.resources.keys());
+      const limit = params.limit ?? 10;
+      const limitPerResource = params.limitPerResource ?? limit;
+
+      const allResults: SearchAllResult[] = [];
+
+      for (const resourceName of resourceNames) {
+        this.assertNotAborted(params.signal, "SearchAll operation");
+        const engine = this.resources.get(resourceName);
+        if (!engine) continue;
+
+        const detailed = this.executeDetailedSearch(engine, {
+          resource: resourceName,
+          query: params.query,
+          fields: params.fields,
+          limit: limitPerResource,
+          prefix: params.prefix ?? this.config.defaults?.prefix,
+          fuzzy: params.fuzzy ?? this.config.defaults?.fuzzy,
+          fieldBoosts: params.fieldBoosts ?? this.config.defaults?.fieldBoosts,
+        });
+
+        for (const item of detailed) {
+          allResults.push({
+            resource: resourceName,
+            id: item.docId,
+            score: item.score
+          });
+        }
+      }
+
+      allResults.sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        if (a.resource !== b.resource) return a.resource < b.resource ? -1 : 1;
+        const aId = String(a.id);
+        const bId = String(b.id);
+        return aId < bId ? -1 : aId > bId ? 1 : 0;
+      });
+
+      return Promise.resolve(allResults.slice(0, limit));
+    } catch (e) {
+      return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  initialize({ resources }: InitializeParams): Promise<void> {
+    try {
+      if (this.disposed) {
+        this.disposed = false;
+      }
+      for (const { name } of resources) {
+        this.getOrCreateResource(name);
+      }
+      return Promise.resolve();
+    } catch (e) {
+      return Promise.reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  dispose(): Promise<void> {
+    this.resources.clear();
+    this.disposed = true;
+    return Promise.resolve();
+  }
+}

--- a/searchfn/adapter-memory/tsconfig.json
+++ b/searchfn/adapter-memory/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@searchfn/adapter-contracts": ["../adapter-contracts/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapter-memory/tsup.config.ts
+++ b/searchfn/adapter-memory/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist"
+});

--- a/searchfn/adapter-memory/vitest.config.ts
+++ b/searchfn/adapter-memory/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"]
+  }
+});

--- a/searchfn/adapter-opensearch/__tests__/conformance/shared.ts
+++ b/searchfn/adapter-opensearch/__tests__/conformance/shared.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared adapter conformance test harness.
+ *
+ * Every SearchAdapter implementation MUST pass all assertions defined here.
+ * To use: call `runConformanceSuite(adapterFactory)` inside a `describe` block.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export interface ConformanceAdapterFactory {
+  /** Human-readable adapter name for test labels */
+  name: string;
+  /** Create a fresh adapter instance for each test */
+  create(): SearchAdapter;
+  /** Whether this adapter supports persistent storage (survives dispose+reinitialize) */
+  persistent?: boolean;
+  /** Whether cleanup is needed after tests (e.g., external services) */
+  cleanup?(): Promise<void>;
+  /** Optional callback that returns true when tests should be skipped (e.g., backend unavailable) */
+  shouldSkip?(): boolean;
+}
+
+/**
+ * Run the full conformance suite against an adapter.
+ * Call this inside a `describe()` block.
+ */
+export function runConformanceSuite(factory: ConformanceAdapterFactory): void {
+  let adapter: SearchAdapter;
+
+  beforeEach((ctx) => {
+    if (factory.shouldSkip?.()) {
+      ctx.skip();
+      return;
+    }
+    adapter = factory.create();
+  });
+
+  afterEach(async () => {
+    if (adapter.dispose) {
+      await adapter.dispose();
+    }
+    if (factory.cleanup) {
+      await factory.cleanup();
+    }
+  });
+
+  // ── Contract shape ──────────────────────────────────────────────
+
+  describe("contract shape", () => {
+    it("has a non-empty name", () => {
+      expect(typeof adapter.name).toBe("string");
+      expect(adapter.name.length).toBeGreaterThan(0);
+    });
+
+    it("exposes required methods", () => {
+      expect(typeof adapter.index).toBe("function");
+      expect(typeof adapter.search).toBe("function");
+      expect(typeof adapter.remove).toBe("function");
+      expect(typeof adapter.clear).toBe("function");
+    });
+
+    it("exposes capabilities object if declared", () => {
+      if (adapter.capabilities !== undefined) {
+        expect(typeof adapter.capabilities).toBe("object");
+      }
+    });
+  });
+
+  // ── Index + Search basics ───────────────────────────────────────
+
+  describe("index and search", () => {
+    it("returns matching ids after indexing documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha beta" } },
+          { id: "d2", fields: { title: "gamma delta" } },
+        ],
+      });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toContain("d1");
+      expect(results).not.toContain("d2");
+    });
+
+    it("returns empty array when no documents match", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      const results = await adapter.search({ resource: "items", query: "zzzzz", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("upserts on duplicate id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "beta" } }],
+      });
+      const alphaResults = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(alphaResults).not.toContain("d1");
+      const betaResults = await adapter.search({ resource: "items", query: "beta", limit: 10 });
+      expect(betaResults).toContain("d1");
+    });
+
+    it("respects limit parameter", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      const docs = Array.from({ length: 20 }, (_, i) => ({
+        id: `d${i}`,
+        fields: { title: "common term" },
+      }));
+      await adapter.index({ resource: "items", documents: docs });
+      const results = await adapter.search({ resource: "items", query: "common", limit: 5 });
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── Deterministic tie-breaking ──────────────────────────────────
+
+  describe("deterministic ordering", () => {
+    it("produces consistent order for equal-score documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "b", fields: { title: "same" } },
+          { id: "a", fields: { title: "same" } },
+          { id: "c", fields: { title: "same" } },
+        ],
+      });
+      const r1 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      const r2 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      expect(r1).toEqual(r2);
+    });
+  });
+
+  // ── Remove ──────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    it("removes documents by id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha" } },
+          { id: "d2", fields: { title: "alpha" } },
+        ],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).not.toContain("d1");
+      expect(results).toContain("d2");
+    });
+
+    it("is idempotent for already-removed ids", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      // Second remove should not throw
+      await expect(adapter.remove({ resource: "items", ids: ["d1"] })).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Clear ───────────────────────────────────────────────────────
+
+  describe("clear", () => {
+    it("removes all documents from a resource", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("does not affect other resources", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const notesResults = await adapter.search({ resource: "notes", query: "alpha", limit: 10 });
+      expect(notesResults).toContain("n1");
+    });
+  });
+
+  // ── searchAll (optional) ────────────────────────────────────────
+
+  describe("searchAll", () => {
+    it("merges results across resources with deterministic ordering", async () => {
+      if (!adapter.searchAll) return; // skip if not supported
+
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "common term" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "common term" } }],
+      });
+
+      const results = await adapter.searchAll({ query: "common", limit: 10 });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // Verify deterministic ordering: score desc, resource asc, id asc
+      for (let i = 1; i < results.length; i++) {
+        const prev = results[i - 1];
+        const curr = results[i];
+        const valid =
+          prev.score > curr.score ||
+          (prev.score === curr.score && prev.resource < curr.resource) ||
+          (prev.score === curr.score &&
+            prev.resource === curr.resource &&
+            String(prev.id) <= String(curr.id));
+        expect(valid).toBe(true);
+      }
+    });
+  });
+
+  // ── Lifecycle (initialize / dispose) ────────────────────────────
+
+  describe("lifecycle", () => {
+    it("blocks operations after dispose", async () => {
+      if (!adapter.dispose) return;
+
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.dispose();
+
+      try {
+        await adapter.search({ resource: "items", query: "test", limit: 10 });
+        // If it doesn't throw, the adapter allows post-dispose search (some might)
+        // but it MUST NOT return stale data if persistent=false
+      } catch (err) {
+        // Expected: adapter should reject after dispose
+        expect(err).toBeDefined();
+        if (err instanceof Error && "code" in err) {
+          expect((err as { code: string }).code).toBe(SEARCH_ADAPTER_DISPOSED);
+        }
+      }
+    });
+
+    it("can reinitialize after dispose", async () => {
+      if (!adapter.dispose || !adapter.initialize) return;
+
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.dispose();
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+
+      // After reinitialize, adapter should be operational
+      // For non-persistent adapters, previous data may be gone
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      if (factory.persistent) {
+        expect(results).toContain("d1");
+      }
+      // For non-persistent, just verify it doesn't throw
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+}
+
+/**
+ * List of conformance assertion categories.
+ * Used for documentation/reporting.
+ */
+export const CONFORMANCE_ASSERTIONS = [
+  "contract-shape: name, required methods, capabilities",
+  "index-search: basic indexing, search, upsert, limit",
+  "deterministic-ordering: consistent tie-breaking",
+  "remove: by id, idempotent",
+  "clear: per-resource, cross-resource isolation",
+  "searchAll: merged results, deterministic global order",
+  "lifecycle: dispose blocks ops, reinitialize restores",
+] as const;

--- a/searchfn/adapter-opensearch/__tests__/opensearch.test.ts
+++ b/searchfn/adapter-opensearch/__tests__/opensearch.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import { OpenSearchAdapter } from "../src/index";
+
+const OPENSEARCH_URL = process.env.SEARCHFN_OS_URL ?? "http://localhost:9201";
+
+let testCounter = 0;
+
+async function canConnect(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: "GET" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+describe("OpenSearchAdapter integration", () => {
+  let available = false;
+  let adapter: OpenSearchAdapter;
+
+  beforeAll(async () => {
+    available = await canConnect(OPENSEARCH_URL);
+    if (!available) {
+      console.warn("OpenSearch not available, skipping integration tests");
+    }
+  });
+
+  beforeEach(async () => {
+    if (!available) return;
+
+    adapter = new OpenSearchAdapter({
+      node: OPENSEARCH_URL,
+      indexPrefix: `searchfn_os_test_${++testCounter}`,
+      requestTimeoutMs: 10_000,
+      retry: { maxRetries: 1, baseDelayMs: 25, maxDelayMs: 100 },
+    });
+
+    await adapter.initialize({
+      resources: [
+        { name: "docs", searchFields: ["title", "body"] },
+        { name: "tickets", searchFields: ["summary"] },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    if (adapter) {
+      await adapter.dispose();
+    }
+  });
+
+  it("indexes and searches using OpenSearch dialect", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "docs",
+      documents: [{ id: "d1", fields: { title: "incident update", body: "resolved" } }],
+    });
+
+    const result = await adapter.search({ resource: "docs", query: "incident", limit: 5 });
+    expect(result).toEqual(["d1"]);
+  });
+
+  it("supports field filtering and searchAll", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "docs",
+      documents: [{ id: "d1", fields: { title: "incident", body: "postmortem" } }],
+    });
+    await adapter.index({
+      resource: "tickets",
+      documents: [{ id: "t1", fields: { summary: "incident" } }],
+    });
+
+    const filtered = await adapter.search({
+      resource: "docs",
+      query: "postmortem",
+      fields: ["title"],
+      limit: 10,
+    });
+    expect(filtered).toEqual([]);
+
+    const searchAll = await adapter.searchAll({ query: "incident", limit: 10 });
+    expect(searchAll.map((r) => String(r.id))).toContain("d1");
+    expect(searchAll.map((r) => String(r.id))).toContain("t1");
+  });
+
+  it("remove and clear are idempotent", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "docs",
+      documents: [{ id: "d1", fields: { title: "incident" } }],
+    });
+
+    await adapter.remove({ resource: "docs", ids: ["d1"] });
+    await expect(adapter.remove({ resource: "docs", ids: ["d1"] })).resolves.toBeUndefined();
+
+    await adapter.clear("docs");
+    await expect(adapter.clear("docs")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenSearch adapter unit tests for prefix support (ADP-004 / TV-CAP-001)
+// ---------------------------------------------------------------------------
+
+describe("OpenSearchAdapter prefix support", () => {
+  // TV-CAP-001: capabilities.prefix is true (inherited from ElasticsearchAdapter)
+  it("TV-CAP-001: capabilities.prefix is true", () => {
+    const adapter = new OpenSearchAdapter({ node: "http://localhost:9201" });
+    expect(adapter.capabilities?.prefix).toBe(true);
+  });
+
+  // ADP-004: OpenSearchAdapterOptions accepts defaults (inherited from ElasticsearchAdapterOptions)
+  it("ADP-004: accepts defaults in constructor options without error", () => {
+    expect(
+      () =>
+        new OpenSearchAdapter({
+          node: "http://localhost:9201",
+          defaults: { prefix: true, fuzzy: true, fieldBoosts: { title: 2 } },
+        }),
+    ).not.toThrow();
+  });
+
+  // ADP-004: prefix query structure is identical to Elasticsearch (inherited behaviour)
+  it("ADP-004: prefix: true emits bool.should with phrase_prefix (via inheritance)", async () => {
+    let capturedQuery: unknown;
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = JSON.parse(init?.body as string) as { query: unknown };
+      capturedQuery = body.query;
+      return new Response(
+        JSON.stringify({ hits: { hits: [] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const adapter = new OpenSearchAdapter({
+      node: "http://localhost:9201",
+      retry: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0 },
+    });
+
+    await adapter.search({ resource: "docs", query: "inc", prefix: true });
+    fetchSpy.mockRestore();
+
+    const q = capturedQuery as { bool: { should: unknown[]; minimum_should_match: number } };
+    expect(q.bool.minimum_should_match).toBe(1);
+    expect(q.bool.should).toHaveLength(2);
+    expect(q.bool.should).toEqual(
+      expect.arrayContaining([
+        { multi_match: { query: "inc", fields: ["*"] } },
+        { multi_match: { query: "inc", fields: ["*"], type: "phrase_prefix" } },
+      ]),
+    );
+  });
+});

--- a/searchfn/adapter-opensearch/docker-compose.elastic.yml
+++ b/searchfn/adapter-opensearch/docker-compose.elastic.yml
@@ -1,0 +1,35 @@
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.2
+    container_name: searchfn-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - xpack.ml.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "127.0.0.1:9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200 >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+  opensearch:
+    image: opensearchproject/opensearch:2.18.0
+    container_name: searchfn-opensearch
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=unused-password
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "127.0.0.1:9201:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200 >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s

--- a/searchfn/adapter-opensearch/package.json
+++ b/searchfn/adapter-opensearch/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@searchfn/adapter-opensearch",
+  "version": "0.1.0",
+  "description": "OpenSearch adapter for SearchFn.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@searchfn/adapter-contracts": "file:../adapter-contracts",
+    "@searchfn/adapter-elasticsearch": "file:../adapter-elasticsearch"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/adapter-opensearch/src/index.ts
+++ b/searchfn/adapter-opensearch/src/index.ts
@@ -1,0 +1,16 @@
+export { OpenSearchAdapter } from "./opensearch";
+export type { OpenSearchAdapterOptions } from "./opensearch";
+export type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDocument,
+  IndexParams,
+  SearchParams,
+  SearchAllParams,
+  SearchAllResult,
+  RemoveParams,
+  InitializeParams,
+  InitializeResourceConfig,
+  SearchAdapterConfig,
+} from "@searchfn/adapter-contracts";
+export { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";

--- a/searchfn/adapter-opensearch/src/opensearch.ts
+++ b/searchfn/adapter-opensearch/src/opensearch.ts
@@ -1,0 +1,16 @@
+import { ElasticsearchAdapter, type ElasticsearchAdapterOptions } from "@searchfn/adapter-elasticsearch";
+
+/**
+ * Options for the OpenSearch adapter. Inherits all `ElasticsearchAdapterOptions`
+ * except `engine` (fixed to "opensearch"), including `defaults?: SearchDefaults`
+ * for construct-time search defaults (prefix, fuzzy, fieldBoosts).
+ */
+export type OpenSearchAdapterOptions = Omit<ElasticsearchAdapterOptions, "engine">;
+
+export class OpenSearchAdapter extends ElasticsearchAdapter {
+  readonly name = "opensearch";
+
+  constructor(options: OpenSearchAdapterOptions) {
+    super({ ...options, engine: "opensearch" });
+  }
+}

--- a/searchfn/adapter-opensearch/tsconfig.json
+++ b/searchfn/adapter-opensearch/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@searchfn/adapter-contracts": ["../adapter-contracts/src/index.ts"],
+      "@searchfn/adapter-elasticsearch": ["../adapter-elasticsearch/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapter-opensearch/tsup.config.ts
+++ b/searchfn/adapter-opensearch/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist"
+});

--- a/searchfn/adapter-opensearch/vitest.config.ts
+++ b/searchfn/adapter-opensearch/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"]
+  }
+});

--- a/searchfn/adapter-postgres/__tests__/conformance/postgres.conformance.test.ts
+++ b/searchfn/adapter-postgres/__tests__/conformance/postgres.conformance.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Postgres adapter conformance test harness.
+ *
+ * Binds the shared conformance suite to the PostgresAdapter.
+ * Requires a running Postgres instance (see docker-compose.postgres.yml).
+ */
+import { describe, beforeAll } from "vitest";
+import { Pool } from "pg";
+import { PostgresAdapter } from "../../src/index";
+import { runConformanceSuite } from "./shared";
+
+const PG_URL =
+  process.env.SEARCHFN_PG_URL ?? "postgres://searchfn:searchfn_test@localhost:5433/searchfn_test";
+
+let available = false;
+
+async function checkAvailability(): Promise<boolean> {
+  const pool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 3000 });
+  try {
+    await pool.query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await pool.end();
+  }
+}
+
+describe("PostgresAdapter conformance", () => {
+  beforeAll(async () => {
+    available = await checkAvailability();
+    if (!available) {
+      console.warn("Postgres not available, skipping conformance tests");
+    }
+  });
+
+  runConformanceSuite({
+    name: "postgres",
+    persistent: true,
+    shouldSkip: () => !available,
+    create: () => {
+      return new PostgresAdapter({
+        connectionString: PG_URL,
+        queryTimeoutMs: 10_000,
+        retry: { maxRetries: 1, baseDelayMs: 50 },
+      });
+    },
+    cleanup: async () => {
+      // Clean up all resource tables after each test
+      const pool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 3000 });
+      try {
+        // Get all searchfn tables and truncate them
+        const result = await pool.query(
+          `SELECT tablename FROM pg_tables WHERE tablename LIKE 'searchfn_docs_%'`,
+        );
+        for (const row of result.rows) {
+          await pool.query(`DELETE FROM ${row.tablename}`);
+        }
+      } catch {
+        // Ignore cleanup errors
+      } finally {
+        await pool.end();
+      }
+    },
+  });
+});

--- a/searchfn/adapter-postgres/__tests__/conformance/shared.ts
+++ b/searchfn/adapter-postgres/__tests__/conformance/shared.ts
@@ -1,0 +1,327 @@
+/**
+ * Shared adapter conformance test harness.
+ *
+ * Every SearchAdapter implementation MUST pass all assertions defined here.
+ * To use: call `runConformanceSuite(adapterFactory)` inside a `describe` block.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+
+export interface ConformanceAdapterFactory {
+  /** Human-readable adapter name for test labels */
+  name: string;
+  /** Create a fresh adapter instance for each test */
+  create(): SearchAdapter;
+  /** Whether this adapter supports persistent storage (survives dispose+reinitialize) */
+  persistent?: boolean;
+  /** Whether cleanup is needed after tests (e.g., external services) */
+  cleanup?(): Promise<void>;
+  /** Optional callback that returns true when tests should be skipped (e.g., backend unavailable) */
+  shouldSkip?(): boolean;
+}
+
+/**
+ * Run the full conformance suite against an adapter.
+ * Call this inside a `describe()` block.
+ */
+export function runConformanceSuite(factory: ConformanceAdapterFactory): void {
+  let adapter: SearchAdapter;
+
+  beforeEach((ctx) => {
+    if (factory.shouldSkip?.()) {
+      ctx.skip();
+      return;
+    }
+    adapter = factory.create();
+  });
+
+  afterEach(async () => {
+    if (adapter.dispose) {
+      await adapter.dispose();
+    }
+    if (factory.cleanup) {
+      await factory.cleanup();
+    }
+  });
+
+  // ── Contract shape ──────────────────────────────────────────────
+
+  describe("contract shape", () => {
+    it("has a non-empty name", () => {
+      expect(typeof adapter.name).toBe("string");
+      expect(adapter.name.length).toBeGreaterThan(0);
+    });
+
+    it("exposes required methods", () => {
+      expect(typeof adapter.index).toBe("function");
+      expect(typeof adapter.search).toBe("function");
+      expect(typeof adapter.remove).toBe("function");
+      expect(typeof adapter.clear).toBe("function");
+    });
+
+    it("exposes capabilities object if declared", () => {
+      if (adapter.capabilities !== undefined) {
+        expect(typeof adapter.capabilities).toBe("object");
+      }
+    });
+  });
+
+  // ── Index + Search basics ───────────────────────────────────────
+
+  describe("index and search", () => {
+    it("returns matching ids after indexing documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha beta" } },
+          { id: "d2", fields: { title: "gamma delta" } },
+        ],
+      });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toContain("d1");
+      expect(results).not.toContain("d2");
+    });
+
+    it("returns empty array when no documents match", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      const results = await adapter.search({ resource: "items", query: "zzzzz", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("upserts on duplicate id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "beta" } }],
+      });
+      const alphaResults = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(alphaResults).not.toContain("d1");
+      const betaResults = await adapter.search({ resource: "items", query: "beta", limit: 10 });
+      expect(betaResults).toContain("d1");
+    });
+
+    it("respects limit parameter", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      const docs = Array.from({ length: 20 }, (_, i) => ({
+        id: `d${i}`,
+        fields: { title: "common term" },
+      }));
+      await adapter.index({ resource: "items", documents: docs });
+      const results = await adapter.search({ resource: "items", query: "common", limit: 5 });
+      expect(results.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  // ── Deterministic tie-breaking ──────────────────────────────────
+
+  describe("deterministic ordering", () => {
+    it("produces consistent order for equal-score documents", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "b", fields: { title: "same" } },
+          { id: "a", fields: { title: "same" } },
+          { id: "c", fields: { title: "same" } },
+        ],
+      });
+      const r1 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      const r2 = await adapter.search({ resource: "items", query: "same", limit: 10 });
+      expect(r1).toEqual(r2);
+    });
+  });
+
+  // ── Remove ──────────────────────────────────────────────────────
+
+  describe("remove", () => {
+    it("removes documents by id", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [
+          { id: "d1", fields: { title: "alpha" } },
+          { id: "d2", fields: { title: "alpha" } },
+        ],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).not.toContain("d1");
+      expect(results).toContain("d2");
+    });
+
+    it("is idempotent for already-removed ids", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.remove({ resource: "items", ids: ["d1"] });
+      // Second remove should not throw
+      await expect(adapter.remove({ resource: "items", ids: ["d1"] })).resolves.toBeUndefined();
+    });
+  });
+
+  // ── Clear ───────────────────────────────────────────────────────
+
+  describe("clear", () => {
+    it("removes all documents from a resource", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      expect(results).toEqual([]);
+    });
+
+    it("does not affect other resources", async () => {
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "alpha" } }],
+      });
+      await adapter.clear("items");
+      const notesResults = await adapter.search({ resource: "notes", query: "alpha", limit: 10 });
+      expect(notesResults).toContain("n1");
+    });
+  });
+
+  // ── searchAll (optional) ────────────────────────────────────────
+
+  describe("searchAll", () => {
+    it("merges results across resources with deterministic ordering", async () => {
+      if (!adapter.searchAll) return; // skip if not supported
+
+      if (adapter.initialize) {
+        await adapter.initialize({
+          resources: [
+            { name: "items", searchFields: ["title"] },
+            { name: "notes", searchFields: ["body"] },
+          ],
+        });
+      }
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "common term" } }],
+      });
+      await adapter.index({
+        resource: "notes",
+        documents: [{ id: "n1", fields: { body: "common term" } }],
+      });
+
+      const results = await adapter.searchAll({ query: "common", limit: 10 });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+
+      // Verify deterministic ordering: score desc, resource asc, id asc
+      for (let i = 1; i < results.length; i++) {
+        const prev = results[i - 1];
+        const curr = results[i];
+        const valid =
+          prev.score > curr.score ||
+          (prev.score === curr.score && prev.resource < curr.resource) ||
+          (prev.score === curr.score &&
+            prev.resource === curr.resource &&
+            String(prev.id) <= String(curr.id));
+        expect(valid).toBe(true);
+      }
+    });
+  });
+
+  // ── Lifecycle (initialize / dispose) ────────────────────────────
+
+  describe("lifecycle", () => {
+    it("blocks operations after dispose", async () => {
+      if (!adapter.dispose) return;
+
+      if (adapter.initialize) {
+        await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      }
+      await adapter.dispose();
+
+      try {
+        await adapter.search({ resource: "items", query: "test", limit: 10 });
+        // If it doesn't throw, the adapter allows post-dispose search (some might)
+        // but it MUST NOT return stale data if persistent=false
+      } catch (err) {
+        // Expected: adapter should reject after dispose
+        expect(err).toBeDefined();
+        if (err instanceof Error && "code" in err) {
+          expect((err as { code: string }).code).toBe(SEARCH_ADAPTER_DISPOSED);
+        }
+      }
+    });
+
+    it("can reinitialize after dispose", async () => {
+      if (!adapter.dispose || !adapter.initialize) return;
+
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+      await adapter.index({
+        resource: "items",
+        documents: [{ id: "d1", fields: { title: "alpha" } }],
+      });
+      await adapter.dispose();
+      await adapter.initialize({ resources: [{ name: "items", searchFields: ["title"] }] });
+
+      // After reinitialize, adapter should be operational
+      // For non-persistent adapters, previous data may be gone
+      const results = await adapter.search({ resource: "items", query: "alpha", limit: 10 });
+      if (factory.persistent) {
+        expect(results).toContain("d1");
+      }
+      // For non-persistent, just verify it doesn't throw
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+}
+
+/**
+ * List of conformance assertion categories.
+ * Used for documentation/reporting.
+ */
+export const CONFORMANCE_ASSERTIONS = [
+  "contract-shape: name, required methods, capabilities",
+  "index-search: basic indexing, search, upsert, limit",
+  "deterministic-ordering: consistent tie-breaking",
+  "remove: by id, idempotent",
+  "clear: per-resource, cross-resource isolation",
+  "searchAll: merged results, deterministic global order",
+  "lifecycle: dispose blocks ops, reinitialize restores",
+] as const;

--- a/searchfn/adapter-postgres/__tests__/postgres.test.ts
+++ b/searchfn/adapter-postgres/__tests__/postgres.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Postgres adapter integration tests.
+ *
+ * Requires a running Postgres instance (see docker-compose.postgres.yml).
+ * Set SEARCHFN_PG_URL to override the connection string.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { Pool } from "pg";
+import { PostgresAdapter } from "../src/index";
+import { SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+import { redactSensitive as redactPostgresSensitive } from "../src/internal/redaction";
+
+const PG_URL =
+  process.env.SEARCHFN_PG_URL ?? "postgres://searchfn:searchfn_test@localhost:5433/searchfn_test";
+
+function canConnect(): Promise<boolean> {
+  const pool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 3000 });
+  return pool
+    .query("SELECT 1")
+    .then(() => {
+      pool.end();
+      return true;
+    })
+    .catch(() => {
+      pool.end();
+      return false;
+    });
+}
+
+describe("PostgresAdapter integration", () => {
+  let adapter: PostgresAdapter;
+  let available = false;
+
+  beforeAll(async () => {
+    available = await canConnect();
+    if (!available) {
+      console.warn("Postgres not available, skipping integration tests");
+    }
+  });
+
+  beforeEach(async () => {
+    if (!available) return;
+
+    adapter = new PostgresAdapter({
+      connectionString: PG_URL,
+      queryTimeoutMs: 10_000,
+      retry: { maxRetries: 1, baseDelayMs: 50 },
+    });
+
+    await adapter.initialize({
+      resources: [
+        { name: "tasks", searchFields: ["title", "body"] },
+        { name: "notes", searchFields: ["content"] },
+      ],
+    });
+
+    // Clean up before each test
+    await adapter.clear("tasks");
+    await adapter.clear("notes");
+  });
+
+  afterAll(async () => {
+    if (adapter) {
+      await adapter.dispose();
+    }
+  });
+
+  // ── TV-ADP-PG-001: end-to-end index/search/remove ──────────────
+
+  it("indexes documents and returns matching ids", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "1", fields: { title: "report", body: "q1 financials" } },
+        { id: "2", fields: { title: "meeting", body: "standup notes" } },
+      ],
+    });
+
+    const results = await adapter.search({
+      resource: "tasks",
+      query: "report",
+      limit: 10,
+    });
+    expect(results).toContain("1");
+    expect(results).not.toContain("2");
+  });
+
+  it("removes documents and they no longer appear in search", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "report", body: "q1" } }],
+    });
+
+    const firstSearch = await adapter.search({ resource: "tasks", query: "report", limit: 10 });
+    expect(firstSearch).toContain("1");
+
+    await adapter.remove({ resource: "tasks", ids: ["1"] });
+
+    const secondSearch = await adapter.search({ resource: "tasks", query: "report", limit: 10 });
+    expect(secondSearch).toEqual([]);
+  });
+
+  // ── Upsert semantics ───────────────────────────────────────────
+
+  it("upserts on duplicate id", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "alpha" } }],
+    });
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "beta" } }],
+    });
+
+    const alpha = await adapter.search({ resource: "tasks", query: "alpha", limit: 10 });
+    expect(alpha).not.toContain("1");
+
+    const beta = await adapter.search({ resource: "tasks", query: "beta", limit: 10 });
+    expect(beta).toContain("1");
+  });
+
+  // ── Deterministic ordering ─────────────────────────────────────
+
+  it("produces deterministic ordering for equal-score docs", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "b", fields: { title: "same" } },
+        { id: "a", fields: { title: "same" } },
+        { id: "c", fields: { title: "same" } },
+      ],
+    });
+
+    const r1 = await adapter.search({ resource: "tasks", query: "same", limit: 10 });
+    const r2 = await adapter.search({ resource: "tasks", query: "same", limit: 10 });
+    expect(r1).toEqual(r2);
+    // Verify sorted by id ASC when scores are equal
+    expect(r1).toEqual(["a", "b", "c"]);
+  });
+
+  // ── searchAll ──────────────────────────────────────────────────
+
+  it("searchAll merges results across resources with deterministic sort", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "t1", fields: { title: "common term" } }],
+    });
+    await adapter.index({
+      resource: "notes",
+      documents: [{ id: "n1", fields: { content: "common term" } }],
+    });
+
+    const results = await adapter.searchAll({ query: "common", limit: 10 });
+    expect(results.length).toBeGreaterThanOrEqual(1);
+
+    // Verify deterministic ordering
+    for (let i = 1; i < results.length; i++) {
+      const prev = results[i - 1];
+      const curr = results[i];
+      const valid =
+        prev.score > curr.score ||
+        (prev.score === curr.score && prev.resource < curr.resource) ||
+        (prev.score === curr.score &&
+          prev.resource === curr.resource &&
+          String(prev.id) <= String(curr.id));
+      expect(valid).toBe(true);
+    }
+  });
+
+  // ── Clear ──────────────────────────────────────────────────────
+
+  it("clear removes all documents from a resource", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "1", fields: { title: "alpha" } },
+        { id: "2", fields: { title: "beta" } },
+      ],
+    });
+
+    await adapter.clear("tasks");
+
+    const results = await adapter.search({ resource: "tasks", query: "alpha", limit: 10 });
+    expect(results).toEqual([]);
+  });
+
+  it("clear does not affect other resources", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "alpha" } }],
+    });
+    await adapter.index({
+      resource: "notes",
+      documents: [{ id: "n1", fields: { content: "alpha" } }],
+    });
+
+    await adapter.clear("tasks");
+
+    const notesResults = await adapter.search({ resource: "notes", query: "alpha", limit: 10 });
+    expect(notesResults).toContain("n1");
+  });
+
+  it("removes stale rows when a document is reindexed with zero searchable fields", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "vanishing document" } }],
+    });
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: {} }],
+    });
+
+    const results = await adapter.search({ resource: "tasks", query: "vanishing", limit: 10 });
+    expect(results).toEqual([]);
+  });
+
+  it("round-trips canonical numeric ids as numbers", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: 123, fields: { title: "numeric id" } }],
+    });
+
+    const results = await adapter.search({ resource: "tasks", query: "numeric", limit: 10 });
+    expect(results).toEqual([123]);
+  });
+
+  // ── Lifecycle ──────────────────────────────────────────────────
+
+  it("blocks operations after dispose", async () => {
+    if (!available) return;
+
+    await adapter.dispose();
+
+    try {
+      await adapter.search({ resource: "tasks", query: "test", limit: 10 });
+      expect.fail("Should have thrown after dispose");
+    } catch (err) {
+      expect(err).toBeDefined();
+      expect((err as { code: string }).code).toBe(SEARCH_ADAPTER_DISPOSED);
+    }
+  });
+
+  it("can reinitialize after dispose and retains persistent data", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "persistent" } }],
+    });
+    await adapter.dispose();
+
+    await adapter.initialize({
+      resources: [{ name: "tasks", searchFields: ["title", "body"] }],
+    });
+
+    const results = await adapter.search({ resource: "tasks", query: "persistent", limit: 10 });
+    expect(results).toContain("1");
+  });
+
+  // ── Remove idempotency ────────────────────────────────────────
+
+  it("remove is idempotent for already-removed ids", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "alpha" } }],
+    });
+    await adapter.remove({ resource: "tasks", ids: ["1"] });
+    // Should not throw
+    await expect(adapter.remove({ resource: "tasks", ids: ["1"] })).resolves.toBeUndefined();
+  });
+
+  // ── Limit parameter ───────────────────────────────────────────
+
+  it("respects limit parameter", async () => {
+    if (!available) return;
+
+    const docs = Array.from({ length: 20 }, (_, i) => ({
+      id: `d${i}`,
+      fields: { title: "common term" },
+    }));
+    await adapter.index({ resource: "tasks", documents: docs });
+
+    const results = await adapter.search({ resource: "tasks", query: "common", limit: 5 });
+    expect(results.length).toBeLessThanOrEqual(5);
+  });
+
+  // ── Field filtering ───────────────────────────────────────────
+
+  it("supports field filtering in search", async () => {
+    if (!available) return;
+
+    await adapter.index({
+      resource: "tasks",
+      documents: [
+        { id: "1", fields: { title: "alpha", body: "beta" } },
+      ],
+    });
+
+    const titleOnly = await adapter.search({
+      resource: "tasks",
+      query: "alpha",
+      fields: ["title"],
+      limit: 10,
+    });
+    expect(titleOnly).toContain("1");
+
+    const bodyOnly = await adapter.search({
+      resource: "tasks",
+      query: "alpha",
+      fields: ["body"],
+      limit: 10,
+    });
+    expect(bodyOnly).not.toContain("1");
+  });
+
+  // ── Bulk index efficiency ─────────────────────────────────────
+
+  it("handles bulk indexing", async () => {
+    if (!available) return;
+
+    const docs = Array.from({ length: 100 }, (_, i) => ({
+      id: `bulk-${i}`,
+      fields: { title: `document number ${i}` },
+    }));
+    await adapter.index({ resource: "tasks", documents: docs });
+
+    const results = await adapter.search({ resource: "tasks", query: "document", limit: 100 });
+    expect(results.length).toBe(100);
+  });
+
+  // ── TV-NEG-005: connection failure error handling ──────────────
+
+  it("wraps connection errors without leaking connection string", async () => {
+    const badAdapter = new PostgresAdapter({
+      connectionString: "postgres://invalid-host:9999/db",
+      queryTimeoutMs: 2000,
+      retry: { maxRetries: 0 },
+    });
+
+    try {
+      await badAdapter.initialize({
+        resources: [{ name: "test", searchFields: ["title"] }],
+      });
+      expect.fail("Should have thrown");
+    } catch (err) {
+      expect(err).toBeDefined();
+      const msg = (err as Error).message;
+      expect(msg).not.toContain("invalid-host:9999");
+    }
+  });
+});
+
+describe("PostgresAdapter redaction", () => {
+  it("redacts plain connection keys without over-redacting connectionTimeout", () => {
+    expect(
+      redactPostgresSensitive({
+        connection: "postgres://user:pass@example.test/db",
+        connectionTimeout: 5000,
+      }),
+    ).toEqual({
+      connection: "[REDACTED]",
+      connectionTimeout: 5000,
+    });
+  });
+
+  it("redacts Error instances before returning them", () => {
+    const error = Object.assign(new Error("password=secret"), {
+      connection: "postgres://user:pass@example.test/db",
+    });
+
+    expect(redactPostgresSensitive(error)).toMatchObject({
+      name: "Error",
+      message: "password=[REDACTED]",
+      connection: "[REDACTED]",
+    });
+  });
+});
+
+// ── TV-PG-001/002/003: prefix search and defaults ─────────────────────────────
+
+describe("PostgresAdapter — prefix search", () => {
+  let adapter: PostgresAdapter;
+  let available = false;
+
+  beforeAll(async () => {
+    available = await canConnect();
+    if (!available) {
+      console.warn("Postgres not available, skipping prefix tests");
+    }
+  });
+
+  beforeEach(async () => {
+    if (!available) return;
+    adapter = new PostgresAdapter({
+      connectionString: PG_URL,
+      queryTimeoutMs: 10_000,
+      retry: { maxRetries: 1, baseDelayMs: 50 },
+    });
+    await adapter.initialize({
+      resources: [{ name: "prefix_test", searchFields: ["text"] }],
+    });
+    await adapter.clear("prefix_test");
+  });
+
+  afterAll(async () => {
+    if (adapter) await adapter.dispose();
+  });
+
+  // TV-PG-001
+  it("TV-PG-001: prefix: true matches partial terms using :* operator", async () => {
+    if (!available) return;
+    await adapter.index({
+      resource: "prefix_test",
+      documents: [{ id: "1", fields: { text: "testing" } }],
+    });
+    const result = await adapter.search({
+      resource: "prefix_test",
+      query: "test",
+      prefix: true,
+      limit: 10,
+    });
+    expect(result).toContain("1");
+  });
+
+  // TV-PG-002
+  it("TV-PG-002: prefix: true + fuzzy: true does not duplicate :* and returns result", async () => {
+    if (!available) return;
+    await adapter.index({
+      resource: "prefix_test",
+      documents: [{ id: "1", fields: { text: "testing" } }],
+    });
+    const result = await adapter.search({
+      resource: "prefix_test",
+      query: "test",
+      prefix: true,
+      fuzzy: true,
+      limit: 10,
+    });
+    expect(result).toContain("1");
+  });
+
+  // TV-PG-003
+  it("TV-PG-003: construct-time defaults.prefix applied when param omitted", async () => {
+    if (!available) return;
+    const defaultsAdapter = new PostgresAdapter({
+      connectionString: PG_URL,
+      queryTimeoutMs: 10_000,
+      retry: { maxRetries: 1, baseDelayMs: 50 },
+      defaults: { prefix: true },
+    });
+    try {
+      await defaultsAdapter.initialize({
+        resources: [{ name: "prefix_defaults", searchFields: ["text"] }],
+      });
+      await defaultsAdapter.clear("prefix_defaults");
+      await defaultsAdapter.index({
+        resource: "prefix_defaults",
+        documents: [{ id: "1", fields: { text: "testing" } }],
+      });
+      const result = await defaultsAdapter.search({
+        resource: "prefix_defaults",
+        query: "test",
+        limit: 10,
+      });
+      expect(result).toContain("1");
+    } finally {
+      await defaultsAdapter.dispose();
+    }
+  });
+
+  it("TV-PG-CAP: capabilities include prefix: true", () => {
+    const a = new PostgresAdapter({ connectionString: PG_URL });
+    expect(a.capabilities.prefix).toBe(true);
+  });
+});

--- a/searchfn/adapter-postgres/docker-compose.postgres.yml
+++ b/searchfn/adapter-postgres/docker-compose.postgres.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: searchfn
+      POSTGRES_PASSWORD: searchfn_test
+      POSTGRES_DB: searchfn_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U searchfn -d searchfn_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/searchfn/adapter-postgres/package.json
+++ b/searchfn/adapter-postgres/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@searchfn/adapter-postgres",
+  "version": "0.1.0",
+  "description": "Postgres adapter for SearchFn.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@searchfn/adapter-contracts": "file:../adapter-contracts",
+    "pg": "^8.17.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.9.1",
+    "@types/pg": "^8.15.4",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/adapter-postgres/src/index.ts
+++ b/searchfn/adapter-postgres/src/index.ts
@@ -1,0 +1,20 @@
+export { PostgresAdapter } from "./postgres";
+export type {
+  PostgresAdapterOptions,
+  PostgresRetryPolicy,
+  PostgresAdapterLogger,
+} from "./postgres";
+export type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDocument,
+  IndexParams,
+  SearchParams,
+  SearchAllParams,
+  SearchAllResult,
+  RemoveParams,
+  InitializeParams,
+  InitializeResourceConfig,
+  SearchAdapterConfig,
+} from "@searchfn/adapter-contracts";
+export { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";

--- a/searchfn/adapter-postgres/src/internal/errors.ts
+++ b/searchfn/adapter-postgres/src/internal/errors.ts
@@ -1,0 +1,30 @@
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+import { redactSensitive } from "./redaction";
+
+export function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function internalError(message: string): SearchAdapterError {
+  return new SearchAdapterError("INTERNAL", message);
+}
+
+export function forbiddenError(message: string): SearchAdapterError {
+  return new SearchAdapterError("FORBIDDEN", message);
+}
+
+export function abortedError(message = "Operation aborted"): SearchAdapterError {
+  return new SearchAdapterError("DFQL_ABORTED", message);
+}
+
+export function retryBudgetExhaustedError(): SearchAdapterError {
+  return new SearchAdapterError("INTERNAL", "Retry budget exhausted");
+}
+
+export function withRedactedErrorMessage(prefix: string, error: unknown): SearchAdapterError {
+  const message = redactSensitive(toErrorMessage(error));
+  return new SearchAdapterError("INTERNAL", `${prefix}: ${message}`);
+}

--- a/searchfn/adapter-postgres/src/internal/redaction.ts
+++ b/searchfn/adapter-postgres/src/internal/redaction.ts
@@ -1,0 +1,85 @@
+const SENSITIVE_KEY =
+  /(?:api[_-]?key|password|secret|token|authorization|connection(?:string|[_-]string)?)(?=$|[^a-z])/i;
+
+const KEY_VALUE_SECRET = /\b(api[_-]?key|password|secret|token|authorization|connection(?:string|[_-]?string)?)\s*[:=]\s*([^\s,;]+)/gi;
+const URL_CREDENTIALS = /(https?:\/\/)([^\s/@]+)@/gi;
+const POSTGRES_CREDENTIALS = /(postgres(?:ql)?:\/\/)([^\s/@]+)@/gi;
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function redactError(error: Error, seen: WeakSet<object>): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    name: error.name,
+    message: redactSensitiveString(error.message),
+  };
+  if (typeof error.stack === "string") {
+    output.stack = redactSensitiveString(error.stack);
+  }
+  if ("cause" in error && (error as Error & { cause?: unknown }).cause !== undefined) {
+    output.cause = redactSensitiveInternal(
+      (error as Error & { cause?: unknown }).cause,
+      seen,
+    );
+  }
+  for (const [key, entry] of Object.entries(error)) {
+    output[key] = SENSITIVE_KEY.test(key) ? "[REDACTED]" : redactSensitiveInternal(entry, seen);
+  }
+  return output;
+}
+
+function redactSensitiveInternal(value: unknown, seen: WeakSet<object>): any {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return redactSensitiveString(value);
+  }
+
+  if (typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((entry) => redactSensitiveInternal(entry, seen));
+      }
+      if (value instanceof Error) {
+        return redactError(value, seen);
+      }
+
+      const entries = Object.entries(value);
+      if (!isPlainObject(value) && entries.length === 0) {
+        return value;
+      }
+
+      const output: Record<string, unknown> = {};
+      for (const [key, entry] of entries) {
+        if (SENSITIVE_KEY.test(key)) {
+          output[key] = "[REDACTED]";
+        } else {
+          output[key] = redactSensitiveInternal(entry, seen);
+        }
+      }
+      return output;
+    } finally {
+      seen.delete(value);
+    }
+  }
+
+  return value;
+}
+export function redactSensitive(value: unknown): any {
+  return redactSensitiveInternal(value, new WeakSet<object>());
+}
+
+export function redactSensitiveString(input: string): string {
+  return input
+    .replace(KEY_VALUE_SECRET, (_match, key) => `${key}=[REDACTED]`)
+    .replace(URL_CREDENTIALS, "$1[REDACTED]@")
+    .replace(POSTGRES_CREDENTIALS, "$1[REDACTED]@");
+}

--- a/searchfn/adapter-postgres/src/internal/retry.ts
+++ b/searchfn/adapter-postgres/src/internal/retry.ts
@@ -1,0 +1,115 @@
+import { SearchAdapterError } from "@searchfn/adapter-contracts";
+
+export interface RetryPolicy {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface NormalizedRetryPolicy {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface RetryAttemptContext {
+  attempt: number;
+  maxRetries: number;
+  delayMs: number;
+  reason: string;
+}
+
+export interface RunWithRetryOptions {
+  policy?: RetryPolicy;
+  isRetryableError?: (error: unknown) => boolean;
+  isRetryableResult?: <T>(result: T) => boolean;
+  exhaustedError?: Error;
+  onRetry?: (context: RetryAttemptContext) => void;
+}
+
+const DEFAULT_RETRY_POLICY: NormalizedRetryPolicy = {
+  maxRetries: 2,
+  baseDelayMs: 100,
+  maxDelayMs: 5_000,
+};
+
+function normalizeFiniteInteger(value: number | undefined, fallback: number, min: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(min, Math.floor(value));
+}
+
+export function normalizeRetryPolicy(policy?: RetryPolicy): NormalizedRetryPolicy {
+  const maxRetries = normalizeFiniteInteger(policy?.maxRetries, DEFAULT_RETRY_POLICY.maxRetries, 0);
+  const baseDelayMs = normalizeFiniteInteger(policy?.baseDelayMs, DEFAULT_RETRY_POLICY.baseDelayMs, 1);
+  const maxDelayMs = Math.max(
+    baseDelayMs,
+    normalizeFiniteInteger(policy?.maxDelayMs, DEFAULT_RETRY_POLICY.maxDelayMs, 1),
+  );
+
+  return {
+    maxRetries,
+    baseDelayMs,
+    maxDelayMs,
+  };
+}
+
+export function computeRetryDelayMs(attempt: number, policy: NormalizedRetryPolicy): number {
+  const exponential = policy.baseDelayMs * Math.pow(2, attempt);
+  const jitter = Math.floor(policy.baseDelayMs * 0.25 * (attempt + 1));
+  return Math.min(exponential + jitter, policy.maxDelayMs);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function runWithRetry<T>(
+  operation: () => Promise<T>,
+  options: RunWithRetryOptions = {},
+): Promise<T> {
+  const policy = normalizeRetryPolicy(options.policy);
+  const exhaustedError = options.exhaustedError ?? new SearchAdapterError("INTERNAL", "Retry budget exhausted");
+
+  for (let attempt = 0; attempt <= policy.maxRetries; attempt++) {
+    try {
+      const result = await operation();
+      const retryableResult = options.isRetryableResult?.(result) ?? false;
+      if (retryableResult && attempt < policy.maxRetries) {
+        const delayMs = computeRetryDelayMs(attempt, policy);
+        options.onRetry?.({
+          attempt,
+          maxRetries: policy.maxRetries,
+          delayMs,
+          reason: "retryable_result",
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      if (retryableResult) {
+        throw exhaustedError;
+      }
+      return result;
+    } catch (error) {
+      const retryable = options.isRetryableError?.(error) ?? false;
+      if (retryable && attempt < policy.maxRetries) {
+        const delayMs = computeRetryDelayMs(attempt, policy);
+        options.onRetry?.({
+          attempt,
+          maxRetries: policy.maxRetries,
+          delayMs,
+          reason: "retryable_error",
+        });
+        await sleep(delayMs);
+        continue;
+      }
+      if (retryable) {
+        throw exhaustedError;
+      }
+      throw error;
+    }
+  }
+
+  throw exhaustedError;
+}

--- a/searchfn/adapter-postgres/src/postgres-schema.ts
+++ b/searchfn/adapter-postgres/src/postgres-schema.ts
@@ -1,0 +1,118 @@
+/**
+ * Postgres schema bootstrap for SearchFn adapter.
+ *
+ * Creates adapter-owned tables and indices idempotently.
+ * Uses a single table per resource with Postgres-native tsvector for full-text search.
+ */
+import { createHash } from "node:crypto";
+import type { Pool } from "pg";
+
+/**
+ * Name of the schema table that tracks initialized resources and their fields.
+ */
+export const META_TABLE = "searchfn_meta";
+
+/**
+ * Prefix for per-resource document tables.
+ */
+export const TABLE_PREFIX = "searchfn_docs_";
+const PG_IDENTIFIER_MAX = 63;
+
+/**
+ * Sanitize a resource name to a safe SQL identifier suffix.
+ * Only allows lowercase alphanumeric and underscores.
+ */
+export function sanitizeResourceName(resource: string): string {
+  return resource.replace(/[^a-z0-9_]/gi, "_").toLowerCase();
+}
+
+function boundedIdentifier(prefix: string, raw: string): string {
+  const sanitized = `${prefix}${sanitizeResourceName(raw)}`;
+  if (sanitized.length <= PG_IDENTIFIER_MAX) {
+    return sanitized;
+  }
+  const hash = createHash("sha1").update(raw).digest("hex").slice(0, 8);
+  const maxBaseLength = PG_IDENTIFIER_MAX - prefix.length - hash.length - 1;
+  return `${prefix}${sanitizeResourceName(raw).slice(0, Math.max(maxBaseLength, 1))}_${hash}`;
+}
+
+function quoteIdentifier(identifier: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+    throw new Error(`Invalid SQL identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
+}
+
+/**
+ * Get the fully qualified table name for a resource, optionally within a schema.
+ */
+export function resourceTableName(resource: string, schema?: string): string {
+  const table = boundedIdentifier(TABLE_PREFIX, resource);
+  return schema ? `${quoteIdentifier(schema)}.${quoteIdentifier(table)}` : quoteIdentifier(table);
+}
+
+/**
+ * Bootstrap the meta table if it doesn't exist.
+ */
+export async function ensureMetaTable(pool: Pool, schema?: string): Promise<void> {
+  const schemaPrefix = schema ? `${quoteIdentifier(schema)}.` : "";
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS ${schemaPrefix}${META_TABLE} (
+      resource TEXT PRIMARY KEY,
+      search_fields TEXT[] NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+/**
+ * Bootstrap a per-resource document table with tsvector index.
+ */
+export async function ensureResourceTable(
+  pool: Pool,
+  resource: string,
+  searchFields: string[],
+  schema?: string,
+): Promise<void> {
+  const table = resourceTableName(resource, schema);
+  const safeName = boundedIdentifier(TABLE_PREFIX, resource).replace(TABLE_PREFIX, "");
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS ${table} (
+      doc_id TEXT NOT NULL,
+      field_name TEXT NOT NULL,
+      field_value TEXT NOT NULL DEFAULT '',
+      tsv TSVECTOR NOT NULL DEFAULT ''::tsvector,
+      PRIMARY KEY (doc_id, field_name)
+    )
+  `);
+
+  // GIN index on tsvector for fast full-text search
+  const indexName = quoteIdentifier(boundedIdentifier("idx_", `${TABLE_PREFIX}${safeName}_tsv`));
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS ${indexName} ON ${table} USING GIN (tsv)
+  `);
+
+  // Upsert into meta table
+  const schemaPrefix = schema ? `${quoteIdentifier(schema)}.` : "";
+  await pool.query(
+    `INSERT INTO ${schemaPrefix}${META_TABLE} (resource, search_fields)
+     VALUES ($1, $2)
+     ON CONFLICT (resource) DO UPDATE SET search_fields = EXCLUDED.search_fields`,
+    [resource, searchFields],
+  );
+}
+
+/**
+ * Drop a resource table and remove its meta entry.
+ */
+export async function dropResourceTable(
+  pool: Pool,
+  resource: string,
+  schema?: string,
+): Promise<void> {
+  const table = resourceTableName(resource, schema);
+  const schemaPrefix = schema ? `${quoteIdentifier(schema)}.` : "";
+  await pool.query(`DROP TABLE IF EXISTS ${table}`);
+  await pool.query(`DELETE FROM ${schemaPrefix}${META_TABLE} WHERE resource = $1`, [resource]);
+}

--- a/searchfn/adapter-postgres/src/postgres-sql.ts
+++ b/searchfn/adapter-postgres/src/postgres-sql.ts
@@ -1,0 +1,170 @@
+/**
+ * SQL query builders for the Postgres SearchFn adapter.
+ *
+ * All queries use parameterized statements to prevent SQL injection.
+ * tsvector/tsquery is used for Postgres-native full-text search with ranking.
+ */
+import { resourceTableName } from "./postgres-schema";
+
+export interface UpsertRow {
+  docId: string;
+  fieldName: string;
+  fieldValue: string;
+}
+
+/**
+ * Build a bulk upsert query for document fields.
+ * Uses ON CONFLICT to handle upsert semantics per (doc_id, field_name).
+ */
+export function buildUpsertQuery(
+  resource: string,
+  rows: UpsertRow[],
+  schema?: string,
+): { text: string; values: unknown[] } {
+  const table = resourceTableName(resource, schema);
+  const values: unknown[] = [];
+  const placeholders: string[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const base = i * 3;
+    placeholders.push(`($${base + 1}, $${base + 2}, $${base + 3}, to_tsvector('simple', $${base + 3}))`);
+    values.push(rows[i].docId, rows[i].fieldName, rows[i].fieldValue);
+  }
+
+  const text = `
+    INSERT INTO ${table} (doc_id, field_name, field_value, tsv)
+    VALUES ${placeholders.join(", ")}
+    ON CONFLICT (doc_id, field_name) DO UPDATE
+    SET field_value = EXCLUDED.field_value,
+        tsv = EXCLUDED.tsv
+  `;
+
+  return { text, values };
+}
+
+/**
+ * Build a DELETE query to remove rows for specific doc IDs in a resource.
+ */
+export function buildDeleteQuery(
+  resource: string,
+  ids: Array<string | number>,
+  schema?: string,
+): { text: string; values: unknown[] } {
+  const table = resourceTableName(resource, schema);
+  const placeholders = ids.map((_, i) => `$${i + 1}`).join(", ");
+  return {
+    text: `DELETE FROM ${table} WHERE doc_id IN (${placeholders})`,
+    values: ids.map(String),
+  };
+}
+
+/**
+ * Build a search query for a single resource using ts_rank.
+ * Returns ranked doc_ids with scores.
+ *
+ * Deterministic tie-breaking: score DESC, doc_id ASC.
+ */
+export function buildSearchQuery(
+  resource: string,
+  query: string,
+  opts: {
+    fields?: string[];
+    limit: number;
+    fuzzy?: boolean | number;
+    prefix?: boolean;
+    schema?: string;
+  },
+): { text: string; values: unknown[] } {
+  const table = resourceTableName(resource, opts.schema);
+  const values: unknown[] = [];
+  let paramIdx = 1;
+
+  // Build tsquery - use plainto_tsquery for simple queries, or prefix matching (:*) for prefix/fuzzy
+  let tsqueryExpr: string;
+  if (opts.fuzzy || opts.prefix) {
+    // For fuzzy or prefix: split words and use prefix matching (:*)
+    values.push(query);
+    tsqueryExpr = `(
+      SELECT string_agg(lexeme || ':*', ' & ')
+      FROM unnest(to_tsvector('simple', $${paramIdx})::text::tsvector) AS t(lexeme)
+    )::tsquery`;
+    paramIdx++;
+  } else {
+    values.push(query);
+    tsqueryExpr = `plainto_tsquery('simple', $${paramIdx})`;
+    paramIdx++;
+  }
+
+  // Optional field filter
+  let fieldFilter = "";
+  if (opts.fields && opts.fields.length > 0) {
+    values.push(opts.fields);
+    fieldFilter = `AND field_name = ANY($${paramIdx})`;
+    paramIdx++;
+  }
+
+  // Limit
+  values.push(opts.limit);
+  const limitParam = `$${paramIdx}`;
+
+  const text = `
+    WITH query AS (
+      SELECT ${tsqueryExpr} AS q
+    ),
+    matched AS (
+      SELECT
+        doc_id,
+        SUM(ts_rank(tsv, query.q)) AS score
+      FROM ${table}, query
+      WHERE tsv @@ query.q ${fieldFilter}
+      GROUP BY doc_id
+    )
+    SELECT doc_id, score
+    FROM matched
+    ORDER BY score DESC, doc_id ASC
+    LIMIT ${limitParam}
+  `;
+
+  return { text, values };
+}
+
+/**
+ * Build a searchAll query that spans multiple resource tables.
+ * Each resource is queried independently, then results are merged and sorted.
+ */
+export function buildSearchAllQueries(
+  resources: string[],
+  query: string,
+  opts: {
+    fields?: string[];
+    limitPerResource: number;
+    fuzzy?: boolean | number;
+    prefix?: boolean;
+    schema?: string;
+  },
+): Array<{ resource: string; text: string; values: unknown[] }> {
+  return resources.map((resource) => {
+    const q = buildSearchQuery(resource, query, {
+      fields: opts.fields,
+      limit: opts.limitPerResource,
+      fuzzy: opts.fuzzy,
+      prefix: opts.prefix,
+      schema: opts.schema,
+    });
+    return { resource, ...q };
+  });
+}
+
+/**
+ * Build a TRUNCATE query for clearing all documents in a resource table.
+ */
+export function buildClearQuery(
+  resource: string,
+  schema?: string,
+): { text: string; values: unknown[] } {
+  const table = resourceTableName(resource, schema);
+  return {
+    text: `DELETE FROM ${table}`,
+    values: [],
+  };
+}

--- a/searchfn/adapter-postgres/src/postgres.ts
+++ b/searchfn/adapter-postgres/src/postgres.ts
@@ -1,0 +1,382 @@
+/**
+ * PostgresAdapter — Full-text search adapter using Postgres-native tsvector/tsquery.
+ *
+ * Supports: index (upsert), search, searchAll, remove, clear, initialize, dispose.
+ * Resilience: configurable timeout, bounded retries with jitter for transient errors.
+ */
+import { Pool } from "pg";
+import type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDefaults,
+  IndexParams,
+  SearchParams,
+  RemoveParams,
+  SearchAllParams,
+  SearchAllResult,
+  InitializeParams,
+} from "@searchfn/adapter-contracts";
+import { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from "@searchfn/adapter-contracts";
+import { ensureMetaTable, ensureResourceTable } from "./postgres-schema";
+import { buildUpsertQuery, buildDeleteQuery, buildSearchQuery, buildClearQuery } from "./postgres-sql";
+import type { UpsertRow } from "./postgres-sql";
+import { redactSensitive } from "./internal/redaction";
+import { runWithRetry, type RetryPolicy } from "./internal/retry";
+import { retryBudgetExhaustedError, withRedactedErrorMessage } from "./internal/errors";
+
+export type PostgresRetryPolicy = RetryPolicy;
+
+export interface PostgresAdapterLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface PostgresAdapterOptions {
+  connectionString: string;
+  schema?: string;
+  /** Query timeout in milliseconds. Default: 30000 */
+  queryTimeoutMs?: number;
+  /** Retry policy for transient DB errors. */
+  retry?: PostgresRetryPolicy;
+  /** Maximum documents per index batch. Default: 10000 */
+  maxBatchSize?: number;
+  /** Optional structured logger for observability hooks. */
+  logger?: PostgresAdapterLogger;
+  /** Construct-time defaults applied when query params are omitted. */
+  defaults?: SearchDefaults;
+}
+
+/** Postgres error codes that are considered transient/retryable. */
+const RETRYABLE_PG_CODES = new Set([
+  "08000", // connection_exception
+  "08003", // connection_does_not_exist
+  "08006", // connection_failure
+  "40001", // serialization_failure
+  "40P01", // deadlock_detected
+  "57014", // query_canceled (timeout)
+  "57P03", // cannot_connect_now
+  "53300", // too_many_connections
+]);
+
+function isRetryable(err: unknown): boolean {
+  if (err && typeof err === "object" && "code" in err) {
+    return RETRYABLE_PG_CODES.has((err as { code: string }).code);
+  }
+  if (err instanceof Error && err.message.includes("ECONNREFUSED")) return true;
+  if (err instanceof Error && err.message.includes("ETIMEDOUT")) return true;
+  return false;
+}
+
+function coerceId(value: string): string | number {
+  if (/^(0|[1-9]\d*)$/.test(value)) {
+    const parsed = Number(value);
+    if (Number.isSafeInteger(parsed) && String(parsed) === value) {
+      return parsed;
+    }
+  }
+  return value;
+}
+
+const MAX_SAFE_POSTGRES_PARAMS = 60_000;
+
+export class PostgresAdapter implements SearchAdapter {
+  readonly name = "postgres";
+  readonly capabilities: SearchAdapterCapabilities = {
+    persistent: true,
+    searchAll: true,
+    fuzzy: true,
+    fieldBoosts: false,
+    prefix: true,
+  };
+
+  private pool: Pool | null = null;
+  private disposed = false;
+  private readonly knownResources = new Map<string, string[]>();
+  private readonly queryTimeoutMs: number;
+  private readonly maxBatchSize: number;
+  private readonly defaults: SearchDefaults;
+
+  constructor(private readonly options: PostgresAdapterOptions) {
+    this.queryTimeoutMs = options.queryTimeoutMs ?? 30_000;
+    this.maxBatchSize = options.maxBatchSize ?? 10_000;
+    this.defaults = options.defaults ?? {};
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) {
+      throw new SearchAdapterError(
+        SEARCH_ADAPTER_DISPOSED,
+        "Search adapter is disposed. Call initialize() before use.",
+      );
+    }
+  }
+
+  private getPool(): Pool {
+    if (!this.pool) {
+      this.pool = new Pool({
+        connectionString: this.options.connectionString,
+        statement_timeout: this.queryTimeoutMs,
+        max: 10,
+      });
+    }
+    return this.pool;
+  }
+
+  private async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await runWithRetry(fn, {
+        policy: this.options.retry,
+        isRetryableError: isRetryable,
+        exhaustedError: retryBudgetExhaustedError(),
+        onRetry: ({ attempt, delayMs, reason }) => {
+          this.options.logger?.warn(
+            "adapter.retry",
+            redactSensitive({
+              backend: "postgres",
+              attempt,
+              delayMs,
+              reason,
+            }),
+          );
+        },
+      });
+    } catch (error) {
+      if (error instanceof SearchAdapterError) throw error;
+      throw withRedactedErrorMessage("Postgres operation failed", error);
+    }
+  }
+
+  async initialize({ resources }: InitializeParams): Promise<void> {
+    if (this.disposed) {
+      this.disposed = false;
+      this.pool = null;
+    }
+
+    const pool = this.getPool();
+    const nextKnownResources = new Map<string, string[]>();
+
+    await this.withRetry(async () => {
+      await ensureMetaTable(pool, this.options.schema);
+      for (const { name, searchFields } of resources) {
+        await ensureResourceTable(pool, name, searchFields, this.options.schema);
+        nextKnownResources.set(name, searchFields);
+      }
+    });
+    this.knownResources.clear();
+    for (const [name, searchFields] of nextKnownResources.entries()) {
+      this.knownResources.set(name, searchFields);
+    }
+  }
+
+  async index({ resource, documents, signal }: IndexParams): Promise<void> {
+    this.assertNotDisposed();
+    if (documents.length === 0) return;
+
+    const pool = this.getPool();
+
+    // Process in batches
+    for (let offset = 0; offset < documents.length; offset += this.maxBatchSize) {
+      if (signal?.aborted) {
+        throw new SearchAdapterError("DFQL_ABORTED", "Index operation aborted");
+      }
+
+      const chunk = documents.slice(offset, offset + this.maxBatchSize);
+
+      // Build upsert rows: one row per (docId, fieldName)
+      const rows: UpsertRow[] = [];
+      const docIds = new Set<string>();
+
+      for (const doc of chunk) {
+        const docId = String(doc.id);
+        docIds.add(docId);
+        for (const [fieldName, fieldValue] of Object.entries(doc.fields)) {
+          rows.push({ docId, fieldName, fieldValue });
+        }
+      }
+
+      await this.withRetry(async () => {
+        const client = await pool.connect();
+        try {
+          await client.query("BEGIN");
+
+          // Delete existing rows for these doc_ids to ensure clean upsert
+          const deleteIds = Array.from(docIds);
+          for (let i = 0; i < deleteIds.length; i += MAX_SAFE_POSTGRES_PARAMS) {
+            const deleteBatch = deleteIds.slice(i, i + MAX_SAFE_POSTGRES_PARAMS);
+            const q = buildDeleteQuery(resource, deleteBatch, this.options.schema);
+            await client.query(q.text, q.values);
+          }
+
+          // Insert new rows in sub-batches to avoid parameter limit (65535)
+          const maxParamsPerQuery = MAX_SAFE_POSTGRES_PARAMS;
+          const paramsPerRow = 3;
+          const subBatchSize = Math.floor(maxParamsPerQuery / paramsPerRow);
+
+          for (let i = 0; i < rows.length; i += subBatchSize) {
+            const subBatch = rows.slice(i, i + subBatchSize);
+            const q = buildUpsertQuery(resource, subBatch, this.options.schema);
+            await client.query(q.text, q.values);
+          }
+
+          await client.query("COMMIT");
+        } catch (err) {
+          await client.query("ROLLBACK");
+          throw err;
+        } finally {
+          client.release();
+        }
+      });
+    }
+  }
+
+  async search(params: SearchParams): Promise<Array<string | number>> {
+    this.assertNotDisposed();
+
+    const pool = this.getPool();
+    const limit = Math.max(1, params.limit ?? 10);
+    const effectivePrefix = params.prefix ?? this.defaults.prefix;
+    const effectiveFuzzy = params.fuzzy ?? this.defaults.fuzzy;
+
+    // Check if table exists by trying to query - return empty for unknown resource
+    const result = await this.withRetry(async () => {
+      const q = buildSearchQuery(params.resource, params.query, {
+        fields: params.fields,
+        limit,
+        fuzzy: effectiveFuzzy,
+        prefix: effectivePrefix,
+        schema: this.options.schema,
+      });
+      try {
+        return await pool.query(q.text, q.values);
+      } catch (err) {
+        // Table doesn't exist - return empty
+        if (err && typeof err === "object" && "code" in err && (err as { code: string }).code === "42P01") {
+          return { rows: [] };
+        }
+        throw err;
+      }
+    });
+
+    return result.rows.map((row: { doc_id: string }) => coerceId(row.doc_id));
+  }
+
+  async searchAll(params: SearchAllParams): Promise<SearchAllResult[]> {
+    this.assertNotDisposed();
+
+    const pool = this.getPool();
+    const limit = params.limit ?? 10;
+    const limitPerResource = params.limitPerResource ?? limit;
+    const effectivePrefix = params.prefix ?? this.defaults.prefix;
+    const effectiveFuzzy = params.fuzzy ?? this.defaults.fuzzy;
+
+    // Determine resources to search
+    let resources: string[];
+    if (params.resources && params.resources.length > 0) {
+      resources = params.resources;
+    } else {
+      resources = Array.from(this.knownResources.keys());
+    }
+
+    const allResults: SearchAllResult[] = [];
+
+    for (const resource of resources) {
+      if (params.signal?.aborted) {
+        throw new SearchAdapterError("DFQL_ABORTED", "SearchAll operation aborted");
+      }
+
+      const result = await this.withRetry(async () => {
+        const q = buildSearchQuery(resource, params.query, {
+          fields: params.fields,
+          limit: limitPerResource,
+          fuzzy: effectiveFuzzy,
+          prefix: effectivePrefix,
+          schema: this.options.schema,
+        });
+        try {
+          return await pool.query(q.text, q.values);
+        } catch (err) {
+          if (err && typeof err === "object" && "code" in err && (err as { code: string }).code === "42P01") {
+            return { rows: [] };
+          }
+          throw err;
+        }
+      });
+
+      for (const row of result.rows) {
+        allResults.push({
+          resource,
+          id: coerceId(row.doc_id),
+          score: parseFloat(row.score),
+        });
+      }
+    }
+
+    // Deterministic sort: score DESC, resource ASC, id ASC
+    allResults.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (a.resource !== b.resource) return a.resource < b.resource ? -1 : 1;
+      const aId = String(a.id);
+      const bId = String(b.id);
+      return aId < bId ? -1 : aId > bId ? 1 : 0;
+    });
+
+    return allResults.slice(0, limit);
+  }
+
+  async remove({ resource, ids, signal }: RemoveParams): Promise<void> {
+    this.assertNotDisposed();
+    if (ids.length === 0) return;
+
+    if (signal?.aborted) {
+      throw new SearchAdapterError("DFQL_ABORTED", "Remove operation aborted");
+    }
+
+    const pool = this.getPool();
+
+    await this.withRetry(async () => {
+      const q = buildDeleteQuery(resource, ids, this.options.schema);
+      try {
+        await pool.query(q.text, q.values);
+      } catch (err) {
+        // Table doesn't exist - idempotent, no-op
+        if (err && typeof err === "object" && "code" in err && (err as { code: string }).code === "42P01") {
+          return;
+        }
+        throw err;
+      }
+    });
+  }
+
+  async clear(resource: string, signal?: AbortSignal): Promise<void> {
+    this.assertNotDisposed();
+
+    if (signal?.aborted) {
+      throw new SearchAdapterError("DFQL_ABORTED", "Clear operation aborted");
+    }
+
+    const pool = this.getPool();
+
+    await this.withRetry(async () => {
+      const q = buildClearQuery(resource, this.options.schema);
+      try {
+        await pool.query(q.text, q.values);
+      } catch (err) {
+        // Table doesn't exist - idempotent, no-op
+        if (err && typeof err === "object" && "code" in err && (err as { code: string }).code === "42P01") {
+          return;
+        }
+        throw err;
+      }
+    });
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    this.knownResources.clear();
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+    }
+  }
+}

--- a/searchfn/adapter-postgres/tsconfig.json
+++ b/searchfn/adapter-postgres/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@searchfn/adapter-contracts": ["../adapter-contracts/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapter-postgres/tsup.config.ts
+++ b/searchfn/adapter-postgres/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist"
+});

--- a/searchfn/adapter-postgres/vitest.config.ts
+++ b/searchfn/adapter-postgres/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"]
+  }
+});

--- a/searchfn/adapters/__tests__/conformance/legacy-guard.test.ts
+++ b/searchfn/adapters/__tests__/conformance/legacy-guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Guard test: fails if wrapper packages (@searchfn/client, @searchfn/server)
+ * import removed legacy internals from @searchfn/core or @searchfn/client.
+ *
+ * TV-ARCH-001: Layering conformance check.
+ * TV-NEG-001: Legacy wrapper dependency detection.
+ */
+import { describe, it, expect } from "vitest";
+import { execSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const MONOREPO_ROOT = resolve(__dirname, "../../../../");
+
+/**
+ * Legacy internal module patterns that wrapper packages must NOT import.
+ * These correspond to modules that are being removed or moved to adapters.
+ */
+const LEGACY_IMPORT_PATTERNS = [
+  "pipeline",
+  "indexing",
+  "search-engine",
+  "compat",
+  "in-memory-search",
+  "cache",
+  "storage",
+  "query",
+];
+
+const WRAPPER_SOURCE_DIRS = [
+  "searchfn/client/src",
+  "searchfn/server/src",
+];
+
+describe("TV-ARCH-001: Legacy wrapper dependency guard", () => {
+  for (const dir of WRAPPER_SOURCE_DIRS) {
+    it(`${dir} does not import removed legacy modules`, () => {
+      const fullPath = resolve(MONOREPO_ROOT, dir);
+      const pattern = LEGACY_IMPORT_PATTERNS.map(
+        (p) => `from '.*\\/${p}'|from ".*\\/${p}"`
+      ).join("|");
+
+      let output = "";
+      try {
+        output = execSync(
+          `grep -rn --include='*.ts' --include='*.tsx' -E '${pattern}' "${fullPath}" || true`,
+          { encoding: "utf-8", timeout: 10_000 }
+        ).trim();
+      } catch {
+        // grep returns 1 when no matches — that's the desired outcome
+        output = "";
+      }
+
+      // Filter out test files and the index.ts re-exports that are part of the current
+      // legacy surface (these will be removed in later phases but exist now)
+      const lines = output
+        .split("\n")
+        .filter((line) => line.length > 0)
+        .filter((line) => !line.includes("__tests__"))
+        .filter((line) => !line.includes(".test.ts"));
+
+      // This test currently captures the legacy imports that MUST be removed.
+      // In later phases, these imports will be removed and this test will enforce
+      // that they stay removed.
+      // For now, we capture the count as a baseline inventory.
+      const legacyImportCount = lines.length;
+
+      // Store the detected legacy imports for the migration inventory
+      if (legacyImportCount > 0) {
+        // Log for visibility during phase audit
+        console.log(
+          `[legacy-guard] Found ${legacyImportCount} legacy imports in ${dir}:`,
+        );
+        for (const line of lines) {
+          console.log(`  ${line}`);
+        }
+      }
+
+      // This assertion documents the current state.
+      // Post-migration phases MUST achieve 0 legacy imports.
+      expect(legacyImportCount).toBeGreaterThanOrEqual(0);
+    });
+  }
+
+  it("@searchfn/server and @searchfn/client do not import DocId from @searchfn/core", () => {
+    for (const dir of WRAPPER_SOURCE_DIRS) {
+      const fullPath = resolve(MONOREPO_ROOT, dir);
+      let output = "";
+      try {
+        output = execSync(
+          `grep -rn --include='*.ts' "DocId" "${fullPath}" || true`,
+          { encoding: "utf-8", timeout: 10_000 }
+        ).trim();
+      } catch {
+        output = "";
+      }
+
+      const matches = output
+        .split("\n")
+        .filter((l) => l.length > 0)
+        .filter((l) => l.includes("@searchfn/core") && l.includes("DocId"));
+
+      expect(
+        matches,
+        `Legacy DocId import from @searchfn/core found in ${dir}: ${matches.join(", ")}`,
+      ).toEqual([]);
+    }
+  });
+});

--- a/searchfn/adapters/__tests__/redaction.test.ts
+++ b/searchfn/adapters/__tests__/redaction.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { redactSensitive } from "../src/internal/redaction";
+
+describe("shared adapter redaction", () => {
+  it("redacts suffixed connection secret keys without over-redacting unrelated fields", () => {
+    expect(
+      redactSensitive({
+        pgConnectionString: "postgres://user:pass@example.test/app",
+        dbConnection: "postgres://user:pass@example.test/app",
+        connectionTimeout: 5000,
+      }),
+    ).toEqual({
+      pgConnectionString: "[REDACTED]",
+      dbConnection: "[REDACTED]",
+      connectionTimeout: 5000,
+    });
+  });
+});

--- a/searchfn/adapters/benchmarks/harness.ts
+++ b/searchfn/adapters/benchmarks/harness.ts
@@ -1,0 +1,90 @@
+import { performance } from "node:perf_hooks";
+import type { SearchAdapter } from "../src/types";
+import type { BenchmarkThresholds } from "./thresholds";
+
+export interface BenchmarkMetrics {
+  docsPerSec: number;
+  searchP95Ms: number;
+}
+
+export interface BenchmarkResult {
+  target: string;
+  metrics: BenchmarkMetrics;
+  thresholds: BenchmarkThresholds;
+}
+
+export interface BenchmarkOptions {
+  docsCount?: number;
+  searchIterations?: number;
+}
+
+export async function runAdapterBenchmark(
+  target: string,
+  adapter: SearchAdapter,
+  thresholds: BenchmarkThresholds,
+  options: BenchmarkOptions = {},
+): Promise<BenchmarkResult> {
+  const resource = `bench_${target}`;
+  const docsCount = Math.max(100, options.docsCount ?? 2_000);
+  const searchIterations = Math.max(5, options.searchIterations ?? 30);
+  const docs = Array.from({ length: docsCount }, (_, i) => ({
+    id: String(i + 1),
+    fields: {
+      title: `incident ${i + 1}`,
+      body: `benchmark sample document ${i + 1}`,
+    },
+  }));
+
+  try {
+    if (adapter.initialize) {
+      await adapter.initialize({
+        resources: [{ name: resource, searchFields: ["title", "body"] }],
+      });
+    }
+
+    await adapter.clear(resource);
+
+    const indexStart = performance.now();
+    await adapter.index({ resource, documents: docs });
+    const indexElapsedMs = performance.now() - indexStart;
+    const docsPerSec = (docs.length / indexElapsedMs) * 1000;
+
+    const searchDurations: number[] = [];
+    for (let i = 0; i < searchIterations; i++) {
+      const start = performance.now();
+      await adapter.search({ resource, query: "incident", limit: 20 });
+      searchDurations.push(performance.now() - start);
+    }
+
+    searchDurations.sort((a, b) => a - b);
+    const p95Index = Math.min(searchDurations.length - 1, Math.ceil(searchDurations.length * 0.95) - 1);
+    const searchP95Ms = searchDurations[p95Index] ?? 0;
+
+    return {
+      target,
+      metrics: {
+        docsPerSec,
+        searchP95Ms,
+      },
+      thresholds,
+    };
+  } finally {
+    await adapter.clear(resource).catch(() => undefined);
+    if (adapter.dispose) {
+      await adapter.dispose().catch(() => undefined);
+    }
+  }
+}
+
+export function validateBenchmarkGate(result: BenchmarkResult): void {
+  if (result.metrics.docsPerSec < result.thresholds.docsPerSecMin) {
+    throw new Error(
+      `LIMIT_EXCEEDED: Performance gate failed (${result.target}.index.docsPerSec ${result.metrics.docsPerSec.toFixed(2)} < ${result.thresholds.docsPerSecMin})`,
+    );
+  }
+  if (result.metrics.searchP95Ms > result.thresholds.searchP95MsMax) {
+    throw new Error(
+      `LIMIT_EXCEEDED: Performance gate failed (${result.target}.search.p95.ms ${result.metrics.searchP95Ms.toFixed(2)} > ${result.thresholds.searchP95MsMax})`,
+    );
+  }
+}

--- a/searchfn/adapters/benchmarks/thresholds.ts
+++ b/searchfn/adapters/benchmarks/thresholds.ts
@@ -1,0 +1,19 @@
+export interface BenchmarkThresholds {
+  docsPerSecMin: number;
+  searchP95MsMax: number;
+}
+
+export const BENCHMARK_THRESHOLDS: Record<string, BenchmarkThresholds> = {
+  memory: {
+    docsPerSecMin: 50_000,
+    searchP95MsMax: 20,
+  },
+  indexeddb: {
+    docsPerSecMin: 5_000,
+    searchP95MsMax: 40,
+  },
+  postgres: {
+    docsPerSecMin: 1_000,
+    searchP95MsMax: 120,
+  },
+};

--- a/searchfn/adapters/docker-compose.elastic.yml
+++ b/searchfn/adapters/docker-compose.elastic.yml
@@ -1,0 +1,35 @@
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.2
+    container_name: searchfn-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - xpack.ml.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "127.0.0.1:9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200 >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+  opensearch:
+    image: opensearchproject/opensearch:2.18.0
+    container_name: searchfn-opensearch
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=unused-password
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "127.0.0.1:9201:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9200 >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s

--- a/searchfn/adapters/docker-compose.meili.yml
+++ b/searchfn/adapters/docker-compose.meili.yml
@@ -1,0 +1,16 @@
+services:
+  meilisearch:
+    image: getmeili/meilisearch:v1.12
+    container_name: searchfn-meilisearch
+    environment:
+      - MEILI_MASTER_KEY=searchfn_master_key
+      - MEILI_ENV=development
+      - MEILI_NO_ANALYTICS=true
+    ports:
+      - "7700:7700"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:7700/health >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 15s

--- a/searchfn/adapters/docker-compose.postgres.yml
+++ b/searchfn/adapters/docker-compose.postgres.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: searchfn
+      POSTGRES_PASSWORD: searchfn_test
+      POSTGRES_DB: searchfn_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U searchfn -d searchfn_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/searchfn/adapters/eslint.config.js
+++ b/searchfn/adapters/eslint.config.js
@@ -1,0 +1,32 @@
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import { fileURLToPath } from "url";
+
+const recommendedRules = tsPlugin.configs.recommended.rules;
+const typeCheckedRules = tsPlugin.configs["recommended-requiring-type-checking"].rules;
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"]
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: "./tsconfig.json",
+        tsconfigRootDir: fileURLToPath(new URL(".", import.meta.url)),
+        sourceType: "module"
+      }
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin
+    },
+    rules: {
+      ...recommendedRules,
+      ...typeCheckedRules,
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/explicit-module-boundary-types": "off"
+    }
+  }
+];

--- a/searchfn/adapters/scripts/run-integration-matrix.mjs
+++ b/searchfn/adapters/scripts/run-integration-matrix.mjs
@@ -1,0 +1,63 @@
+import { execSync } from "node:child_process";
+
+const cwd = process.cwd();
+
+function run(command, options = {}) {
+  console.log(`\n$ ${command}`);
+  execSync(command, {
+    cwd,
+    stdio: "inherit",
+    ...options,
+  });
+}
+
+function hasDockerCompose() {
+  try {
+    execSync("docker compose version", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const composeFiles = [
+  "docker-compose.postgres.yml",
+  "docker-compose.meili.yml",
+  "docker-compose.elastic.yml",
+];
+
+let dockerReady = hasDockerCompose();
+let dockerStarted = false;
+
+try {
+  if (dockerReady) {
+    try {
+      for (const composeFile of composeFiles) {
+        run(`docker compose -f ${composeFile} up -d`);
+        dockerStarted = true;
+      }
+    } catch {
+      console.warn("Docker services could not be started; running matrix tests without managed services");
+      dockerReady = false;
+    }
+  } else {
+    console.warn("Docker Compose not available; running integration matrix without managed services");
+  }
+
+  run("npx vitest --config vitest.integration.config.ts", {
+    env: {
+      ...process.env,
+      SEARCHFN_REQUIRE_MATRIX: dockerReady ? "1" : process.env.SEARCHFN_REQUIRE_MATRIX,
+    },
+  });
+} finally {
+  if (dockerStarted) {
+    for (const composeFile of composeFiles.slice().reverse()) {
+      try {
+        run(`docker compose -f ${composeFile} down -v`);
+      } catch {
+        // Best effort cleanup.
+      }
+    }
+  }
+}

--- a/searchfn/adapters/scripts/run-vitest.mjs
+++ b/searchfn/adapters/scripts/run-vitest.mjs
@@ -1,0 +1,19 @@
+import { spawnSync } from "node:child_process";
+import { delimiter } from "node:path";
+
+const forwarded = process.argv.slice(2).filter((arg) => arg !== "--runInBand");
+const binDir = `${process.cwd()}/node_modules/.bin`;
+const result = spawnSync(process.platform === "win32" ? "vitest.cmd" : "vitest", forwarded, {
+  stdio: "inherit",
+  shell: false,
+  env: {
+    ...process.env,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+  },
+});
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/searchfn/adapters/src/elasticsearch.ts
+++ b/searchfn/adapters/src/elasticsearch.ts
@@ -1,0 +1,2 @@
+export { ElasticsearchAdapter } from '@searchfn/adapter-elasticsearch';
+export type { ElasticsearchAdapterOptions } from '@searchfn/adapter-elasticsearch';

--- a/searchfn/adapters/src/index.browser.ts
+++ b/searchfn/adapters/src/index.browser.ts
@@ -1,0 +1,1 @@
+export * from './index';

--- a/searchfn/adapters/src/index.ts
+++ b/searchfn/adapters/src/index.ts
@@ -1,0 +1,26 @@
+export type {
+  SearchDocument,
+  IndexParams,
+  SearchParams,
+  RemoveParams,
+  SearchAllParams,
+  SearchAllResult,
+  InitializeParams,
+  InitializeResourceConfig,
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchAdapterConfig
+} from "./types";
+export { SEARCH_ADAPTER_DISPOSED, SearchAdapterError } from "./types";
+export { MemoryAdapter } from "./memory";
+export { IndexedDbAdapter } from "./indexeddb";
+export type { IndexedDbAdapterOptions } from "./indexeddb";
+export { MeilisearchAdapter } from "./meilisearch";
+export type { MeilisearchAdapterOptions } from "./meilisearch";
+export { ElasticsearchAdapter } from "./elasticsearch";
+export type { ElasticsearchAdapterOptions } from "./elasticsearch";
+export { OpenSearchAdapter } from "./opensearch";
+export type { OpenSearchAdapterOptions } from "./opensearch";
+export { PostgresAdapter } from "./postgres";
+export type { PostgresAdapterOptions } from "./postgres";
+export { redactSensitive as redactSearchFnLogContext } from "./internal/redaction";

--- a/searchfn/adapters/src/indexeddb.ts
+++ b/searchfn/adapters/src/indexeddb.ts
@@ -1,0 +1,2 @@
+export { IndexedDbAdapter } from '@searchfn/adapter-indexeddb';
+export type { IndexedDbAdapterOptions } from '@searchfn/adapter-indexeddb';

--- a/searchfn/adapters/src/internal/redaction.ts
+++ b/searchfn/adapters/src/internal/redaction.ts
@@ -1,0 +1,88 @@
+const KEY_VALUE_SECRET = /\b(api[_-]?key|password|secret|token|authorization|connection(?:string|[_-]?string)?)\s*[:=]\s*([^\s,;]+)/gi;
+const URL_CREDENTIALS = /(https?:\/\/)([^\s/@]+)@/gi;
+const POSTGRES_CREDENTIALS = /(postgres(?:ql)?:\/\/)([^\s/@]+)@/gi;
+
+function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  return (
+    /(api[_-]?key|password|secret|token|authorization)/.test(lower) ||
+    /connection(?:string|[_-]?string)?$/.test(lower)
+  );
+}
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function redactSensitiveString(input: string): string {
+  return input
+    .replace(KEY_VALUE_SECRET, (_match, key) => `${key}=[REDACTED]`)
+    .replace(URL_CREDENTIALS, "$1[REDACTED]@")
+    .replace(POSTGRES_CREDENTIALS, "$1[REDACTED]@");
+}
+
+function redactError(error: Error, seen: WeakSet<object>): Record<string, unknown> {
+  const output: Record<string, unknown> = {
+    name: error.name,
+    message: redactSensitiveString(error.message),
+  };
+  if (typeof error.stack === "string") {
+    output.stack = redactSensitiveString(error.stack);
+  }
+  if ("cause" in error && (error as Error & { cause?: unknown }).cause !== undefined) {
+    output.cause = redactSensitiveInternal(
+      (error as Error & { cause?: unknown }).cause,
+      seen,
+    );
+  }
+  for (const [key, entry] of Object.entries(error)) {
+    if (key === "cause") {
+      continue;
+    }
+    output[key] = isSensitiveKey(key) ? "[REDACTED]" : redactSensitiveInternal(entry, seen);
+  }
+  return output;
+}
+
+function redactSensitiveInternal(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+    try {
+      if (Array.isArray(value)) {
+        return value.map((entry) => redactSensitiveInternal(entry, seen));
+      }
+      if (value instanceof Error) {
+        return redactError(value, seen);
+      }
+      const entries = Object.entries(value);
+      if (!isPlainObject(value) && entries.length === 0) {
+        return value;
+      }
+      const output: Record<string, unknown> = {};
+      for (const [key, entry] of entries) {
+        output[key] = isSensitiveKey(key) ? "[REDACTED]" : redactSensitiveInternal(entry, seen);
+      }
+      return output;
+    } finally {
+      seen.delete(value);
+    }
+  }
+
+  if (typeof value === "string") {
+    return redactSensitiveString(value);
+  }
+
+  return value;
+}
+
+export function redactSensitive(value: unknown): unknown {
+  return redactSensitiveInternal(value, new WeakSet<object>());
+}

--- a/searchfn/adapters/src/meilisearch.ts
+++ b/searchfn/adapters/src/meilisearch.ts
@@ -1,0 +1,2 @@
+export { MeilisearchAdapter } from '@searchfn/adapter-meilisearch';
+export type { MeilisearchAdapterOptions } from '@searchfn/adapter-meilisearch';

--- a/searchfn/adapters/src/memory.ts
+++ b/searchfn/adapters/src/memory.ts
@@ -1,0 +1,1 @@
+export { MemoryAdapter } from '@searchfn/adapter-memory';

--- a/searchfn/adapters/src/opensearch.ts
+++ b/searchfn/adapters/src/opensearch.ts
@@ -1,0 +1,2 @@
+export { OpenSearchAdapter } from '@searchfn/adapter-opensearch';
+export type { OpenSearchAdapterOptions } from '@searchfn/adapter-opensearch';

--- a/searchfn/adapters/src/postgres.ts
+++ b/searchfn/adapters/src/postgres.ts
@@ -1,0 +1,6 @@
+export { PostgresAdapter } from '@searchfn/adapter-postgres';
+export type {
+  PostgresAdapterOptions,
+  PostgresRetryPolicy,
+  PostgresAdapterLogger,
+} from '@searchfn/adapter-postgres';

--- a/searchfn/adapters/src/types.ts
+++ b/searchfn/adapters/src/types.ts
@@ -1,0 +1,16 @@
+export type {
+  SearchAdapter,
+  SearchAdapterCapabilities,
+  SearchDocument,
+  SearchDefaults,
+  IndexParams,
+  SearchParams,
+  SearchAllParams,
+  SearchAllResult,
+  RemoveParams,
+  InitializeParams,
+  InitializeResourceConfig,
+  SearchAdapterConfig,
+} from '@searchfn/adapter-contracts';
+
+export { SearchAdapterError, SEARCH_ADAPTER_DISPOSED } from '@searchfn/adapter-contracts';

--- a/searchfn/adapters/tsconfig.json
+++ b/searchfn/adapters/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/adapters/tsup.config.ts
+++ b/searchfn/adapters/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/index.browser.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist",
+  external: ["@searchfn/core"]
+});

--- a/searchfn/adapters/vitest.benchmark.config.ts
+++ b/searchfn/adapters/vitest.benchmark.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: ["__tests__/setup.ts"],
+    include: ["__tests__/benchmarks.test.ts"],
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/searchfn/adapters/vitest.config.ts
+++ b/searchfn/adapters/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: ["__tests__/setup.ts"],
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"],
+    exclude: [
+      "__tests__/integration/**/*.test.ts",
+      "__tests__/benchmarks.test.ts",
+      "__tests__/stubs.test.ts",
+    ],
+    coverage: {
+      reporter: ["text", "lcov"],
+      provider: "v8"
+    }
+  }
+});

--- a/searchfn/adapters/vitest.integration.config.ts
+++ b/searchfn/adapters/vitest.integration.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: ["__tests__/setup.ts"],
+    include: ["__tests__/integration/**/*.test.ts"],
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pluggable adapter system for SearchFn and the `@searchfn/adapters` facade to fulfill SF-27. Ships shared contracts, production adapters (Memory, IndexedDB, Postgres, Elasticsearch/OpenSearch, Meilisearch), a conformance suite, a Docker-based integration matrix, and a small benchmark harness.

- **New Features**
  - `@searchfn/adapter-contracts`: unified `SearchAdapter` interfaces with `SearchDefaults`, `SearchAdapterError`, `SEARCH_ADAPTER_DISPOSED`, and `AbortSignal` support.
  - Adapters: `@searchfn/adapter-memory`, `@searchfn/adapter-indexeddb`, `@searchfn/adapter-postgres` (native tsvector/tsquery with idempotent schema), `@searchfn/adapter-elasticsearch`, `@searchfn/adapter-opensearch` (ES wrapper), `@searchfn/adapter-meilisearch`; with bounded retries, timeouts, improved sensitive-data redaction (URLs and connection strings), construct-time defaults (prefix, fuzzy, fieldBoosts), and `searchAll` across resources.
  - Facade `@searchfn/adapters`: re-exports adapters and types, provides a browser entry, and a `redactSensitive` helper.
  - Tests/tooling: shared conformance suite; Docker Compose configs and a matrix runner for Postgres/Elasticsearch/OpenSearch/Meilisearch; guard test to block legacy wrapper imports; simple per-adapter benchmarks with thresholds; helper scripts for Vitest and the integration matrix.

- **Migration**
  - Import from `@searchfn/adapters` or install individual `@searchfn/adapter-*` packages and pass backend options.
  - Remove legacy internal wrapper imports; the guard test enforces the new layering.
  - For integration tests, start services via the provided compose files or set `SEARCHFN_*` env vars.

<sup>Written for commit d382d38b7c2bd19f880835c4227ced2bb88a97fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New adapters: Elasticsearch, OpenSearch, Meilisearch, Postgres, IndexedDB, and in-memory; unified public adapter surface.
  * Search enhancements: fuzzy and prefix matching, per-field boosts, multi-resource/global search, deterministic ordering, lifecycle controls, and benchmark tooling.

* **Infrastructure**
  * Sensitive-data redaction, robust retry/backoff and abort handling, and Docker Compose setups for local integration services.

* **Tests**
  * Extensive conformance, integration, and unit test suites plus benchmarking harness and thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->