### PR TITLE
SF-27 - client - PR review fixes

### DIFF
--- a/searchfn/client/__tests__/client.test.ts
+++ b/searchfn/client/__tests__/client.test.ts
@@ -108,6 +108,18 @@ describe("createSearchClient", () => {
       expect(adapter.search).toHaveBeenCalledWith(expect.objectContaining({ limit: 25 }));
     });
 
+    it("rejects invalid default limit at client creation", () => {
+      expect(() =>
+        createSearchClient({ adapter, defaults: { limit: 0 } }),
+      ).toThrow("defaults.limit must be a positive number");
+    });
+
+    it("rejects invalid default limitPerResource at client creation", () => {
+      expect(() =>
+        createSearchClient({ adapter, defaults: { limitPerResource: 0 } }),
+      ).toThrow("defaults.limitPerResource must be a positive number");
+    });
+
     it("applies custom default fuzzy", async () => {
       const client = createSearchClient({ adapter, defaults: { fuzzy: 1 } });
       await client.search({ resource: "tasks", query: "test" });

--- a/searchfn/client/package.json
+++ b/searchfn/client/package.json
@@ -62,10 +62,10 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@searchfn/core": "file:../core",
-    "@searchfn/adapter-contracts": "file:../adapter-contracts",
-    "@searchfn/adapter-memory": "file:../adapter-memory",
-    "@searchfn/adapter-indexeddb": "file:../adapter-indexeddb"
+    "@searchfn/core": "^0.3.0",
+    "@searchfn/adapter-contracts": "^0.1.0",
+    "@searchfn/adapter-memory": "^0.1.0",
+    "@searchfn/adapter-indexeddb": "^0.1.0"
   },
   "superfunctions": {
     "initFunction": "searchFn",

--- a/searchfn/client/src/client.ts
+++ b/searchfn/client/src/client.ts
@@ -77,6 +77,8 @@ export function createSearchClient(config: SearchClientConfig): SearchClient {
   if (!adapter) {
     throw new SearchClientValidationError("DFQL_INVALID", "adapter is required", "adapter");
   }
+  validateLimit(defaults.limit, "defaults.limit", MAX_LIMIT);
+  validateLimit(defaults.limitPerResource, "defaults.limitPerResource", MAX_LIMIT_PER_RESOURCE);
 
   const client: SearchClient = {
     async index(params: IndexParams): Promise<void> {


### PR DESCRIPTION
## Summary by Sourcery

Validate default search limits on client creation and align client package dependencies with published versions.

Bug Fixes:
- Ensure createSearchClient rejects non-positive default limit and limitPerResource values at configuration time.

Build:
- Update client package.json to depend on released @searchfn packages instead of local file references.

Tests:
- Add unit tests covering validation of invalid default limit and limitPerResource values during client creation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces validation for default limits in the search client and switches to published `@searchfn/*` packages. Addresses SF-27 by preventing invalid defaults at client creation.

- **Bug Fixes**
  - Validate `defaults.limit` and `defaults.limitPerResource` in `createSearchClient`; throw clear errors and add tests.

- **Dependencies**
  - Use published versions for `@searchfn/core` (^0.3.0), `@searchfn/adapter-contracts` (^0.1.0), `@searchfn/adapter-memory` (^0.1.0), and `@searchfn/adapter-indexeddb` (^0.1.0).

<sup>Written for commit e7f2dd1d1b4bb4deb043a1edf76cbb2625ccb0b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client now validates default limit settings at creation and fails fast with clearer error messages for invalid values.

* **Tests**
  * Added tests to verify upfront validation of default limit constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->