### PR TITLE
SF-14: feat(filefn): add client package

### DIFF
--- a/filefn/client/package.json
+++ b/filefn/client/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@filefn/client",
+  "version": "0.1.0",
+  "description": "FileFn client SDK for browser file uploads",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "file",
+    "upload",
+    "client",
+    "browser",
+    "filefn"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "filefn/client"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/filefn/client/src/__tests__/offline.test.ts
+++ b/filefn/client/src/__tests__/offline.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createFileFnClient } from '../index.js';
+import { OPFSStore } from '../offline/opfs-store.js';
+
+// Mock mocks
+const stagedUploads = new Map();
+const mockUploadFile = vi.fn().mockResolvedValue({ fileId: 'f1', versionId: 'v1' });
+let lastInitFileId: string | undefined;
+let lastInitIdempotencyKey: string | undefined;
+
+// Mock HttpClient
+vi.mock('../client.js', async (importOriginal) => {
+    const actual = await importOriginal() as Record<string, unknown>;
+    return {
+        ...actual,
+        createHttpClient: () => ({
+            // But used by sync
+            // The upload manager uses http client.
+            // We can mock the upload manager or http client.
+            // The sync logic calls manager.startUpload -> http.initUpload etc.
+            // But we mocked UploadManager in sync? No, we mocked UploadClient in SyncConfig.
+            // In index.ts, we create OfflineSync with a client that uses UploadManager.
+            // So we need to mock HttpClient methods that UploadManager calls.
+            initUpload: vi.fn().mockImplementation(async (params: { fileId?: string }) => {
+                lastInitFileId = params.fileId;
+                lastInitIdempotencyKey = (params as { idempotencyKey?: string }).idempotencyKey;
+                return {
+                    uploadSessionId: 'upl_real', totalParts: 1, chunkSizeBytes: 100
+                };
+            }),
+            signPart: vi.fn().mockResolvedValue({ url: 'http://upload' }),
+            uploadPartToSignedUrl: vi.fn().mockResolvedValue({ recorded: true }),
+            completeUpload: vi.fn().mockImplementation(async () => ({ fileId: lastInitFileId || 'f1', versionId: 'v1' })),
+            getRenderDescriptor: vi.fn().mockImplementation(async (fileId: string, options: { intent: string; versionId?: string }) => ({
+                fileId,
+                versionId: options.versionId ?? 'ver_remote',
+                intent: options.intent,
+                state: 'ready',
+                mimeType: 'application/pdf',
+                name: 'remote.pdf',
+                size: 10,
+                source: {
+                    mode: 'artifact',
+                    artifactId: 'art_remote',
+                    artifactKind: 'pdf-preview-page-1-large',
+                    url: '/remote/artifact'
+                }
+            })),
+        })
+    };
+});
+
+// Mock OPFSStore
+vi.mock('../offline/opfs-store.js', () => {
+  return {
+    OPFSStore: class {
+      constructor() {}
+      static isSupported = vi.fn().mockReturnValue(true);
+      async init() {}
+      async stagePendingUpload(u: any) { stagedUploads.set(u.uploadSessionId, u); }
+      async getPendingUpload(id: string) { return stagedUploads.get(id); }
+      async getPendingUploadByFileId(fileId: string) {
+        return Array.from(stagedUploads.values()).find((upload: any) => upload.fileId === fileId) || null;
+      }
+      async getPendingLocalDescriptor(fileId: string) {
+        const upload = Array.from(stagedUploads.values()).find((entry: any) => entry.fileId === fileId);
+        if (!upload) return null;
+        return {
+          fileId: upload.fileId,
+          uploadSessionId: upload.uploadSessionId,
+          state: 'pending-local',
+          source: {
+            ...upload.localSource,
+            url: `blob:${fileId}`,
+          },
+        };
+      }
+      async listPendingUploads() { return Array.from(stagedUploads.keys()); }
+      async deletePendingUpload(id: string) { stagedUploads.delete(id); }
+      async incrementRetryCount() {}
+    }
+  };
+});
+
+describe('Offline Client', () => {
+  let onlineCallback: (() => void) | undefined;
+
+  beforeEach(() => {
+    stagedUploads.clear();
+    mockUploadFile.mockClear();
+    lastInitFileId = undefined;
+    lastInitIdempotencyKey = undefined;
+    
+    // Mock navigator
+    if (typeof navigator === 'undefined') {
+        global.navigator = {} as any;
+    }
+    Object.defineProperty(navigator, 'onLine', {
+        writable: true,
+        value: true
+    });
+
+    // Mock window events
+    if (typeof window === 'undefined') {
+        global.window = {
+            addEventListener: vi.fn((event, cb) => {
+                if (event === 'online') onlineCallback = cb;
+            }),
+            removeEventListener: vi.fn((event, cb) => {
+                if (event === 'online' && onlineCallback === cb) onlineCallback = undefined;
+            }),
+        } as any;
+    } else {
+        vi.spyOn(window, 'addEventListener').mockImplementation((event, cb) => {
+            if (event === 'online') onlineCallback = cb as any;
+        });
+        vi.spyOn(window, 'removeEventListener').mockImplementation((event, cb) => {
+            if (event === 'online' && onlineCallback === cb) onlineCallback = undefined;
+        });
+    }
+  });
+
+  afterEach(() => {
+    onlineCallback = undefined;
+    vi.clearAllMocks();
+  });
+
+  it('TV-CLIENT-OFFLINE-001: should stage when offline and sync when online', async () => {
+    // Go offline
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+        baseUrl: 'http://test',
+        offline: { enabled: true }
+    });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    const handle = client.uploadFile({ policy: 'p', file });
+
+    // Wait for done() - it should block until sync
+    const donePromise = handle.done();
+
+    // Wait for staging (microtasks)
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Verify staged
+    expect(stagedUploads.size).toBe(1);
+    expect(stagedUploads.values().next().value.fileName).toBe('test.txt');
+    expect(stagedUploads.values().next().value.fileId).toBe(handle.fileId);
+
+    // Go online and trigger sync
+    Object.defineProperty(navigator, 'onLine', { value: true });
+    if (onlineCallback) await onlineCallback();
+
+    // Wait for done to resolve
+    const result = await donePromise;
+
+    expect(result.fileId).toBe(handle.fileId);
+    expect(stagedUploads.size).toBe(0);
+  });
+
+  it('syncs immediately after staging if connectivity already returned', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    const handle = client.uploadFile({ policy: 'p', file });
+    const donePromise = handle.done();
+
+    Object.defineProperty(navigator, 'onLine', { value: true });
+    const result = await donePromise;
+
+    expect(result.fileId).toBe(handle.fileId);
+    expect(stagedUploads.size).toBe(0);
+  });
+
+  it('persists idempotency keys through offline replay', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    const handle = client.uploadFile({
+      policy: 'p',
+      file,
+      idempotencyKey: 'idem_001',
+    });
+
+    const donePromise = handle.done();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    Object.defineProperty(navigator, 'onLine', { value: true });
+    if (onlineCallback) await onlineCallback();
+
+    await donePromise;
+    expect(lastInitIdempotencyKey).toBe('idem_001');
+  });
+
+  it('TV-CLIENT-002: should expose a pending-local descriptor for staged offline files', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    const file = new File(['image-bytes'], 'photo.jpg', { type: 'image/jpeg' });
+    const handle = client.uploadFile({ policy: 'p', file });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const descriptor = await client.getPendingLocalDescriptor(handle.fileId);
+
+    expect(descriptor).toEqual({
+      fileId: handle.fileId,
+      uploadSessionId: handle.uploadSessionId,
+      state: 'pending-local',
+      source: expect.objectContaining({
+        mode: 'local-object-url',
+        kind: 'image',
+        mimeType: 'image/jpeg',
+        fileName: 'photo.jpg',
+        previewBehavior: 'direct-image',
+        url: `blob:${handle.fileId}`,
+      }),
+    });
+  });
+
+  it('TV-VIEW-002: should prefer a pending-local PDF source when requested', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    const file = new File(['%PDF-1.4'], 'draft.pdf', { type: 'application/pdf' });
+    const handle = client.uploadFile({ policy: 'p', file });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const descriptor = await client.resolveRenderable({
+      fileId: handle.fileId,
+      intent: 'preview',
+      preferLocal: true,
+    });
+
+    expect(descriptor).toEqual({
+      fileId: handle.fileId,
+      versionId: handle.uploadSessionId,
+      intent: 'preview',
+      state: 'pending-local',
+      mimeType: 'application/pdf',
+      name: 'draft.pdf',
+      size: file.size,
+      source: {
+        mode: 'placeholder',
+        placeholderKind: 'pdf-processing',
+      },
+      warnings: ['Pending local PDF preview artifact is not available yet.'],
+    });
+  });
+
+  it('uses direct-pdf preview behavior when a staged source exposes it', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    const file = new File(['%PDF-1.4'], 'draft.pdf', { type: 'application/pdf' });
+    const handle = client.uploadFile({ policy: 'p', file });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const staged = stagedUploads.get(handle.uploadSessionId);
+    staged.localSource = {
+      ...staged.localSource,
+      kind: 'pdf',
+      previewBehavior: 'direct-pdf',
+    };
+
+    const descriptor = await client.resolveRenderable({
+      fileId: handle.fileId,
+      intent: 'preview',
+      preferLocal: true,
+    });
+
+    expect(descriptor).toEqual(expect.objectContaining({
+      state: 'pending-local',
+      source: {
+        mode: 'original',
+        url: `blob:${handle.fileId}`,
+      },
+    }));
+  });
+
+  it('TV-VIEW-003: should ignore pending-local sources when an explicit version is requested', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    const file = new File(['%PDF-1.4'], 'draft.pdf', { type: 'application/pdf' });
+    const handle = client.uploadFile({ policy: 'p', file });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const descriptor = await client.resolveRenderable({
+      fileId: handle.fileId,
+      versionId: 'ver_remote_1',
+      intent: 'preview',
+      preferLocal: true,
+    });
+
+    expect(descriptor.versionId).toBe('ver_remote_1');
+    expect((descriptor.source as { mode: string }).mode).not.toBe('placeholder');
+  });
+
+  it('TV-CLIENT-OFFLINE-003: aborting an offline upload rejects done() and clears staged data', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false });
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    const handle = client.uploadFile({ policy: 'p', file });
+
+    const donePromise = handle.done();
+    handle.abort();
+
+    await expect(donePromise).rejects.toThrow('Aborted');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(stagedUploads.size).toBe(0);
+  });
+
+  it('TV-CLIENT-OFFLINE-NEG-001: defers OPFS errors until offline staging is selected', async () => {
+    // Mock OPFS unsupported
+    // @ts-ignore
+    OPFSStore.isSupported.mockReturnValueOnce(false);
+
+    const client = createFileFnClient({
+      baseUrl: 'http://test',
+      offline: { enabled: true }
+    });
+
+    expect(client).toBeDefined();
+
+    Object.defineProperty(navigator, 'onLine', { value: false });
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+
+    expect(() => client.uploadFile({ policy: 'p', file })).toThrow(/OPFS unavailable/);
+  });
+});

