### PR TITLE
SF-27: feat(searchfn): add datafn provider package

### DIFF
--- a/searchfn/datafn-provider/__tests__/factory.test.ts
+++ b/searchfn/datafn-provider/__tests__/factory.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { createSearchProvider } from "../src/index";
+
+function makeAdapter(overrides?: Partial<SearchAdapter>): SearchAdapter {
+  return {
+    name: "mock",
+    index: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockResolvedValue([]),
+    remove: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+// TV-PROV-004
+describe("createSearchProvider — factory creates valid SearchProvider", () => {
+  it("returns an object with all required SearchProvider methods", () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter);
+
+    expect(typeof provider.name).toBe("string");
+    expect(typeof provider.search).toBe("function");
+    expect(typeof provider.updateIndices).toBe("function");
+    expect(typeof provider.searchAll).toBe("function");
+    expect(typeof provider.initialize).toBe("function");
+    expect(typeof provider.dispose).toBe("function");
+  });
+
+  it("name getter delegates to adapter.name", () => {
+    const adapter = makeAdapter({ name: "custom-adapter" });
+    const provider = createSearchProvider(adapter);
+    expect(provider.name).toBe("custom-adapter");
+  });
+
+  it("factory does not modify the adapter instance", () => {
+    const adapter = makeAdapter();
+    const originalKeys = Object.keys(adapter);
+    const originalName = adapter.name;
+
+    createSearchProvider(adapter);
+
+    expect(Object.keys(adapter)).toEqual(originalKeys);
+    expect(adapter.name).toBe(originalName);
+  });
+
+  it("multiple providers from same adapter are independent", () => {
+    const adapter = makeAdapter();
+    const p1 = createSearchProvider(adapter, { resourceFields: { tasks: ["title"] } });
+    const p2 = createSearchProvider(adapter, { resourceFields: { notes: ["content"] } });
+    expect(p1).not.toBe(p2);
+  });
+});
+
+// TV-PROV-005
+describe("createSearchProvider — search delegates to adapter.search", () => {
+  let adapter: SearchAdapter;
+
+  beforeEach(() => {
+    adapter = makeAdapter({
+      search: vi.fn().mockResolvedValue(["doc-1", "doc-2"]),
+    });
+  });
+
+  it("returns string IDs from adapter.search result", async () => {
+    const provider = createSearchProvider(adapter);
+    const result = await provider.search({ resource: "tasks", query: "hello" });
+    expect(result).toEqual(["doc-1", "doc-2"]);
+  });
+
+  it("passes resource and query to adapter.search", async () => {
+    const provider = createSearchProvider(adapter);
+    await provider.search({ resource: "notes", query: "report" });
+    expect(adapter.search).toHaveBeenCalledWith(
+      expect.objectContaining({ resource: "notes", query: "report" }),
+    );
+  });
+
+  it("defaults limit to 50 when not provided", async () => {
+    const provider = createSearchProvider(adapter);
+    await provider.search({ resource: "tasks", query: "x" });
+    expect(adapter.search).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+    );
+  });
+
+  it("uses provided limit when specified", async () => {
+    const provider = createSearchProvider(adapter);
+    await provider.search({ resource: "tasks", query: "x", limit: 10 });
+    expect(adapter.search).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10 }),
+    );
+  });
+
+  it("converts numeric DocId results to strings", async () => {
+    (adapter.search as ReturnType<typeof vi.fn>).mockResolvedValue([1, 2, 3]);
+    const provider = createSearchProvider(adapter);
+    const result = await provider.search({ resource: "tasks", query: "x" });
+    expect(result).toEqual(["1", "2", "3"]);
+  });
+
+  it("forwards AbortSignal to adapter.search", async () => {
+    const provider = createSearchProvider(adapter);
+    const controller = new AbortController();
+    await provider.search({
+      resource: "tasks",
+      query: "x",
+      signal: controller.signal,
+    });
+    expect(adapter.search).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});
+
+describe("createSearchProvider — updateIndices", () => {
+  it("calls adapter.remove on delete operation", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter);
+    await provider.updateIndices({
+      resource: "tasks",
+      records: [{ id: "1" }, { id: "2" }],
+      operation: "delete",
+    });
+    expect(adapter.remove).toHaveBeenCalledWith({ resource: "tasks", ids: ["1", "2"] });
+    expect(adapter.index).not.toHaveBeenCalled();
+  });
+
+  it("stringifies delete ids before delegating to adapter.remove", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter);
+    await provider.updateIndices({
+      resource: "tasks",
+      records: [{ id: 1 }, { id: 2 }],
+      operation: "delete",
+    });
+    expect(adapter.remove).toHaveBeenCalledWith({ resource: "tasks", ids: ["1", "2"] });
+  });
+
+  it("calls adapter.index on upsert operation", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"] },
+    });
+    await provider.updateIndices({
+      resource: "tasks",
+      records: [{ id: "1", title: "Hello" }],
+      operation: "upsert",
+    });
+    expect(adapter.index).toHaveBeenCalledWith({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "Hello" } }],
+    });
+  });
+
+  it("converts non-string field values to strings", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter);
+    await provider.updateIndices({
+      resource: "tasks",
+      records: [{ id: "1", count: 42, active: true, meta: { x: 1 } }],
+      operation: "upsert",
+    });
+    expect(adapter.index).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documents: [
+          {
+            id: "1",
+            fields: { count: "42", active: "true", meta: '{"x":1}' },
+          },
+        ],
+      }),
+    );
+  });
+
+  it("uses configured resourceFields when extracting indexed fields", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"] },
+    });
+
+    await provider.updateIndices({
+      resource: "tasks",
+      records: [{ id: "1", title: "Hello", body: "Ignored" }],
+      operation: "upsert",
+    });
+
+    expect(adapter.index).toHaveBeenCalledWith({
+      resource: "tasks",
+      documents: [{ id: "1", fields: { title: "Hello" } }],
+    });
+  });
+
+  it("falls back to String(value) when JSON serialization fails", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter);
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await provider.updateIndices({
+      resource: "tasks",
+      records: [{ id: "1", meta: circular }],
+      operation: "upsert",
+    });
+
+    expect(adapter.index).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documents: [{ id: "1", fields: { meta: "[object Object]" } }],
+      }),
+    );
+  });
+});
+
+describe("createSearchProvider — searchAll native delegation", () => {
+  it("forwards AbortSignal to adapter.searchAll when available", async () => {
+    const searchAll = vi.fn().mockResolvedValue([]);
+    const adapter = makeAdapter({ searchAll });
+    const provider = createSearchProvider(adapter);
+    const controller = new AbortController();
+
+    await provider.searchAll({
+      query: "hello",
+      resources: ["tasks"],
+      signal: controller.signal,
+    });
+
+    expect(searchAll).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});
+
+describe("createSearchProvider — initialize and dispose delegation", () => {
+  it("initialize delegates to adapter.initialize when present", async () => {
+    const initFn = vi.fn().mockResolvedValue(undefined);
+    const adapter = makeAdapter({ initialize: initFn });
+    const provider = createSearchProvider(adapter);
+    const config = { resources: [{ name: "tasks", searchFields: ["title"] }] };
+    await provider.initialize(config);
+    expect(initFn).toHaveBeenCalledWith(config);
+  });
+
+  it("initialize is a no-op when adapter lacks initialize", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter);
+    await expect(
+      provider.initialize({ resources: [{ name: "tasks", searchFields: ["title"] }] }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("dispose delegates to adapter.dispose when present", async () => {
+    const disposeFn = vi.fn().mockResolvedValue(undefined);
+    const adapter = makeAdapter({ dispose: disposeFn });
+    const provider = createSearchProvider(adapter);
+    await provider.dispose();
+    expect(disposeFn).toHaveBeenCalled();
+  });
+
+  it("dispose is a no-op when adapter lacks dispose", async () => {
+    const adapter = makeAdapter();
+    const provider = createSearchProvider(adapter);
+    await expect(provider.dispose()).resolves.toBeUndefined();
+  });
+});
+
+// TV-DFP-001: provider forwards fuzzy, prefix, fieldBoosts to adapter.search
+describe("createSearchProvider — TV-DFP-001: forwards search options to adapter.search", () => {
+  it("forwards fuzzy, prefix, and fieldBoosts from params to adapter.search", async () => {
+    const searchSpy = vi.fn().mockResolvedValue([]);
+    const adapter = makeAdapter({ search: searchSpy });
+    const provider = createSearchProvider(adapter);
+
+    await provider.search({
+      resource: "todos",
+      query: "to",
+      fuzzy: true,
+      prefix: true,
+      fieldBoosts: { title: 2 },
+    } as any);
+
+    expect(searchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: "todos",
+        query: "to",
+        fuzzy: true,
+        prefix: true,
+        fieldBoosts: { title: 2 },
+      }),
+    );
+  });
+
+  it("forwards undefined options when not provided (no accidental overrides)", async () => {
+    const searchSpy = vi.fn().mockResolvedValue([]);
+    const adapter = makeAdapter({ search: searchSpy });
+    const provider = createSearchProvider(adapter);
+
+    await provider.search({ resource: "todos", query: "hello" } as any);
+
+    const call = searchSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.fuzzy).toBeUndefined();
+    expect(call.prefix).toBeUndefined();
+    expect(call.fieldBoosts).toBeUndefined();
+  });
+});
+
+// TV-DFP-002: provider forwards fuzzy, prefix, fieldBoosts to adapter.searchAll
+describe("createSearchProvider — TV-DFP-002: forwards search options to adapter.searchAll", () => {
+  it("forwards fuzzy, prefix, and fieldBoosts to native adapter.searchAll", async () => {
+    const searchAllSpy = vi.fn().mockResolvedValue([]);
+    const adapter = makeAdapter({ searchAll: searchAllSpy });
+    const provider = createSearchProvider(adapter);
+
+    await provider.searchAll({
+      query: "to",
+      resources: ["todos"],
+      fuzzy: true,
+      prefix: true,
+    } as any);
+
+    expect(searchAllSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "to",
+        fuzzy: true,
+        prefix: true,
+      }),
+    );
+  });
+
+  it("forwards fuzzy and prefix to fallback per-resource search when searchAll unavailable", async () => {
+    const searchSpy = vi.fn().mockResolvedValue([]);
+    const adapter = makeAdapter({ search: searchSpy });
+    // No searchAll on this adapter
+    const provider = createSearchProvider(adapter, { resourceFields: { todos: ["title"] } });
+
+    await provider.searchAll({
+      query: "to",
+      resources: ["todos"],
+      fuzzy: true,
+      prefix: true,
+    } as any);
+
+    expect(searchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: "todos",
+        query: "to",
+        fuzzy: true,
+        prefix: true,
+      }),
+    );
+  });
+
+  it("continues fallback searchAll results when one resource search fails", async () => {
+    const searchSpy = vi.fn()
+      .mockResolvedValueOnce(["a1"])
+      .mockRejectedValueOnce(new Error("boom"));
+    const adapter = makeAdapter({ search: searchSpy });
+    delete (adapter as Partial<SearchAdapter>).searchAll;
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { alpha: ["title"], beta: ["title"] },
+    });
+
+    const results = await provider.searchAll({
+      query: "to",
+      resources: ["alpha", "beta"],
+    } as any);
+
+    expect(results).toEqual([{ resource: "alpha", id: "a1", score: 50 }]);
+  });
+});

