### PR TITLE
SF-26 extract shared config module loader from packages/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "superfunctions": "./dist/cli.js",
     "sfs": "./dist/cli.js"

--- a/packages/cli/src/__tests__/load-config-module.test.ts
+++ b/packages/cli/src/__tests__/load-config-module.test.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadConfigModule } from '../utils/load-config-module.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('loadConfigModule', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = path.join(__dirname, `test-temp-config-module-${Date.now()}`);
+    fs.mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('loads a TypeScript default export through the shared runtime loader', async () => {
+    const configPath = path.join(testDir, 'extfn.config.ts');
+    fs.writeFileSync(
+      configPath,
+      `
+      export default {
+        name: 'Example',
+        targets: ['chromium-mv3'],
+      };
+      `,
+      'utf8'
+    );
+
+    const loaded = await loadConfigModule(configPath);
+
+    expect(loaded.path).toBe(configPath);
+    expect(loaded.exportName).toBe('default');
+    expect(loaded.value).toEqual({
+      name: 'Example',
+      targets: ['chromium-mv3'],
+    });
+  });
+
+  it('loads a named config export without requiring a second TS loader', async () => {
+    const configPath = path.join(testDir, 'tool.config.ts');
+    fs.writeFileSync(
+      configPath,
+      `
+      export const config = {
+        source: 'named',
+        enabled: true,
+      };
+      `,
+      'utf8'
+    );
+
+    const loaded = await loadConfigModule(configPath, {
+      exportNames: ['config'],
+      fallbackToModule: false,
+    });
+
+    expect(loaded.exportName).toBe('config');
+    expect(loaded.value).toEqual({
+      source: 'named',
+      enabled: true,
+    });
+  });
+
+  it('supports callers that need named exports to win over default exports', async () => {
+    const configPath = path.join(testDir, 'tool.config.ts');
+    fs.writeFileSync(
+      configPath,
+      `
+      export const config = {
+        source: 'named',
+      };
+
+      export default {
+        source: 'default',
+      };
+      `,
+      'utf8'
+    );
+
+    const loaded = await loadConfigModule(configPath, {
+      exportNames: ['config'],
+      exportPriority: 'named-first',
+      fallbackToModule: false,
+    });
+
+    expect(loaded.exportName).toBe('config');
+    expect(loaded.value).toEqual({
+      source: 'named',
+    });
+  });
+
+  it('supports JSON configs', async () => {
+    const configPath = path.join(testDir, 'tool.config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ source: 'json', ok: true }),
+      'utf8'
+    );
+
+    const loaded = await loadConfigModule(configPath);
+
+    expect(loaded.exportName).toBe('default');
+    expect(loaded.value).toEqual({
+      source: 'json',
+      ok: true,
+    });
+  });
+
+  it('can preserve missing-default state for callers that require explicit default exports', async () => {
+    const configPath = path.join(testDir, 'extfn.config.ts');
+    fs.writeFileSync(
+      configPath,
+      `
+      export const config = {
+        source: 'named-only',
+      };
+      `,
+      'utf8'
+    );
+
+    const loaded = await loadConfigModule(configPath, {
+      fallbackToModule: false,
+      resolveFunctions: false,
+    });
+
+    expect(loaded.exportName).toBeNull();
+    expect(loaded.value).toBeUndefined();
+    expect(loaded.module).toMatchObject({
+      config: {
+        source: 'named-only',
+      },
+    });
+  });
+
+  it('resolves function exports when requested by shared callers', async () => {
+    const configPath = path.join(testDir, 'tool.config.js');
+    fs.writeFileSync(
+      configPath,
+      `
+      export default async function config() {
+        return {
+          source: 'function',
+          count: 3,
+        };
+      }
+      `,
+      'utf8'
+    );
+
+    const loaded = await loadConfigModule(configPath);
+
+    expect(loaded.value).toEqual({
+      source: 'function',
+      count: 3,
+    });
+  });
+
+  it('throws for unsupported config file extensions', async () => {
+    const configPath = path.join(testDir, 'tool.config.txt');
+
+    await expect(loadConfigModule(configPath)).rejects.toThrow(
+      'Unsupported config module extension: .txt'
+    );
+  });
+
+  it('propagates missing-file errors for supported extensions', async () => {
+    const configPath = path.join(testDir, 'missing.config.js');
+
+    await expect(loadConfigModule(configPath)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+});

--- a/packages/cli/src/__tests__/load-library-config.test.ts
+++ b/packages/cli/src/__tests__/load-library-config.test.ts
@@ -289,6 +289,26 @@ describe('loadLibraryConfig', () => {
       expect(loaded.namespace).toBe('correct');
     });
 
+    it('should preserve TypeScript config-export priority for backward compatibility', async () => {
+      const configPath = path.join(testDir, 'test.config.ts');
+      fs.writeFileSync(
+        configPath,
+        `
+        export const config = {
+          namespace: 'named',
+        };
+
+        export default {
+          namespace: 'default',
+        };
+        `
+      );
+
+      const loaded = await loadLibraryConfig(configPath);
+
+      expect(loaded.namespace).toBe('named');
+    });
+
     it('should fallback to entire module if neither default nor config exists', async () => {
       const configPath = path.join(testDir, 'test.config.js');
       fs.writeFileSync(
@@ -467,6 +487,27 @@ describe('loadLibraryConfig', () => {
       expect(typeof config.validators.custom).toBe('function');
       expect(config.validators.custom('test')).toBe(true);
       expect(config.validators.custom('')).toBe(false);
+    });
+
+    it('should not auto-invoke top-level function exports', async () => {
+      const configPath = path.join(testDir, 'factory.config.js');
+      fs.writeFileSync(
+        configPath,
+        `
+        export default function configFactory() {
+          return {
+            namespace: 'conduct',
+          };
+        }
+        `
+      );
+
+      const config = await loadLibraryConfig(configPath);
+
+      expect(typeof config).toBe('function');
+      expect(config()).toEqual({
+        namespace: 'conduct',
+      });
     });
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,3 +63,11 @@ export interface KyselyConfig {
 export function defineConfig(config: SuperfunctionsConfig): SuperfunctionsConfig {
   return config;
 }
+
+export {
+  loadConfigModule,
+  type LoadConfigModuleOptions,
+  type LoadedConfigModule,
+  type LoadedConfigModuleContext,
+} from './utils/load-config-module.js';
+export { loadLibraryConfig } from './utils/load-library-config.js';

--- a/packages/cli/src/utils/load-config-module.ts
+++ b/packages/cli/src/utils/load-config-module.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export interface LoadConfigModuleOptions<TValue = unknown> {
+  exportNames?: readonly string[];
+  exportPriority?: 'default-first' | 'named-first';
+  fallbackToModule?: boolean;
+  resolveFunctions?: boolean;
+  transform?: (
+    value: unknown,
+    context: LoadedConfigModuleContext
+  ) => Promise<TValue> | TValue;
+}
+
+export interface LoadedConfigModuleContext {
+  path: string;
+  module: Record<string, unknown>;
+  exportName: string | null;
+}
+
+export interface LoadedConfigModule<TValue = unknown>
+  extends LoadedConfigModuleContext {
+  value: TValue;
+}
+
+const SUPPORTED_CONFIG_EXTENSIONS = new Set([
+  '.ts',
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.json',
+]);
+
+export async function loadConfigModule<TValue = unknown>(
+  configPath: string,
+  options: LoadConfigModuleOptions<TValue> = {}
+): Promise<LoadedConfigModule<TValue>> {
+  const resolvedPath = path.resolve(configPath);
+  const extension = path.extname(resolvedPath).toLowerCase();
+
+  if (!SUPPORTED_CONFIG_EXTENSIONS.has(extension)) {
+    throw new Error(
+      `Unsupported config module extension: ${extension || '(none)'}`
+    );
+  }
+
+  await fs.access(resolvedPath);
+
+  const module = await importConfigModule(resolvedPath, extension);
+  const selection = selectExport(module, options);
+  const value = await transformSelectedValue(
+    selection.value,
+    {
+      path: resolvedPath,
+      module,
+      exportName: selection.exportName,
+    },
+    options
+  );
+
+  return {
+    path: resolvedPath,
+    module,
+    exportName: selection.exportName,
+    value,
+  };
+}
+
+async function importConfigModule(
+  resolvedPath: string,
+  extension: string
+): Promise<Record<string, unknown>> {
+  if (extension === '.json') {
+    const raw = await fs.readFile(resolvedPath, 'utf8');
+    return { default: JSON.parse(raw) as unknown };
+  }
+
+  if (extension === '.ts') {
+    const jitiImport = await import('jiti');
+    const createJiti = jitiImport.default || jitiImport;
+    const loader = createJiti(path.dirname(resolvedPath), {
+      interopDefault: false,
+      extensions: ['.ts', '.js', '.mjs', '.cjs', '.json'],
+    });
+
+    return (await Promise.resolve(
+      loader(resolvedPath)
+    )) as Record<string, unknown>;
+  }
+
+  return (await import(pathToFileURL(resolvedPath).href)) as Record<
+    string,
+    unknown
+  >;
+}
+
+function selectExport(
+  module: Record<string, unknown>,
+  options: LoadConfigModuleOptions<unknown>
+): { exportName: string | null; value: unknown } {
+  const exportNames = options.exportNames ?? [];
+  const exportPriority = options.exportPriority ?? 'default-first';
+
+  const selectNamedExport = (): { exportName: string | null; value: unknown } | null => {
+    for (const exportName of exportNames) {
+      if (exportName in module) {
+        return {
+          exportName,
+          value: module[exportName],
+        };
+      }
+    }
+
+    return null;
+  };
+
+  const selectDefaultExport = (): { exportName: string | null; value: unknown } | null => {
+    if ('default' in module) {
+      return {
+        exportName: 'default',
+        value: module.default,
+      };
+    }
+
+    return null;
+  };
+
+  const preferred = exportPriority === 'named-first' ? selectNamedExport() : selectDefaultExport();
+  if (preferred) {
+    return preferred;
+  }
+
+  const secondary = exportPriority === 'named-first' ? selectDefaultExport() : selectNamedExport();
+  if (secondary) {
+    return secondary;
+  }
+
+  if (options.fallbackToModule !== false) {
+    return {
+      exportName: null,
+      value: module,
+    };
+  }
+
+  return {
+    exportName: null,
+    value: undefined,
+  };
+}
+
+async function transformSelectedValue<TValue>(
+  value: unknown,
+  context: LoadedConfigModuleContext,
+  options: LoadConfigModuleOptions<TValue>
+): Promise<TValue> {
+  let resolvedValue = value;
+
+  if (options.resolveFunctions !== false && typeof resolvedValue === 'function') {
+    resolvedValue = await Promise.resolve(
+      (resolvedValue as () => unknown | Promise<unknown>)()
+    );
+  }
+
+  if (options.transform) {
+    return await options.transform(resolvedValue, context);
+  }
+
+  return resolvedValue as TValue;
+}

--- a/packages/cli/src/utils/load-library-config.ts
+++ b/packages/cli/src/utils/load-library-config.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+
+import { loadConfigModule } from './load-config-module.js';
 
 /**
  * Load library config file
@@ -8,33 +9,12 @@ import { pathToFileURL } from 'node:url';
 export async function loadLibraryConfig(
   configPath: string
 ): Promise<any> {
-  const ext = path.extname(configPath);
-  
-  if (ext === '.ts') {
-    // Use jiti for TypeScript (like better-auth does)
-    const jiti = await import('jiti').then(m => m.default || m);
-    const loader = jiti(process.cwd(), {
-      interopDefault: true,
-      extensions: ['.ts', '.js', '.mjs'],
-    });
-    
-    const loaded = loader(configPath);
-    
-    // jiti with interopDefault wraps named exports in a default object
-    // So for "export const config = {...}", loaded.default = { config: {...} }
-    // and loaded.config = {...}
-    // Prefer loaded.config over loaded.default to avoid getting wrapped object
-    if (loaded.config !== undefined) {
-      return loaded.config;
-    }
-    if (loaded.default !== undefined) {
-      return loaded.default;
-    }
-    return loaded;
-  }
-  
-  // JS/MJS - use dynamic import
-  const fileUrl = pathToFileURL(configPath).href;
-  const loaded = await import(fileUrl);
-  return loaded.default || loaded.config || loaded;
+  const extension = path.extname(configPath).toLowerCase();
+  const loaded = await loadConfigModule(configPath, {
+    exportNames: ['config'],
+    exportPriority: extension === '.ts' ? 'named-first' : 'default-first',
+    resolveFunctions: false,
+  });
+
+  return loaded.value;
 }


### PR DESCRIPTION
## Summary
- extract shared config module loading into `packages/cli/src/utils/load-config-module.ts`
- update `load-library-config` to reuse the shared loader instead of carrying its own TS module-loading path
- export the new helper and add focused regression tests for both loaders

## Notes
- target base is `origin/dev`
- `.conduct` content is intentionally excluded for this target

## Tests
- `npm install --ignore-scripts`
- `npm run test -- --filter=@superfunctions/cli -- load-config-module load-library-config`
- `npm run build -- --filter=@superfunctions/cli`

## Summary by Sourcery

Extract a reusable configuration module loader in the CLI package and update library config loading and public exports to use it.

New Features:
- Introduce a generic loadConfigModule helper for loading configuration modules across multiple formats and runtimes.

Enhancements:
- Refactor loadLibraryConfig to delegate to the shared loadConfigModule helper instead of maintaining its own TypeScript and JS loading logic.
- Re-export the new configuration loading utilities from the CLI package entrypoint for external reuse.
- Add an exports map to the CLI package to clarify ESM entrypoints and types.

Tests:
- Add focused tests for loadConfigModule covering TypeScript, JavaScript, and JSON configs, named and default exports, function resolution, and fallback behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared config module loader and refactored the CLI to use it, unifying TS/JS/MJS/CJS/JSON config loading. Addresses SF-26 and simplifies export resolution across tools.

- **Refactors**
  - Added `packages/cli/src/utils/load-config-module.ts` using `jiti` for TS, with configurable export selection (`exportNames`, `exportPriority`), optional function resolution, fallback handling, and a transform hook.
  - Updated `load-library-config` to use the shared loader with `exportNames: ['config']`, `named-first` for `.ts` (default-first otherwise), and `resolveFunctions: false`.
  - Re-exported `loadConfigModule`, related types, and `loadLibraryConfig` from `@superfunctions/cli`; added `package.json` `exports` for typed ESM.
  - Added targeted tests for JSON support, export priority (TS named-over-default), missing-default preservation, function resolution, and non-invocation of function exports.

<sup>Written for commit 4bdc21752c4b3f1bb0ae96aa33868cec7d671ba9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `loadConfigModule` utility function for programmatic loading of configuration files with support for TypeScript, JavaScript, and JSON formats, plus customizable export resolution and transformation capabilities.

* **Chores**
  * Enhanced package exports configuration to improve module resolution and provide explicit type definitions for the CLI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->