--- a/filefn/client/src/__tests__/preprocessing.test.ts
+++ b/filefn/client/src/__tests__/preprocessing.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFileFnClient, FILEFN_HEIC_CONVERSION_FAILED } from '../index.js';
+
+describe('PHASE_04 client preprocessing', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('TV-CLIENT-003: built-in HEIC preprocessor converts browser uploads deterministically', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          uploadSessionId: 'upl_heic',
+          uploadMode: 'multipart-signed-url',
+          chunkSizeBytes: 1024,
+          totalParts: 1,
+          expiresAt: '2025-01-01T00:00:00Z',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          url: 'https://storage.test/heic-part-1',
+          headers: {},
+          expiresAt: '2025-01-01T00:00:00Z',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ ETag: '"etag-heic"' }),
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ recorded: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({ fileId: 'file_heic_001', versionId: 'ver_heic_001' }),
+      });
+
+    const client = createFileFnClient({
+      baseUrl: 'https://api.test/files',
+      preprocessing: {
+        heic: {
+          converter: async () => new Blob(['jpeg-data'], { type: 'image/jpeg' }),
+        },
+      },
+    });
+
+    const file = new File(['heic-data'], 'photo.heic', { type: 'image/heic' });
+    const result = await client.uploadFile({
+      policy: 'photos',
+      file,
+      fileId: 'file_heic_001',
+    }).done();
+
+    expect(result).toEqual({ fileId: 'file_heic_001', versionId: 'ver_heic_001' });
+
+    const initBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(initBody.fileName).toBe('photo.jpg');
+    expect(initBody.mimeType).toBe('image/jpeg');
+    expect(initBody.fileId).toBe('file_heic_001');
+  });
+
+  it('TV-CLIENT-003 negative: failed HEIC conversion surfaces a stable FileFn error code', async () => {
+    const client = createFileFnClient({
+      baseUrl: 'https://api.test/files',
+      preprocessing: {
+        heic: {
+          converter: async () => {
+            throw new Error('decoder exploded');
+          },
+        },
+      },
+    });
+
+    const file = new File(['heic-data'], 'photo.heic', { type: 'image/heic' });
+
+    await expect(
+      client.uploadFile({
+        policy: 'photos',
+        file,
+        fileId: 'file_heic_fail',
+      }).done(),
+    ).rejects.toMatchObject({
+      code: FILEFN_HEIC_CONVERSION_FAILED,
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/filefn/client/src/__tests__/resume-contract.test.ts
+++ b/filefn/client/src/__tests__/resume-contract.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFileFnClient } from '../index.js';
+
+const mockFetch = vi.fn();
+
+function createResponse(data: unknown, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: new Headers(headers),
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('PHASE_00 CLIENT-001 resume contract conformance', () => {
+  it('TV-CLIENT-001: anonymous upload should carry uploadSessionToken on follow-up requests', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        createResponse({
+          ok: true,
+          data: {
+            uploadSessionId: 'upl_0001',
+            uploadSessionToken: 'upls_live_0001',
+            uploadMode: 'proxy',
+            chunkSizeBytes: 3,
+            totalParts: 1,
+            expiresAt: '2026-03-21T12:56:10Z',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          ok: true,
+          data: {
+            url: '/upload/upl_0001/parts/1',
+            headers: { 'content-type': 'application/octet-stream' },
+            expiresAt: '2026-03-21T12:56:10Z',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        createResponse(
+          {
+            ok: true,
+            data: {
+              etag: 'proxy-etag-1',
+              size: 3,
+              recorded: true,
+            },
+          },
+          200,
+          { 'content-type': 'application/json' }
+        )
+      )
+      .mockResolvedValueOnce(
+        createResponse({
+          ok: true,
+          data: {
+            fileId: 'file_0001',
+            versionId: 'ver_0001',
+          },
+        })
+      );
+
+    const handle = client.uploadFile({
+      policy: 'user-avatar',
+      file: new Blob(['abc'], { type: 'application/octet-stream' }),
+      fileName: 'a.bin',
+      fileId: 'file_0001',
+    });
+
+    const result = await handle.done();
+
+    expect(result).toEqual({ fileId: 'file_0001', versionId: 'ver_0001' });
+
+    const signCall = mockFetch.mock.calls[1];
+    const signRequestInit = signCall[1] as RequestInit;
+    const signHeaders = signRequestInit.headers as Record<string, string>;
+
+    expect(signHeaders['x-upload-session-token']).toBe('upls_live_0001');
+  });
+});

--- a/filefn/client/src/__tests__/retry.test.ts
+++ b/filefn/client/src/__tests__/retry.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isRetryableError } from '../retry.js';
+
+describe('isRetryableError', () => {
+  it('returns false for unknown non-network values', () => {
+    expect(isRetryableError({ code: 'INVALID_STATE' })).toBe(false);
+    expect(isRetryableError(42)).toBe(false);
+    expect(isRetryableError(null)).toBe(false);
+  });
+
+  it('keeps retrying server and network failures', () => {
+    expect(isRetryableError({ status: 503 })).toBe(true);
+    expect(isRetryableError(new Error('network connection reset'))).toBe(true);
+    expect(isRetryableError('fetch failed')).toBe(true);
+  });
+});

--- a/filefn/client/src/__tests__/sync.test.ts
+++ b/filefn/client/src/__tests__/sync.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OfflineSync } from '../offline/sync.js';
+
+describe('OfflineSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries transient sync failures while online and resolves late waiters once', async () => {
+    let retryCount = 0;
+    const pending = {
+      uploadSessionId: 'offline_retry_1',
+      fileId: 'file_retry_1',
+      policy: 'p',
+      fileName: 'retry.txt',
+      size: 4,
+      mimeType: 'text/plain',
+      fileData: new TextEncoder().encode('test').buffer,
+      createdAt: new Date().toISOString(),
+      retryCount: 0,
+    };
+
+    const store = {
+      async listPendingUploads() {
+        return ['offline_retry_1'];
+      },
+      async getPendingUpload() {
+        return pending;
+      },
+      async deletePendingUpload() {
+        return;
+      },
+      async incrementRetryCount() {
+        retryCount += 1;
+        pending.retryCount = retryCount;
+      },
+    };
+
+    const client = {
+      uploadFile: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('network timeout'))
+        .mockResolvedValueOnce({ fileId: 'file_retry_1', versionId: 'ver_retry_1' }),
+    };
+
+    const sync = new OfflineSync({
+      store: store as any,
+      client,
+      retryDelayMs: 25,
+      maxRetries: 2,
+    });
+    sync.setConnectivityChecker({
+      isOnline: () => true,
+      onOnline: () => () => {},
+      onOffline: () => () => {},
+    });
+
+    await sync.syncAll();
+    expect(client.uploadFile).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(25);
+    const settled = await sync.waitForUpload('offline_retry_1');
+    expect(settled).toEqual({ fileId: 'file_retry_1', versionId: 'ver_retry_1' });
+    await expect(sync.waitForUpload('offline_retry_1')).resolves.toEqual({
+      fileId: 'file_retry_1',
+      versionId: 'ver_retry_1',
+    });
+  });
+
+  it('keeps settled results available on the fast path until expiry', async () => {
+    const sync = new OfflineSync({
+      store: {
+        async listPendingUploads() { return []; },
+        async getPendingUpload() { return null; },
+        async deletePendingUpload() { return; },
+        async incrementRetryCount() { return; },
+      } as any,
+      client: {
+        async uploadFile() {
+          return { fileId: 'file', versionId: 'ver' };
+        },
+      },
+    });
+
+    sync.setConnectivityChecker({
+      isOnline: () => true,
+      onOnline: () => () => {},
+      onOffline: () => () => {},
+    });
+
+    const notify = sync as unknown as {
+      notifyListeners: (uploadSessionId: string, result: { fileId: string; versionId: string } | Error) => void;
+    };
+    notify.notifyListeners('offline_done_1', { fileId: 'file_done_1', versionId: 'ver_done_1' });
+
+    await expect(sync.waitForUpload('offline_done_1')).resolves.toEqual({
+      fileId: 'file_done_1',
+      versionId: 'ver_done_1',
+    });
+    await expect(sync.waitForUpload('offline_done_1')).resolves.toEqual({
+      fileId: 'file_done_1',
+      versionId: 'ver_done_1',
+    });
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    const thirdWait = Promise.race([
+      sync.waitForUpload('offline_done_1').then(() => 'resolved'),
+      new Promise((resolve) => setTimeout(() => resolve('pending'), 0)),
+    ]);
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(thirdWait).resolves.toBe('pending');
+  });
+
+  it('rejects waiting uploads after cancellation and removes staged data', async () => {
+    const store = {
+      async listPendingUploads() { return ['offline_cancel_1']; },
+      async getPendingUpload() { return null; },
+      async deletePendingUpload() { return; },
+      async incrementRetryCount() { return; },
+    };
+
+    const sync = new OfflineSync({
+      store: store as any,
+      client: {
+        async uploadFile() {
+          return { fileId: 'file', versionId: 'ver' };
+        },
+      },
+    });
+
+    const waitPromise = sync.waitForUpload('offline_cancel_1');
+    await sync.cancelUpload('offline_cancel_1');
+
+    await expect(waitPromise).rejects.toThrow('Aborted');
+  });
+
+  it('aborts an in-flight sync without scheduling a retry', async () => {
+    let deleted = false;
+    const pending = {
+      uploadSessionId: 'offline_cancel_live_1',
+      fileId: 'file_cancel_live_1',
+      policy: 'p',
+      idempotencyKey: 'idem_cancel_live_1',
+      fileName: 'cancel.txt',
+      size: 4,
+      mimeType: 'text/plain',
+      fileData: new TextEncoder().encode('test').buffer,
+      createdAt: new Date().toISOString(),
+      retryCount: 0,
+    };
+
+    const store = {
+      async listPendingUploads() {
+        return deleted ? [] : [pending.uploadSessionId];
+      },
+      async getPendingUpload() {
+        return deleted ? null : pending;
+      },
+      async deletePendingUpload() {
+        deleted = true;
+      },
+      async incrementRetryCount() {
+        throw new Error('retry count should not increment after abort');
+      },
+    };
+
+    let abortSignal: AbortSignal | undefined;
+    const client = {
+      uploadFile: vi.fn().mockImplementation(async (input: { signal?: AbortSignal }) => {
+        abortSignal = input.signal;
+        return await new Promise((_resolve, reject) => {
+          input.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          }, { once: true });
+        });
+      }),
+    };
+
+    const sync = new OfflineSync({
+      store: store as any,
+      client,
+      retryDelayMs: 25,
+      maxRetries: 2,
+    });
+    sync.setConnectivityChecker({
+      isOnline: () => true,
+      onOnline: () => () => {},
+      onOffline: () => () => {},
+    });
+
+    const syncPromise = sync.syncUpload(pending.uploadSessionId);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(abortSignal).toBeDefined();
+
+    await sync.cancelUpload(pending.uploadSessionId);
+    await expect(syncPromise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(25);
+    expect(client.uploadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes duplicate sync attempts for the same upload session', async () => {
+    const pending = {
+      uploadSessionId: 'offline_dup_1',
+      fileId: 'file_dup_1',
+      policy: 'p',
+      fileName: 'dup.txt',
+      size: 4,
+      mimeType: 'text/plain',
+      fileData: new TextEncoder().encode('test').buffer,
+      createdAt: new Date().toISOString(),
+      retryCount: 0,
+    };
+
+    const store = {
+      async listPendingUploads() {
+        return [pending.uploadSessionId];
+      },
+      async getPendingUpload() {
+        return pending;
+      },
+      async deletePendingUpload() {
+        return;
+      },
+      async incrementRetryCount() {
+        return;
+      },
+    };
+
+    let release!: () => void;
+    const client = {
+      uploadFile: vi.fn().mockImplementation(async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { fileId: 'file_dup_1', versionId: 'ver_dup_1' };
+      }),
+    };
+
+    const sync = new OfflineSync({
+      store: store as any,
+      client,
+    });
+    sync.setConnectivityChecker({
+      isOnline: () => true,
+      onOnline: () => () => {},
+      onOffline: () => () => {},
+    });
+
+    const first = sync.syncUpload(pending.uploadSessionId);
+    const second = sync.syncUpload(pending.uploadSessionId);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(client.uploadFile).toHaveBeenCalledTimes(1);
+
+    release();
+    await Promise.all([first, second]);
+    expect(client.uploadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry non-retryable failures', async () => {
+    const pending = {
+      uploadSessionId: 'offline_perm_1',
+      fileId: 'file_perm_1',
+      policy: 'p',
+      fileName: 'perm.txt',
+      size: 4,
+      mimeType: 'text/plain',
+      fileData: new TextEncoder().encode('test').buffer,
+      createdAt: new Date().toISOString(),
+      retryCount: 0,
+    };
+
+    const store = {
+      async listPendingUploads() {
+        return [pending.uploadSessionId];
+      },
+      async getPendingUpload() {
+        return pending;
+      },
+      async deletePendingUpload() {
+        return;
+      },
+      async incrementRetryCount() {
+        pending.retryCount += 1;
+      },
+    };
+
+    const authError = new Error('forbidden') as Error & { status?: number };
+    authError.status = 403;
+
+    const sync = new OfflineSync({
+      store: store as any,
+      client: {
+        uploadFile: vi.fn().mockRejectedValue(authError),
+      },
+      retryDelayMs: 25,
+      maxRetries: 2,
+    });
+    sync.setConnectivityChecker({
+      isOnline: () => true,
+      onOnline: () => () => {},
+      onOffline: () => () => {},
+    });
+
+    const result = await sync.syncAll();
+    expect(result.failed).toEqual(['offline_perm_1']);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(pending.retryCount).toBe(1);
+  });
+});

--- a/filefn/client/src/__tests__/upload-proxy.test.ts
+++ b/filefn/client/src/__tests__/upload-proxy.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UploadManager } from '../upload-manager.js';
+import { createHttpClient } from '../client.js';
+
+describe('PHASE_02 client proxy upload', () => {
+  const mockFetch = vi.fn();
+
+  const httpClient = createHttpClient({ baseUrl: 'http://localhost' });
+  const manager = new UploadManager(httpClient);
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('TV-CLIENT-001: anonymous proxy upload forwards uploadSessionToken on follow-up requests', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        data: {
+          uploadSessionId: 'sess_1',
+          uploadSessionToken: 'upls_live_0001',
+          uploadMode: 'proxy',
+          chunkSizeBytes: 100,
+          totalParts: 1,
+        },
+      }),
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        data: {
+          url: '/upload/sess_1/parts/1',
+          headers: { 'content-type': 'text/plain' },
+          expiresAt: '2026-03-21T00:00:00Z',
+        },
+      }),
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: async () => ({
+        ok: true,
+        data: { etag: 'proxy-sha256-test', recorded: true },
+      }),
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        data: { fileId: 'f1', versionId: 'v1' },
+      }),
+    });
+
+    const file = new Blob(['hello'], { type: 'text/plain' });
+    const handle = manager.createHandle(
+      {
+        policy: 'p1',
+        file: file as any,
+        fileName: 'test.txt',
+        fileId: 'f1',
+      },
+      () =>
+        manager.startUpload({
+          policy: 'p1',
+          file: file as any,
+          fileName: 'test.txt',
+          fileId: 'f1',
+        }),
+    );
+
+    const result = await handle.done();
+
+    expect(result).toEqual({ fileId: 'f1', versionId: 'v1' });
+    expect(handle.uploadSessionId).toBe('sess_1');
+    expect(handle.uploadSessionToken).toBe('upls_live_0001');
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+
+    const signCall = mockFetch.mock.calls[1];
+    expect(signCall[0]).toBe('http://localhost/upload/sess_1/parts/1/sign');
+    const signHeaders = new Headers(signCall[1].headers as HeadersInit);
+    expect(signHeaders.get('x-upload-session-token')).toBe('upls_live_0001');
+
+    const putCall = mockFetch.mock.calls[2];
+    expect(putCall[0]).toBe('http://localhost/upload/sess_1/parts/1');
+    expect(putCall[1].method).toBe('PUT');
+    const putHeaders = new Headers(putCall[1].headers as HeadersInit);
+    expect(putHeaders.get('x-upload-session-token')).toBe('upls_live_0001');
+
+    const completeCall = mockFetch.mock.calls[3];
+    expect(completeCall[0]).toBe('http://localhost/upload/sess_1/complete');
+    const completeHeaders = new Headers(completeCall[1].headers as HeadersInit);
+    expect(completeHeaders.get('x-upload-session-token')).toBe('upls_live_0001');
+  });
+});