--- a/searchfn/datafn-provider/__tests__/fallback.test.ts
+++ b/searchfn/datafn-provider/__tests__/fallback.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import { createSearchProvider } from "../src/index";
+
+function makeAdapterWithoutSearchAll(
+  searchFn?: (params: { resource: string; query: string; limit?: number }) => Promise<string[]>,
+): SearchAdapter {
+  return {
+    name: "no-searchall",
+    index: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockImplementation(searchFn ?? (() => Promise.resolve([]))),
+    remove: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// TV-FALL-001
+describe("searchAll fallback — adapter without native searchAll", () => {
+  it("calls adapter.search per resource and merges results", async () => {
+    const searchFn = vi.fn().mockImplementation(({ resource }: { resource: string }) =>
+      Promise.resolve(resource === "tasks" ? ["t1", "t2"] : ["n1"]),
+    );
+    const adapter: SearchAdapter = {
+      name: "no-searchall",
+      index: vi.fn().mockResolvedValue(undefined),
+      search: searchFn,
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    };
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"], notes: ["content"] },
+    });
+
+    const results = await provider.searchAll({ query: "hello" });
+
+    expect(searchFn).toHaveBeenCalledWith(expect.objectContaining({ resource: "tasks", query: "hello" }));
+    expect(searchFn).toHaveBeenCalledWith(expect.objectContaining({ resource: "notes", query: "hello" }));
+
+    const ids = results.map((r) => r.id);
+    expect(ids).toContain("t1");
+    expect(ids).toContain("t2");
+    expect(ids).toContain("n1");
+  });
+
+  it("results have resource, id (string), and numeric score", async () => {
+    const adapter = makeAdapterWithoutSearchAll(() => Promise.resolve(["x1"]));
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { items: ["title"] },
+    });
+
+    const results = await provider.searchAll({ query: "test" });
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(typeof r.resource).toBe("string");
+      expect(typeof r.id).toBe("string");
+      expect(typeof r.score).toBe("number");
+    }
+  });
+
+  it("uses resources from params when provided instead of resourceFields keys", async () => {
+    const searchFn = vi.fn().mockResolvedValue(["doc1"]);
+    const adapter: SearchAdapter = {
+      name: "no-searchall",
+      index: vi.fn().mockResolvedValue(undefined),
+      search: searchFn,
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    };
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"] },
+    });
+
+    await provider.searchAll({ query: "x", resources: ["projects"] });
+
+    const calledResources = searchFn.mock.calls.map((c) => c[0].resource);
+    expect(calledResources).toContain("projects");
+    expect(calledResources).not.toContain("tasks");
+  });
+
+  it("sorts results by score DESC, resource ASC, id ASC", async () => {
+    const searchFn = vi.fn().mockImplementation(({ resource }: { resource: string }) => {
+      if (resource === "alpha") return Promise.resolve(["z", "a"]);
+      if (resource === "beta") return Promise.resolve(["b"]);
+      return Promise.resolve([]);
+    });
+    const adapter: SearchAdapter = {
+      name: "no-searchall",
+      index: vi.fn().mockResolvedValue(undefined),
+      search: searchFn,
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    };
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { alpha: ["title"], beta: ["title"] },
+    });
+
+    const results = await provider.searchAll({ query: "test", limitPerResource: 50 });
+
+    for (let i = 1; i < results.length; i++) {
+      const prev = results[i - 1];
+      const curr = results[i];
+      if (prev.score === curr.score) {
+        if (prev.resource === curr.resource) {
+          expect(prev.id <= curr.id).toBe(true);
+        } else {
+          expect(prev.resource <= curr.resource).toBe(true);
+        }
+      } else {
+        expect(prev.score).toBeGreaterThan(curr.score);
+      }
+    }
+  });
+
+  it("global limit trims final result set", async () => {
+    const adapter = makeAdapterWithoutSearchAll(() =>
+      Promise.resolve(["1", "2", "3", "4", "5"]),
+    );
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"], notes: ["title"] },
+    });
+
+    const results = await provider.searchAll({ query: "x", limit: 3 });
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it("forwards AbortSignal to adapter.search fallback calls", async () => {
+    const searchFn = vi.fn().mockResolvedValue(["doc1"]);
+    const adapter: SearchAdapter = {
+      name: "no-searchall",
+      index: vi.fn().mockResolvedValue(undefined),
+      search: searchFn,
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    };
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"] },
+    });
+
+    const controller = new AbortController();
+    await provider.searchAll({ query: "x", signal: controller.signal });
+
+    expect(searchFn).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});
+
+// TV-FALL-002
+describe("searchAll fallback — respects limitPerResource", () => {
+  it("passes limitPerResource as limit to each adapter.search call", async () => {
+    const searchFn = vi.fn().mockResolvedValue([]);
+    const adapter: SearchAdapter = {
+      name: "no-searchall",
+      index: vi.fn().mockResolvedValue(undefined),
+      search: searchFn,
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    };
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"], notes: ["content"] },
+    });
+
+    await provider.searchAll({ query: "x", limitPerResource: 5 });
+
+    for (const call of searchFn.mock.calls) {
+      expect(call[0].limit).toBe(5);
+    }
+  });
+
+  it("assigns synthetic scores based on position within limitPerResource", async () => {
+    const adapter = makeAdapterWithoutSearchAll(() =>
+      Promise.resolve(["id0", "id1", "id2"]),
+    );
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { items: ["title"] },
+    });
+
+    const results = await provider.searchAll({ query: "x", limitPerResource: 10 });
+
+    expect(results[0].score).toBe(10);
+    expect(results[1].score).toBe(9);
+    expect(results[2].score).toBe(8);
+  });
+
+  it("defaults limitPerResource to 50 when not provided", async () => {
+    const searchFn = vi.fn().mockResolvedValue([]);
+    const adapter: SearchAdapter = {
+      name: "no-searchall",
+      index: vi.fn().mockResolvedValue(undefined),
+      search: searchFn,
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    };
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"] },
+    });
+
+    await provider.searchAll({ query: "x" });
+
+    expect(searchFn).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+    );
+  });
+});
+
+// TV-FALL-003
+describe("searchAll fallback — no resolvable resources throws DFQL_INVALID", () => {
+  it("throws when adapter lacks searchAll and no resources are resolvable", async () => {
+    const adapter = makeAdapterWithoutSearchAll();
+    const provider = createSearchProvider(adapter);
+
+    await expect(provider.searchAll({ query: "x" })).rejects.toMatchObject({
+      code: "DFQL_INVALID",
+    });
+  });
+
+  it("throws with descriptive message", async () => {
+    const adapter = makeAdapterWithoutSearchAll();
+    const provider = createSearchProvider(adapter);
+
+    await expect(provider.searchAll({ query: "x" })).rejects.toThrow(
+      "resources are required when adapter.searchAll is unavailable",
+    );
+  });
+
+  it("throws when explicit empty resources array is passed", async () => {
+    const adapter = makeAdapterWithoutSearchAll();
+    const provider = createSearchProvider(adapter, {
+      resourceFields: { tasks: ["title"] },
+    });
+
+    await expect(provider.searchAll({ query: "x", resources: [] })).rejects.toMatchObject({
+      code: "DFQL_INVALID",
+    });
+  });
+
+  it("does not throw when adapter has native searchAll", async () => {
+    const adapter: SearchAdapter = {
+      name: "with-searchall",
+      index: vi.fn().mockResolvedValue(undefined),
+      search: vi.fn().mockResolvedValue([]),
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+      searchAll: vi.fn().mockResolvedValue([]),
+    };
+    const provider = createSearchProvider(adapter);
+
+    await expect(provider.searchAll({ query: "x" })).resolves.toEqual([]);
+  });
+});

--- a/searchfn/datafn-provider/package.json
+++ b/searchfn/datafn-provider/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@searchfn/datafn-provider",
+  "version": "0.3.0",
+  "description": "Factory that bridges any SearchAdapter into a DataFn SearchProvider.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  },
+  "keywords": [
+    "search",
+    "datafn",
+    "searchfn",
+    "provider",
+    "adapter"
+  ],
+  "author": "21n",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "searchfn/datafn-provider"
+  },
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "@searchfn/adapter-contracts": "^0.3.0"
+  },
+  "peerDependencies": {
+    "@datafn/core": "*"
+  },
+  "devDependencies": {
+    "@datafn/core": "*",
+    "@types/node": "^24.9.1",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/searchfn/datafn-provider/src/index.ts
+++ b/searchfn/datafn-provider/src/index.ts
@@ -1,0 +1,226 @@
+import type { SearchAdapter } from "@searchfn/adapter-contracts";
+import type { SearchProvider } from "@datafn/core";
+
+export type { SearchProvider };
+
+export interface CreateSearchProviderOptions {
+  /**
+   * Per-resource search field configuration.
+   * Used to extract searchable fields from mutation records when calling updateIndices().
+   * Keys are resource names; values are arrays of field names to index.
+   *
+   * @example
+   * { tasks: ["title", "description"], notes: ["content"] }
+   */
+  resourceFields?: Record<string, string[]>;
+}
+
+interface SearchProviderSearchParams {
+  resource: string;
+  query: string;
+  fields?: string[];
+  limit?: number;
+  prefix?: boolean;
+  fuzzy?: boolean | number;
+  fieldBoosts?: Record<string, number>;
+  signal?: AbortSignal;
+}
+
+interface SearchProviderSearchAllParams {
+  query: string;
+  resources?: string[];
+  fields?: string[];
+  limit?: number;
+  limitPerResource?: number;
+  prefix?: boolean;
+  fuzzy?: boolean | number;
+  fieldBoosts?: Record<string, number>;
+  signal?: AbortSignal;
+}
+
+interface UpdateIndicesParams {
+  resource: string;
+  records: Record<string, unknown>[];
+  operation: "upsert" | "delete";
+}
+
+class SearchProviderError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "SearchProviderError";
+    this.code = code;
+  }
+}
+
+const FALLBACK_CONCURRENCY = 10;
+
+/**
+ * Creates a DataFn SearchProvider from any SearchAdapter.
+ * The factory does NOT modify the adapter instance.
+ */
+export function createSearchProvider(
+  adapter: SearchAdapter,
+  options?: CreateSearchProviderOptions,
+): SearchProvider {
+  const resourceFields = options?.resourceFields ?? {};
+
+  return {
+    get name() {
+      return adapter.name;
+    },
+
+    async search(params: SearchProviderSearchParams) {
+      const ids = await adapter.search({
+        resource: params.resource,
+        query: params.query,
+        fields: params.fields,
+        limit: params.limit ?? 50,
+        fuzzy: params.fuzzy,
+        prefix: params.prefix,
+        fieldBoosts: params.fieldBoosts,
+        signal: params.signal,
+      });
+      return ids.map((id: string | number) => String(id));
+    },
+
+    async updateIndices({ resource, records, operation }: UpdateIndicesParams) {
+      if (operation === "delete") {
+        await adapter.remove({
+          resource,
+          ids: records.map((r: Record<string, unknown>) => String(r.id)),
+        });
+      } else {
+        const searchFieldNames = resourceFields[resource];
+        const documents = records.map((r: Record<string, unknown>) => ({
+          id: String(r.id),
+          fields: extractFields(r, searchFieldNames),
+        }));
+        await adapter.index({ resource, documents });
+      }
+    },
+
+    async searchAll(params: SearchProviderSearchAllParams) {
+      if (adapter.searchAll) {
+        const results = await adapter.searchAll({
+          query: params.query,
+          resources: params.resources,
+          fields: params.fields,
+          limit: params.limit,
+          limitPerResource: params.limitPerResource,
+          fuzzy: params.fuzzy,
+          prefix: params.prefix,
+          fieldBoosts: params.fieldBoosts,
+          signal: params.signal,
+        });
+        return results.map((r: { resource: string; id: string | number; score: number }) => ({
+          resource: r.resource,
+          id: String(r.id),
+          score: r.score,
+        }));
+      }
+
+      const resources = params.resources ?? Object.keys(resourceFields);
+      if (resources.length === 0) {
+        throw new SearchProviderError(
+          "DFQL_INVALID",
+          "resources are required when adapter.searchAll is unavailable",
+        );
+      }
+
+      const limitPerResource = params.limitPerResource ?? 50;
+      const allResults: Array<{ resource: string; id: string; score: number }> = [];
+      let firstError: unknown;
+
+      for (let i = 0; i < resources.length; i += FALLBACK_CONCURRENCY) {
+        const batch = resources.slice(i, i + FALLBACK_CONCURRENCY);
+        const batchResults = await Promise.allSettled(
+          batch.map(async (resource: string) => {
+            const ids = await adapter.search({
+              resource,
+              query: params.query,
+              fields: params.fields,
+              limit: limitPerResource,
+              fuzzy: params.fuzzy,
+              prefix: params.prefix,
+              fieldBoosts: params.fieldBoosts,
+              signal: params.signal,
+            });
+            return ids.map((id: string | number, index: number) => ({
+              resource,
+              id: String(id),
+              score: limitPerResource - index,
+            }));
+          }),
+        );
+        for (const result of batchResults) {
+          if (result.status === "fulfilled") {
+            allResults.push(...result.value);
+            continue;
+          }
+          if (firstError === undefined) {
+            firstError = result.reason;
+          }
+        }
+      }
+
+      if (allResults.length === 0 && firstError !== undefined) {
+        throw firstError;
+      }
+
+      allResults.sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        if (a.resource !== b.resource) return a.resource < b.resource ? -1 : 1;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      });
+
+      if (params.limit !== undefined) {
+        return allResults.slice(0, params.limit);
+      }
+      return allResults;
+    },
+
+    async initialize(config: { resources: Array<{ name: string; searchFields: string[] }> }) {
+      if (adapter.initialize) {
+        await adapter.initialize(config);
+      }
+    },
+
+    async dispose() {
+      if (adapter.dispose) {
+        await adapter.dispose();
+      }
+    },
+  };
+}
+
+function extractFields(
+  record: Record<string, unknown>,
+  fields?: string[],
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  const keys = fields ?? Object.keys(record).filter((k) => k !== "id");
+  for (const key of keys) {
+    const value = record[key];
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === "string") {
+      result[key] = value;
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      result[key] = String(value);
+    } else if (typeof value === "object") {
+      result[key] = safeStringify(value);
+    }
+  }
+  return result;
+}
+
+function safeStringify(value: object): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/searchfn/datafn-provider/tsconfig.json
+++ b/searchfn/datafn-provider/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/searchfn/datafn-provider/tsup.config.ts
+++ b/searchfn/datafn-provider/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2021",
+  minify: false,
+  splitting: false,
+  treeshake: true,
+  outDir: "dist",
+  external: ["@searchfn/adapter-contracts", "@datafn/core"],
+});