--- a/filefn/client/src/__tests__/upload.test.ts
+++ b/filefn/client/src/__tests__/upload.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createFileFnClient, generateFileId, type UploadProgress } from '../index.js';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function createMockResponse(data: unknown, status = 200, headers: Record<string, string> = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: new Headers(headers),
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  };
+}
+
+function createMockBlob(size: number): Blob {
+  const data = new Uint8Array(size).fill(1);
+  return new Blob([data], { type: 'application/octet-stream' });
+}
+
+describe('createFileFnClient', () => {
+  it('should create a client with uploadFile method', () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    expect(client.uploadFile).toBeDefined();
+    expect(typeof client.uploadFile).toBe('function');
+  });
+
+  it('should create a client with resumeUpload method', () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    expect(client.resumeUpload).toBeDefined();
+    expect(typeof client.resumeUpload).toBe('function');
+  });
+
+  it('should export generateFileId()', () => {
+    const first = generateFileId();
+    const second = generateFileId();
+
+    expect(first).toMatch(/^file_/);
+    expect(second).toMatch(/^file_/);
+    expect(first).not.toBe(second);
+  });
+});
+
+describe('uploadFile', () => {
+  it('should complete full upload flow (TV-CLIENT-UPLOAD-001)', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(100);
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_001',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 5 * 1024 * 1024,
+        totalParts: 1,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({
+        url: 'https://storage.test/upload/part1',
+        headers: { 'x-amz-content-sha256': 'UNSIGNED-PAYLOAD' },
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"abc123"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({
+        fileId: 'file_0001',
+        versionId: 'ver_0001',
+      }));
+
+    const handle = client.uploadFile({
+      policy: 'user-avatar',
+      file,
+      fileName: 'avatar.png',
+      fileId: 'file_0001',
+    });
+
+    const result = await handle.done();
+
+    expect(result).toEqual({ fileId: 'file_0001', versionId: 'ver_0001' });
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+
+    expect(mockFetch.mock.calls[0][0]).toBe('https://api.test/files/upload/init');
+    expect(mockFetch.mock.calls[1][0]).toBe('https://api.test/files/upload/session_001/parts/1/sign');
+    expect(mockFetch.mock.calls[2][0]).toBe('https://storage.test/upload/part1');
+    expect(mockFetch.mock.calls[3][0]).toBe('https://api.test/files/upload/session_001/parts/1/complete');
+    expect(mockFetch.mock.calls[4][0]).toBe('https://api.test/files/upload/session_001/complete');
+  });
+
+  it('should upload multiple parts for large files', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(15 * 1024 * 1024);
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_002',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 5 * 1024 * 1024,
+        totalParts: 3,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part1', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag1"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part2', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag2"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part3', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag3"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_0002', versionId: 'ver_0002' }));
+
+    const handle = client.uploadFile({ policy: 'attachments', file, fileId: 'file_0002' });
+    const result = await handle.done();
+
+    expect(result).toEqual({ fileId: 'file_0002', versionId: 'ver_0002' });
+    expect(mockFetch).toHaveBeenCalledTimes(11);
+  });
+
+  it('should fire progress callbacks (TV-CLIENT-HOOKS-001)', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(200);
+    const progressEvents: UploadProgress[] = [];
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_003',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 100,
+        totalParts: 2,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part1', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag1"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part2', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag2"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_0003', versionId: 'ver_0003' }));
+
+    const handle = client.uploadFile({ policy: 'test', file, fileId: 'file_0003' });
+    handle.onProgress((progress) => progressEvents.push({ ...progress }));
+
+    await handle.done();
+
+    expect(progressEvents).toHaveLength(2);
+    expect(progressEvents[0]).toEqual({
+      bytesUploaded: 100,
+      bytesTotal: 200,
+      partsCompleted: 1,
+      totalParts: 2,
+    });
+    expect(progressEvents[1]).toEqual({
+      bytesUploaded: 200,
+      bytesTotal: 200,
+      partsCompleted: 2,
+      totalParts: 2,
+    });
+  });
+
+  it('should abort and stop progress (TV-CLIENT-HOOKS-NEG-001)', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(300);
+    const progressEvents: UploadProgress[] = [];
+    let rejectUpload!: (reason?: unknown) => void;
+    const pendingUpload = new Promise((_, reject) => {
+      rejectUpload = reject;
+    });
+    pendingUpload.catch(() => {});
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_004',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 100,
+        totalParts: 3,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part1', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag1"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockImplementationOnce(() => pendingUpload);
+
+    const handle = client.uploadFile({ policy: 'test', file, fileId: 'file_abort' });
+    handle.onProgress((progress) => progressEvents.push({ ...progress }));
+    const donePromise = handle.done();
+    const rejectedUpload = expect(donePromise).rejects.toThrow('Aborted');
+    handle.abort();
+    rejectUpload(new DOMException('Aborted', 'AbortError'));
+
+    await rejectedUpload;
+    expect(progressEvents.length).toBeLessThanOrEqual(1);
+  });
+
+  it('should include auth headers when provided', async () => {
+    const client = createFileFnClient({
+      baseUrl: 'https://api.test/files',
+      getAuthHeaders: () => ({ Authorization: 'Bearer token123' }),
+    });
+    const file = createMockBlob(50);
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_005',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 5 * 1024 * 1024,
+        totalParts: 1,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part1', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_0005', versionId: 'ver_0005' }));
+
+    await client.uploadFile({ policy: 'test', file, fileId: 'file_0005' }).done();
+
+    const initCall = mockFetch.mock.calls[0];
+    expect(initCall[1].headers.Authorization).toBe('Bearer token123');
+  });
+
+  it('exposes upload session metadata as soon as init succeeds', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(50);
+    let releaseSign!: () => void;
+    const signBlocked = new Promise((resolve) => {
+      releaseSign = () => resolve(undefined);
+    });
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_early',
+        uploadSessionToken: 'upls_early',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 5 * 1024 * 1024,
+        totalParts: 1,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockImplementationOnce(async () => {
+        await signBlocked;
+        return createMockResponse({ url: 'https://storage.test/part1', headers: {}, expiresAt: '2025-01-01T00:00:00Z' });
+      })
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_early', versionId: 'ver_early' }));
+
+    const handle = client.uploadFile({ policy: 'test', file, fileId: 'file_early' });
+    const donePromise = handle.done();
+    await vi.waitFor(() => {
+      expect(handle.uploadSessionId).toBe('session_early');
+      expect(handle.uploadSessionToken).toBe('upls_early');
+      expect(handle.fileId).toBe('file_early');
+    });
+
+    releaseSign();
+    await expect(donePromise).resolves.toEqual({ fileId: 'file_early', versionId: 'ver_early' });
+  });
+});
+
+describe('resumeUpload', () => {
+  it('should resume upload from status and skip completed parts', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(300);
+    const progressEvents: UploadProgress[] = [];
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        fileId: 'file_resume',
+        status: 'in_progress',
+        recordedParts: [1, 2],
+        totalParts: 3,
+        chunkSizeBytes: 100,
+        fileSize: 300,
+      }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part3', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag3"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_resume', versionId: 'ver_resume' }));
+
+    const handle = client.resumeUpload('session_resume', file, {
+      uploadSessionToken: 'upls_resume',
+    });
+    handle.onProgress((progress) => progressEvents.push({ ...progress }));
+
+    expect(handle.uploadSessionId).toBe('session_resume');
+    expect(handle.uploadSessionToken).toBe('upls_resume');
+    expect(handle.fileId).toBeUndefined();
+
+    const result = await handle.done();
+
+    expect(result).toEqual({ fileId: 'file_resume', versionId: 'ver_resume' });
+    expect(handle.fileId).toBe('file_resume');
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(mockFetch.mock.calls[0][0]).toBe('https://api.test/files/upload/session_resume/status');
+    expect(mockFetch.mock.calls[1][0]).toBe('https://api.test/files/upload/session_resume/parts/3/sign');
+
+    expect(progressEvents[0]).toEqual({
+      bytesUploaded: 200,
+      bytesTotal: 300,
+      partsCompleted: 2,
+      totalParts: 3,
+    });
+    expect(progressEvents[progressEvents.length - 1]).toEqual({
+      bytesUploaded: 300,
+      bytesTotal: 300,
+      partsCompleted: 3,
+      totalParts: 3,
+    });
+  });
+
+  it('should preserve a caller-supplied fileId while resuming', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(100);
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        status: 'in_progress',
+        recordedParts: [],
+        totalParts: 1,
+        chunkSizeBytes: 100,
+        fileSize: 100,
+      }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part1', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag1"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_known', versionId: 'ver_known' }));
+
+    const handle = client.resumeUpload('session_known', file, { fileId: 'file_known' });
+    expect(handle.fileId).toBe('file_known');
+
+    const result = await handle.done();
+    expect(result.fileId).toBe('file_known');
+    expect(handle.fileId).toBe('file_known');
+  });
+});
+
+describe('retry behavior', () => {
+  it('should retry on 500 errors', async () => {
+    const client = createFileFnClient({
+      baseUrl: 'https://api.test/files',
+      retryOptions: { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 50 },
+    });
+    const file = createMockBlob(50);
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({ error: 'Server Error' }, 500))
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_retry',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 5 * 1024 * 1024,
+        totalParts: 1,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({ url: 'https://storage.test/part1', headers: {}, expiresAt: '2025-01-01T00:00:00Z' }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_retry', versionId: 'ver_retry' }));
+
+    const result = await client.uploadFile({ policy: 'test', file, fileId: 'file_retry' }).done();
+
+    expect(result).toEqual({ fileId: 'file_retry', versionId: 'ver_retry' });
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it('TV-CLIENT-001 negative: should reject when the server completes with a different fileId', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(100);
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse({
+        uploadSessionId: 'session_mismatch',
+        uploadMode: 'multipart-signed-url',
+        chunkSizeBytes: 100,
+        totalParts: 1,
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({
+        url: 'https://storage.test/upload/part1',
+        headers: {},
+        expiresAt: '2025-01-01T00:00:00Z',
+      }))
+      .mockResolvedValueOnce(createMockResponse({}, 200, { ETag: '"etag1"' }))
+      .mockResolvedValueOnce(createMockResponse({ recorded: true }))
+      .mockResolvedValueOnce(createMockResponse({ fileId: 'file_other', versionId: 'ver_other' }));
+
+    const handle = client.uploadFile({
+      policy: 'test',
+      file,
+      fileId: 'file_expected',
+    });
+
+    await expect(handle.done()).rejects.toMatchObject({
+      code: 'FILEFN_CLIENT_FILE_ID_MISMATCH',
+      details: {
+        expectedFileId: 'file_expected',
+        actualFileId: 'file_other',
+      },
+    });
+  });
+
+  it('should not retry on 4xx client errors', async () => {
+    const client = createFileFnClient({
+      baseUrl: 'https://api.test/files',
+      retryOptions: { maxRetries: 2, baseDelayMs: 10 },
+    });
+    const file = createMockBlob(50);
+
+    mockFetch.mockResolvedValue(createMockResponse({ error: 'Bad Request' }, 400));
+
+    await expect(client.uploadFile({ policy: 'test', file }).done()).rejects.toThrow('HTTP 400');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should exhaust retries and throw', async () => {
+    const client = createFileFnClient({
+      baseUrl: 'https://api.test/files',
+      retryOptions: { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 20 },
+    });
+    const file = createMockBlob(50);
+
+    mockFetch.mockResolvedValue(createMockResponse({ error: 'Server Error' }, 500));
+
+    await expect(client.uploadFile({ policy: 'test', file }).done()).rejects.toThrow('HTTP 500');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('error handling', () => {
+  it('should propagate policy errors', async () => {
+    const client = createFileFnClient({ baseUrl: 'https://api.test/files' });
+    const file = createMockBlob(50);
+
+    mockFetch.mockResolvedValue(createMockResponse({
+      error: 'POLICY_NOT_FOUND',
+      message: 'Policy "invalid" not found',
+    }, 404));
+
+    await expect(client.uploadFile({ policy: 'invalid', file }).done()).rejects.toThrow('HTTP 404');
+  });
+});

--- a/filefn/client/src/client.ts
+++ b/filefn/client/src/client.ts
@@ -1,0 +1,442 @@
+import type {
+  ArtifactDescriptor,
+  RenderDescriptor,
+  FileFnClientConfig,
+  InitUploadResponse,
+  UploadStatusResponse,
+  SignPartResponse,
+  CompletePartResponse,
+  CompleteUploadResponse,
+  AbortUploadResponse,
+} from "./types.js";
+import {
+  resolveRetryOptions,
+  withRetry,
+  type ResolvedRetryOptions,
+} from "./retry.js";
+
+export interface FileFnErrorDetails {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export class FileFnHttpError extends Error {
+  public readonly code?: string;
+  public readonly requestId?: string;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: unknown,
+  ) {
+    super(message);
+    this.name = "FileFnHttpError";
+
+    // Extract structured error from canonical envelope
+    if (body && typeof body === "object" && "error" in body) {
+      const envelope = body as {
+        ok: false;
+        error: FileFnErrorDetails;
+        requestId?: string;
+      };
+      this.code = envelope.error.code;
+      this.details = envelope.error.details;
+      if (envelope.requestId) {
+        this.requestId = envelope.requestId;
+      }
+    }
+  }
+}
+
+export interface HttpClient {
+  initUpload(
+    params: {
+      policy: string;
+      fileName: string;
+      size: number;
+      mimeType: string;
+      metadata?: Record<string, unknown>;
+      fileId?: string;
+      idempotencyKey?: string;
+    },
+    signal?: AbortSignal,
+  ): Promise<InitUploadResponse>;
+
+  getFile(
+    fileId: string,
+    signal?: AbortSignal,
+  ): Promise<Record<string, unknown>>;
+
+  listArtifacts(
+    fileId: string,
+    signal?: AbortSignal,
+  ): Promise<ArtifactDescriptor[]>;
+
+  downloadUrl(
+    fileId: string,
+    options?: { versionId?: string },
+    signal?: AbortSignal,
+  ): Promise<{ url: string }>;
+
+  downloadArtifact(
+    fileId: string,
+    artifactId: string,
+    signal?: AbortSignal,
+  ): Promise<{ url: string; headers?: Record<string, string> }>;
+
+  getRenderDescriptor(
+    fileId: string,
+    options: { intent: string; versionId?: string },
+    signal?: AbortSignal,
+  ): Promise<RenderDescriptor>;
+
+  deleteFile(fileId: string, signal?: AbortSignal): Promise<void>;
+
+  getUploadStatus(
+    uploadSessionId: string,
+    uploadSessionToken?: string,
+    signal?: AbortSignal,
+  ): Promise<UploadStatusResponse>;
+
+  signPart(
+    uploadSessionId: string,
+    partNumber: number,
+    contentLength: number,
+    uploadSessionToken?: string,
+    signal?: AbortSignal,
+  ): Promise<SignPartResponse>;
+
+  completePart(
+    uploadSessionId: string,
+    partNumber: number,
+    etag: string,
+    size: number,
+    uploadSessionToken?: string,
+    signal?: AbortSignal,
+  ): Promise<CompletePartResponse>;
+
+  completeUpload(
+    uploadSessionId: string,
+    uploadSessionToken?: string,
+    signal?: AbortSignal,
+  ): Promise<CompleteUploadResponse>;
+
+  abortUpload(
+    uploadSessionId: string,
+    uploadSessionToken?: string,
+    signal?: AbortSignal,
+  ): Promise<AbortUploadResponse>;
+
+  uploadPartToSignedUrl(
+    url: string,
+    headers: Record<string, string>,
+    body: Blob,
+    uploadSessionToken?: string,
+    signal?: AbortSignal,
+  ): Promise<{ etag: string; recorded?: boolean }>;
+}
+
+export function createHttpClient(config: FileFnClientConfig): HttpClient {
+  const retryOptions = resolveRetryOptions(config.retryOptions);
+  const baseUrl = config.baseUrl.replace(/\/$/, "");
+
+  async function readResponseBody(response: Response): Promise<{
+    rawBody: string;
+    parsedBody: unknown;
+    isJson: boolean;
+  }> {
+    if (typeof response.text === "function") {
+      const rawBody = await response.text();
+      if (!rawBody) {
+        return { rawBody, parsedBody: undefined, isJson: false };
+      }
+
+      try {
+        return { rawBody, parsedBody: JSON.parse(rawBody), isJson: true };
+      } catch {
+        if (typeof response.json === "function") {
+          try {
+            const parsedBody = await response.json();
+            return { rawBody, parsedBody, isJson: true };
+          } catch {
+            // Fall back to the raw text body when a second parse is not possible.
+          }
+        }
+        return { rawBody, parsedBody: rawBody, isJson: false };
+      }
+    }
+
+    if (typeof response.json === "function") {
+      const parsedBody = await response.json();
+      return {
+        rawBody: typeof parsedBody === "string" ? parsedBody : "",
+        parsedBody,
+        isJson: true,
+      };
+    }
+
+    return { rawBody: "", parsedBody: undefined, isJson: false };
+  }
+
+  async function getHeaders(includeJsonContentType = false): Promise<Record<string, string>> {
+    const headers: Record<string, string> = {};
+
+    if (includeJsonContentType) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    if (config.getAuthHeaders) {
+      const authHeaders = await config.getAuthHeaders();
+      Object.assign(headers, authHeaders);
+    }
+
+    return headers;
+  }
+
+  async function request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    signal?: AbortSignal,
+    options: ResolvedRetryOptions = retryOptions,
+    extraHeaders?: Record<string, string>,
+  ): Promise<T> {
+    return withRetry(
+      async () => {
+        const hasJsonBody = body !== undefined;
+        const headers = await getHeaders(hasJsonBody);
+        if (extraHeaders) {
+          Object.assign(headers, extraHeaders);
+        }
+        const response = await fetch(`${baseUrl}${path}`, {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+          signal,
+        });
+
+        if (!response.ok) {
+          const { rawBody, parsedBody, isJson } = await readResponseBody(response);
+          const errorBody = rawBody ? (isJson ? parsedBody : rawBody) : parsedBody;
+          throw new FileFnHttpError(
+            `HTTP ${response.status}: ${response.statusText}`,
+            response.status,
+            errorBody,
+          );
+        }
+
+        const contentLength =
+          typeof response.headers?.get === "function"
+            ? response.headers.get("content-length")
+            : null;
+        const contentType =
+          typeof response.headers?.get === "function"
+            ? response.headers.get("content-type") || ""
+            : "";
+        if (response.status === 204 || contentLength === '0') {
+          return undefined as T;
+        }
+
+        const { rawBody, parsedBody, isJson } = await readResponseBody(response);
+        if (!rawBody) {
+          if (parsedBody === undefined) {
+            return undefined as T;
+          }
+          if (!isJson) {
+            return parsedBody as T;
+          }
+        }
+
+        const json = parsedBody;
+
+        // Unwrap canonical envelope { ok: true, data: T }
+        if (
+          json &&
+          typeof json === "object" &&
+          "ok" in json &&
+          json.ok === true &&
+          "data" in json
+        ) {
+          return json.data as T;
+        }
+
+        // If not a canonical envelope, return as-is for backwards compatibility
+        return json as T;
+      },
+      options,
+      signal,
+    );
+  }
+
+  return {
+    async initUpload(params, signal) {
+      return request<InitUploadResponse>(
+        "POST",
+        "/upload/init",
+        params,
+        signal,
+      );
+    },
+
+    async getFile(fileId, signal) {
+      return request<Record<string, unknown>>(
+        "GET",
+        `/${fileId}`,
+        undefined,
+        signal,
+      );
+    },
+
+    async listArtifacts(fileId, signal) {
+      const response = await request<{ artifacts: ArtifactDescriptor[] }>(
+        "GET",
+        `/${fileId}/artifacts`,
+        undefined,
+        signal,
+      );
+      return response.artifacts;
+    },
+
+    async downloadUrl(fileId, options, signal) {
+      const path = options?.versionId
+        ? `/${fileId}/versions/${options.versionId}/download`
+        : `/${fileId}/download`;
+      return request<{ url: string }>("GET", path, undefined, signal);
+    },
+
+    async downloadArtifact(fileId, artifactId, signal) {
+      return request<{ url: string; headers?: Record<string, string> }>(
+        "GET",
+        `/${fileId}/artifacts/${artifactId}/download`,
+        undefined,
+        signal,
+      );
+    },
+
+    async getRenderDescriptor(fileId, options, signal) {
+      const search = new URLSearchParams({ intent: options.intent });
+      if (options.versionId) {
+        search.set("versionId", options.versionId);
+      }
+      return request<RenderDescriptor>(
+        "GET",
+        `/${fileId}/render?${search.toString()}`,
+        undefined,
+        signal,
+      );
+    },
+
+    async deleteFile(fileId, signal) {
+      await request<void>("DELETE", `/${fileId}`, undefined, signal);
+    },
+
+    async getUploadStatus(uploadSessionId, uploadSessionToken, signal) {
+      return request<UploadStatusResponse>(
+        "GET",
+        `/upload/${uploadSessionId}/status`,
+        undefined,
+        signal,
+        retryOptions,
+        uploadSessionToken ? { "x-upload-session-token": uploadSessionToken } : undefined,
+      );
+    },
+
+    async signPart(uploadSessionId, partNumber, contentLength, uploadSessionToken, signal) {
+      return request<SignPartResponse>(
+        "POST",
+        `/upload/${uploadSessionId}/parts/${partNumber}/sign`,
+        { contentLength },
+        signal,
+        retryOptions,
+        uploadSessionToken ? { "x-upload-session-token": uploadSessionToken } : undefined,
+      );
+    },
+
+    async completePart(uploadSessionId, partNumber, etag, size, uploadSessionToken, signal) {
+      return request<CompletePartResponse>(
+        "POST",
+        `/upload/${uploadSessionId}/parts/${partNumber}/complete`,
+        { etag, size },
+        signal,
+        retryOptions,
+        uploadSessionToken ? { "x-upload-session-token": uploadSessionToken } : undefined,
+      );
+    },
+
+    async completeUpload(uploadSessionId, uploadSessionToken, signal) {
+      return request<CompleteUploadResponse>(
+        "POST",
+        `/upload/${uploadSessionId}/complete`,
+        undefined,
+        signal,
+        retryOptions,
+        uploadSessionToken ? { "x-upload-session-token": uploadSessionToken } : undefined,
+      );
+    },
+
+    async abortUpload(uploadSessionId, uploadSessionToken, signal) {
+      return request<AbortUploadResponse>(
+        "POST",
+        `/upload/${uploadSessionId}/abort`,
+        undefined,
+        signal,
+        retryOptions,
+        uploadSessionToken ? { "x-upload-session-token": uploadSessionToken } : undefined,
+      );
+    },
+
+    async uploadPartToSignedUrl(url, headers, body, uploadSessionToken, signal) {
+      return withRetry(
+        async () => {
+          // If URL is relative (proxy upload), prepend baseUrl
+          const finalUrl = url.startsWith("/") ? `${baseUrl}${url}` : url;
+
+          const requestHeaders = {
+            ...headers,
+            ...(uploadSessionToken ? { "x-upload-session-token": uploadSessionToken } : {}),
+          };
+          const response = await fetch(finalUrl, {
+            method: "PUT",
+            headers: requestHeaders,
+            body,
+            signal,
+          });
+
+          if (!response.ok) {
+            throw new FileFnHttpError(
+              `Upload failed: HTTP ${response.status}`,
+              response.status,
+            );
+          }
+
+          // Check if response is JSON (proxy upload)
+          const contentType = response.headers.get("content-type");
+          if (contentType && contentType.includes("application/json")) {
+            const json = await response.json();
+            // Canonical envelope check
+            if (
+              json &&
+              typeof json === "object" &&
+              "ok" in json &&
+              json.ok === true &&
+              "data" in json
+            ) {
+              return {
+                etag: json.data.etag,
+                recorded: json.data.recorded,
+              };
+            }
+            // Fallback or raw json
+            return { etag: json.etag || "", recorded: json.recorded };
+          }
+
+          return { etag: response.headers.get("ETag") || "" };
+        },
+        retryOptions,
+        signal,
+      );
+    },
+  };
+}

--- a/filefn/client/src/index.test.ts
+++ b/filefn/client/src/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+
+describe('@filefn/client', () => {
+  it('should export createFileFnClient', async () => {
+    const mod = await import('./index.js');
+    expect(mod.createFileFnClient).toBeDefined();
+    expect(typeof mod.createFileFnClient).toBe('function');
+    expect(mod.generateFileId).toBeDefined();
+    expect(mod.createHeicPreprocessor).toBeDefined();
+  });
+});

--- a/filefn/client/src/index.ts
+++ b/filefn/client/src/index.ts
@@ -1,0 +1,419 @@
+import { createHttpClient, FileFnHttpError } from './client.js';
+import { UploadManager, generateFileId, prepareUploadInput } from './upload-manager.js';
+import type {
+  ArtifactDescriptor,
+  FileFnClientConfig,
+  PendingLocalDescriptor,
+  RenderDescriptor,
+  RenderIntent,
+  RenderPlaceholderKind,
+  UploadInput,
+  UploadHandle,
+  UploadHandleWithFileId,
+  UploadResult,
+} from './types.js';
+import type { UploadPreprocessor } from './preprocessing/types.js';
+import { createHeicPreprocessor } from './preprocessing/heic.js';
+
+import {
+  OPFSStore,
+  type PendingUpload,
+} from './offline/opfs-store.js';
+
+import {
+  OfflineSync,
+  shouldUseOfflineMode,
+  generateOfflineSessionId,
+} from './offline/sync.js';
+
+export type {
+  ArtifactDescriptor,
+  FileFnClientConfig,
+  PendingLocalDescriptor,
+  RenderDescriptor,
+  RenderIntent,
+  RenderPlaceholderKind,
+  UploadInput,
+  UploadHandle,
+  UploadHandleWithFileId,
+  UploadProgress,
+  UploadResult,
+  RetryOptions,
+  InitUploadResponse,
+  UploadStatusResponse,
+  SignPartResponse,
+  CompletePartResponse,
+  CompleteUploadResponse,
+  AbortUploadResponse,
+} from './types.js';
+export type {
+  HeicConversionFunction,
+  HeicConversionInput,
+  HeicConversionResult,
+  HeicPreprocessorOptions,
+  PendingLocalPreviewBehavior,
+  PendingLocalSourceKind,
+  PendingLocalSourceMetadata,
+  UploadPreprocessor,
+  UploadPreprocessorContext,
+  UploadPreprocessorResult,
+} from './preprocessing/types.js';
+
+export { FileFnHttpError } from './client.js';
+export { resolveRetryOptions, computeDelay, isRetryableError, withRetry } from './retry.js';
+export { createHeicPreprocessor, FILEFN_HEIC_CONVERSION_FAILED } from './preprocessing/heic.js';
+export { generateFileId } from './upload-manager.js';
+
+export type {
+  PendingUpload,
+  OPFSStoreConfig,
+} from './offline/opfs-store.js';
+
+export {
+  OPFSStore,
+} from './offline/opfs-store.js';
+
+export type {
+  UploadClient,
+  SyncConfig,
+  SyncProgress,
+  SyncResult,
+  ConnectivityChecker,
+} from './offline/sync.js';
+
+export {
+  OfflineSync,
+  shouldUseOfflineMode,
+  generateOfflineSessionId,
+} from './offline/sync.js';
+
+export interface FileFnClient {
+  uploadFile(input: UploadInput): UploadHandleWithFileId;
+  resumeUpload(
+    uploadSessionId: string,
+    file: Blob,
+    options?: { uploadSessionToken?: string; fileId?: string }
+  ): UploadHandle;
+  getFile(fileId: string): Promise<Record<string, unknown>>;
+  listArtifacts(fileId: string): Promise<ArtifactDescriptor[]>;
+  downloadUrl(fileId: string, options?: { versionId?: string }): Promise<string>;
+  downloadArtifact(fileId: string, artifactId: string): Promise<string>;
+  resolveRenderable(input: {
+    fileId: string;
+    intent: RenderIntent;
+    versionId?: string;
+    preferLocal?: boolean;
+  }): Promise<RenderDescriptor>;
+  deleteFile(fileId: string): Promise<void>;
+  getPendingLocalDescriptor(fileId: string): Promise<PendingLocalDescriptor | null>;
+}
+
+function createAbortError(): DOMException {
+  return new DOMException('Aborted', 'AbortError');
+}
+
+function createPlaceholderDescriptor(input: {
+  fileId: string;
+  versionId: string;
+  intent: RenderIntent;
+  state: 'processing' | 'unsupported' | 'pending-local';
+  mimeType: string;
+  name: string;
+  size: number;
+  placeholderKind: RenderPlaceholderKind;
+  warnings?: string[];
+}): RenderDescriptor {
+  return {
+    fileId: input.fileId,
+    versionId: input.versionId,
+    intent: input.intent,
+    state: input.state,
+    mimeType: input.mimeType,
+    name: input.name,
+    size: input.size,
+    source: {
+      mode: 'placeholder',
+      placeholderKind: input.placeholderKind,
+    },
+    warnings: input.warnings,
+  };
+}
+
+function resolvePendingLocalRenderable(
+  input: { intent: RenderIntent },
+  pending: PendingLocalDescriptor,
+): RenderDescriptor {
+  const base = {
+    fileId: pending.fileId,
+    versionId: pending.uploadSessionId,
+    intent: input.intent,
+    mimeType: pending.source.mimeType,
+    name: pending.source.fileName,
+    size: pending.source.size,
+  } as const;
+
+  if (input.intent === 'full' || input.intent === 'download') {
+    return {
+      ...base,
+      state: 'pending-local',
+      source: {
+        mode: 'original',
+        url: pending.source.url,
+      },
+    };
+  }
+
+  if (pending.source.previewBehavior === 'direct-image' && pending.source.kind === 'image') {
+    return {
+      ...base,
+      state: 'pending-local',
+      source: {
+        mode: 'original',
+        url: pending.source.url,
+      },
+    };
+  }
+
+  if (pending.source.previewBehavior === 'direct-pdf' && pending.source.kind === 'pdf') {
+    return {
+      ...base,
+      state: 'pending-local',
+      source: {
+        mode: 'original',
+        url: pending.source.url,
+      },
+    };
+  }
+
+  if (pending.source.kind === 'pdf' || pending.source.previewBehavior === 'deterministic-placeholder') {
+    return createPlaceholderDescriptor({
+      ...base,
+      state: 'pending-local',
+      placeholderKind: 'pdf-processing',
+      warnings: ['Pending local PDF preview artifact is not available yet.'],
+    });
+  }
+
+  if (pending.source.mimeType.startsWith('audio/') || pending.source.mimeType.startsWith('video/')) {
+    if (input.intent === 'preview') {
+      return {
+        ...base,
+        state: 'pending-local',
+        source: {
+          mode: 'original',
+          url: pending.source.url,
+        },
+      };
+    }
+  }
+
+  return createPlaceholderDescriptor({
+    ...base,
+    state: 'unsupported',
+    placeholderKind: input.intent === 'thumbnail' ? 'generic-file' : 'unsupported-preview',
+  });
+}
+
+function buildPreprocessors(config: FileFnClientConfig): UploadPreprocessor[] {
+  const preprocessors: UploadPreprocessor[] = [];
+  const heicEnabled = config.preprocessing?.heic?.enabled ?? true;
+  if (heicEnabled) {
+    preprocessors.push(createHeicPreprocessor(config.preprocessing?.heic));
+  }
+  if (config.preprocessing?.preprocessors?.length) {
+    preprocessors.push(...config.preprocessing.preprocessors);
+  }
+  return preprocessors;
+}
+
+export function createFileFnClient(config: FileFnClientConfig): FileFnClient {
+  const httpClient = createHttpClient(config);
+  const preprocessors = buildPreprocessors(config);
+  
+  let offlineSync: OfflineSync | undefined;
+  let offlineStore: OPFSStore | undefined;
+
+  function ensureOfflineSupport(): { store: OPFSStore; sync: OfflineSync } {
+    if (!config.offline?.enabled) {
+      const error = new Error('Offline uploads are disabled') as Error & { code?: string };
+      error.code = 'FILEFN_OFFLINE_DISABLED';
+      throw error;
+    }
+    if (!OPFSStore.isSupported()) {
+      const error = new Error('OPFS unavailable') as Error & { code?: string };
+      error.code = 'FILEFN_OFFLINE_UNSUPPORTED';
+      throw error;
+    }
+    if (!offlineStore || !offlineSync) {
+      const store = new OPFSStore({ rootDir: config.offline.opfsDir });
+      store.init().catch(() => {});
+      offlineStore = store;
+      offlineSync = new OfflineSync({
+        store,
+        client: {
+          uploadFile: async (input) => {
+            const manager = new UploadManager(httpClient);
+            manager.bindAbortSignal(input.signal);
+            return manager.startUpload(input);
+          }
+        }
+      });
+      offlineSync.startAutoSync();
+    }
+    return { store: offlineStore, sync: offlineSync };
+  }
+
+  return {
+    uploadFile(input: UploadInput): UploadHandleWithFileId {
+      const normalizedInput: UploadInput = {
+        ...input,
+        fileId: input.fileId ?? generateFileId(),
+      };
+
+      if (config.offline?.enabled && shouldUseOfflineMode(true)) {
+        const { store: activeOfflineStore, sync: activeOfflineSync } = ensureOfflineSupport();
+        const uploadSessionId = generateOfflineSessionId();
+        let aborted = false;
+        let rejectStage: ((reason?: unknown) => void) | undefined;
+        const stagePromise = new Promise<void>((resolve, reject) => {
+          rejectStage = reject;
+          void (async () => {
+            try {
+              const prepared = await prepareUploadInput(normalizedInput, [
+                ...preprocessors,
+                ...(normalizedInput.preprocessors || []),
+              ]);
+              if (aborted) {
+                throw createAbortError();
+              }
+
+              const fileData = await prepared.file.arrayBuffer();
+              if (aborted) {
+                throw createAbortError();
+              }
+
+              const pending: PendingUpload = {
+                uploadSessionId,
+                fileId: prepared.fileId,
+                policy: prepared.policy,
+                idempotencyKey: prepared.idempotencyKey,
+                fileName: prepared.fileName,
+                size: prepared.size,
+                mimeType: prepared.mimeType,
+                fileData,
+                localSource: prepared.localSource,
+                metadata: prepared.metadata,
+                createdAt: new Date().toISOString(),
+                retryCount: 0
+              };
+              await activeOfflineStore.stagePendingUpload(pending);
+              if (aborted) {
+                await activeOfflineStore.deletePendingUpload(uploadSessionId);
+                throw createAbortError();
+              }
+              if (activeOfflineSync.isOnline()) {
+                void activeOfflineSync.syncUpload(uploadSessionId).catch(() => {});
+              }
+              resolve();
+            } catch (error) {
+              reject(error);
+            }
+          })();
+        });
+        void stagePromise.catch(() => {});
+
+        const handle: UploadHandleWithFileId = {
+          uploadSessionId,
+          fileId: normalizedInput.fileId!,
+          abort: () => {
+            if (aborted) {
+              return;
+            }
+            aborted = true;
+            void activeOfflineSync.cancelUpload(uploadSessionId, createAbortError());
+            rejectStage?.(createAbortError());
+          },
+          onProgress: (_cb) => {
+            // Staging progress not implemented
+          },
+          done: async () => {
+            if (aborted) {
+              throw createAbortError();
+            }
+            await stagePromise;
+            if (aborted) {
+              throw createAbortError();
+            }
+            // Wait for sync to complete when online
+            return activeOfflineSync.waitForUpload(uploadSessionId);
+          }
+        };
+
+        return handle;
+      }
+
+      const manager = new UploadManager(httpClient, preprocessors);
+      return manager.createHandle(
+        normalizedInput,
+        (handle) => manager.startUpload(normalizedInput, handle),
+      ) as UploadHandleWithFileId;
+    },
+
+    resumeUpload(uploadSessionId: string, file: Blob, options?: { uploadSessionToken?: string; fileId?: string }): UploadHandle {
+      const manager = new UploadManager(httpClient);
+      const dummyInput: UploadInput = { policy: '', file, fileId: options?.fileId };
+      return manager.createHandle(
+        dummyInput,
+        (handle) => manager.resumeUpload(uploadSessionId, file, options?.uploadSessionToken, handle),
+        {
+          uploadSessionId,
+          uploadSessionToken: options?.uploadSessionToken,
+          fileId: options?.fileId,
+        },
+      );
+    },
+
+    async getFile(fileId: string): Promise<Record<string, unknown>> {
+      return httpClient.getFile(fileId);
+    },
+
+    async listArtifacts(fileId: string): Promise<ArtifactDescriptor[]> {
+      return httpClient.listArtifacts(fileId);
+    },
+
+    async downloadUrl(fileId: string, options?: { versionId?: string }): Promise<string> {
+      const response = await httpClient.downloadUrl(fileId, options);
+      return response.url;
+    },
+
+    async downloadArtifact(fileId: string, artifactId: string): Promise<string> {
+      const response = await httpClient.downloadArtifact(fileId, artifactId);
+      return response.url;
+    },
+
+    async resolveRenderable(input): Promise<RenderDescriptor> {
+      if (input.preferLocal && !input.versionId && config.offline?.enabled && OPFSStore.isSupported()) {
+        const pending = await (offlineStore ?? ensureOfflineSupport().store).getPendingLocalDescriptor(input.fileId);
+        if (pending) {
+          return resolvePendingLocalRenderable({ intent: input.intent }, pending);
+        }
+      }
+
+      return httpClient.getRenderDescriptor(input.fileId, {
+        intent: input.intent,
+        versionId: input.versionId,
+      });
+    },
+
+    async deleteFile(fileId: string): Promise<void> {
+      await httpClient.deleteFile(fileId);
+    },
+
+    async getPendingLocalDescriptor(fileId: string): Promise<PendingLocalDescriptor | null> {
+      if (!config.offline?.enabled || !OPFSStore.isSupported()) {
+        return null;
+      }
+      return (offlineStore ?? ensureOfflineSupport().store).getPendingLocalDescriptor(fileId);
+    },
+  };
+}

--- a/filefn/client/src/offline/opfs-store.ts
+++ b/filefn/client/src/offline/opfs-store.ts
@@ -1,0 +1,389 @@
+import type { PendingLocalDescriptor } from '../types.js';
+import type { PendingLocalSourceMetadata } from '../preprocessing/types.js';
+
+export interface PendingUpload {
+  uploadSessionId: string;
+  fileId?: string;
+  policy: string;
+  idempotencyKey?: string;
+  fileName: string;
+  size: number;
+  mimeType: string;
+  fileData: ArrayBuffer;
+  localSource?: PendingLocalSourceMetadata;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  retryCount: number;
+}
+
+function deriveFallbackLocalSource(upload: Pick<PendingUpload, 'fileName' | 'mimeType' | 'size'>): PendingLocalSourceMetadata {
+  if (upload.mimeType.startsWith('image/')) {
+    return {
+      mode: 'local-object-url',
+      kind: 'image',
+      fileName: upload.fileName,
+      mimeType: upload.mimeType,
+      size: upload.size,
+      opfsDataFile: 'data.bin',
+      previewBehavior: 'direct-image',
+    };
+  }
+
+  if (upload.mimeType === 'application/pdf') {
+    return {
+      mode: 'local-object-url',
+      kind: 'pdf',
+      fileName: upload.fileName,
+      mimeType: upload.mimeType,
+      size: upload.size,
+      opfsDataFile: 'data.bin',
+      previewBehavior: 'deterministic-placeholder',
+    };
+  }
+
+  return {
+    mode: 'local-object-url',
+    kind: 'binary',
+    fileName: upload.fileName,
+    mimeType: upload.mimeType,
+    size: upload.size,
+    opfsDataFile: 'data.bin',
+    previewBehavior: 'download-only',
+  };
+}
+
+export interface OPFSStoreConfig {
+  rootDir?: string;
+}
+
+export class OPFSStore {
+  private static readonly LOCAL_OBJECT_URL_REVOKE_DELAY_MS = 5 * 60 * 1000;
+  private rootDirName: string;
+  private rootDir: FileSystemDirectoryHandle | null = null;
+  private isInitialized = false;
+  private localObjectUrls = new Map<string, string>();
+  private localObjectUrlTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(config: OPFSStoreConfig = {}) {
+    this.rootDirName = config.rootDir || 'filefn-pending-uploads';
+  }
+
+  /**
+   * Check if OPFS is supported in the current environment.
+   */
+  static isSupported(): boolean {
+    return (
+      typeof navigator !== 'undefined' &&
+      'storage' in navigator &&
+      'getDirectory' in (navigator.storage as any)
+    );
+  }
+
+  /**
+   * Initialize the OPFS store by getting the root directory handle.
+   */
+  async init(): Promise<void> {
+    if (this.isInitialized) return;
+
+    if (!OPFSStore.isSupported()) {
+      throw new Error('OPFS is not supported in this environment');
+    }
+
+    try {
+      const opfsRoot = await (navigator.storage as any).getDirectory();
+      this.rootDir = await opfsRoot.getDirectoryHandle(this.rootDirName, { create: true });
+      this.isInitialized = true;
+    } catch (error) {
+      throw new Error(
+        `Failed to initialize OPFS: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * Stage a pending upload to OPFS.
+   */
+  async stagePendingUpload(upload: PendingUpload): Promise<void> {
+    await this.ensureInitialized();
+
+    const uploadDir = await this.rootDir!.getDirectoryHandle(upload.uploadSessionId, {
+      create: true,
+    });
+
+    try {
+      const dataFileHandle = await uploadDir.getFileHandle('data.bin', { create: true });
+      const dataWritable = await dataFileHandle.createWritable();
+      await dataWritable.write(upload.fileData);
+      await dataWritable.close();
+
+      const metadata = {
+        uploadSessionId: upload.uploadSessionId,
+        fileId: upload.fileId || upload.uploadSessionId,
+        policy: upload.policy,
+        idempotencyKey: upload.idempotencyKey,
+        fileName: upload.fileName,
+        size: upload.size,
+        mimeType: upload.mimeType,
+        localSource: upload.localSource || deriveFallbackLocalSource(upload),
+        metadata: upload.metadata,
+        createdAt: upload.createdAt,
+        retryCount: upload.retryCount,
+      };
+
+      const metaFileHandle = await uploadDir.getFileHandle('metadata.json', { create: true });
+      const metaWritable = await metaFileHandle.createWritable();
+      await metaWritable.write(JSON.stringify(metadata, null, 2));
+      await metaWritable.close();
+    } catch (error) {
+      await this.rootDir!.removeEntry(upload.uploadSessionId, { recursive: true }).catch(() => {});
+      throw error;
+    }
+  }
+
+  /**
+   * Get a pending upload from OPFS.
+   */
+  async getPendingUpload(uploadSessionId: string): Promise<PendingUpload | null> {
+    await this.ensureInitialized();
+
+    try {
+      const metadata = await this.readPendingMetadata(uploadSessionId);
+      if (!metadata) {
+        return null;
+      }
+
+      // Read file data
+      const uploadDir = await this.rootDir!.getDirectoryHandle(uploadSessionId);
+      const dataFileHandle = await uploadDir.getFileHandle('data.bin');
+      const dataFile = await dataFileHandle.getFile();
+      const fileData = await dataFile.arrayBuffer();
+
+      return {
+        ...metadata,
+        fileId: metadata.fileId || uploadSessionId,
+        localSource: metadata.localSource || deriveFallbackLocalSource(metadata),
+        fileData,
+      };
+    } catch (error) {
+      // Directory doesn't exist
+      return null;
+    }
+  }
+
+  /**
+   * List all pending uploads.
+   */
+  async listPendingUploads(): Promise<string[]> {
+    await this.ensureInitialized();
+
+    const uploadSessionIds: string[] = [];
+
+    for await (const entry of (this.rootDir as any).values()) {
+      if (entry.kind === 'directory') {
+        uploadSessionIds.push(entry.name);
+      }
+    }
+
+    return uploadSessionIds;
+  }
+
+  async getPendingUploadByFileId(fileId: string): Promise<PendingUpload | null> {
+    const uploadSessionIds = await this.listPendingUploads();
+    let bestMatch: Omit<PendingUpload, 'fileData'> | null = null;
+    for (const uploadSessionId of uploadSessionIds) {
+      const metadata = await this.readPendingMetadata(uploadSessionId);
+      if (metadata?.fileId !== fileId) {
+        continue;
+      }
+      if (!bestMatch || this.isPreferredPendingUpload(metadata, bestMatch)) {
+        bestMatch = metadata;
+      }
+    }
+    if (!bestMatch) {
+      return null;
+    }
+    return this.getPendingUpload(bestMatch.uploadSessionId);
+  }
+
+  async getPendingLocalDescriptor(fileId: string): Promise<PendingLocalDescriptor | null> {
+    const upload = await this.getPendingUploadByFileId(fileId);
+    if (!upload) {
+      return null;
+    }
+
+    if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+      const error = new Error('Local preview unavailable') as Error & { code?: string };
+      error.code = 'FILEFN_OFFLINE_PREVIEW_UNSUPPORTED';
+      throw error;
+    }
+
+    let url = this.localObjectUrls.get(upload.uploadSessionId);
+    if (!url) {
+      this.clearLocalObjectUrlTimer(upload.uploadSessionId);
+      const blob = new Blob([upload.fileData], { type: upload.mimeType });
+      url = URL.createObjectURL(blob);
+      this.localObjectUrls.set(upload.uploadSessionId, url);
+    }
+    const resolvedFileId = upload.fileId ?? upload.uploadSessionId;
+    const resolvedLocalSource = upload.localSource ?? deriveFallbackLocalSource(upload);
+
+    return {
+      fileId: resolvedFileId,
+      uploadSessionId: upload.uploadSessionId,
+      state: 'pending-local',
+      source: {
+        ...resolvedLocalSource,
+        url,
+      },
+    };
+  }
+
+  /**
+   * Delete a pending upload from OPFS.
+   */
+  async deletePendingUpload(uploadSessionId: string): Promise<void> {
+    await this.ensureInitialized();
+
+    try {
+      await this.rootDir!.removeEntry(uploadSessionId, { recursive: true });
+    } catch (error) {
+      // Ignore errors if directory doesn't exist
+    } finally {
+      this.scheduleLocalObjectUrlRevoke(uploadSessionId);
+    }
+  }
+
+  /**
+   * Increment retry count for a pending upload.
+   */
+  async incrementRetryCount(uploadSessionId: string): Promise<void> {
+    await this.ensureInitialized();
+    const metadata = await this.readPendingMetadata(uploadSessionId);
+    if (!metadata) return;
+
+    await this.writePendingMetadata(uploadSessionId, {
+      ...metadata,
+      retryCount: metadata.retryCount + 1,
+    });
+  }
+
+  /**
+   * Clear all pending uploads.
+   */
+  async clearAll(): Promise<void> {
+    await this.ensureInitialized();
+
+    const uploadSessionIds = await this.listPendingUploads();
+
+    for (const uploadSessionId of uploadSessionIds) {
+      await this.deletePendingUpload(uploadSessionId);
+    }
+  }
+
+  /**
+   * Get the total size of all pending uploads.
+   */
+  async getTotalSize(): Promise<number> {
+    await this.ensureInitialized();
+
+    let totalSize = 0;
+    const uploadSessionIds = await this.listPendingUploads();
+
+    for (const uploadSessionId of uploadSessionIds) {
+      const upload = await this.getPendingUpload(uploadSessionId);
+      if (upload) {
+        totalSize += upload.size;
+      }
+    }
+
+    return totalSize;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.isInitialized) {
+      await this.init();
+    }
+  }
+
+  private async readPendingMetadata(uploadSessionId: string): Promise<Omit<PendingUpload, 'fileData'> | null> {
+    try {
+      const uploadDir = await this.rootDir!.getDirectoryHandle(uploadSessionId);
+      const metaFileHandle = await uploadDir.getFileHandle('metadata.json');
+      const metaFile = await metaFileHandle.getFile();
+      const metaText = await metaFile.text();
+      const metadata = JSON.parse(metaText);
+      return {
+        ...metadata,
+        fileId: metadata.fileId || uploadSessionId,
+        localSource: metadata.localSource || deriveFallbackLocalSource(metadata),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async writePendingMetadata(
+    uploadSessionId: string,
+    metadata: Omit<PendingUpload, 'fileData'>,
+  ): Promise<void> {
+    await this.ensureInitialized();
+
+    const uploadDir = await this.rootDir!.getDirectoryHandle(uploadSessionId, {
+      create: true,
+    });
+    const metaFileHandle = await uploadDir.getFileHandle('metadata.json', { create: true });
+    const metaWritable = await metaFileHandle.createWritable();
+    await metaWritable.write(JSON.stringify(metadata, null, 2));
+    await metaWritable.close();
+  }
+
+  private revokeLocalObjectUrl(uploadSessionId: string): void {
+    this.clearLocalObjectUrlTimer(uploadSessionId);
+    const url = this.localObjectUrls.get(uploadSessionId);
+    if (!url) {
+      return;
+    }
+    this.localObjectUrls.delete(uploadSessionId);
+    if (typeof URL !== 'undefined' && typeof URL.revokeObjectURL === 'function') {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  private scheduleLocalObjectUrlRevoke(uploadSessionId: string): void {
+    if (!this.localObjectUrls.has(uploadSessionId)) {
+      return;
+    }
+    this.clearLocalObjectUrlTimer(uploadSessionId);
+    const timer = setTimeout(() => {
+      this.revokeLocalObjectUrl(uploadSessionId);
+    }, OPFSStore.LOCAL_OBJECT_URL_REVOKE_DELAY_MS);
+    this.localObjectUrlTimers.set(uploadSessionId, timer);
+  }
+
+  private clearLocalObjectUrlTimer(uploadSessionId: string): void {
+    const timer = this.localObjectUrlTimers.get(uploadSessionId);
+    if (!timer) {
+      return;
+    }
+    clearTimeout(timer);
+    this.localObjectUrlTimers.delete(uploadSessionId);
+  }
+
+  private isPreferredPendingUpload(
+    candidate: Omit<PendingUpload, 'fileData'>,
+    current: Omit<PendingUpload, 'fileData'>,
+  ): boolean {
+    const candidateTime = Date.parse(candidate.createdAt);
+    const currentTime = Date.parse(current.createdAt);
+    if (Number.isFinite(candidateTime) && Number.isFinite(currentTime) && candidateTime !== currentTime) {
+      return candidateTime > currentTime;
+    }
+    if (Number.isFinite(candidateTime) && !Number.isFinite(currentTime)) {
+      return true;
+    }
+    if (!Number.isFinite(candidateTime) && Number.isFinite(currentTime)) {
+      return false;
+    }
+    return candidate.uploadSessionId > current.uploadSessionId;
+  }
+}

--- a/filefn/client/src/offline/sync.ts
+++ b/filefn/client/src/offline/sync.ts
@@ -1,0 +1,414 @@
+import type { OPFSStore, PendingUpload } from './opfs-store.js';
+import { isRetryableError } from '../retry.js';
+
+export interface UploadClient {
+  uploadFile(input: {
+    policy: string;
+    file: File;
+    metadata?: Record<string, unknown>;
+    fileId?: string;
+    idempotencyKey?: string;
+    signal?: AbortSignal;
+  }): Promise<{ fileId: string; versionId: string }>;
+}
+
+export interface SyncConfig {
+  store: OPFSStore;
+  client: UploadClient;
+  maxRetries?: number;
+  retryDelayMs?: number;
+  onSyncProgress?: (progress: SyncProgress) => void;
+  onSyncComplete?: (result: SyncResult) => void;
+  onSyncError?: (error: Error, uploadSessionId: string) => void;
+}
+
+export interface SyncProgress {
+  totalPending: number;
+  completed: number;
+  failed: number;
+  current: string | null;
+}
+
+export interface SyncResult {
+  succeeded: string[];
+  failed: string[];
+  totalProcessed: number;
+}
+
+export interface ConnectivityChecker {
+  isOnline(): boolean;
+  onOnline(callback: () => void): () => void;
+  onOffline(callback: () => void): () => void;
+}
+
+type UploadCompletionListener = (result: { fileId: string; versionId: string } | Error) => void;
+
+export class OfflineSync {
+  private static readonly SETTLED_RESULT_TTL_MS = 5 * 60 * 1000;
+  private config: Required<SyncConfig>;
+  private isSyncing = false;
+  private connectivityChecker: ConnectivityChecker;
+  private listeners: Map<string, UploadCompletionListener[]> = new Map();
+  private settledResults: Map<string, { fileId: string; versionId: string } | Error> = new Map();
+  private settledResultTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private stopOnlineListener?: () => void;
+  private retryTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private cancelledUploads: Set<string> = new Set();
+  private activeSyncControllers: Map<string, AbortController> = new Map();
+  private inFlightSyncs: Map<string, Promise<{ fileId: string; versionId: string }>> = new Map();
+
+  constructor(config: SyncConfig) {
+    this.config = {
+      maxRetries: 3,
+      retryDelayMs: 1000,
+      onSyncProgress: () => {},
+      onSyncComplete: () => {},
+      onSyncError: () => {},
+      ...config,
+    };
+
+    // Default connectivity checker using browser APIs
+    this.connectivityChecker = this.createDefaultConnectivityChecker();
+  }
+
+  /**
+   * Start listening for online events and automatically sync when online.
+   */
+  startAutoSync(): void {
+    this.stopAutoSync();
+    this.stopOnlineListener = this.connectivityChecker.onOnline(() => {
+      void this.syncAll().catch(() => {});
+    });
+    if (this.connectivityChecker.isOnline()) {
+      void this.syncAll().catch(() => {});
+    }
+  }
+
+  /**
+   * Stop listening for online events.
+   */
+  stopAutoSync(): void {
+    this.stopOnlineListener?.();
+    this.stopOnlineListener = undefined;
+  }
+
+  /**
+   * Check if currently online.
+   */
+  isOnline(): boolean {
+    return this.connectivityChecker.isOnline();
+  }
+
+  /**
+   * Register a listener for a specific upload session completion.
+   */
+  waitForUpload(uploadSessionId: string): Promise<{ fileId: string; versionId: string }> {
+    const settled = this.settledResults.get(uploadSessionId);
+    if (settled) {
+      if (settled instanceof Error) {
+        return Promise.reject(settled);
+      }
+      return Promise.resolve(settled);
+    }
+
+    return new Promise((resolve, reject) => {
+      if (!this.listeners.has(uploadSessionId)) {
+        this.listeners.set(uploadSessionId, []);
+      }
+      this.listeners.get(uploadSessionId)!.push((result) => {
+        if (result instanceof Error) {
+          reject(result);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  }
+
+  private notifyListeners(uploadSessionId: string, result: { fileId: string; versionId: string } | Error) {
+    this.clearRetry(uploadSessionId);
+    this.clearSettledResult(uploadSessionId);
+    this.settledResults.set(uploadSessionId, result);
+    const expiry = setTimeout(() => {
+      this.clearSettledResult(uploadSessionId);
+      this.settledResults.delete(uploadSessionId);
+    }, OfflineSync.SETTLED_RESULT_TTL_MS);
+    this.settledResultTimers.set(uploadSessionId, expiry);
+    const listeners = this.listeners.get(uploadSessionId);
+    if (listeners) {
+      listeners.forEach(l => l(result));
+      this.listeners.delete(uploadSessionId);
+    }
+  }
+
+  /**
+   * Sync all pending uploads.
+   */
+  async syncAll(): Promise<SyncResult> {
+    if (this.isSyncing) {
+      // Return a promise that resolves when current sync finishes? 
+      // For simplicity, throw or ignore.
+      return { succeeded: [], failed: [], totalProcessed: 0 };
+    }
+
+    if (!this.isOnline()) {
+      throw new Error('Cannot sync while offline');
+    }
+
+    this.isSyncing = true;
+
+    try {
+      const pendingSessionIds = await this.config.store.listPendingUploads();
+
+      const result: SyncResult = {
+        succeeded: [],
+        failed: [],
+        totalProcessed: 0,
+      };
+
+      const progress: SyncProgress = {
+        totalPending: pendingSessionIds.length,
+        completed: 0,
+        failed: 0,
+        current: null,
+      };
+
+      for (const uploadSessionId of pendingSessionIds) {
+        if (this.cancelledUploads.has(uploadSessionId)) {
+          await this.config.store.deletePendingUpload(uploadSessionId);
+          continue;
+        }
+        progress.current = uploadSessionId;
+        this.config.onSyncProgress(progress);
+
+        try {
+          const uploadResult = await this.syncOne(uploadSessionId);
+          result.succeeded.push(uploadSessionId);
+          progress.completed += 1;
+          this.notifyListeners(uploadSessionId, uploadResult);
+        } catch (error) {
+          if (this.cancelledUploads.has(uploadSessionId)) {
+            this.cancelledUploads.delete(uploadSessionId);
+            continue;
+          }
+          const err = error instanceof Error ? error : new Error('Unknown error');
+          result.failed.push(uploadSessionId);
+          progress.failed += 1;
+          this.config.onSyncError(err, uploadSessionId);
+
+          // Check if we should notify listeners of failure (max retries reached)
+          const pending = await this.config.store.getPendingUpload(uploadSessionId);
+          if (pending && pending.retryCount >= this.config.maxRetries) {
+            this.notifyListeners(uploadSessionId, err);
+          } else if (pending && this.isOnline() && isRetryableError(err)) {
+            this.scheduleRetry(uploadSessionId);
+          } else {
+            this.notifyListeners(uploadSessionId, err);
+          }
+        }
+
+        result.totalProcessed += 1;
+        this.config.onSyncProgress(progress);
+      }
+
+      progress.current = null;
+      this.config.onSyncComplete(result);
+
+      return result;
+    } finally {
+      this.isSyncing = false;
+    }
+  }
+
+  /**
+   * Sync a single pending upload.
+   */
+  async syncOne(uploadSessionId: string): Promise<{ fileId: string; versionId: string }> {
+    const existing = this.inFlightSyncs.get(uploadSessionId);
+    if (existing) {
+      return existing;
+    }
+
+    const task = (async () => {
+      const pendingUpload = await this.config.store.getPendingUpload(uploadSessionId);
+
+      if (!pendingUpload) {
+        throw new Error(`Pending upload ${uploadSessionId} not found`);
+      }
+
+      if (pendingUpload.retryCount >= this.config.maxRetries) {
+        throw new Error(`Max retries exceeded for ${uploadSessionId}`);
+      }
+
+      try {
+        const controller = new AbortController();
+        this.activeSyncControllers.set(uploadSessionId, controller);
+        const file = new File([pendingUpload.fileData], pendingUpload.fileName, {
+          type: pendingUpload.mimeType,
+        });
+
+        const result = await this.config.client.uploadFile({
+          policy: pendingUpload.policy,
+          file,
+          metadata: pendingUpload.metadata,
+          fileId: pendingUpload.fileId,
+          idempotencyKey: pendingUpload.idempotencyKey,
+          signal: controller.signal,
+        });
+
+        await this.config.store.deletePendingUpload(uploadSessionId);
+        return result;
+      } catch (error) {
+        if (this.cancelledUploads.has(uploadSessionId) || (error instanceof DOMException && error.name === 'AbortError')) {
+          throw error;
+        }
+        await this.config.store.incrementRetryCount(uploadSessionId);
+        throw error;
+      } finally {
+        this.activeSyncControllers.delete(uploadSessionId);
+      }
+    })();
+
+    this.inFlightSyncs.set(uploadSessionId, task);
+    try {
+      return await task;
+    } finally {
+      if (this.inFlightSyncs.get(uploadSessionId) === task) {
+        this.inFlightSyncs.delete(uploadSessionId);
+      }
+    }
+  }
+
+  /**
+   * Manually trigger sync for a specific upload.
+   */
+  async syncUpload(uploadSessionId: string): Promise<void> {
+    if (this.cancelledUploads.has(uploadSessionId)) {
+      return;
+    }
+    if (!this.isOnline()) {
+      throw new Error('Cannot sync while offline');
+    }
+
+    try {
+      const result = await this.syncOne(uploadSessionId);
+      this.notifyListeners(uploadSessionId, result);
+    } catch (error) {
+      if (this.cancelledUploads.has(uploadSessionId)) {
+        this.cancelledUploads.delete(uploadSessionId);
+        return;
+      }
+      const err = error instanceof Error ? error : new Error('Unknown error');
+      const pending = await this.config.store.getPendingUpload(uploadSessionId);
+      if (pending && pending.retryCount >= this.config.maxRetries) {
+        this.notifyListeners(uploadSessionId, err);
+        return;
+      }
+      if (pending && this.isOnline() && isRetryableError(err)) {
+        this.scheduleRetry(uploadSessionId);
+        return;
+      }
+      this.notifyListeners(uploadSessionId, err);
+    }
+  }
+
+  /**
+   * Set a custom connectivity checker.
+   */
+  setConnectivityChecker(checker: ConnectivityChecker): void {
+    this.connectivityChecker = checker;
+  }
+
+  async cancelUpload(uploadSessionId: string, reason: Error = new DOMException('Aborted', 'AbortError')): Promise<void> {
+    this.cancelledUploads.add(uploadSessionId);
+    this.clearRetry(uploadSessionId);
+    this.activeSyncControllers.get(uploadSessionId)?.abort();
+    this.notifyListeners(uploadSessionId, reason);
+    await this.config.store.deletePendingUpload(uploadSessionId);
+  }
+
+  private scheduleRetry(uploadSessionId: string): void {
+    if (this.retryTimers.has(uploadSessionId)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(uploadSessionId);
+      void this.syncUpload(uploadSessionId).catch((error) => {
+        const err = error instanceof Error ? error : new Error('Unknown error');
+        this.config.onSyncError(err, uploadSessionId);
+      });
+    }, this.config.retryDelayMs);
+    this.retryTimers.set(uploadSessionId, timer);
+  }
+
+  private clearRetry(uploadSessionId: string): void {
+    const timer = this.retryTimers.get(uploadSessionId);
+    if (!timer) {
+      return;
+    }
+    clearTimeout(timer);
+    this.retryTimers.delete(uploadSessionId);
+  }
+
+  private clearSettledResult(uploadSessionId: string): void {
+    const timer = this.settledResultTimers.get(uploadSessionId);
+    if (!timer) {
+      return;
+    }
+    clearTimeout(timer);
+    this.settledResultTimers.delete(uploadSessionId);
+  }
+
+  private createDefaultConnectivityChecker(): ConnectivityChecker {
+    return {
+      isOnline: () => {
+        if (typeof navigator !== 'undefined' && 'onLine' in navigator) {
+          return navigator.onLine;
+        }
+        return true; // Assume online if can't detect
+      },
+      onOnline: (callback: () => void) => {
+        if (typeof window !== 'undefined') {
+          window.addEventListener('online', callback);
+        }
+        return () => {
+          if (typeof window !== 'undefined') {
+            window.removeEventListener('online', callback);
+          }
+        };
+      },
+      onOffline: (callback: () => void) => {
+        if (typeof window !== 'undefined') {
+          window.addEventListener('offline', callback);
+        }
+        return () => {
+          if (typeof window !== 'undefined') {
+            window.removeEventListener('offline', callback);
+          }
+        };
+      },
+    };
+  }
+}
+
+/**
+ * Check if offline mode is currently needed.
+ */
+export function shouldUseOfflineMode(isOfflineEnabled: boolean): boolean {
+  if (!isOfflineEnabled) return false;
+
+  // Check if online
+  if (typeof navigator !== 'undefined' && 'onLine' in navigator) {
+    return !navigator.onLine;
+  }
+
+  return false;
+}
+
+/**
+ * Generate a unique upload session ID for offline staging.
+ */
+export function generateOfflineSessionId(): string {
+  return `offline_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+}

--- a/filefn/client/src/preprocessing/heic.ts
+++ b/filefn/client/src/preprocessing/heic.ts
@@ -1,0 +1,137 @@
+import type {
+  HeicConversionFunction,
+  HeicConversionResult,
+  HeicPreprocessorOptions,
+  UploadPreprocessor,
+} from './types.js';
+
+export const FILEFN_HEIC_CONVERSION_FAILED = 'FILEFN_HEIC_CONVERSION_FAILED';
+
+type Heic2AnyLike = (input: {
+  blob: Blob;
+  toType: 'image/jpeg';
+  quality: number;
+}) => Promise<Blob | Blob[]>;
+
+function isHeicLike(fileName: string, mimeType: string): boolean {
+  return /^image\/hei(c|f)$/i.test(mimeType) || /\.(heic|heif)$/i.test(fileName);
+}
+
+function normalizeOutputFileName(fileName: string): string {
+  if (/\.(heic|heif)$/i.test(fileName)) {
+    return fileName.replace(/\.(heic|heif)$/i, '.jpg');
+  }
+  return `${fileName}.jpg`;
+}
+
+function toBlob(result: HeicConversionResult): Blob | File {
+  if (result instanceof Blob) {
+    return result;
+  }
+  return result.file;
+}
+
+function extractFileName(result: HeicConversionResult, fallback: string): string {
+  if (result instanceof Blob) {
+    return fallback;
+  }
+  if ('name' in result.file && typeof result.file.name === 'string' && result.file.name.length > 0) {
+    return result.file.name;
+  }
+  return result.fileName || fallback;
+}
+
+function extractMimeType(result: HeicConversionResult, fallback: string): string {
+  if (result instanceof Blob) {
+    return result.type || fallback;
+  }
+  return result.mimeType || result.file.type || fallback;
+}
+
+function buildClientError(code: string, message: string, cause?: unknown): Error & { code: string; cause?: unknown } {
+  const error = new Error(message) as Error & { code: string; cause?: unknown };
+  error.code = code;
+  if (cause !== undefined) {
+    error.cause = cause;
+  }
+  return error;
+}
+
+function resolveConverter(
+  options: HeicPreprocessorOptions,
+): HeicConversionFunction | undefined {
+  if (options.converter) {
+    return options.converter;
+  }
+
+  const globalConverter = (globalThis as typeof globalThis & { heic2any?: Heic2AnyLike }).heic2any;
+  if (typeof globalConverter !== 'function') {
+    return undefined;
+  }
+
+  return async ({ file, targetMimeType, quality }) => {
+    const blob = await globalConverter({
+      blob: file,
+      toType: targetMimeType,
+      quality,
+    });
+    if (Array.isArray(blob)) {
+      return blob[0];
+    }
+    return blob;
+  };
+}
+
+function toNamedFile(blob: Blob | File, fileName: string, mimeType: string): File | Blob {
+  if (typeof File !== 'undefined') {
+    return new File([blob], fileName, { type: mimeType });
+  }
+  return new Blob([blob], { type: mimeType });
+}
+
+export function createHeicPreprocessor(options: HeicPreprocessorOptions = {}): UploadPreprocessor {
+  return {
+    name: 'heic',
+    matches(context) {
+      return isHeicLike(context.fileName, context.mimeType);
+    },
+    async process(context) {
+      const converter = resolveConverter(options);
+      if (!converter) {
+        throw buildClientError(
+          FILEFN_HEIC_CONVERSION_FAILED,
+          'HEIC conversion is unavailable in this environment',
+        );
+      }
+
+      try {
+        const outputFileName = normalizeOutputFileName(context.fileName);
+        const converted = await converter({
+          file: context.file,
+          fileName: context.fileName,
+          mimeType: context.mimeType,
+          targetMimeType: 'image/jpeg',
+          quality: options.quality ?? 0.92,
+        });
+        const convertedMimeType = extractMimeType(converted, 'image/jpeg') || 'image/jpeg';
+        const namedFile = toNamedFile(toBlob(converted), extractFileName(converted, outputFileName), convertedMimeType);
+
+        return {
+          file: namedFile,
+          fileName: extractFileName(converted, outputFileName),
+          mimeType: convertedMimeType,
+          localSource: {
+            kind: 'image',
+            previewBehavior: 'direct-image',
+          },
+        };
+      } catch (error) {
+        throw buildClientError(
+          FILEFN_HEIC_CONVERSION_FAILED,
+          'HEIC conversion failed',
+          error,
+        );
+      }
+    },
+  };
+}

--- a/filefn/client/src/preprocessing/types.ts
+++ b/filefn/client/src/preprocessing/types.ts
@@ -1,0 +1,65 @@
+export type PendingLocalSourceKind = 'image' | 'pdf' | 'binary';
+export type PendingLocalPreviewBehavior =
+  | 'direct-image'
+  | 'direct-pdf'
+  | 'deterministic-placeholder'
+  | 'download-only';
+
+export interface PendingLocalSourceMetadata {
+  mode: 'local-object-url';
+  kind: PendingLocalSourceKind;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  opfsDataFile: string;
+  previewBehavior: PendingLocalPreviewBehavior;
+}
+
+export interface UploadPreprocessorContext {
+  fileId: string;
+  file: File | Blob;
+  fileName: string;
+  mimeType: string;
+  metadata?: Record<string, unknown>;
+  localSource: PendingLocalSourceMetadata;
+}
+
+export interface UploadPreprocessorResult {
+  file: File | Blob;
+  fileName?: string;
+  mimeType?: string;
+  metadata?: Record<string, unknown>;
+  localSource?: Partial<PendingLocalSourceMetadata>;
+}
+
+export interface UploadPreprocessor {
+  name: string;
+  matches(context: UploadPreprocessorContext): boolean | Promise<boolean>;
+  process(context: UploadPreprocessorContext): Promise<UploadPreprocessorResult>;
+}
+
+export interface HeicConversionInput {
+  file: File | Blob;
+  fileName: string;
+  mimeType: string;
+  targetMimeType: 'image/jpeg';
+  quality: number;
+}
+
+export type HeicConversionResult =
+  | Blob
+  | File
+  | {
+      file: File | Blob;
+      fileName?: string;
+      mimeType?: string;
+    };
+
+export type HeicConversionFunction = (
+  input: HeicConversionInput,
+) => Promise<HeicConversionResult>;
+
+export interface HeicPreprocessorOptions {
+  converter?: HeicConversionFunction;
+  quality?: number;
+}

--- a/filefn/client/src/retry.ts
+++ b/filefn/client/src/retry.ts
@@ -1,0 +1,98 @@
+import type { RetryOptions } from './types.js';
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+export interface ResolvedRetryOptions {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export function resolveRetryOptions(options?: RetryOptions): ResolvedRetryOptions {
+  return {
+    maxRetries: options?.maxRetries ?? DEFAULT_MAX_RETRIES,
+    baseDelayMs: options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+    maxDelayMs: options?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+  };
+}
+
+export function computeDelay(attempt: number, options: ResolvedRetryOptions): number {
+  const exponentialDelay = options.baseDelayMs * Math.pow(2, attempt);
+  const jitter = Math.random() * options.baseDelayMs * 0.5;
+  return Math.min(exponentialDelay + jitter, options.maxDelayMs);
+}
+
+export function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    if (error.name === 'AbortError') return false;
+    if ('status' in error) {
+      const status = (error as { status: number }).status;
+      return status >= 500 || status === 429 || status === 408;
+    }
+    const message = error.message.toLowerCase();
+    return message.includes('network') || message.includes('fetch');
+  }
+
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === 'number') {
+      return status >= 500 || status === 429 || status === 408;
+    }
+  }
+
+  if (typeof error === 'string') {
+    const message = error.toLowerCase();
+    return message.includes('network') || message.includes('fetch');
+  }
+
+  return false;
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: ResolvedRetryOptions,
+  signal?: AbortSignal
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (!isRetryableError(error)) {
+        throw error;
+      }
+
+      if (attempt < options.maxRetries) {
+        const delay = computeDelay(attempt, options);
+        await sleep(delay, signal);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    const timeoutId = setTimeout(resolve, ms);
+
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timeoutId);
+      reject(new DOMException('Aborted', 'AbortError'));
+    }, { once: true });
+  });
+}

--- a/filefn/client/src/types.ts
+++ b/filefn/client/src/types.ts
@@ -1,0 +1,153 @@
+import type {
+  HeicPreprocessorOptions,
+  PendingLocalSourceMetadata,
+  UploadPreprocessor,
+} from './preprocessing/types.js';
+
+export interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface FileFnClientConfig {
+  baseUrl: string;
+  getAuthHeaders?: () => Promise<Record<string, string>> | Record<string, string>;
+  retryOptions?: RetryOptions;
+  offline?: {
+    enabled: boolean;
+    opfsDir?: string;
+  };
+  preprocessing?: {
+    preprocessors?: UploadPreprocessor[];
+    heic?: HeicPreprocessorOptions & {
+      enabled?: boolean;
+    };
+  };
+}
+
+export interface UploadInput {
+  policy: string;
+  file: File | Blob;
+  fileName?: string;
+  metadata?: Record<string, unknown>;
+  fileId?: string;
+  idempotencyKey?: string;
+  preprocessors?: UploadPreprocessor[];
+}
+
+export interface UploadProgress {
+  bytesUploaded: number;
+  bytesTotal: number;
+  partsCompleted: number;
+  totalParts: number;
+}
+
+export interface UploadResult {
+  fileId: string;
+  versionId: string;
+}
+
+export type RenderIntent = 'thumbnail' | 'preview' | 'full' | 'download';
+export type RenderState = 'ready' | 'processing' | 'pending-local' | 'unsupported';
+export type RenderPlaceholderKind = 'generic-file' | 'pdf-processing' | 'unsupported-preview';
+
+export interface ArtifactDescriptor {
+  artifactId: string;
+  fileId: string;
+  versionId: string;
+  kind: string;
+  mimeType: string;
+  size: number;
+  createdAt: string;
+}
+
+export interface RenderDescriptor {
+  fileId: string;
+  versionId: string;
+  intent: RenderIntent;
+  state: RenderState;
+  mimeType: string;
+  name: string;
+  size: number;
+  source:
+    | {
+        mode: 'artifact';
+        artifactId: string;
+        artifactKind: string;
+        url: string;
+        headers?: Record<string, string>;
+      }
+    | {
+        mode: 'original';
+        url: string;
+        headers?: Record<string, string>;
+      }
+    | {
+        mode: 'placeholder';
+        placeholderKind: RenderPlaceholderKind;
+      };
+  warnings?: string[];
+}
+
+export interface UploadHandle {
+  uploadSessionId: string;
+  uploadSessionToken?: string;
+  fileId?: string;
+  onProgress(callback: (progress: UploadProgress) => void): void;
+  abort(): void;
+  done(): Promise<UploadResult>;
+}
+
+export interface UploadHandleWithFileId extends UploadHandle {
+  fileId: string;
+}
+
+export interface PendingLocalDescriptor {
+  fileId: string;
+  uploadSessionId: string;
+  state: 'pending-local';
+  source: PendingLocalSourceMetadata & {
+    url: string;
+  };
+}
+
+export interface InitUploadResponse {
+  uploadSessionId: string;
+  uploadSessionToken?: string;
+  uploadMode: string;
+  chunkSizeBytes: number;
+  totalParts: number;
+  expiresAt: string;
+}
+
+export interface UploadStatusResponse {
+  uploadSessionId?: string;
+  fileId?: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'aborted';
+  recordedParts: number[];
+  uploadedParts?: number[];
+  totalParts: number;
+  chunkSizeBytes: number;
+  fileSize: number;
+  expiresAt?: string;
+}
+
+export interface SignPartResponse {
+  url: string;
+  headers: Record<string, string>;
+  expiresAt: string;
+}
+
+export interface CompletePartResponse {
+  recorded: boolean;
+}
+
+export interface CompleteUploadResponse {
+  fileId: string;
+  versionId: string;
+}
+
+export interface AbortUploadResponse {
+  aborted: boolean;
+}

--- a/filefn/client/src/upload-manager.ts
+++ b/filefn/client/src/upload-manager.ts
@@ -1,0 +1,473 @@
+import type { HttpClient } from "./client.js";
+import type {
+  PendingLocalDescriptor,
+  UploadInput,
+  UploadHandle,
+  UploadProgress,
+  UploadResult,
+  UploadStatusResponse,
+} from "./types.js";
+import type {
+  PendingLocalSourceMetadata,
+  UploadPreprocessor,
+  UploadPreprocessorContext,
+} from "./preprocessing/types.js";
+
+interface UploadSession {
+  uploadSessionId: string;
+  totalParts: number;
+  chunkSizeBytes: number;
+  fileSize: number;
+}
+
+export interface PreparedUploadInput {
+  fileId: string;
+  file: File | Blob;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  metadata?: Record<string, unknown>;
+  policy: string;
+  idempotencyKey?: string;
+  localSource: PendingLocalSourceMetadata;
+}
+
+const FILE_ID_MISMATCH_ERROR = 'FILEFN_CLIENT_FILE_ID_MISMATCH';
+
+function createClientError(code: string, message: string, details?: Record<string, unknown>): Error & {
+  code: string;
+  details?: Record<string, unknown>;
+} {
+  const error = new Error(message) as Error & {
+    code: string;
+    details?: Record<string, unknown>;
+  };
+  error.code = code;
+  if (details) {
+    error.details = details;
+  }
+  return error;
+}
+
+function currentFileName(file: File | Blob, fallback?: string): string {
+  if (fallback) {
+    return fallback;
+  }
+  if (typeof File !== 'undefined' && file instanceof File) {
+    return file.name;
+  }
+  return 'blob';
+}
+
+function currentMimeType(file: File | Blob): string {
+  return file.type || 'application/octet-stream';
+}
+
+function derivePendingLocalSource(
+  fileName: string,
+  mimeType: string,
+  size: number,
+): PendingLocalSourceMetadata {
+  if (mimeType.startsWith('image/')) {
+    return {
+      mode: 'local-object-url',
+      kind: 'image',
+      fileName,
+      mimeType,
+      size,
+      opfsDataFile: 'data.bin',
+      previewBehavior: 'direct-image',
+    };
+  }
+
+  if (mimeType === 'application/pdf') {
+    return {
+      mode: 'local-object-url',
+      kind: 'pdf',
+      fileName,
+      mimeType,
+      size,
+      opfsDataFile: 'data.bin',
+      previewBehavior: 'deterministic-placeholder',
+    };
+  }
+
+  return {
+    mode: 'local-object-url',
+    kind: 'binary',
+    fileName,
+    mimeType,
+    size,
+    opfsDataFile: 'data.bin',
+    previewBehavior: 'download-only',
+  };
+}
+
+export function generateFileId(): string {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+    return `file_${cryptoApi.randomUUID().replace(/-/g, '')}`;
+  }
+
+  return `file_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export async function prepareUploadInput(
+  input: UploadInput,
+  preprocessors: UploadPreprocessor[] = [],
+): Promise<PreparedUploadInput> {
+  const fileId = input.fileId ?? generateFileId();
+  let prepared: PreparedUploadInput = {
+    fileId,
+    file: input.file,
+    fileName: currentFileName(input.file, input.fileName),
+    mimeType: currentMimeType(input.file),
+    size: input.file.size,
+    metadata: input.metadata,
+    policy: input.policy,
+    idempotencyKey: input.idempotencyKey,
+    localSource: derivePendingLocalSource(
+      currentFileName(input.file, input.fileName),
+      currentMimeType(input.file),
+      input.file.size,
+    ),
+  };
+
+  for (const preprocessor of preprocessors) {
+    const context: UploadPreprocessorContext = {
+      fileId,
+      file: prepared.file,
+      fileName: prepared.fileName,
+      mimeType: prepared.mimeType,
+      metadata: prepared.metadata,
+      localSource: prepared.localSource,
+    };
+    const matches = await preprocessor.matches(context);
+    if (!matches) {
+      continue;
+    }
+
+    const result = await preprocessor.process(context);
+    const nextFile = result.file;
+    const nextFileName = result.fileName || currentFileName(nextFile, prepared.fileName);
+    const derivedMimeType = currentMimeType(nextFile);
+    const nextMimeType =
+      result.mimeType ||
+      (derivedMimeType !== 'application/octet-stream' ? derivedMimeType : prepared.mimeType);
+    const nextMetadata = result.metadata ?? prepared.metadata;
+    const nextLocalSource = {
+      ...derivePendingLocalSource(nextFileName, nextMimeType, nextFile.size),
+      ...result.localSource,
+      fileName: nextFileName,
+      mimeType: nextMimeType,
+      size: nextFile.size,
+    };
+
+    prepared = {
+      ...prepared,
+      file: nextFile,
+      fileName: nextFileName,
+      mimeType: nextMimeType,
+      size: nextFile.size,
+      metadata: nextMetadata,
+      localSource: nextLocalSource,
+    };
+  }
+
+  return prepared;
+}
+
+export class UploadManager {
+  private progressCallbacks: Array<(progress: UploadProgress) => void> = [];
+  private abortController: AbortController;
+  private session: UploadSession | null = null;
+  private file: Blob | null = null;
+  private completedParts: Set<number> = new Set();
+  private bytesUploaded = 0;
+  private uploadSessionToken?: string;
+
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly preprocessors: UploadPreprocessor[] = [],
+  ) {
+    this.abortController = new AbortController();
+  }
+
+  bindAbortSignal(signal: AbortSignal | undefined): void {
+    if (!signal) {
+      return;
+    }
+    if (signal.aborted) {
+      this.abortController.abort();
+      return;
+    }
+    signal.addEventListener('abort', () => {
+      this.abortController.abort();
+    }, { once: true });
+  }
+
+  createHandle(
+    input: UploadInput,
+    startUpload: (handle: UploadHandle) => Promise<UploadResult>,
+    initialState?: Partial<Pick<UploadHandle, 'uploadSessionId' | 'uploadSessionToken' | 'fileId'>>,
+  ): UploadHandle {
+    let uploadPromise: Promise<UploadResult> | null = null;
+    const isResumedUpload = Boolean(initialState?.uploadSessionId);
+    const fileId = input.fileId ?? (isResumedUpload ? undefined : generateFileId());
+    if (!input.fileId && fileId) {
+      input.fileId = fileId;
+    }
+
+    const handle: UploadHandle = {
+      uploadSessionId: initialState?.uploadSessionId ?? "",
+      uploadSessionToken: initialState?.uploadSessionToken,
+      fileId: initialState?.fileId ?? fileId,
+      onProgress: (callback) => {
+        this.progressCallbacks.push(callback);
+      },
+      abort: () => {
+        this.abortController.abort();
+      },
+      done: async () => {
+        if (!uploadPromise) {
+          uploadPromise = startUpload(handle);
+        }
+        const result = await uploadPromise;
+        handle.uploadSessionId = this.session?.uploadSessionId || "";
+        handle.uploadSessionToken = this.uploadSessionToken;
+        handle.fileId = result.fileId;
+        return result;
+      },
+    };
+
+    return handle;
+  }
+
+  async startUpload(input: UploadInput, handle?: UploadHandle): Promise<UploadResult> {
+    const signal = this.abortController.signal;
+    const prepared = await prepareUploadInput(input, [...this.preprocessors, ...(input.preprocessors || [])]);
+    this.file = prepared.file;
+
+    const rawInit = await this.httpClient.initUpload(
+      {
+        policy: prepared.policy,
+        fileName: prepared.fileName,
+        size: prepared.size,
+        mimeType: prepared.mimeType,
+        metadata: prepared.metadata,
+        fileId: prepared.fileId,
+        idempotencyKey: prepared.idempotencyKey,
+      },
+      signal,
+    );
+
+    // Accept both unwrapped { uploadSessionId, ... } and envelope { data: { uploadSessionId, ... } }
+    const initResponse = (
+      rawInit && typeof rawInit === "object" && "uploadSessionId" in rawInit
+        ? rawInit
+        : (
+            rawInit as {
+              data?: {
+                uploadSessionId?: string;
+                totalParts?: number;
+                chunkSizeBytes?: number;
+                uploadSessionToken?: string;
+              };
+            }
+          )?.data
+    ) as {
+      uploadSessionId?: string;
+      totalParts?: number;
+      chunkSizeBytes?: number;
+      uploadSessionToken?: string;
+    };
+
+    const uploadSessionId = initResponse?.uploadSessionId;
+    if (!uploadSessionId) {
+      throw new Error(
+        "Failed to create upload session: no session ID returned. Ensure the server returns { ok: true, data: { uploadSessionId, totalParts, chunkSizeBytes, ... } } or { uploadSessionId, ... }.",
+      );
+    }
+
+    this.session = {
+      uploadSessionId,
+      totalParts: initResponse.totalParts ?? 1,
+      chunkSizeBytes: initResponse.chunkSizeBytes ?? 0,
+      fileSize: prepared.size,
+    };
+    this.uploadSessionToken = initResponse.uploadSessionToken;
+    if (handle) {
+      handle.uploadSessionId = uploadSessionId;
+      handle.uploadSessionToken = this.uploadSessionToken;
+      handle.fileId = prepared.fileId;
+    }
+
+    await this.uploadAllParts(signal);
+
+    const result = await this.httpClient.completeUpload(
+      this.session.uploadSessionId,
+      this.uploadSessionToken,
+      signal,
+    );
+
+    if (result.fileId !== prepared.fileId) {
+      throw createClientError(
+        FILE_ID_MISMATCH_ERROR,
+        'Server completed upload with a different fileId than the client requested',
+        {
+          expectedFileId: prepared.fileId,
+          actualFileId: result.fileId,
+        },
+      );
+    }
+
+    return result;
+  }
+
+  async resumeUpload(
+    uploadSessionId: string,
+    file: Blob,
+    uploadSessionToken?: string,
+    handle?: UploadHandle,
+  ): Promise<UploadResult> {
+    const signal = this.abortController.signal;
+    this.file = file;
+    this.uploadSessionToken = uploadSessionToken;
+
+    const status = await this.httpClient.getUploadStatus(
+      uploadSessionId,
+      this.uploadSessionToken,
+      signal,
+    );
+
+    this.session = {
+      uploadSessionId,
+      totalParts: status.totalParts,
+      chunkSizeBytes: status.chunkSizeBytes,
+      fileSize: status.fileSize,
+    };
+    if (handle) {
+      handle.uploadSessionId = uploadSessionId;
+      handle.uploadSessionToken = this.uploadSessionToken;
+      if (status.fileId) {
+        handle.fileId = status.fileId;
+      }
+    }
+
+    const recordedParts = status.recordedParts || status.uploadedParts || [];
+    this.completedParts = new Set(recordedParts);
+    this.bytesUploaded = this.calculateUploadedBytes(status);
+
+    this.emitProgress();
+
+    await this.uploadAllParts(signal);
+
+    const result = await this.httpClient.completeUpload(
+      uploadSessionId,
+      this.uploadSessionToken,
+      signal,
+    );
+    if (handle) {
+      handle.fileId = result.fileId;
+    }
+    return result;
+  }
+
+  private calculateUploadedBytes(status: UploadStatusResponse): number {
+    let bytes = 0;
+    const recordedParts = status.recordedParts || status.uploadedParts || [];
+    for (const partNum of recordedParts) {
+      if (partNum < status.totalParts) {
+        bytes += status.chunkSizeBytes;
+      } else {
+        bytes +=
+          status.fileSize - (status.totalParts - 1) * status.chunkSizeBytes;
+      }
+    }
+    return bytes;
+  }
+
+  private async uploadAllParts(signal: AbortSignal): Promise<void> {
+    if (!this.session || !this.file) {
+      throw new Error("No active session");
+    }
+
+    for (let partNum = 1; partNum <= this.session.totalParts; partNum++) {
+      if (signal.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
+      if (this.completedParts.has(partNum)) {
+        continue;
+      }
+
+      await this.uploadPart(partNum, signal);
+    }
+  }
+
+  private async uploadPart(
+    partNumber: number,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (!this.session || !this.file) {
+      throw new Error("No active session");
+    }
+
+    const { uploadSessionId, chunkSizeBytes, totalParts, fileSize } =
+      this.session;
+
+    const start = (partNumber - 1) * chunkSizeBytes;
+    const end = partNumber === totalParts ? fileSize : start + chunkSizeBytes;
+    const chunk = this.file.slice(start, end);
+
+    const signResponse = await this.httpClient.signPart(
+      uploadSessionId,
+      partNumber,
+      chunk.size,
+      this.uploadSessionToken,
+      signal,
+    );
+
+    const { etag, recorded } = await this.httpClient.uploadPartToSignedUrl(
+      signResponse.url,
+      signResponse.headers || {},
+      chunk,
+      this.uploadSessionToken,
+      signal,
+    );
+
+    if (!recorded) {
+      await this.httpClient.completePart(
+        uploadSessionId,
+        partNumber,
+        etag,
+        chunk.size,
+        this.uploadSessionToken,
+        signal,
+      );
+    }
+
+    this.completedParts.add(partNumber);
+    this.bytesUploaded += chunk.size;
+    this.emitProgress();
+  }
+
+  private emitProgress(): void {
+    if (!this.session) return;
+
+    const progress: UploadProgress = {
+      bytesUploaded: this.bytesUploaded,
+      bytesTotal: this.session.fileSize,
+      partsCompleted: this.completedParts.size,
+      totalParts: this.session.totalParts,
+    };
+
+    for (const callback of this.progressCallbacks) {
+      try {
+        callback(progress);
+      } catch {
+        // Ignore callback errors
+      }
+    }
+  }
+}

--- a/filefn/client/tests/envelope-unwrapping.test.ts
+++ b/filefn/client/tests/envelope-unwrapping.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Test vectors for client envelope unwrapping (CLIENT-001)
+ * 
+ * These tests encode the audit gaps for client/server contract:
+ * - TV-CLIENT-ENVELOPE-UNWRAP-001: Client unwraps server success envelopes
+ * - TV-CLIENT-UPLOAD-001: Client runs the canonical upload flow
+ * - TV-CLIENT-UPLOAD-NEG-001: Client surfaces server policy error
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFileFnClient } from '../src/index.js';
+import type { FileFnClient } from '../src/index.js';
+
+describe('@filefn/client envelope unwrapping', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('TV-CLIENT-ENVELOPE-UNWRAP-001: Unwrap success envelopes', () => {
+    it('should unwrap { ok: true, data } and return data to higher-level methods', async () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      // Mock server response for GET /file_0001
+      const serverResponse = {
+        ok: true,
+        data: { fileId: 'file_0001', fileName: 'test.png', mimeType: 'image/png' },
+        requestId: 'req_013',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => serverResponse,
+      });
+
+      // The client should have a getFile method that returns unwrapped data
+      // This will fail until the client implements getFile and envelope unwrapping
+      const file = await (client as any).getFile('file_0001');
+
+      expect(file.fileId).toBe('file_0001');
+      expect(file.fileName).toBe('test.png');
+      // Should NOT have ok, data wrapper
+      expect(file.ok).toBeUndefined();
+      expect(file.data).toBeUndefined();
+      expect((mockFetch.mock.calls[0]?.[1] as RequestInit)?.headers).not.toMatchObject({
+        'Content-Type': 'application/json',
+      });
+    });
+
+    it('should unwrap listArtifacts and downloadArtifact envelopes', async () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            data: {
+              artifacts: [
+                {
+                  artifactId: 'art_pdf_001',
+                  fileId: 'file_0001',
+                  versionId: 'ver_0001',
+                  kind: 'pdf-preview-page-1-large',
+                  mimeType: 'image/png',
+                  size: 123,
+                  createdAt: '2026-03-22T00:00:00Z',
+                },
+              ],
+            },
+            requestId: 'req_artifacts',
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            data: {
+              url: '/proxy/files/file_0001/artifacts/art_pdf_001/download',
+            },
+            requestId: 'req_artifact_download',
+          }),
+        });
+
+      const artifacts = await client.listArtifacts('file_0001');
+      const artifactUrl = await client.downloadArtifact('file_0001', 'art_pdf_001');
+
+      expect(artifacts).toEqual([
+        expect.objectContaining({
+          artifactId: 'art_pdf_001',
+          kind: 'pdf-preview-page-1-large',
+        }),
+      ]);
+      expect(artifactUrl).toBe('/proxy/files/file_0001/artifacts/art_pdf_001/download');
+    });
+
+    it('should unwrap render descriptor envelopes for resolveRenderable', async () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: {
+            fileId: 'file_pdf_1',
+            versionId: 'ver_pdf_1',
+            intent: 'preview',
+            state: 'ready',
+            mimeType: 'image/png',
+            name: 'note.pdf',
+            size: 456,
+            source: {
+              mode: 'artifact',
+              artifactId: 'art_pdf_1',
+              artifactKind: 'pdf-preview-page-1-large',
+              url: '/proxy/files/file_pdf_1/artifacts/art_pdf_1/download',
+            },
+          },
+          requestId: 'req_render',
+        }),
+      });
+
+      const descriptor = await client.resolveRenderable({
+        fileId: 'file_pdf_1',
+        intent: 'preview',
+      });
+
+      expect(descriptor).toMatchObject({
+        fileId: 'file_pdf_1',
+        versionId: 'ver_pdf_1',
+        intent: 'preview',
+        state: 'ready',
+        source: {
+          mode: 'artifact',
+          artifactKind: 'pdf-preview-page-1-large',
+          url: '/proxy/files/file_pdf_1/artifacts/art_pdf_1/download',
+        },
+      });
+    });
+
+    it('should unwrap upload init response and set uploadSessionId after done()', async () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      // Server sends canonical envelope for init
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: {
+            uploadSessionId: 'upl_0001',
+            uploadMode: 'multipart-signed-url',
+            chunkSizeBytes: 8388608,
+            totalParts: 1,
+            expiresAt: '2026-01-25T13:46:33Z',
+          },
+          warnings: [],
+          requestId: 'req_001',
+        }),
+      });
+
+      // Mock sign part response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: {
+            url: 'https://storage.test/upload/stor_upl_0001/part/1',
+            headers: { 'content-type': 'image/png' },
+            expiresAt: '2026-01-24T14:01:33Z',
+          },
+          requestId: 'req_005',
+        }),
+      });
+
+      // Mock upload to signed URL
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ ETag: 'etag_part_1' }),
+      });
+
+      // Mock complete part response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: { recorded: true },
+          requestId: 'req_007',
+        }),
+      });
+
+      // Mock complete upload response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: { fileId: 'file_0001', versionId: 'ver_0001' },
+          requestId: 'req_010',
+        }),
+      });
+
+      // Internal initUpload should return the unwrapped data
+      const file = new File([new Uint8Array([1])], 'avatar.png', { type: 'image/png' });
+      const handle = client.uploadFile({
+        policy: 'user-avatar',
+        file,
+        fileId: 'file_0001',
+      });
+
+      // The uploadSessionId should be set after the upload completes
+      await handle.done();
+
+      // The handle should have uploadSessionId set (from unwrapped data)
+      expect(handle.uploadSessionId).toBe('upl_0001');
+    });
+  });
+
+  describe('TV-CLIENT-UPLOAD-001: Canonical upload flow', () => {
+    it('should complete upload and return { fileId, versionId }', async () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      // Mock init response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: {
+            uploadSessionId: 'upl_0001',
+            uploadMode: 'multipart-signed-url',
+            chunkSizeBytes: 8388608,
+            totalParts: 1,
+            expiresAt: '2026-01-25T13:46:33Z',
+          },
+          requestId: 'req_001',
+        }),
+      });
+
+      // Mock sign part response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: {
+            url: 'https://storage.test/upload/stor_upl_0001/part/1',
+            headers: { 'content-type': 'image/png' },
+            expiresAt: '2026-01-24T14:01:33Z',
+          },
+          requestId: 'req_005',
+        }),
+      });
+
+      // Mock upload to signed URL
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ ETag: 'etag_part_1' }),
+      });
+
+      // Mock complete part response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: { recorded: true },
+          requestId: 'req_007',
+        }),
+      });
+
+      // Mock complete upload response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: { fileId: 'file_0001', versionId: 'ver_0001' },
+          requestId: 'req_010',
+        }),
+      });
+
+      const file = new File([new Uint8Array([1])], 'avatar.png', { type: 'image/png' });
+      const handle = client.uploadFile({
+        policy: 'user-avatar',
+        file,
+        fileId: 'file_0001',
+      });
+
+      const result = await handle.done();
+
+      expect(result.fileId).toBe('file_0001');
+      expect(result.versionId).toBe('ver_0001');
+    });
+  });
+
+  describe('TV-CLIENT-UPLOAD-NEG-001: Client surfaces server policy error', () => {
+    it('should surface structured error with code from server', async () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      // Mock server error response
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: async () => ({
+          ok: false,
+          error: {
+            code: 'FILEFN_POLICY_CONTENT_TYPE_NOT_ALLOWED',
+            message: 'Content type not allowed',
+            details: { policy: 'user-avatar', mimeType: 'image/gif' },
+          },
+          requestId: 'req_002',
+        }),
+        text: async () => 'Bad Request',
+      });
+
+      const file = new File([new Uint8Array([1])], 'avatar.gif', { type: 'image/gif' });
+      const handle = client.uploadFile({
+        policy: 'user-avatar',
+        file,
+      });
+
+      // The error should include the structured error from server
+      // This will fail until client properly surfaces error envelopes
+      await expect(handle.done()).rejects.toMatchObject({
+        body: {
+          ok: false,
+          error: {
+            code: 'FILEFN_POLICY_CONTENT_TYPE_NOT_ALLOWED',
+          },
+        },
+      });
+    });
+  });
+
+  describe('Client sends correct request fields', () => {
+    it('should send size and mimeType (not fileSize and contentType) to upload init', async () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      let capturedBody: any = null;
+      let initCalled = false;
+
+      mockFetch.mockImplementation(async (url: string, options: any) => {
+        if (url.includes('/upload/init')) {
+          initCalled = true;
+          capturedBody = JSON.parse(options.body);
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              ok: true,
+              data: {
+                uploadSessionId: 'upl_0001',
+                uploadMode: 'multipart-signed-url',
+                chunkSizeBytes: 8388608,
+                totalParts: 1,
+                expiresAt: '2026-01-25T13:46:33Z',
+              },
+            }),
+          };
+        }
+        if (url.includes('/parts/') && url.includes('/sign')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              ok: true,
+              data: {
+                url: 'https://storage.test/upload',
+                headers: { 'content-type': 'image/png' },
+                expiresAt: '2026-01-25T14:00:00Z',
+              },
+            }),
+          };
+        }
+        if (url.includes('storage.test')) {
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers({ ETag: 'etag1' }),
+          };
+        }
+        if (url.includes('/complete')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              ok: true,
+              data: { recorded: true, fileId: 'file_0001', versionId: 'ver_0001' },
+            }),
+          };
+        }
+        // Return default for other requests
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, data: {} }),
+          headers: new Headers(),
+        };
+      });
+
+      const file = new File([new Uint8Array([1, 2, 3])], 'avatar.png', { type: 'image/png' });
+      const handle = client.uploadFile({
+        policy: 'user-avatar',
+        file,
+        fileId: 'file_0001',
+      });
+
+      // Actually complete the upload to ensure init is called
+      await handle.done();
+
+      // Verify init was called
+      expect(initCalled).toBe(true);
+
+      // The client should send `size` and `mimeType`, NOT `fileSize` and `contentType`
+      // This is the core audit gap - client/server field name mismatch
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody.size).toBe(3);
+      expect(capturedBody.mimeType).toBe('image/png');
+      // Should NOT have the old field names
+      expect(capturedBody.fileSize).toBeUndefined();
+      expect(capturedBody.contentType).toBeUndefined();
+    });
+  });
+});
+
+describe('@filefn/client public API surface', () => {
+  describe('Client exposes required methods', () => {
+    it('should expose uploadFile, getFile, listArtifacts, downloadUrl, downloadArtifact, resolveRenderable, deleteFile', () => {
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      }) as any;
+
+      // These are required by the spec
+      expect(typeof client.uploadFile).toBe('function');
+      expect(typeof client.getFile).toBe('function');
+      expect(typeof client.listArtifacts).toBe('function');
+      expect(typeof client.downloadUrl).toBe('function');
+      expect(typeof client.downloadArtifact).toBe('function');
+      expect(typeof client.resolveRenderable).toBe('function');
+      expect(typeof client.deleteFile).toBe('function');
+    });
+  });
+
+  describe('UploadHandle interface', () => {
+    it('should have uploadSessionId, abort, onProgress, done', () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          data: {
+            uploadSessionId: 'upl_0001',
+            uploadMode: 'multipart-signed-url',
+            chunkSizeBytes: 8388608,
+            totalParts: 1,
+            expiresAt: '2026-01-25T13:46:33Z',
+          },
+        }),
+      }));
+
+      const client = createFileFnClient({
+        baseUrl: 'https://api.test/files',
+      });
+
+      const file = new File([new Uint8Array([1])], 'test.png', { type: 'image/png' });
+      const handle = client.uploadFile({ policy: 'test', file, fileId: 'file_handle_001' });
+
+      expect(handle.uploadSessionId).toBeDefined();
+      expect(handle.fileId).toBe('file_handle_001');
+      expect(typeof handle.abort).toBe('function');
+      expect(typeof handle.onProgress).toBe('function');
+      expect(typeof handle.done).toBe('function');
+    });
+  });
+});

--- a/filefn/client/tests/offline.test.ts
+++ b/filefn/client/tests/offline.test.ts
@@ -1,0 +1,666 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OPFSStore } from '../src/offline/opfs-store.js';
+import { OfflineSync, shouldUseOfflineMode, generateOfflineSessionId } from '../src/offline/sync.js';
+import type { PendingUpload } from '../src/offline/opfs-store.js';
+import type { ConnectivityChecker, UploadClient } from '../src/offline/sync.js';
+
+// Mock OPFS API
+class MockFileSystemDirectoryHandle {
+  private entries = new Map<string, MockFileSystemDirectoryHandle | MockFileSystemFileHandle>();
+
+  async getDirectoryHandle(name: string, options?: { create?: boolean }) {
+    if (!this.entries.has(name)) {
+      if (options?.create) {
+        const dir = new MockFileSystemDirectoryHandle();
+        this.entries.set(name, dir);
+        return dir;
+      }
+      throw new Error(`Directory ${name} not found`);
+    }
+    const entry = this.entries.get(name)!;
+    if (!(entry instanceof MockFileSystemDirectoryHandle)) {
+      throw new Error(`${name} is not a directory`);
+    }
+    return entry;
+  }
+
+  async getFileHandle(name: string, options?: { create?: boolean }) {
+    if (!this.entries.has(name)) {
+      if (options?.create) {
+        const file = new MockFileSystemFileHandle();
+        this.entries.set(name, file);
+        return file;
+      }
+      throw new Error(`File ${name} not found`);
+    }
+    const entry = this.entries.get(name)!;
+    if (!(entry instanceof MockFileSystemFileHandle)) {
+      throw new Error(`${name} is not a file`);
+    }
+    return entry;
+  }
+
+  async removeEntry(name: string, options?: { recursive?: boolean }) {
+    void options;
+    this.entries.delete(name);
+  }
+
+  async *values() {
+    for (const [name, entry] of this.entries.entries()) {
+      yield {
+        name,
+        kind: entry instanceof MockFileSystemDirectoryHandle ? 'directory' : 'file',
+      };
+    }
+  }
+}
+
+class MockFileSystemFileHandle {
+  private content: ArrayBuffer | string = new ArrayBuffer(0);
+
+  async createWritable() {
+    return {
+      write: async (data: ArrayBuffer | string) => {
+        this.content = data;
+      },
+      close: async () => {},
+    };
+  }
+
+  async getFile() {
+    return {
+      arrayBuffer: async () => {
+        if (typeof this.content === 'string') {
+          return new TextEncoder().encode(this.content).buffer;
+        }
+        return this.content;
+      },
+      text: async () => {
+        if (typeof this.content === 'string') {
+          return this.content;
+        }
+        return new TextDecoder().decode(this.content);
+      },
+    };
+  }
+}
+
+describe('OPFSStore', () => {
+  let mockRoot: MockFileSystemDirectoryHandle;
+
+  beforeEach(() => {
+    mockRoot = new MockFileSystemDirectoryHandle();
+
+    // Mock navigator.storage
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory: async () => mockRoot,
+      },
+    });
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:pending-local'),
+    });
+  });
+
+  describe('TV-CLIENT-OFFLINE-NEG-001: OPFS unavailable', () => {
+    it('should detect when OPFS is not supported', () => {
+      vi.stubGlobal('navigator', undefined);
+
+      const isSupported = OPFSStore.isSupported();
+      expect(isSupported).toBe(false);
+
+      // Restore for other tests
+      vi.stubGlobal('navigator', {
+        storage: {
+          getDirectory: async () => mockRoot,
+        },
+      });
+    });
+
+    it('should throw error when initializing without OPFS support', async () => {
+      vi.stubGlobal('navigator', undefined);
+
+      const store = new OPFSStore();
+
+      await expect(store.init()).rejects.toThrow('OPFS is not supported');
+
+      // Restore for other tests
+      vi.stubGlobal('navigator', {
+        storage: {
+          getDirectory: async () => mockRoot,
+        },
+      });
+    });
+
+    it('should throw FILEFN_OFFLINE_UNSUPPORTED equivalent error', async () => {
+      vi.stubGlobal('navigator', undefined);
+
+      const store = new OPFSStore();
+
+      try {
+        await store.init();
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('OPFS is not supported');
+      }
+
+      // Restore for other tests
+      vi.stubGlobal('navigator', {
+        storage: {
+          getDirectory: async () => mockRoot,
+        },
+      });
+    });
+  });
+
+  describe('TV-CLIENT-OFFLINE-001: Staging and syncing', () => {
+    it('should stage pending upload in OPFS', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      const testData = new TextEncoder().encode('Test file content');
+      const pendingUpload: PendingUpload = {
+        uploadSessionId: 'offline_001',
+        policy: 'test-policy',
+        fileName: 'test.txt',
+        size: testData.length,
+        mimeType: 'text/plain',
+        fileData: testData.buffer,
+        metadata: { userId: 'user_123' },
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      };
+
+      await store.stagePendingUpload(pendingUpload);
+
+      const retrieved = await store.getPendingUpload('offline_001');
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.uploadSessionId).toBe('offline_001');
+      expect(retrieved!.policy).toBe('test-policy');
+      expect(retrieved!.fileName).toBe('test.txt');
+      expect(retrieved!.size).toBe(testData.length);
+      expect(retrieved!.mimeType).toBe('text/plain');
+      expect(new Uint8Array(retrieved!.fileData)).toEqual(testData);
+      expect(retrieved!.fileId).toBe('offline_001');
+      expect(retrieved!.localSource).toMatchObject({
+        mode: 'local-object-url',
+        previewBehavior: 'download-only',
+      });
+    });
+
+    it('TV-CLIENT-002: should resolve a pending-local descriptor by fileId', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      await store.stagePendingUpload({
+        uploadSessionId: 'offline_img_001',
+        fileId: 'file_local_img',
+        policy: 'images',
+        fileName: 'photo.jpg',
+        size: 12,
+        mimeType: 'image/jpeg',
+        fileData: new TextEncoder().encode('image-bytes').buffer,
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      const descriptor = await store.getPendingLocalDescriptor('file_local_img');
+
+      expect(descriptor).toEqual({
+        fileId: 'file_local_img',
+        uploadSessionId: 'offline_img_001',
+        state: 'pending-local',
+        source: expect.objectContaining({
+          mode: 'local-object-url',
+          kind: 'image',
+          fileName: 'photo.jpg',
+          mimeType: 'image/jpeg',
+          previewBehavior: 'direct-image',
+          url: 'blob:pending-local',
+        }),
+      });
+    });
+
+    it('prefers the newest pending upload when a fileId is reused', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      await store.stagePendingUpload({
+        uploadSessionId: 'offline_old_001',
+        fileId: 'file_reused',
+        policy: 'images',
+        fileName: 'older.jpg',
+        size: 12,
+        mimeType: 'image/jpeg',
+        fileData: new TextEncoder().encode('old').buffer,
+        createdAt: '2026-04-02T10:00:00.000Z',
+        retryCount: 0,
+      });
+      await store.stagePendingUpload({
+        uploadSessionId: 'offline_new_001',
+        fileId: 'file_reused',
+        policy: 'images',
+        fileName: 'newer.jpg',
+        size: 12,
+        mimeType: 'image/jpeg',
+        fileData: new TextEncoder().encode('new').buffer,
+        createdAt: '2026-04-02T11:00:00.000Z',
+        retryCount: 0,
+      });
+
+      const descriptor = await store.getPendingLocalDescriptor('file_reused');
+
+      expect(descriptor?.uploadSessionId).toBe('offline_new_001');
+      expect(descriptor?.source.fileName).toBe('newer.jpg');
+    });
+
+    it('should list all pending uploads', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      const uploads = [
+        { uploadSessionId: 'offline_001', policy: 'p1', fileName: 'f1.txt', size: 10, mimeType: 'text/plain', fileData: new ArrayBuffer(10), createdAt: new Date().toISOString(), retryCount: 0 },
+        { uploadSessionId: 'offline_002', policy: 'p2', fileName: 'f2.txt', size: 20, mimeType: 'text/plain', fileData: new ArrayBuffer(20), createdAt: new Date().toISOString(), retryCount: 0 },
+        { uploadSessionId: 'offline_003', policy: 'p3', fileName: 'f3.txt', size: 30, mimeType: 'text/plain', fileData: new ArrayBuffer(30), createdAt: new Date().toISOString(), retryCount: 0 },
+      ];
+
+      for (const upload of uploads) {
+        await store.stagePendingUpload(upload);
+      }
+
+      const list = await store.listPendingUploads();
+
+      expect(list).toHaveLength(3);
+      expect(list).toContain('offline_001');
+      expect(list).toContain('offline_002');
+      expect(list).toContain('offline_003');
+    });
+
+    it('should delete pending upload after successful sync', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      const pendingUpload: PendingUpload = {
+        uploadSessionId: 'offline_001',
+        policy: 'test-policy',
+        fileName: 'test.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(100),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      };
+
+      await store.stagePendingUpload(pendingUpload);
+
+      let retrieved = await store.getPendingUpload('offline_001');
+      expect(retrieved).not.toBeNull();
+
+      await store.deletePendingUpload('offline_001');
+
+      retrieved = await store.getPendingUpload('offline_001');
+      expect(retrieved).toBeNull();
+    });
+
+    it('should increment retry count', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      const pendingUpload: PendingUpload = {
+        uploadSessionId: 'offline_001',
+        policy: 'test-policy',
+        fileName: 'test.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(100),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      };
+
+      await store.stagePendingUpload(pendingUpload);
+
+      await store.incrementRetryCount('offline_001');
+
+      const retrieved = await store.getPendingUpload('offline_001');
+      expect(retrieved!.retryCount).toBe(1);
+
+      await store.incrementRetryCount('offline_001');
+
+      const retrieved2 = await store.getPendingUpload('offline_001');
+      expect(retrieved2!.retryCount).toBe(2);
+    });
+
+    it('cleans up partial staging directories when metadata write fails', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      const rootDir = (store as any).rootDir;
+      const originalGetDirectoryHandle = rootDir.getDirectoryHandle.bind(rootDir);
+      rootDir.getDirectoryHandle = async (name: string, options?: { create?: boolean }) => {
+        const dir = await originalGetDirectoryHandle(name, options);
+        const originalGetFileHandle = dir.getFileHandle.bind(dir);
+        dir.getFileHandle = async (fileName: string, fileOptions?: { create?: boolean }) => {
+          const handle = await originalGetFileHandle(fileName, fileOptions);
+          if (fileName === 'metadata.json') {
+            return {
+              async createWritable() {
+                return {
+                  write: async () => {
+                    throw new Error('metadata write failed');
+                  },
+                  close: async () => {},
+                };
+              },
+            };
+          }
+          return handle;
+        };
+        return dir;
+      };
+
+      const pendingUpload: PendingUpload = {
+        uploadSessionId: 'offline_partial_001',
+        policy: 'test-policy',
+        fileName: 'test.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(100),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      };
+
+      await expect(store.stagePendingUpload(pendingUpload)).rejects.toThrow('metadata write failed');
+      expect(await store.listPendingUploads()).toEqual([]);
+    });
+
+    it('should calculate total size of pending uploads', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      await store.stagePendingUpload({
+        uploadSessionId: 'offline_001',
+        policy: 'p',
+        fileName: 'f1.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(100),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      await store.stagePendingUpload({
+        uploadSessionId: 'offline_002',
+        policy: 'p',
+        fileName: 'f2.txt',
+        size: 250,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(250),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      const totalSize = await store.getTotalSize();
+      expect(totalSize).toBe(350);
+    });
+
+    it('should clear all pending uploads', async () => {
+      const store = new OPFSStore();
+      await store.init();
+
+      await store.stagePendingUpload({
+        uploadSessionId: 'offline_001',
+        policy: 'p',
+        fileName: 'f1.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(100),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      await store.stagePendingUpload({
+        uploadSessionId: 'offline_002',
+        policy: 'p',
+        fileName: 'f2.txt',
+        size: 200,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(200),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      let list = await store.listPendingUploads();
+      expect(list).toHaveLength(2);
+
+      await store.clearAll();
+
+      list = await store.listPendingUploads();
+      expect(list).toHaveLength(0);
+    });
+  });
+});
+
+describe('OfflineSync', () => {
+  let mockStore: OPFSStore;
+  let mockClient: UploadClient;
+  let mockConnectivityChecker: ConnectivityChecker;
+
+  beforeEach(() => {
+    const mockRoot = new MockFileSystemDirectoryHandle();
+
+    vi.stubGlobal('navigator', {
+      storage: {
+        getDirectory: async () => mockRoot,
+      },
+      onLine: true,
+    });
+
+    mockStore = new OPFSStore();
+
+    mockClient = {
+      uploadFile: vi.fn().mockResolvedValue({ fileId: 'file_001', versionId: 'ver_001' }),
+    };
+
+    mockConnectivityChecker = {
+      isOnline: () => true,
+      onOnline: vi.fn(),
+      onOffline: vi.fn(),
+    };
+  });
+
+  describe('Sync functionality', () => {
+    it('should sync all pending uploads when online', async () => {
+      await mockStore.init();
+
+      // Stage some uploads
+      await mockStore.stagePendingUpload({
+        uploadSessionId: 'offline_001',
+        policy: 'test-policy',
+        fileName: 'file1.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new TextEncoder().encode('File 1 content').buffer,
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      await mockStore.stagePendingUpload({
+        uploadSessionId: 'offline_002',
+        policy: 'test-policy',
+        fileName: 'file2.txt',
+        size: 200,
+        mimeType: 'text/plain',
+        fileData: new TextEncoder().encode('File 2 content').buffer,
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      const sync = new OfflineSync({
+        store: mockStore,
+        client: mockClient,
+      });
+
+      sync.setConnectivityChecker(mockConnectivityChecker);
+
+      const result = await sync.syncAll();
+
+      expect(result.succeeded).toHaveLength(2);
+      expect(result.failed).toHaveLength(0);
+      expect(result.totalProcessed).toBe(2);
+
+      // Verify uploads were called
+      expect(mockClient.uploadFile).toHaveBeenCalledTimes(2);
+
+      // Verify uploads were deleted
+      const remainingUploads = await mockStore.listPendingUploads();
+      expect(remainingUploads).toHaveLength(0);
+    });
+
+    it('should handle failed uploads and increment retry count', async () => {
+      await mockStore.init();
+
+      await mockStore.stagePendingUpload({
+        uploadSessionId: 'offline_001',
+        policy: 'test-policy',
+        fileName: 'file1.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new TextEncoder().encode('File content').buffer,
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      // Mock client to fail
+      const failingClient: UploadClient = {
+        uploadFile: vi.fn().mockRejectedValue(new Error('Upload failed')),
+      };
+
+      const sync = new OfflineSync({
+        store: mockStore,
+        client: failingClient,
+      });
+
+      sync.setConnectivityChecker(mockConnectivityChecker);
+
+      const result = await sync.syncAll();
+
+      expect(result.succeeded).toHaveLength(0);
+      expect(result.failed).toHaveLength(1);
+      expect(result.totalProcessed).toBe(1);
+
+      // Verify retry count was incremented
+      const upload = await mockStore.getPendingUpload('offline_001');
+      expect(upload!.retryCount).toBe(1);
+    });
+
+    it('should respect max retries limit', async () => {
+      await mockStore.init();
+
+      await mockStore.stagePendingUpload({
+        uploadSessionId: 'offline_001',
+        policy: 'test-policy',
+        fileName: 'file1.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new TextEncoder().encode('File content').buffer,
+        createdAt: new Date().toISOString(),
+        retryCount: 3, // Already at max
+      });
+
+      const sync = new OfflineSync({
+        store: mockStore,
+        client: mockClient,
+        maxRetries: 3,
+      });
+
+      sync.setConnectivityChecker(mockConnectivityChecker);
+
+      const result = await sync.syncAll();
+
+      expect(result.failed).toHaveLength(1);
+      expect(mockClient.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should call progress callbacks', async () => {
+      await mockStore.init();
+
+      await mockStore.stagePendingUpload({
+        uploadSessionId: 'offline_001',
+        policy: 'test-policy',
+        fileName: 'file1.txt',
+        size: 100,
+        mimeType: 'text/plain',
+        fileData: new ArrayBuffer(100),
+        createdAt: new Date().toISOString(),
+        retryCount: 0,
+      });
+
+      const onProgress = vi.fn();
+      const onComplete = vi.fn();
+
+      const sync = new OfflineSync({
+        store: mockStore,
+        client: mockClient,
+        onSyncProgress: onProgress,
+        onSyncComplete: onComplete,
+      });
+
+      sync.setConnectivityChecker(mockConnectivityChecker);
+
+      await sync.syncAll();
+
+      expect(onProgress).toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          succeeded: ['offline_001'],
+          failed: [],
+          totalProcessed: 1,
+        })
+      );
+    });
+
+    it('should throw when trying to sync while offline', async () => {
+      const offlineChecker: ConnectivityChecker = {
+        isOnline: () => false,
+        onOnline: vi.fn(),
+        onOffline: vi.fn(),
+      };
+
+      const sync = new OfflineSync({
+        store: mockStore,
+        client: mockClient,
+      });
+
+      sync.setConnectivityChecker(offlineChecker);
+
+      await expect(sync.syncAll()).rejects.toThrow('Cannot sync while offline');
+    });
+  });
+});
+
+describe('Offline helpers', () => {
+  it('should detect when offline mode is needed', () => {
+    vi.stubGlobal('navigator', { onLine: false });
+
+    const shouldUse = shouldUseOfflineMode(true);
+    expect(shouldUse).toBe(true);
+  });
+
+  it('should not use offline mode when disabled', () => {
+    vi.stubGlobal('navigator', { onLine: false });
+
+    const shouldUse = shouldUseOfflineMode(false);
+    expect(shouldUse).toBe(false);
+  });
+
+  it('should generate unique offline session IDs', () => {
+    const id1 = generateOfflineSessionId();
+    const id2 = generateOfflineSessionId();
+
+    expect(id1).toMatch(/^offline_\d+_[a-z0-9]+$/);
+    expect(id2).toMatch(/^offline_\d+_[a-z0-9]+$/);
+    expect(id1).not.toBe(id2);
+  });
+});

--- a/filefn/client/tsconfig.json
+++ b/filefn/client/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/filefn/client/vitest.config.ts
+++ b/filefn/client/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', '__tests__/**/*.test.ts', 'tests/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'lcov'],
+      provider: 'v8',
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2567,6 +2567,16 @@
         }
       }
     },
+    "filefn/client": {
+      "name": "@filefn/client",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^3.2.4"
+      }
+    },
     "filefn/processing": {
       "name": "@filefn/processing",
       "version": "0.1.0",
@@ -2589,6 +2599,16 @@
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
         "vitest": "^3.2.4"
+      }
+    },
+    "filefn/client/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "filefn/processing/node_modules/@types/node": {
@@ -4129,6 +4149,10 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@filefn/client": {
+      "resolved": "filefn/client",
+      "link": true
     },
     "node_modules/@filefn/processing": {
       "resolved": "filefn/processing",


### PR DESCRIPTION
## Summary
- add the `@filefn/client` browser SDK package
- include the minimal root workspace wiring for `filefn/*`
- keep `.conduct` excluded for the `origin/dev` target

## Testing
- `cd filefn/client && npm run build`
- `cd filefn/client && npm run typecheck`
- `cd filefn/client && npm test -- --run`

## Notes
- `.conduct` was intentionally excluded from this PR
- `.gitignore` was not changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@filefn/client`, a browser SDK for resilient uploads with offline staging, preprocessing, and retry/resume. Delivers SF‑14 by enabling end‑to‑end uploads via proxy or signed URLs and wiring the `filefn/*` workspace.

- **New Features**
  - Client factory with envelope unwrapping and typed `FileFnHttpError`; supports init/status/sign/complete/abort.
  - `UploadManager` for multipart uploads with progress, idempotency, and resume/abort across proxy and signed‑URL flows.
  - Offline mode via `OPFSStore` and `OfflineSync`: deterministic placeholders, local object‑URL fallbacks, and auto sync on reconnect.
  - Pluggable preprocessing with built‑in HEIC→JPEG; stable output names; exports `createHeicPreprocessor` and `FILEFN_HEIC_CONVERSION_FAILED`.
  - Retry helpers with exponential backoff/jitter and retryable error detection; exports `generateFileId`.

- **Bug Fixes**
  - Enforced resume contract by forwarding `uploadSessionToken` on follow‑ups in proxy and signed‑URL flows.
  - Improved envelope error surfacing with `code`/`requestId` extraction and tighter retryable error classification.
  - Offline sync robustness: retries transient failures, resolves late waiters once, and better online/offline handling.

<sup>Written for commit 1d8411bf17fd68b065d6821c1da7731f15ab7f6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser client SDK: public client factory, upload/resume, downloads, artifact listing, render resolution, progress/abort, session tokens, retry/backoff helpers, and stable file-id generation
  * Offline: OPFS-backed staging, pending-local previews/placeholders, automatic sync, cancel/retry controls, and offline-aware render resolution
  * HEIC→JPEG client-side preprocessing

* **Tests**
  * Broad Vitest coverage for uploads, proxy/resume flows, offline sync, preprocessing, retry logic, and response envelope handling

* **Chores**
  * Client package manifest, TypeScript and Vitest configs added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->