--- a/searchfn/datafn-provider/vitest.config.ts
+++ b/searchfn/datafn-provider/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts"],
+    coverage: {
+      reporter: ["text", "lcov"],
+      provider: "v8",
+    },
+  },
+});


### PR DESCRIPTION
## Summary by Sourcery

Introduce a DataFn-compatible search provider package that wraps generic SearchAdapter implementations and provides unified search, indexing, and searchAll capabilities, including a fallback when adapters lack native searchAll support.

New Features:
- Add @searchfn/datafn-provider package exposing a createSearchProvider factory to bridge SearchAdapter implementations into the DataFn SearchProvider interface.
- Support per-resource search field configuration for indexing and automatic conversion of record fields to string-based search documents.
- Provide searchAll support that either delegates to adapter.searchAll or performs concurrent per-resource searches with scoring, sorting, and global limiting.

Enhancements:
- Ensure provider methods transparently delegate initialize and dispose lifecycle hooks to the underlying adapter when available and otherwise behave as no-ops.

Build:
- Add build, typecheck, and test configuration for the new package using tsup, TypeScript, and Vitest, including tsconfig, bundler config, and vitest configuration.

Tests:
- Add comprehensive Vitest coverage for provider factory behavior, search delegation, index updates, searchAll native and fallback flows, option forwarding, limits, scoring, sorting, and error handling when resources are not resolvable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@searchfn/datafn-provider`, a factory that wraps any `SearchAdapter` as an `@datafn/core` SearchProvider with native or fallback `searchAll`. Implements SF-27 so DataFn can use SearchFn adapters without custom glue.

- **New Features**
  - `createSearchProvider(adapter, { resourceFields })` exposes `search`, `searchAll`, `updateIndices`, `initialize`, `dispose`.
  - `search` forwards `fields`, `fuzzy`, `prefix`, `fieldBoosts`, `signal`; defaults `limit` to 50; returns string IDs.
  - `updateIndices` supports `delete` (adapter.remove) and `upsert` (adapter.index) with per-resource field extraction; non-strings are stringified with a safe fallback.
  - `searchAll` delegates to adapter or falls back to per-resource searches with synthetic scoring, sort (score DESC, resource/id ASC), `limit`, `limitPerResource` (default 50), option/signal forwarding, and string IDs; throws `DFQL_INVALID` if no resolvable resources.

- **Bug Fixes**
  - Forward `fuzzy`, `prefix`, `fieldBoosts`, and `AbortSignal` to both native and fallback `searchAll`.
  - Fallback continues when a resource search fails and returns available results; bubbles the first error only when all searches fail.

<sup>Written for commit 26de523cca166dc62c1e6866e9228f2957e33dc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the @searchfn/datafn-provider package with a createSearchProvider factory that wraps adapters, normalizes IDs, supports per-resource and aggregated searches (with fallback), field extraction/stringification, and adapter lifecycle delegation.

* **Tests**
  * Added comprehensive test suites covering provider creation, search/updateIndices/searchAll behaviors, result normalization, fallback aggregation/order/limits, and lifecycle/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->