### PR TITLE
SF-14: feat(filefn): add processing package

### DIFF
--- a/filefn/processing/package.json
+++ b/filefn/processing/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@filefn/processing",
+  "version": "0.1.0",
+  "description": "FileFn file processing pipelines",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "file",
+    "processing",
+    "pipeline",
+    "filefn"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "filefn/processing"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "sharp": "^0.33.5",
+    "tesseract.js": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/filefn/processing/src/index.test.ts
+++ b/filefn/processing/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { createPipeline } from './index.js';
+
+describe('@filefn/processing', () => {
+  it('should export createPipeline', () => {
+    expect(createPipeline).toBeDefined();
+  });
+});

--- a/filefn/processing/src/index.ts
+++ b/filefn/processing/src/index.ts
@@ -1,0 +1,101 @@
+export type {
+  Processor,
+  ProcessorInput,
+  ProcessorOutputArtifact,
+  ProcessorResult,
+  ProcessingConfig,
+  ProcessingJobInput,
+  ProcessingJobResult,
+  ThumbnailConfig,
+  ThumbnailSize,
+  PdfPreviewConfig,
+  CompressionConfig,
+  OCRConfig,
+  OCRProcessorProvider,
+  OCRProviderRequest,
+  OCRProviderResult,
+  ImageTransformOperation,
+  ImageTransformConfig,
+  ResizeOptions,
+  CropOptions,
+  RotateOptions,
+  VideoConfig,
+  VideoMetadataRequest,
+  VideoTranscodeOptions,
+  VideoTranscodeRequest,
+  VideoTranscodeResult,
+  VideoPosterOptions,
+  VideoPosterRequest,
+  VideoProcessorProvider,
+  AudioConfig,
+  AudioMetadataRequest,
+  AudioProcessorProvider,
+  AudioTranscodeOptions,
+  AudioTranscodeRequest,
+  AudioTranscodeResult,
+  AudioWaveformRequest,
+  AudioWaveformResult,
+} from './types.js';
+
+export {
+  createThumbnailProcessor,
+  THUMBNAIL_SUPPORTED_MIME_TYPES,
+} from './processors/thumbnail.js';
+
+export {
+  createPdfPreviewProcessor,
+  PDF_PREVIEW_SUPPORTED_MIME_TYPES,
+} from './processors/pdf-preview.js';
+
+export {
+  createCompressionProcessor,
+  COMPRESSION_SUPPORTED_MIME_TYPES,
+} from './processors/compression.js';
+
+export {
+  createOCRProcessor,
+  OCR_SUPPORTED_MIME_TYPES,
+} from './processors/ocr.js';
+export { createTesseractJsOCRProvider } from './providers/tesseract-ocr.js';
+
+export {
+  createImageTransformProcessor,
+  IMAGE_TRANSFORM_SUPPORTED_MIME_TYPES,
+} from './processors/image-transform.js';
+
+export {
+  createVideoProcessor,
+  VIDEO_SUPPORTED_MIME_TYPES,
+} from './processors/video.js';
+export { createCommandVideoProvider } from './providers/video-command.js';
+
+export {
+  createAudioProcessor,
+  AUDIO_SUPPORTED_MIME_TYPES,
+} from './processors/audio.js';
+export { createCommandAudioProvider } from './providers/audio-command.js';
+
+export interface ProcessingPipeline {
+  name: string;
+  process(data: Uint8Array): Promise<Uint8Array>;
+}
+
+export function createPipeline(steps: ProcessingPipeline[]): ProcessingPipeline {
+  return {
+    name: 'composite',
+    async process(data: Uint8Array): Promise<Uint8Array> {
+      let result = data;
+      for (const step of steps) {
+        result = await step.process(result);
+      }
+      return result;
+    },
+  };
+}
+
+export function supportsProcessor(processor: { supportedMimeTypes: string[] }, mimeType: string): boolean {
+  if (processor.supportedMimeTypes.includes('*/*')) {
+    return true;
+  }
+  return processor.supportedMimeTypes.includes(mimeType);
+}

--- a/filefn/processing/src/processors/audio.ts
+++ b/filefn/processing/src/processors/audio.ts
@@ -1,0 +1,160 @@
+import type {
+  AudioConfig,
+  AudioProcessorProvider,
+  Processor,
+  ProcessorInput,
+  ProcessorResult,
+} from '../types.js';
+
+const SUPPORTED_MIME_TYPES = [
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/mp4',
+  'audio/aac',
+  'audio/ogg',
+  'audio/opus',
+  'audio/webm',
+  'audio/wav',
+  'audio/flac',
+  'audio/x-m4a',
+];
+
+function requireProvider(provider: AudioProcessorProvider | undefined): AudioProcessorProvider {
+  if (!provider) {
+    throw new Error(
+      'Audio processing requires a provider. Pass config.provider.',
+    );
+  }
+  return provider;
+}
+
+export function createAudioProcessor(config: AudioConfig = {}): Processor {
+  const {
+    transcode = true,
+    transcodeOptions = {},
+    extractMetadata = false,
+    generateWaveform = false,
+    provider,
+  } = config;
+
+  const {
+    codec = 'aac',
+    bitrate = '128k',
+    sampleRate = 44100,
+    channels = 2,
+  } = transcodeOptions;
+
+  return {
+    name: 'audio',
+    supportedMimeTypes: SUPPORTED_MIME_TYPES,
+
+    async process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult> {
+      if (!SUPPORTED_MIME_TYPES.includes(input.mimeType)) {
+        return {
+          success: false,
+          artifacts: [],
+          error: `Unsupported MIME type: ${input.mimeType}`,
+        };
+      }
+
+      try {
+        if (!transcode && !extractMetadata && !generateWaveform) {
+          return {
+            success: true,
+            artifacts: [],
+          };
+        }
+
+        const runtime = requireProvider(provider);
+        const audioData = await getData();
+        const artifacts = [];
+        const baseKey = input.storageKey.replace(/\.[^/.]+$/, '');
+
+        if (transcode) {
+          const transcoded = await runtime.transcode({
+            input,
+            audioData,
+            codec,
+            bitrate,
+            sampleRate,
+            channels,
+          });
+
+          artifacts.push({
+            kind: `audio-transcoded-${codec}`,
+            data: transcoded.data,
+            mimeType: transcoded.mimeType,
+            storageKey: `${baseKey}-${codec}.${transcoded.extension}`,
+            metadata: {
+              codec,
+              bitrate,
+              sampleRate,
+              channels,
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              originalSize: audioData.length,
+              transcodedSize: transcoded.data.length,
+              compressionRatio: audioData.length > 0 ? transcoded.data.length / audioData.length : 0,
+            },
+          });
+        }
+
+        if (extractMetadata) {
+          const metadata = await runtime.extractMetadata({
+            input,
+            audioData,
+          });
+          const metadataJson = JSON.stringify(metadata, null, 2);
+          const metadataBytes = new TextEncoder().encode(metadataJson);
+
+          artifacts.push({
+            kind: 'audio-metadata',
+            data: metadataBytes,
+            mimeType: 'application/json',
+            storageKey: `${baseKey}-metadata.json`,
+            metadata: {
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              extractedAt: new Date().toISOString(),
+            },
+          });
+        }
+
+        if (generateWaveform) {
+          const waveformData = await runtime.generateWaveform({
+            input,
+            audioData,
+          });
+          const waveformJson = JSON.stringify(waveformData, null, 2);
+          const waveformBytes = new TextEncoder().encode(waveformJson);
+
+          artifacts.push({
+            kind: 'audio-waveform',
+            data: waveformBytes,
+            mimeType: 'application/json',
+            storageKey: `${baseKey}-waveform.json`,
+            metadata: {
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              samples: waveformData.samples.length,
+              peakAmplitude: waveformData.peakAmplitude,
+            },
+          });
+        }
+
+        return {
+          success: true,
+          artifacts,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          artifacts: [],
+          error: error instanceof Error ? error.message : 'Unknown audio processing error',
+        };
+      }
+    },
+  };
+}
+
+export { SUPPORTED_MIME_TYPES as AUDIO_SUPPORTED_MIME_TYPES };

--- a/filefn/processing/src/processors/compression.ts
+++ b/filefn/processing/src/processors/compression.ts
@@ -1,0 +1,86 @@
+import { deflate, gzip } from 'node:zlib';
+import { promisify } from 'node:util';
+import type { Processor, ProcessorInput, ProcessorResult, CompressionConfig } from '../types.js';
+
+const gzipAsync = promisify(gzip);
+const deflateAsync = promisify(deflate);
+
+const ALL_MIME_TYPES = ['*/*'];
+
+export function createCompressionProcessor(config: CompressionConfig = {}): Processor {
+  const { algorithm = 'gzip', level = 6 } = config;
+
+  return {
+    name: 'compression',
+    supportedMimeTypes: ALL_MIME_TYPES,
+
+    async process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult> {
+      try {
+        const data = await getData();
+
+        if (data.length === 0) {
+          return {
+            success: true,
+            artifacts: [],
+          };
+        }
+
+        const compressedData = await compress(data, algorithm, level);
+
+        const compressionRatio = compressedData.length / data.length;
+
+        if (compressionRatio >= 0.95) {
+          return {
+            success: true,
+            artifacts: [],
+          };
+        }
+
+        const extension = algorithm === 'gzip' ? 'gz' : 'deflate';
+        const mimeType = algorithm === 'gzip' ? 'application/gzip' : 'application/octet-stream';
+
+        return {
+          success: true,
+          artifacts: [
+            {
+              kind: `compressed-${algorithm}`,
+              data: compressedData,
+              mimeType,
+              storageKey: `${input.storageKey}.${extension}`,
+              metadata: {
+                algorithm,
+                level,
+                originalSize: data.length,
+                compressedSize: compressedData.length,
+                compressionRatio,
+                sourceFileId: input.fileId,
+                sourceVersionId: input.versionId,
+              },
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          success: false,
+          artifacts: [],
+          error: error instanceof Error ? error.message : 'Unknown compression error',
+        };
+      }
+    },
+  };
+}
+
+async function compress(data: Uint8Array, algorithm: 'gzip' | 'deflate', level: number): Promise<Uint8Array> {
+  const options = { level };
+  const buffer = Buffer.from(data);
+
+  if (algorithm === 'gzip') {
+    const result = await gzipAsync(buffer, options);
+    return new Uint8Array(result);
+  } else {
+    const result = await deflateAsync(buffer, options);
+    return new Uint8Array(result);
+  }
+}
+
+export { ALL_MIME_TYPES as COMPRESSION_SUPPORTED_MIME_TYPES };

--- a/filefn/processing/src/processors/image-transform.ts
+++ b/filefn/processing/src/processors/image-transform.ts
@@ -1,0 +1,176 @@
+import sharp from 'sharp';
+import type { Processor, ProcessorInput, ProcessorResult } from '../types.js';
+
+const SUPPORTED_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/gif',
+  'image/tiff',
+];
+
+export type ImageTransformOperation = 'resize' | 'crop' | 'rotate';
+
+export interface ResizeOptions {
+  width?: number;
+  height?: number;
+  fit?: 'cover' | 'contain' | 'fill' | 'inside' | 'outside';
+  withoutEnlargement?: boolean;
+}
+
+export interface CropOptions {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface RotateOptions {
+  angle: number;
+  background?: { r: number; g: number; b: number; alpha?: number };
+}
+
+export interface ImageTransformConfig {
+  operations: Array<{
+    operation: ImageTransformOperation;
+    options: ResizeOptions | CropOptions | RotateOptions;
+    suffix?: string;
+  }>;
+  outputFormat?: 'jpeg' | 'png' | 'webp';
+  outputQuality?: number;
+}
+
+export function createImageTransformProcessor(config: ImageTransformConfig): Processor {
+  const { operations, outputFormat = 'jpeg', outputQuality = 85 } = config;
+
+  if (!operations || operations.length === 0) {
+    throw new Error('ImageTransformProcessor requires at least one operation');
+  }
+
+  return {
+    name: 'image-transform',
+    supportedMimeTypes: SUPPORTED_MIME_TYPES,
+
+    async process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult> {
+      if (!SUPPORTED_MIME_TYPES.includes(input.mimeType)) {
+        return {
+          success: false,
+          artifacts: [],
+          error: `Unsupported MIME type: ${input.mimeType}`,
+        };
+      }
+
+      try {
+        const imageData = await getData();
+        const artifacts = [];
+
+        for (const { operation, options, suffix } of operations) {
+          const transformedData = await applyTransform(
+            imageData,
+            operation,
+            options,
+            outputFormat,
+            outputQuality
+          );
+
+          const outputMimeType =
+            outputFormat === 'png' ? 'image/png' : outputFormat === 'webp' ? 'image/webp' : 'image/jpeg';
+          const extension = outputFormat === 'png' ? 'png' : outputFormat === 'webp' ? 'webp' : 'jpg';
+
+          const baseKey = input.storageKey.replace(/\.[^.]+$/, '');
+          const operationSuffix = suffix || `${operation}`;
+
+          artifacts.push({
+            kind: `transform-${operationSuffix}`,
+            data: transformedData,
+            mimeType: outputMimeType,
+            storageKey: `${baseKey}-${operationSuffix}.${extension}`,
+            metadata: {
+              operation,
+              options,
+              outputFormat,
+              outputQuality,
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              originalSize: imageData.length,
+              transformedSize: transformedData.length,
+            },
+          });
+        }
+
+        return {
+          success: true,
+          artifacts,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          artifacts: [],
+          error: error instanceof Error ? error.message : 'Unknown image transform error',
+        };
+      }
+    },
+  };
+}
+
+async function applyTransform(
+  imageData: Uint8Array,
+  operation: ImageTransformOperation,
+  options: ResizeOptions | CropOptions | RotateOptions,
+  outputFormat: 'jpeg' | 'png' | 'webp',
+  outputQuality: number
+): Promise<Uint8Array> {
+  const buffer = Buffer.from(imageData);
+  let pipeline = sharp(buffer);
+
+  switch (operation) {
+    case 'resize': {
+      const resizeOpts = options as ResizeOptions;
+      pipeline = pipeline.resize(resizeOpts.width, resizeOpts.height, {
+        fit: resizeOpts.fit || 'cover',
+        withoutEnlargement: resizeOpts.withoutEnlargement !== false,
+      });
+      break;
+    }
+
+    case 'crop': {
+      const cropOpts = options as CropOptions;
+      pipeline = pipeline.extract({
+        left: cropOpts.left,
+        top: cropOpts.top,
+        width: cropOpts.width,
+        height: cropOpts.height,
+      });
+      break;
+    }
+
+    case 'rotate': {
+      const rotateOpts = options as RotateOptions;
+      pipeline = pipeline.rotate(rotateOpts.angle, {
+        background: rotateOpts.background || { r: 255, g: 255, b: 255, alpha: 1 },
+      });
+      break;
+    }
+
+    default:
+      throw new Error(`Unsupported operation: ${operation}`);
+  }
+
+  switch (outputFormat) {
+    case 'jpeg':
+      pipeline = pipeline.jpeg({ quality: outputQuality, mozjpeg: true });
+      break;
+    case 'png':
+      pipeline = pipeline.png({ quality: outputQuality, compressionLevel: 9 });
+      break;
+    case 'webp':
+      pipeline = pipeline.webp({ quality: outputQuality });
+      break;
+  }
+
+  const result = await pipeline.toBuffer();
+  return new Uint8Array(result);
+}
+
+export { SUPPORTED_MIME_TYPES as IMAGE_TRANSFORM_SUPPORTED_MIME_TYPES };

--- a/filefn/processing/src/processors/ocr.ts
+++ b/filefn/processing/src/processors/ocr.ts
@@ -1,0 +1,169 @@
+import type { OCRProcessorProvider, Processor, ProcessorInput, ProcessorResult } from '../types.js';
+import { createTesseractJsOCRProvider } from '../providers/tesseract-ocr.js';
+import type { OCRConfig } from '../types.js';
+
+const SUPPORTED_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'image/tiff',
+  'image/bmp',
+];
+
+function resolveProvider(provider?: OCRProcessorProvider): OCRProcessorProvider {
+  return provider ?? createTesseractJsOCRProvider();
+}
+
+function generateHOCR(text: string, fileName: string): string {
+  const lines = text.split('\n').filter((line) => line.trim().length > 0);
+
+  const wordBlocks = lines
+    .map((line, idx) => {
+      return `    <span class='ocr_line' id='line_${idx + 1}' title='bbox 0 ${idx * 30} 800 ${(idx + 1) * 30}'>${escapeHtml(line)}</span>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <title>${escapeHtml(fileName)} - OCR Output</title>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta name='ocr-system' content='filefn-ocr' />
+  <meta name='ocr-capabilities' content='ocr_page ocr_carea ocr_par ocr_line' />
+</head>
+<body>
+  <div class='ocr_page' id='page_1' title='bbox 0 0 800 ${Math.max(lines.length, 1) * 30}'>
+${wordBlocks}
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+export function createOCRProcessor(config: OCRConfig = {}): Processor {
+  const { language = 'eng', outputFormat = 'text', provider } = config;
+
+  return {
+    name: 'ocr',
+    supportedMimeTypes: SUPPORTED_MIME_TYPES,
+
+    async process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult> {
+      if (!SUPPORTED_MIME_TYPES.includes(input.mimeType)) {
+        return {
+          success: false,
+          artifacts: [],
+          error: `Unsupported MIME type: ${input.mimeType}`,
+        };
+      }
+
+      try {
+        const imageData = await getData();
+        const artifacts = [];
+        const baseKey = input.storageKey.replace(/\.[^/.]+$/, '');
+        const runtime = resolveProvider(provider);
+        const needsHOCR = outputFormat === 'hocr' || outputFormat === 'all';
+        const extracted = await runtime.recognize({
+          input,
+          imageData,
+          language,
+          includeHOCR: needsHOCR,
+        });
+        const extractedAt = new Date().toISOString();
+
+        if (outputFormat === 'text' || outputFormat === 'all') {
+          const textData = new TextEncoder().encode(extracted.text);
+
+          artifacts.push({
+            kind: 'ocr-text',
+            data: textData,
+            mimeType: 'text/plain',
+            storageKey: `${baseKey}-ocr.txt`,
+            metadata: {
+              language,
+              format: 'text',
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              originalSize: imageData.length,
+              textLength: extracted.text.length,
+              confidence: extracted.confidence,
+              extractedAt,
+            },
+          });
+        }
+
+        if (outputFormat === 'json' || outputFormat === 'all') {
+          const jsonData = JSON.stringify(
+            {
+              text: extracted.text,
+              language,
+              confidence: extracted.confidence,
+              extractedAt,
+            },
+            null,
+            2,
+          );
+          const jsonBytes = new TextEncoder().encode(jsonData);
+
+          artifacts.push({
+            kind: 'ocr-json',
+            data: jsonBytes,
+            mimeType: 'application/json',
+            storageKey: `${baseKey}-ocr.json`,
+            metadata: {
+              language,
+              format: 'json',
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              textLength: extracted.text.length,
+              confidence: extracted.confidence,
+            },
+          });
+        }
+
+        if (outputFormat === 'hocr' || outputFormat === 'all') {
+          const hocrData = extracted.hocr && extracted.hocr.trim().length > 0
+            ? extracted.hocr
+            : generateHOCR(extracted.text, input.fileName);
+          const hocrBytes = new TextEncoder().encode(hocrData);
+
+          artifacts.push({
+            kind: 'ocr-hocr',
+            data: hocrBytes,
+            mimeType: 'text/html',
+            storageKey: `${baseKey}-ocr.hocr`,
+            metadata: {
+              language,
+              format: 'hocr',
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              confidence: extracted.confidence,
+            },
+          });
+        }
+
+        return {
+          success: true,
+          artifacts,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          artifacts: [],
+          error: error instanceof Error ? error.message : 'Unknown OCR error',
+        };
+      }
+    },
+  };
+}
+
+export { SUPPORTED_MIME_TYPES as OCR_SUPPORTED_MIME_TYPES };

--- a/filefn/processing/src/processors/pdf-preview.ts
+++ b/filefn/processing/src/processors/pdf-preview.ts
@@ -1,0 +1,193 @@
+import sharp from 'sharp';
+import type { PdfPreviewConfig, Processor, ProcessorInput, ProcessorResult, ThumbnailSize } from '../types.js';
+
+const DEFAULT_SIZES: ThumbnailSize[] = [
+  { name: 'small', width: 150, height: 150 },
+  { name: 'medium', width: 300, height: 300 },
+  { name: 'large', width: 600, height: 600 },
+];
+
+const SUPPORTED_MIME_TYPES = ['application/pdf'];
+const UNSUPPORTED_MIME_TYPE_ERROR = 'FILEFN_PROCESSING_UNSUPPORTED_MIME_TYPE';
+const PDF_PREVIEW_FAILED_ERROR = 'FILEFN_PROCESSING_PDF_PREVIEW_FAILED';
+
+export function createPdfPreviewProcessor(config: PdfPreviewConfig = {}): Processor {
+  const {
+    sizes = DEFAULT_SIZES,
+    density = 144,
+    quality = 85,
+    format = 'png',
+  } = config;
+
+  return {
+    name: 'pdf-preview',
+    supportedMimeTypes: SUPPORTED_MIME_TYPES,
+
+    async process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult> {
+      if (!SUPPORTED_MIME_TYPES.includes(input.mimeType)) {
+        return {
+          success: false,
+          artifacts: [],
+          error: UNSUPPORTED_MIME_TYPE_ERROR,
+        };
+      }
+
+      try {
+        const pdfData = await getData();
+        const renderedFirstPage = await renderPdfFirstPage(pdfData, density);
+        const artifacts = [];
+
+        for (const size of sizes) {
+          const previewData = renderedFirstPage
+            ? await renderResizedPreview(renderedFirstPage, size, format, quality)
+            : await renderPlaceholderPreview(pdfData, input.fileName, size, format, quality);
+          const extension = outputExtension(format);
+          const outputMimeType = outputMime(format);
+          const baseKey = input.storageKey.replace(/\.[^.]+$/, '');
+
+          artifacts.push({
+            kind: `pdf-preview-page-1-${size.name}`,
+            data: previewData,
+            mimeType: outputMimeType,
+            storageKey: `${baseKey}-pdf-preview-page-1-${size.name}.${extension}`,
+            metadata: {
+              width: size.width,
+              height: size.height,
+              density,
+              pageNumber: 1,
+              format,
+              renderMode: renderedFirstPage ? 'page-rasterized' : 'placeholder',
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              originalSize: pdfData.length,
+              previewSize: previewData.length,
+            },
+          });
+        }
+
+        return {
+          success: true,
+          artifacts,
+        };
+      } catch (error) {
+        void error;
+        return {
+          success: false,
+          artifacts: [],
+          error: PDF_PREVIEW_FAILED_ERROR,
+        };
+      }
+    },
+  };
+}
+
+async function renderPdfFirstPage(pdfData: Uint8Array, density: number): Promise<Buffer | null> {
+  try {
+    return await sharp(Buffer.from(pdfData), { density, page: 0 }).png().toBuffer();
+  } catch {
+    return null;
+  }
+}
+
+async function renderResizedPreview(
+  renderedFirstPage: Buffer,
+  size: ThumbnailSize,
+  format: 'jpeg' | 'png' | 'webp',
+  quality: number,
+): Promise<Uint8Array> {
+  const output = await encodeImage(
+    sharp(renderedFirstPage).resize(size.width, size.height, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    }),
+    format,
+    quality,
+  );
+
+  return new Uint8Array(output);
+}
+
+async function renderPlaceholderPreview(
+  pdfData: Uint8Array,
+  fileName: string,
+  size: ThumbnailSize,
+  format: 'jpeg' | 'png' | 'webp',
+  quality: number,
+): Promise<Uint8Array> {
+  const accent = Array.from(hashSeed(pdfData)).slice(0, 3);
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${size.width}" height="${size.height}" viewBox="0 0 ${size.width} ${size.height}">
+  <rect width="${size.width}" height="${size.height}" fill="rgb(243,244,246)"/>
+  <rect x="${Math.round(size.width * 0.12)}" y="${Math.round(size.height * 0.08)}" rx="${Math.max(6, Math.round(size.width * 0.03))}" ry="${Math.max(6, Math.round(size.width * 0.03))}" width="${Math.round(size.width * 0.76)}" height="${Math.round(size.height * 0.84)}" fill="white" stroke="rgb(209,213,219)" stroke-width="2"/>
+  <rect x="${Math.round(size.width * 0.12)}" y="${Math.round(size.height * 0.08)}" width="${Math.round(size.width * 0.76)}" height="${Math.max(18, Math.round(size.height * 0.14))}" fill="rgb(${accent[0]},${accent[1]},${accent[2]})"/>
+  <text x="${Math.round(size.width * 0.16)}" y="${Math.round(size.height * 0.18)}" font-family="Arial, sans-serif" font-weight="700" font-size="${Math.max(14, Math.round(size.width * 0.11))}" fill="white">PDF</text>
+  <text x="${Math.round(size.width * 0.16)}" y="${Math.round(size.height * 0.33)}" font-family="Arial, sans-serif" font-size="${Math.max(10, Math.round(size.width * 0.055))}" fill="rgb(31,41,55)">${escapeXml(trimLabel(fileName, 18))}</text>
+  <line x1="${Math.round(size.width * 0.18)}" y1="${Math.round(size.height * 0.46)}" x2="${Math.round(size.width * 0.76)}" y2="${Math.round(size.height * 0.46)}" stroke="rgb(203,213,225)" stroke-width="6" stroke-linecap="round"/>
+  <line x1="${Math.round(size.width * 0.18)}" y1="${Math.round(size.height * 0.58)}" x2="${Math.round(size.width * 0.7)}" y2="${Math.round(size.height * 0.58)}" stroke="rgb(226,232,240)" stroke-width="6" stroke-linecap="round"/>
+  <line x1="${Math.round(size.width * 0.18)}" y1="${Math.round(size.height * 0.7)}" x2="${Math.round(size.width * 0.74)}" y2="${Math.round(size.height * 0.7)}" stroke="rgb(226,232,240)" stroke-width="6" stroke-linecap="round"/>
+</svg>`;
+  const output = await encodeImage(sharp(Buffer.from(svg)), format, quality);
+  return new Uint8Array(output);
+}
+
+async function encodeImage(
+  instance: sharp.Sharp,
+  format: 'jpeg' | 'png' | 'webp',
+  quality: number,
+): Promise<Buffer> {
+  switch (format) {
+    case 'jpeg':
+      return instance.jpeg({ quality, mozjpeg: true }).toBuffer();
+    case 'webp':
+      return instance.webp({ quality }).toBuffer();
+    default:
+      return instance.png({ quality, compressionLevel: 9 }).toBuffer();
+  }
+}
+
+function hashSeed(data: Uint8Array): Uint8Array {
+  const seed = new Uint8Array(3);
+  for (let i = 0; i < data.length; i++) {
+    seed[i % seed.length] = (seed[i % seed.length] + data[i] + i) % 256;
+  }
+  return seed;
+}
+
+function escapeXml(input: string): string {
+  return input
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function trimLabel(input: string, maxLength: number): string {
+  if (input.length <= maxLength) return input;
+  return `${input.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function outputMime(format: 'jpeg' | 'png' | 'webp'): string {
+  switch (format) {
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'webp':
+      return 'image/webp';
+    default:
+      return 'image/png';
+  }
+}
+
+function outputExtension(format: 'jpeg' | 'png' | 'webp'): string {
+  switch (format) {
+    case 'jpeg':
+      return 'jpg';
+    case 'webp':
+      return 'webp';
+    default:
+      return 'png';
+  }
+}
+
+export { SUPPORTED_MIME_TYPES as PDF_PREVIEW_SUPPORTED_MIME_TYPES };
+export { PDF_PREVIEW_FAILED_ERROR, UNSUPPORTED_MIME_TYPE_ERROR as PDF_PREVIEW_UNSUPPORTED_MIME_TYPE_ERROR };

--- a/filefn/processing/src/processors/thumbnail.ts
+++ b/filefn/processing/src/processors/thumbnail.ts
@@ -1,0 +1,107 @@
+import sharp from 'sharp';
+import type { Processor, ProcessorInput, ProcessorResult, ThumbnailConfig, ThumbnailSize } from '../types.js';
+
+const UNSUPPORTED_MIME_TYPE_ERROR = 'FILEFN_PROCESSING_UNSUPPORTED_MIME_TYPE';
+const THUMBNAIL_FAILED_ERROR = 'FILEFN_PROCESSING_THUMBNAIL_FAILED';
+
+const DEFAULT_SIZES: ThumbnailSize[] = [
+  { name: 'small', width: 150, height: 150 },
+  { name: 'medium', width: 300, height: 300 },
+  { name: 'large', width: 600, height: 600 },
+];
+
+const SUPPORTED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/gif', 'image/tiff'];
+
+export function createThumbnailProcessor(config: ThumbnailConfig = { sizes: DEFAULT_SIZES }): Processor {
+  const { sizes = DEFAULT_SIZES, quality = 80, format = 'jpeg' } = config;
+
+  return {
+    name: 'thumbnail',
+    supportedMimeTypes: SUPPORTED_MIME_TYPES,
+
+    async process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult> {
+      if (!SUPPORTED_MIME_TYPES.includes(input.mimeType)) {
+        return {
+          success: false,
+          artifacts: [],
+          error: UNSUPPORTED_MIME_TYPE_ERROR,
+        };
+      }
+
+      try {
+        const imageData = await getData();
+        const artifacts = [];
+
+        for (const size of sizes) {
+          const thumbnailData = await generateThumbnail(imageData, size, quality, format);
+          const outputMimeType = format === 'png' ? 'image/png' : format === 'webp' ? 'image/webp' : 'image/jpeg';
+          const extension = format === 'png' ? 'png' : format === 'webp' ? 'webp' : 'jpg';
+
+          const baseKey = input.storageKey.replace(/\.[^.]+$/, '');
+
+          artifacts.push({
+            kind: `thumbnail-${size.name}`,
+            data: thumbnailData,
+            mimeType: outputMimeType,
+            storageKey: `${baseKey}-thumb-${size.name}.${extension}`,
+            metadata: {
+              width: size.width,
+              height: size.height,
+              quality,
+              format,
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              originalSize: imageData.length,
+              thumbnailSize: thumbnailData.length,
+            },
+          });
+        }
+
+        return {
+          success: true,
+          artifacts,
+        };
+      } catch (error) {
+        void error;
+        return {
+          success: false,
+          artifacts: [],
+          error: THUMBNAIL_FAILED_ERROR,
+        };
+      }
+    },
+  };
+}
+
+async function generateThumbnail(
+  imageData: Uint8Array,
+  size: ThumbnailSize,
+  quality: number,
+  format: 'jpeg' | 'png' | 'webp'
+): Promise<Uint8Array> {
+  const buffer = Buffer.from(imageData);
+
+  let pipeline = sharp(buffer)
+    .resize(size.width, size.height, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    });
+
+  switch (format) {
+    case 'jpeg':
+      pipeline = pipeline.jpeg({ quality, mozjpeg: true });
+      break;
+    case 'png':
+      pipeline = pipeline.png({ quality, compressionLevel: 9 });
+      break;
+    case 'webp':
+      pipeline = pipeline.webp({ quality });
+      break;
+  }
+
+  const result = await pipeline.toBuffer();
+  return new Uint8Array(result);
+}
+
+export { SUPPORTED_MIME_TYPES as THUMBNAIL_SUPPORTED_MIME_TYPES };
+export { THUMBNAIL_FAILED_ERROR, UNSUPPORTED_MIME_TYPE_ERROR };

--- a/filefn/processing/src/processors/video.ts
+++ b/filefn/processing/src/processors/video.ts
@@ -1,0 +1,172 @@
+import type {
+  Processor,
+  ProcessorInput,
+  ProcessorResult,
+  VideoConfig,
+  VideoProcessorProvider,
+} from '../types.js';
+
+const SUPPORTED_MIME_TYPES = [
+  'video/mp4',
+  'video/webm',
+  'video/ogg',
+  'video/quicktime',
+  'video/x-msvideo',
+  'video/x-matroska',
+];
+
+function requireProvider(provider: VideoProcessorProvider | undefined): VideoProcessorProvider {
+  if (!provider) {
+    throw new Error(
+      'Video processing requires a provider. Pass config.provider or use createCommandVideoProvider().',
+    );
+  }
+  return provider;
+}
+
+export function createVideoProcessor(config: VideoConfig = {}): Processor {
+  const {
+    generatePoster = true,
+    posterOptions = {},
+    transcode = true,
+    transcodeOptions = {},
+    extractMetadata = false,
+    provider,
+  } = config;
+
+  const {
+    timestamp = 1.0,
+    width = 1280,
+    height = 720,
+    format = 'jpeg',
+    quality = 85,
+  } = posterOptions;
+
+  const {
+    codec = 'h264',
+    resolution = '720p',
+    bitrate = '2M',
+    fps = 30,
+  } = transcodeOptions;
+
+  return {
+    name: 'video',
+    supportedMimeTypes: SUPPORTED_MIME_TYPES,
+
+    async process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult> {
+      if (!SUPPORTED_MIME_TYPES.includes(input.mimeType)) {
+        return {
+          success: false,
+          artifacts: [],
+          error: `Unsupported MIME type: ${input.mimeType}`,
+        };
+      }
+
+      try {
+        const videoData = await getData();
+        const artifacts = [];
+        const baseKey = input.storageKey.replace(/\.[^.]+$/, '');
+        const runtime = (generatePoster || transcode || extractMetadata)
+          ? requireProvider(provider)
+          : undefined;
+
+        if (generatePoster && runtime) {
+          const posterData = await runtime.generatePoster({
+            input,
+            videoData,
+            timestamp,
+            width,
+            height,
+            format,
+            quality,
+          });
+
+          const posterMimeType =
+            format === 'png' ? 'image/png' : format === 'webp' ? 'image/webp' : 'image/jpeg';
+          const extension = format === 'png' ? 'png' : format === 'webp' ? 'webp' : 'jpg';
+
+          artifacts.push({
+            kind: 'video-poster',
+            data: posterData,
+            mimeType: posterMimeType,
+            storageKey: `${baseKey}-poster.${extension}`,
+            metadata: {
+              timestamp,
+              width,
+              height,
+              format,
+              quality,
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              originalSize: videoData.length,
+              posterSize: posterData.length,
+            },
+          });
+        }
+
+        if (transcode && runtime) {
+          const transcoded = await runtime.transcode({
+            input,
+            videoData,
+            codec,
+            resolution,
+            bitrate,
+            fps,
+          });
+
+          artifacts.push({
+            kind: `video-transcoded-${resolution}`,
+            data: transcoded.data,
+            mimeType: transcoded.mimeType,
+            storageKey: `${baseKey}-${resolution}.${transcoded.extension}`,
+            metadata: {
+              codec,
+              resolution,
+              bitrate,
+              fps,
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              originalSize: videoData.length,
+              transcodedSize: transcoded.data.length,
+              compressionRatio: videoData.length > 0 ? transcoded.data.length / videoData.length : 0,
+            },
+          });
+        }
+
+        if (extractMetadata && runtime) {
+          const metadata = await runtime.extractMetadata({
+            input,
+            videoData,
+          });
+          const metadataJson = JSON.stringify(metadata, null, 2);
+          const metadataBytes = new TextEncoder().encode(metadataJson);
+
+          artifacts.push({
+            kind: 'video-metadata',
+            data: metadataBytes,
+            mimeType: 'application/json',
+            storageKey: `${baseKey}-metadata.json`,
+            metadata: {
+              sourceFileId: input.fileId,
+              sourceVersionId: input.versionId,
+              extractedAt: new Date().toISOString(),
+            },
+          });
+        }
+
+        return {
+          success: true,
+          artifacts,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          artifacts: [],
+          error: error instanceof Error ? error.message : 'Unknown video processing error',
+        };
+      }
+    },
+  };
+}
+
+export { SUPPORTED_MIME_TYPES as VIDEO_SUPPORTED_MIME_TYPES };

--- a/filefn/processing/src/providers/audio-command.ts
+++ b/filefn/processing/src/providers/audio-command.ts
@@ -1,0 +1,224 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type {
+  AudioMetadataRequest,
+  AudioProcessorProvider,
+  AudioTranscodeRequest,
+  AudioTranscodeResult,
+  AudioWaveformRequest,
+  AudioWaveformResult,
+} from '../types.js';
+import { resolveBinaryPath, runBinary, runBinaryCapture, withTempDir } from './command-utils.js';
+
+const AUDIO_CODEC_ARGS: Record<string, string[]> = {
+  mp3: ['-c:a', 'libmp3lame'],
+  aac: ['-c:a', 'aac'],
+  opus: ['-c:a', 'libopus'],
+  vorbis: ['-c:a', 'libvorbis'],
+  flac: ['-c:a', 'flac'],
+};
+
+const AUDIO_OUTPUTS: Record<string, { extension: string; mimeType: string }> = {
+  mp3: { extension: 'mp3', mimeType: 'audio/mpeg' },
+  aac: { extension: 'm4a', mimeType: 'audio/mp4' },
+  opus: { extension: 'opus', mimeType: 'audio/opus' },
+  vorbis: { extension: 'ogg', mimeType: 'audio/ogg' },
+  flac: { extension: 'flac', mimeType: 'audio/flac' },
+};
+
+export interface CommandAudioProviderConfig {
+  ffmpegPath?: string;
+  ffprobePath?: string;
+}
+
+function outputExtensionForInput(mimeType: string): string {
+  switch (mimeType) {
+    case 'audio/flac':
+      return 'flac';
+    case 'audio/ogg':
+      return 'ogg';
+    case 'audio/opus':
+      return 'opus';
+    case 'audio/wav':
+      return 'wav';
+    case 'audio/mp4':
+    case 'audio/aac':
+    case 'audio/x-m4a':
+      return 'm4a';
+    default:
+      return 'mp3';
+  }
+}
+
+function validateBitrate(bitrate: string): string {
+  const normalized = bitrate.trim();
+  if (!/^\d+(?:\.\d+)?(?:[kKmM])?$/.test(normalized)) {
+    throw new Error(`Invalid bitrate: ${bitrate}`);
+  }
+  return normalized;
+}
+
+function readStringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function buildWaveformFromPcm(
+  pcm: Buffer,
+  sampleRate: number,
+  sampleCount = 100,
+): AudioWaveformResult {
+  if (pcm.length < 2 || sampleRate <= 0 || sampleCount <= 0) {
+    return {
+      samples: [],
+      peakAmplitude: 0,
+      duration: 0,
+    };
+  }
+
+  const totalFrames = Math.floor(pcm.length / 2);
+  if (totalFrames === 0) {
+    return {
+      samples: [],
+      peakAmplitude: 0,
+      duration: 0,
+    };
+  }
+
+  const samples: number[] = [];
+  const windowSize = Math.max(1, Math.floor(totalFrames / sampleCount));
+  let peakAmplitude = 0;
+
+  for (let offset = 0; offset < totalFrames; offset += windowSize) {
+    const end = Math.min(totalFrames, offset + windowSize);
+    let peak = 0;
+    for (let index = offset; index < end; index += 1) {
+      const amplitude = Math.abs(pcm.readInt16LE(index * 2) / 32768);
+      if (amplitude > peak) {
+        peak = amplitude;
+      }
+    }
+    const rounded = Number(peak.toFixed(4));
+    samples.push(rounded);
+    if (rounded > peakAmplitude) {
+      peakAmplitude = rounded;
+    }
+  }
+
+  return {
+    samples,
+    peakAmplitude,
+    duration: Number((totalFrames / sampleRate).toFixed(4)),
+  };
+}
+
+export function createCommandAudioProvider(config: CommandAudioProviderConfig = {}): AudioProcessorProvider {
+  const ffmpegPath = resolveBinaryPath(config.ffmpegPath, ['FILEFN_FFMPEG_PATH', 'FFMPEG_PATH'], 'ffmpeg');
+  const ffprobePath = resolveBinaryPath(config.ffprobePath, ['FILEFN_FFPROBE_PATH', 'FFPROBE_PATH'], 'ffprobe');
+
+  async function extractMetadata(request: AudioMetadataRequest): Promise<Record<string, unknown>> {
+    return await withTempDir('filefn-processing-audio-', async (dir) => {
+      const inputPath = join(dir, `input.${outputExtensionForInput(request.input.mimeType)}`);
+      await writeFile(inputPath, Buffer.from(request.audioData));
+
+      const stdout = await runBinaryCapture(ffprobePath, [
+        '-v',
+        'error',
+        '-print_format',
+        'json',
+        '-show_streams',
+        '-show_format',
+        inputPath,
+      ]);
+      const parsed = JSON.parse(stdout) as {
+        streams?: Array<Record<string, unknown>>;
+        format?: Record<string, unknown>;
+      };
+      const audioStream = parsed.streams?.find((stream) => stream.codec_type === 'audio') ?? {};
+      const format = parsed.format ?? {};
+      const tags =
+        format.tags && typeof format.tags === 'object'
+          ? (format.tags as Record<string, unknown>)
+          : {};
+
+      return {
+        duration: Number(format.duration ?? audioStream.duration ?? 0),
+        codec: readStringValue(audioStream.codec_name),
+        bitrate: readStringValue(format.bit_rate) ?? readStringValue(audioStream.bit_rate),
+        sampleRate: audioStream.sample_rate ? Number(audioStream.sample_rate) : null,
+        channels: audioStream.channels ? Number(audioStream.channels) : null,
+        fileSize: request.audioData.length,
+        format: readStringValue(format.format_name),
+        title: readStringValue(tags.title),
+        artist: readStringValue(tags.artist),
+        album: readStringValue(tags.album),
+        year: readStringValue(tags.date) ?? readStringValue(tags.year),
+        genre: readStringValue(tags.genre),
+        creationTime: readStringValue(tags.creation_time),
+      };
+    });
+  }
+
+  async function transcode(request: AudioTranscodeRequest): Promise<AudioTranscodeResult> {
+    return await withTempDir('filefn-processing-audio-', async (dir) => {
+      const inputPath = join(dir, `input.${outputExtensionForInput(request.input.mimeType)}`);
+      const outputInfo = AUDIO_OUTPUTS[request.codec] ?? AUDIO_OUTPUTS.aac;
+      const outputPath = join(dir, `output.${outputInfo.extension}`);
+
+      await writeFile(inputPath, Buffer.from(request.audioData));
+
+      const args = [
+        '-y',
+        '-i',
+        inputPath,
+        ...(AUDIO_CODEC_ARGS[request.codec] ?? AUDIO_CODEC_ARGS.aac),
+        '-b:a',
+        validateBitrate(request.bitrate),
+        '-ar',
+        String(request.sampleRate),
+        '-ac',
+        String(request.channels),
+        outputPath,
+      ];
+
+      await runBinary(ffmpegPath, args);
+
+      return {
+        data: new Uint8Array(await readFile(outputPath)),
+        mimeType: outputInfo.mimeType,
+        extension: outputInfo.extension,
+      };
+    });
+  }
+
+  async function generateWaveform(request: AudioWaveformRequest): Promise<AudioWaveformResult> {
+    return await withTempDir('filefn-processing-audio-', async (dir) => {
+      const inputPath = join(dir, `input.${outputExtensionForInput(request.input.mimeType)}`);
+      const pcmPath = join(dir, 'waveform.pcm');
+
+      await writeFile(inputPath, Buffer.from(request.audioData));
+
+      await runBinary(ffmpegPath, [
+        '-y',
+        '-i',
+        inputPath,
+        '-ac',
+        '1',
+        '-ar',
+        '16000',
+        '-f',
+        's16le',
+        pcmPath,
+      ]);
+
+      const pcm = await readFile(pcmPath);
+      return buildWaveformFromPcm(pcm, 16000, request.samples ?? 100);
+    });
+  }
+
+  return {
+    transcode,
+    extractMetadata,
+    generateWaveform,
+  };
+}

--- a/filefn/processing/src/providers/command-utils.ts
+++ b/filefn/processing/src/providers/command-utils.ts
@@ -1,0 +1,123 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+
+export function resolveBinaryPath(configured: string | undefined, envKeys: string[], label: string): string {
+  const fromEnv = envKeys.map((key) => process.env[key]).find(Boolean);
+  const binaryPath = configured ?? fromEnv;
+  if (!binaryPath) {
+    throw new Error(
+      `${label} path is required. Provide it via the provider config or ${envKeys.join(' / ')}.`,
+    );
+  }
+  return binaryPath;
+}
+
+export async function runBinary(binary: string, args: string[], timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(binary, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let settled = false;
+    let stderr = '';
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.kill('SIGKILL');
+      reject(new Error(`${binary} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(stderr.trim() || `${binary} exited with code ${code ?? 'unknown'}`));
+    });
+  });
+}
+
+export async function runBinaryCapture(
+  binary: string,
+  args: string[],
+  timeoutMs = DEFAULT_COMMAND_TIMEOUT_MS,
+): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawn(binary, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.kill('SIGKILL');
+      reject(new Error(`${binary} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(new Error(stderr.trim() || `${binary} exited with code ${code ?? 'unknown'}`));
+    });
+  });
+}
+
+export async function withTempDir<T>(prefix: string, runner: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    return await runner(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/filefn/processing/src/providers/tesseract-ocr.ts
+++ b/filefn/processing/src/providers/tesseract-ocr.ts
@@ -1,0 +1,45 @@
+import sharp from 'sharp';
+import { createWorker, PSM } from 'tesseract.js';
+
+import type { OCRProcessorProvider, OCRProviderRequest, OCRProviderResult } from '../types.js';
+
+async function preprocessImage(imageData: Uint8Array): Promise<Buffer> {
+  return await sharp(Buffer.from(imageData))
+    .grayscale()
+    .normalize()
+    .sharpen()
+    .png()
+    .toBuffer();
+}
+
+export function createTesseractJsOCRProvider(): OCRProcessorProvider {
+  return {
+    async recognize(request: OCRProviderRequest): Promise<OCRProviderResult> {
+      const worker = await createWorker(request.language, 1, {
+        logger: () => {},
+      });
+
+      try {
+        const normalized = await preprocessImage(request.imageData);
+        await worker.setParameters({
+          tessedit_pageseg_mode: PSM.SINGLE_BLOCK,
+          preserve_interword_spaces: '1',
+        });
+
+        const result = await worker.recognize(
+          normalized,
+          {},
+          request.includeHOCR ? { hocr: true } : undefined,
+        );
+
+        return {
+          text: result.data.text.trim(),
+          confidence: result.data.confidence,
+          hocr: result.data.hocr,
+        };
+      } finally {
+        await worker.terminate();
+      }
+    },
+  };
+}

--- a/filefn/processing/src/providers/video-command.ts
+++ b/filefn/processing/src/providers/video-command.ts
@@ -1,0 +1,223 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type {
+  VideoMetadataRequest,
+  VideoPosterRequest,
+  VideoProcessorProvider,
+  VideoTranscodeRequest,
+  VideoTranscodeResult,
+} from '../types.js';
+import { resolveBinaryPath, runBinary, runBinaryCapture, withTempDir } from './command-utils.js';
+
+const RESOLUTION_HEIGHTS: Record<string, number> = {
+  '1080p': 1080,
+  '720p': 720,
+  '480p': 480,
+  '360p': 360,
+};
+
+const VIDEO_CODEC_ARGS: Record<string, string[]> = {
+  h264: ['-c:v', 'libx264'],
+  h265: ['-c:v', 'libx265'],
+  vp9: ['-c:v', 'libvpx-vp9'],
+  av1: ['-c:v', 'libaom-av1'],
+};
+
+const VIDEO_OUTPUTS: Record<string, { extension: string; mimeType: string }> = {
+  h264: { extension: 'mp4', mimeType: 'video/mp4' },
+  h265: { extension: 'mp4', mimeType: 'video/mp4' },
+  vp9: { extension: 'webm', mimeType: 'video/webm' },
+  av1: { extension: 'webm', mimeType: 'video/webm' },
+};
+
+export interface CommandVideoProviderConfig {
+  ffmpegPath?: string;
+  ffprobePath?: string;
+  ffmpegTimeoutMs?: number;
+  ffprobeTimeoutMs?: number;
+}
+
+function outputExtensionForInput(mimeType: string): string {
+  switch (mimeType) {
+    case 'video/webm':
+      return 'webm';
+    case 'video/ogg':
+      return 'ogv';
+    case 'video/quicktime':
+      return 'mov';
+    case 'video/x-msvideo':
+      return 'avi';
+    case 'video/x-matroska':
+      return 'mkv';
+    default:
+      return 'mp4';
+  }
+}
+
+function validateBitrate(bitrate: string): string {
+  const normalized = bitrate.trim();
+  if (!/^\d+(?:\.\d+)?(?:[kKmM])?$/.test(normalized)) {
+    throw new Error(`Invalid bitrate: ${bitrate}`);
+  }
+  return normalized;
+}
+
+
+function coerceDuration(metadata: Record<string, unknown>): number {
+  const duration = metadata.duration;
+  return typeof duration === 'number' && Number.isFinite(duration) ? duration : 0;
+}
+
+export function createCommandVideoProvider(config: CommandVideoProviderConfig = {}): VideoProcessorProvider {
+  const ffmpegPath = resolveBinaryPath(config.ffmpegPath, ['FILEFN_FFMPEG_PATH', 'FFMPEG_PATH'], 'ffmpeg');
+  const ffprobePath = resolveBinaryPath(config.ffprobePath, ['FILEFN_FFPROBE_PATH', 'FFPROBE_PATH'], 'ffprobe');
+  const ffmpegTimeoutMs = config.ffmpegTimeoutMs ?? 10 * 60 * 1000;
+  const ffprobeTimeoutMs = config.ffprobeTimeoutMs ?? 60 * 1000;
+
+  async function extractMetadata(request: VideoMetadataRequest): Promise<Record<string, unknown>> {
+    return await withTempDir('filefn-processing-video-', async (dir) => {
+      const inputPath = join(dir, `input.${outputExtensionForInput(request.input.mimeType)}`);
+      await writeFile(inputPath, Buffer.from(request.videoData));
+
+      const stdout = await runBinaryCapture(ffprobePath, [
+        '-v',
+        'error',
+        '-print_format',
+        'json',
+        '-show_streams',
+        '-show_format',
+        inputPath,
+      ], ffprobeTimeoutMs);
+
+      const parsed = JSON.parse(stdout) as {
+        streams?: Array<Record<string, unknown>>;
+        format?: Record<string, unknown>;
+      };
+
+      const videoStream = parsed.streams?.find((stream) => stream.codec_type === 'video') ?? {};
+      const audioStream = parsed.streams?.find((stream) => stream.codec_type === 'audio') ?? {};
+      const format = parsed.format ?? {};
+
+      return {
+        duration: Number(format.duration ?? videoStream.duration ?? 0),
+        width: Number(videoStream.width ?? 0),
+        height: Number(videoStream.height ?? 0),
+        codec: videoStream.codec_name ?? null,
+        fps: videoStream.avg_frame_rate ?? videoStream.r_frame_rate ?? null,
+        bitrate: format.bit_rate ?? videoStream.bit_rate ?? null,
+        audioCodec: audioStream.codec_name ?? null,
+        audioSampleRate: audioStream.sample_rate ? Number(audioStream.sample_rate) : null,
+        audioChannels: audioStream.channels ? Number(audioStream.channels) : null,
+        fileSize: request.videoData.length,
+        container: format.format_name ?? null,
+        creationTime:
+          format.tags && typeof format.tags === 'object'
+            ? (format.tags as Record<string, unknown>).creation_time ?? null
+            : null,
+      };
+    });
+  }
+
+  async function generatePoster(request: VideoPosterRequest): Promise<Uint8Array> {
+    return await withTempDir('filefn-processing-video-', async (dir) => {
+      const inputPath = join(dir, `input.${outputExtensionForInput(request.input.mimeType)}`);
+      const outputPath = join(dir, `poster.${request.format === 'jpeg' ? 'jpg' : request.format}`);
+
+      await writeFile(inputPath, Buffer.from(request.videoData));
+
+      const duration = request.duration ?? coerceDuration(await extractMetadata({
+        input: request.input,
+        videoData: request.videoData,
+      }));
+      const safeTimestamp = duration > 0
+        ? Math.min(Math.max(request.timestamp, 0), Math.max(duration - 0.05, 0))
+        : Math.max(request.timestamp, 0);
+
+      const filter = [
+        'thumbnail=30',
+        `scale=${request.width}:${request.height}:force_original_aspect_ratio=decrease`,
+        `pad=${request.width}:${request.height}:(ow-iw)/2:(oh-ih)/2:black`,
+      ].join(',');
+
+      const args = [
+        '-y',
+        '-ss',
+        String(safeTimestamp),
+        '-i',
+        inputPath,
+        '-frames:v',
+        '1',
+        '-vf',
+        filter,
+      ];
+
+      if (request.format === 'jpeg') {
+        args.push('-q:v', String(Math.max(2, Math.round((100 - request.quality) / 4) || 2)));
+      } else if (request.format === 'webp') {
+        args.push('-quality', String(request.quality));
+      }
+
+      args.push(outputPath);
+
+      await runBinary(ffmpegPath, args, ffmpegTimeoutMs);
+      return new Uint8Array(await readFile(outputPath));
+    });
+  }
+
+  async function transcode(request: VideoTranscodeRequest): Promise<VideoTranscodeResult> {
+    return await withTempDir('filefn-processing-video-', async (dir) => {
+      const inputPath = join(dir, `input.${outputExtensionForInput(request.input.mimeType)}`);
+      const outputInfo = VIDEO_OUTPUTS[request.codec] ?? VIDEO_OUTPUTS.h264;
+      const outputPath = join(dir, `output.${outputInfo.extension}`);
+      const targetHeight = RESOLUTION_HEIGHTS[request.resolution] ?? RESOLUTION_HEIGHTS['720p'];
+
+      await writeFile(inputPath, Buffer.from(request.videoData));
+
+      const args = [
+        '-y',
+        '-i',
+        inputPath,
+        '-vf',
+        `scale=-2:${targetHeight}`,
+        '-r',
+        String(request.fps),
+        ...(VIDEO_CODEC_ARGS[request.codec] ?? VIDEO_CODEC_ARGS.h264),
+        '-b:v',
+        validateBitrate(request.bitrate),
+      ];
+
+      if (request.includeAudio === false) {
+        args.push('-an');
+      } else {
+        const defaultAudioCodec = outputInfo.extension === 'webm' ? 'opus' : 'aac';
+        const selectedAudioCodec = request.audioCodec ?? defaultAudioCodec;
+        if (selectedAudioCodec === 'copy') {
+          args.push('-c:a', 'copy');
+        } else {
+          args.push('-c:a', selectedAudioCodec);
+        }
+      }
+
+      if (outputInfo.extension === 'mp4') {
+        args.push('-movflags', '+faststart');
+      }
+
+      args.push(outputPath);
+
+      await runBinary(ffmpegPath, args, ffmpegTimeoutMs);
+
+      return {
+        data: new Uint8Array(await readFile(outputPath)),
+        mimeType: outputInfo.mimeType,
+        extension: outputInfo.extension,
+      };
+    });
+  }
+
+  return {
+    generatePoster,
+    transcode,
+    extractMetadata,
+  };
+}

--- a/filefn/processing/src/types.ts
+++ b/filefn/processing/src/types.ts
@@ -1,0 +1,249 @@
+export interface ProcessorInput {
+  fileId: string;
+  versionId: string;
+  storageKey: string;
+  mimeType: string;
+  size: number;
+  fileName: string;
+  tenantId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProcessorOutputArtifact {
+  kind: string;
+  data: Uint8Array;
+  mimeType: string;
+  storageKey: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProcessorResult {
+  success: boolean;
+  artifacts: ProcessorOutputArtifact[];
+  error?: string;
+}
+
+export interface Processor {
+  name: string;
+  supportedMimeTypes: string[];
+  process(input: ProcessorInput, getData: () => Promise<Uint8Array>): Promise<ProcessorResult>;
+}
+
+export interface ProcessingConfig {
+  processors: Processor[];
+  enabled?: boolean;
+}
+
+export interface ProcessingJobInput {
+  fileId: string;
+  versionId: string;
+  storageKey: string;
+  mimeType: string;
+  size: number;
+  fileName: string;
+  tenantId?: string;
+}
+
+export interface ProcessingJobResult {
+  fileId: string;
+  versionId: string;
+  success: boolean;
+  artifactsCreated: number;
+  errors?: string[];
+}
+
+export interface ThumbnailConfig {
+  sizes?: ThumbnailSize[];
+  quality?: number;
+  format?: 'jpeg' | 'png' | 'webp';
+}
+
+export interface PdfPreviewConfig {
+  sizes?: ThumbnailSize[];
+  density?: number;
+  quality?: number;
+  format?: 'jpeg' | 'png' | 'webp';
+}
+
+export interface ThumbnailSize {
+  name: string;
+  width: number;
+  height: number;
+}
+
+export interface CompressionConfig {
+  algorithm?: 'gzip' | 'deflate';
+  level?: number;
+}
+
+export interface OCRConfig {
+  language?: string;
+  outputFormat?: 'text' | 'hocr' | 'json' | 'all';
+  provider?: OCRProcessorProvider;
+}
+
+export type ImageTransformOperation = 'resize' | 'crop' | 'rotate';
+
+export interface ResizeOptions {
+  width?: number;
+  height?: number;
+  fit?: 'cover' | 'contain' | 'fill' | 'inside' | 'outside';
+  withoutEnlargement?: boolean;
+}
+
+export interface CropOptions {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface RotateOptions {
+  angle: number;
+  background?: { r: number; g: number; b: number; alpha?: number };
+}
+
+export interface ImageTransformConfig {
+  operations: Array<{
+    operation: ImageTransformOperation;
+    options: ResizeOptions | CropOptions | RotateOptions;
+    suffix?: string;
+  }>;
+  outputFormat?: 'jpeg' | 'png' | 'webp';
+  outputQuality?: number;
+}
+
+export interface VideoTranscodeOptions {
+  codec?: 'h264' | 'h265' | 'vp9' | 'av1';
+  resolution?: '1080p' | '720p' | '480p' | '360p';
+  bitrate?: string;
+  fps?: number;
+  includeAudio?: boolean;
+  audioCodec?: 'aac' | 'opus' | 'copy';
+}
+
+export interface VideoPosterOptions {
+  timestamp?: number;
+  width?: number;
+  height?: number;
+  format?: 'jpeg' | 'png' | 'webp';
+  quality?: number;
+}
+
+export interface VideoConfig {
+  generatePoster?: boolean;
+  posterOptions?: VideoPosterOptions;
+  transcode?: boolean;
+  transcodeOptions?: VideoTranscodeOptions;
+  extractMetadata?: boolean;
+  provider?: VideoProcessorProvider;
+}
+
+export interface VideoPosterRequest {
+  input: ProcessorInput;
+  videoData: Uint8Array;
+  timestamp: number;
+  duration?: number;
+  width: number;
+  height: number;
+  format: 'jpeg' | 'png' | 'webp';
+  quality: number;
+}
+
+export interface VideoTranscodeRequest {
+  input: ProcessorInput;
+  videoData: Uint8Array;
+  codec: 'h264' | 'h265' | 'vp9' | 'av1';
+  resolution: '1080p' | '720p' | '480p' | '360p';
+  bitrate: string;
+  fps: number;
+  includeAudio?: boolean;
+  audioCodec?: 'aac' | 'opus' | 'copy';
+}
+
+export interface VideoMetadataRequest {
+  input: ProcessorInput;
+  videoData: Uint8Array;
+}
+
+export interface VideoTranscodeResult {
+  data: Uint8Array;
+  mimeType: string;
+  extension: string;
+}
+
+export interface VideoProcessorProvider {
+  generatePoster(request: VideoPosterRequest): Promise<Uint8Array>;
+  transcode(request: VideoTranscodeRequest): Promise<VideoTranscodeResult>;
+  extractMetadata(request: VideoMetadataRequest): Promise<Record<string, unknown>>;
+}
+
+export interface OCRProviderRequest {
+  input: ProcessorInput;
+  imageData: Uint8Array;
+  language: string;
+  includeHOCR: boolean;
+}
+
+export interface OCRProviderResult {
+  text: string;
+  confidence: number;
+  hocr?: string | null;
+}
+
+export interface OCRProcessorProvider {
+  recognize(request: OCRProviderRequest): Promise<OCRProviderResult>;
+}
+
+export interface AudioTranscodeOptions {
+  codec?: 'mp3' | 'aac' | 'opus' | 'vorbis' | 'flac';
+  bitrate?: string;
+  sampleRate?: number;
+  channels?: number;
+}
+
+export interface AudioConfig {
+  transcode?: boolean;
+  transcodeOptions?: AudioTranscodeOptions;
+  extractMetadata?: boolean;
+  generateWaveform?: boolean;
+  provider?: AudioProcessorProvider;
+}
+
+export interface AudioMetadataRequest {
+  input: ProcessorInput;
+  audioData: Uint8Array;
+}
+
+export interface AudioWaveformRequest {
+  input: ProcessorInput;
+  audioData: Uint8Array;
+  samples?: number;
+}
+
+export interface AudioTranscodeRequest {
+  input: ProcessorInput;
+  audioData: Uint8Array;
+  codec: 'mp3' | 'aac' | 'opus' | 'vorbis' | 'flac';
+  bitrate: string;
+  sampleRate: number;
+  channels: number;
+}
+
+export interface AudioWaveformResult {
+  samples: number[];
+  peakAmplitude: number;
+  duration: number;
+}
+
+export interface AudioTranscodeResult {
+  data: Uint8Array;
+  mimeType: string;
+  extension: string;
+}
+
+export interface AudioProcessorProvider {
+  transcode(request: AudioTranscodeRequest): Promise<AudioTranscodeResult>;
+  extractMetadata(request: AudioMetadataRequest): Promise<Record<string, unknown>>;
+  generateWaveform(request: AudioWaveformRequest): Promise<AudioWaveformResult>;
+}

--- a/filefn/processing/tests/ocr.test.ts
+++ b/filefn/processing/tests/ocr.test.ts
@@ -1,0 +1,505 @@
+import { describe, it, expect, vi } from 'vitest';
+import sharp from 'sharp';
+import {
+  createOCRProcessor,
+  createImageTransformProcessor,
+  supportsProcessor,
+  OCR_SUPPORTED_MIME_TYPES,
+  IMAGE_TRANSFORM_SUPPORTED_MIME_TYPES,
+} from '../src/index.js';
+
+function normalizeOCRText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().toUpperCase();
+}
+
+async function createTestImage(width: number, height: number, text: string = 'HELLO FILEFN'): Promise<Uint8Array> {
+  const svg = Buffer.from(`
+    <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+      <rect width="100%" height="100%" fill="white"/>
+      <text x="50%" y="45%" text-anchor="middle" font-size="72" font-family="Arial" font-weight="700" fill="black">${text}</text>
+      <text x="50%" y="65%" text-anchor="middle" font-size="72" font-family="Arial" font-weight="700" fill="black">OCR TEST</text>
+    </svg>
+  `);
+  const buffer = await sharp(svg).png().toBuffer();
+  return new Uint8Array(buffer);
+}
+
+describe('OCR Processor', () => {
+  describe('Contract compliance', () => {
+    it('should export Processor-compatible OCR processor', () => {
+      const processor = createOCRProcessor();
+      expect(processor).toBeDefined();
+      expect(processor.name).toBe('ocr');
+      expect(processor.supportedMimeTypes).toEqual(OCR_SUPPORTED_MIME_TYPES);
+      expect(typeof processor.process).toBe('function');
+    });
+
+    it('should support correct MIME types', () => {
+      const processor = createOCRProcessor();
+      expect(supportsProcessor(processor, 'image/png')).toBe(true);
+      expect(supportsProcessor(processor, 'image/jpeg')).toBe(true);
+      expect(supportsProcessor(processor, 'image/webp')).toBe(true);
+      expect(supportsProcessor(processor, 'image/gif')).toBe(true);
+      expect(supportsProcessor(processor, 'image/tiff')).toBe(true);
+      expect(supportsProcessor(processor, 'application/pdf')).toBe(false);
+      expect(supportsProcessor(processor, 'text/plain')).toBe(false);
+    });
+  });
+
+  describe('OCR processing', () => {
+    it('should reject unsupported MIME types', async () => {
+      const processor = createOCRProcessor();
+      const getData = vi.fn();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/document.pdf',
+          mimeType: 'application/pdf',
+          size: 1000,
+          fileName: 'document.pdf',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unsupported MIME type');
+      expect(getData).not.toHaveBeenCalled();
+    });
+
+    it('should extract text from PNG image (text format)', async () => {
+      const processor = createOCRProcessor({ outputFormat: 'text', language: 'eng' });
+
+      const testImage = await createTestImage(1200, 800);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'image.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('ocr-text');
+      expect(result.artifacts[0].mimeType).toBe('text/plain');
+      expect(result.artifacts[0].storageKey).toBe('test/image-ocr.txt');
+
+      const extractedText = new TextDecoder().decode(result.artifacts[0].data);
+      expect(normalizeOCRText(extractedText)).toContain('HELLO FILEFN');
+      expect(extractedText.length).toBeGreaterThan(0);
+
+      expect(result.artifacts[0].metadata).toMatchObject({
+        language: 'eng',
+        format: 'text',
+        sourceFileId: 'file_001',
+        sourceVersionId: 'ver_001',
+      });
+    });
+
+    it('should extract text in JSON format', async () => {
+      const processor = createOCRProcessor({ outputFormat: 'json', language: 'eng' });
+
+      const testImage = await createTestImage(1200, 800, 'BONJOUR FILEFN');
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_002',
+          versionId: 'ver_002',
+          storageKey: 'test/french.jpg',
+          mimeType: 'image/jpeg',
+          size: testImage.length,
+          fileName: 'french.jpg',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('ocr-json');
+      expect(result.artifacts[0].mimeType).toBe('application/json');
+      expect(result.artifacts[0].storageKey).toBe('test/french-ocr.json');
+
+      const jsonData = JSON.parse(new TextDecoder().decode(result.artifacts[0].data));
+      expect(jsonData).toHaveProperty('text');
+      expect(jsonData).toHaveProperty('language', 'eng');
+      expect(jsonData).toHaveProperty('confidence');
+      expect(jsonData).toHaveProperty('extractedAt');
+      expect(normalizeOCRText(jsonData.text)).toContain('BONJOUR FILEFN');
+    });
+
+    it('should extract text in hOCR format', async () => {
+      const processor = createOCRProcessor({ outputFormat: 'hocr' });
+
+      const testImage = await createTestImage(1200, 800);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_003',
+          versionId: 'ver_003',
+          storageKey: 'test/document.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'document.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('ocr-hocr');
+      expect(result.artifacts[0].mimeType).toBe('text/html');
+      expect(result.artifacts[0].storageKey).toBe('test/document-ocr.hocr');
+
+      const hocrContent = new TextDecoder().decode(result.artifacts[0].data);
+      expect(hocrContent).toContain('ocr_page');
+      expect(hocrContent).toContain('ocr_line');
+      expect(normalizeOCRText(hocrContent)).toContain('HELLO');
+    });
+
+    it('should extract text in all formats when format is "all"', async () => {
+      const processor = createOCRProcessor({ outputFormat: 'all' });
+
+      const testImage = await createTestImage(1200, 800);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_004',
+          versionId: 'ver_004',
+          storageKey: 'test/multiformat.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'multiformat.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(3);
+
+      const kinds = result.artifacts.map((a) => a.kind);
+      expect(kinds).toContain('ocr-text');
+      expect(kinds).toContain('ocr-json');
+      expect(kinds).toContain('ocr-hocr');
+
+      const mimeTypes = result.artifacts.map((a) => a.mimeType);
+      expect(mimeTypes).toContain('text/plain');
+      expect(mimeTypes).toContain('application/json');
+      expect(mimeTypes).toContain('text/html');
+    });
+
+    it('should handle getData errors gracefully', async () => {
+      const processor = createOCRProcessor();
+      const getData = vi.fn().mockRejectedValue(new Error('Storage failure'));
+
+      const result = await processor.process(
+        {
+          fileId: 'file_005',
+          versionId: 'ver_005',
+          storageKey: 'test/error.png',
+          mimeType: 'image/png',
+          size: 1000,
+          fileName: 'error.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Storage failure');
+      expect(result.artifacts).toHaveLength(0);
+    });
+  });
+});
+
+describe('Image Transform Processor', () => {
+  describe('Contract compliance', () => {
+    it('should export Processor-compatible image transform processor', () => {
+      const processor = createImageTransformProcessor({
+        operations: [{ operation: 'resize', options: { width: 100 } }],
+      });
+      expect(processor).toBeDefined();
+      expect(processor.name).toBe('image-transform');
+      expect(processor.supportedMimeTypes).toEqual(IMAGE_TRANSFORM_SUPPORTED_MIME_TYPES);
+      expect(typeof processor.process).toBe('function');
+    });
+
+    it('should support correct MIME types', () => {
+      const processor = createImageTransformProcessor({
+        operations: [{ operation: 'resize', options: { width: 100 } }],
+      });
+      expect(supportsProcessor(processor, 'image/png')).toBe(true);
+      expect(supportsProcessor(processor, 'image/jpeg')).toBe(true);
+      expect(supportsProcessor(processor, 'image/webp')).toBe(true);
+      expect(supportsProcessor(processor, 'image/gif')).toBe(true);
+      expect(supportsProcessor(processor, 'application/pdf')).toBe(false);
+    });
+
+    it('should throw when no operations are provided', () => {
+      expect(() => {
+        createImageTransformProcessor({ operations: [] });
+      }).toThrow('requires at least one operation');
+    });
+  });
+
+  describe('Resize operation', () => {
+    it('should resize image to specified dimensions', async () => {
+      const processor = createImageTransformProcessor({
+        operations: [
+          {
+            operation: 'resize',
+            options: { width: 400, height: 300, fit: 'cover' },
+            suffix: 'resized',
+          },
+        ],
+        outputFormat: 'jpeg',
+        outputQuality: 85,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_006',
+          versionId: 'ver_006',
+          storageKey: 'test/original.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'original.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('transform-resized');
+      expect(result.artifacts[0].mimeType).toBe('image/jpeg');
+      expect(result.artifacts[0].storageKey).toBe('test/original-resized.jpg');
+
+      expect(result.artifacts[0].metadata).toMatchObject({
+        operation: 'resize',
+        options: { width: 400, height: 300, fit: 'cover' },
+        outputFormat: 'jpeg',
+        outputQuality: 85,
+        sourceFileId: 'file_006',
+        sourceVersionId: 'ver_006',
+      });
+
+      const resizedImage = await sharp(Buffer.from(result.artifacts[0].data)).metadata();
+      expect(resizedImage.width).toBeLessThanOrEqual(400);
+      expect(resizedImage.height).toBeLessThanOrEqual(300);
+    });
+
+    it('should respect withoutEnlargement option', async () => {
+      const processor = createImageTransformProcessor({
+        operations: [
+          {
+            operation: 'resize',
+            options: { width: 1600, height: 1200, withoutEnlargement: true },
+          },
+        ],
+      });
+
+      const testImage = await createTestImage(800, 600);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_007',
+          versionId: 'ver_007',
+          storageKey: 'test/small.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'small.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      const resizedImage = await sharp(Buffer.from(result.artifacts[0].data)).metadata();
+      expect(resizedImage.width).toBe(800);
+      expect(resizedImage.height).toBe(600);
+    });
+  });
+
+  describe('Crop operation', () => {
+    it('should crop image to specified region', async () => {
+      const processor = createImageTransformProcessor({
+        operations: [
+          {
+            operation: 'crop',
+            options: { left: 100, top: 50, width: 200, height: 150 },
+            suffix: 'cropped',
+          },
+        ],
+        outputFormat: 'png',
+      });
+
+      const testImage = await createTestImage(800, 600);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_008',
+          versionId: 'ver_008',
+          storageKey: 'test/photo.jpg',
+          mimeType: 'image/jpeg',
+          size: testImage.length,
+          fileName: 'photo.jpg',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('transform-cropped');
+      expect(result.artifacts[0].mimeType).toBe('image/png');
+      expect(result.artifacts[0].storageKey).toBe('test/photo-cropped.png');
+
+      const croppedImage = await sharp(Buffer.from(result.artifacts[0].data)).metadata();
+      expect(croppedImage.width).toBe(200);
+      expect(croppedImage.height).toBe(150);
+    });
+  });
+
+  describe('Rotate operation', () => {
+    it('should rotate image by specified angle', async () => {
+      const processor = createImageTransformProcessor({
+        operations: [
+          {
+            operation: 'rotate',
+            options: { angle: 90, background: { r: 255, g: 255, b: 255 } },
+            suffix: 'rotated-90',
+          },
+        ],
+        outputFormat: 'jpeg',
+      });
+
+      const testImage = await createTestImage(800, 600);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_009',
+          versionId: 'ver_009',
+          storageKey: 'test/landscape.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'landscape.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('transform-rotated-90');
+      expect(result.artifacts[0].mimeType).toBe('image/jpeg');
+      expect(result.artifacts[0].storageKey).toBe('test/landscape-rotated-90.jpg');
+
+      const rotatedImage = await sharp(Buffer.from(result.artifacts[0].data)).metadata();
+      expect(rotatedImage.width).toBe(600);
+      expect(rotatedImage.height).toBe(800);
+    });
+  });
+
+  describe('Multiple operations', () => {
+    it('should apply multiple transformations', async () => {
+      const processor = createImageTransformProcessor({
+        operations: [
+          {
+            operation: 'resize',
+            options: { width: 400, height: 300 },
+            suffix: 'small',
+          },
+          {
+            operation: 'rotate',
+            options: { angle: 45 },
+            suffix: 'rotated',
+          },
+        ],
+        outputFormat: 'webp',
+        outputQuality: 80,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_010',
+          versionId: 'ver_010',
+          storageKey: 'test/multi.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'multi.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(2);
+      expect(result.artifacts[0].kind).toBe('transform-small');
+      expect(result.artifacts[1].kind).toBe('transform-rotated');
+      expect(result.artifacts[0].mimeType).toBe('image/webp');
+      expect(result.artifacts[1].mimeType).toBe('image/webp');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should reject unsupported MIME types', async () => {
+      const processor = createImageTransformProcessor({
+        operations: [{ operation: 'resize', options: { width: 100 } }],
+      });
+      const getData = vi.fn();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_011',
+          versionId: 'ver_011',
+          storageKey: 'test/document.pdf',
+          mimeType: 'application/pdf',
+          size: 1000,
+          fileName: 'document.pdf',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unsupported MIME type');
+      expect(getData).not.toHaveBeenCalled();
+    });
+
+    it('should handle getData errors gracefully', async () => {
+      const processor = createImageTransformProcessor({
+        operations: [{ operation: 'resize', options: { width: 100 } }],
+      });
+      const getData = vi.fn().mockRejectedValue(new Error('Download failed'));
+
+      const result = await processor.process(
+        {
+          fileId: 'file_012',
+          versionId: 'ver_012',
+          storageKey: 'test/error.png',
+          mimeType: 'image/png',
+          size: 1000,
+          fileName: 'error.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Download failed');
+      expect(result.artifacts).toHaveLength(0);
+    });
+  });
+});

--- a/filefn/processing/tests/processing.test.ts
+++ b/filefn/processing/tests/processing.test.ts
@@ -1,0 +1,481 @@
+import { describe, it, expect, vi } from 'vitest';
+import sharp from 'sharp';
+import {
+  createThumbnailProcessor,
+  createPdfPreviewProcessor,
+  createCompressionProcessor,
+  supportsProcessor,
+  THUMBNAIL_SUPPORTED_MIME_TYPES,
+  PDF_PREVIEW_SUPPORTED_MIME_TYPES,
+  COMPRESSION_SUPPORTED_MIME_TYPES,
+} from '../src/index.js';
+
+async function createTestImage(width: number, height: number): Promise<Uint8Array> {
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 255, g: 0, b: 0 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return new Uint8Array(buffer);
+}
+
+describe('@filefn/processing', () => {
+  describe('Processor contracts', () => {
+    it('should export Processor-compatible thumbnail processor', () => {
+      const processor = createThumbnailProcessor();
+      expect(processor).toBeDefined();
+      expect(processor.name).toBe('thumbnail');
+      expect(processor.supportedMimeTypes).toEqual(THUMBNAIL_SUPPORTED_MIME_TYPES);
+      expect(typeof processor.process).toBe('function');
+    });
+
+    it('should export Processor-compatible compression processor', () => {
+      const processor = createCompressionProcessor();
+      expect(processor).toBeDefined();
+      expect(processor.name).toBe('compression');
+      expect(processor.supportedMimeTypes).toEqual(COMPRESSION_SUPPORTED_MIME_TYPES);
+      expect(typeof processor.process).toBe('function');
+    });
+
+    it('should export Processor-compatible PDF preview processor', () => {
+      const processor = createPdfPreviewProcessor();
+      expect(processor).toBeDefined();
+      expect(processor.name).toBe('pdf-preview');
+      expect(processor.supportedMimeTypes).toEqual(PDF_PREVIEW_SUPPORTED_MIME_TYPES);
+      expect(typeof processor.process).toBe('function');
+    });
+  });
+
+  describe('supportsProcessor', () => {
+    it('should match specific MIME types', () => {
+      const processor = createThumbnailProcessor();
+      expect(supportsProcessor(processor, 'image/png')).toBe(true);
+      expect(supportsProcessor(processor, 'image/jpeg')).toBe(true);
+      expect(supportsProcessor(processor, 'image/webp')).toBe(true);
+      expect(supportsProcessor(processor, 'application/pdf')).toBe(false);
+    });
+
+    it('should match wildcard MIME types', () => {
+      const processor = createCompressionProcessor();
+      expect(supportsProcessor(processor, 'image/png')).toBe(true);
+      expect(supportsProcessor(processor, 'application/json')).toBe(true);
+      expect(supportsProcessor(processor, 'text/plain')).toBe(true);
+    });
+  });
+
+  describe('ThumbnailProcessor', () => {
+    it('should reject unsupported MIME types', async () => {
+      const processor = createThumbnailProcessor();
+      const getData = vi.fn();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/document.pdf',
+          mimeType: 'application/pdf',
+          size: 1000,
+          fileName: 'document.pdf',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('FILEFN_PROCESSING_UNSUPPORTED_MIME_TYPE');
+      expect(getData).not.toHaveBeenCalled();
+    });
+
+    it('should generate real thumbnail artifacts for PNG images', async () => {
+      const processor = createThumbnailProcessor({
+        sizes: [
+          { name: 'small', width: 100, height: 100 },
+          { name: 'large', width: 400, height: 400 },
+        ],
+        quality: 80,
+        format: 'jpeg',
+      });
+
+      const testImage = await createTestImage(800, 600);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'image.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(2);
+
+      const smallThumb = result.artifacts[0];
+      expect(smallThumb.kind).toBe('thumbnail-small');
+      expect(smallThumb.mimeType).toBe('image/jpeg');
+      expect(smallThumb.storageKey).toContain('-thumb-small.jpg');
+      expect(smallThumb.data.length).toBeGreaterThan(0);
+
+      const smallMeta = await sharp(Buffer.from(smallThumb.data)).metadata();
+      expect(smallMeta.width).toBeLessThanOrEqual(100);
+      expect(smallMeta.height).toBeLessThanOrEqual(100);
+
+      const largeThumb = result.artifacts[1];
+      expect(largeThumb.kind).toBe('thumbnail-large');
+      expect(largeThumb.mimeType).toBe('image/jpeg');
+
+      const largeMeta = await sharp(Buffer.from(largeThumb.data)).metadata();
+      expect(largeMeta.width).toBeLessThanOrEqual(400);
+      expect(largeMeta.height).toBeLessThanOrEqual(400);
+
+      expect(getData).toHaveBeenCalledOnce();
+    });
+
+    it('should preserve aspect ratio (fit inside)', async () => {
+      const processor = createThumbnailProcessor({
+        sizes: [{ name: 'thumb', width: 100, height: 100 }],
+      });
+
+      const wideImage = await createTestImage(1000, 500);
+      const getData = vi.fn().mockResolvedValue(wideImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/wide.png',
+          mimeType: 'image/png',
+          size: wideImage.length,
+          fileName: 'wide.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      const meta = await sharp(Buffer.from(result.artifacts[0].data)).metadata();
+      expect(meta.width).toBe(100);
+      expect(meta.height).toBe(50);
+    });
+
+    it('should not enlarge small images', async () => {
+      const processor = createThumbnailProcessor({
+        sizes: [{ name: 'thumb', width: 500, height: 500 }],
+      });
+
+      const smallImage = await createTestImage(100, 100);
+      const getData = vi.fn().mockResolvedValue(smallImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/small.png',
+          mimeType: 'image/png',
+          size: smallImage.length,
+          fileName: 'small.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      const meta = await sharp(Buffer.from(result.artifacts[0].data)).metadata();
+      expect(meta.width).toBe(100);
+      expect(meta.height).toBe(100);
+    });
+
+    it('should support webp output format', async () => {
+      const processor = createThumbnailProcessor({
+        sizes: [{ name: 'thumb', width: 100, height: 100 }],
+        format: 'webp',
+        quality: 90,
+      });
+
+      const testImage = await createTestImage(400, 400);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'image.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts[0].mimeType).toBe('image/webp');
+      expect(result.artifacts[0].storageKey).toContain('.webp');
+
+      const meta = await sharp(Buffer.from(result.artifacts[0].data)).metadata();
+      expect(meta.format).toBe('webp');
+    });
+
+    it('should support png output format', async () => {
+      const processor = createThumbnailProcessor({
+        sizes: [{ name: 'thumb', width: 100, height: 100 }],
+        format: 'png',
+      });
+
+      const testImage = await createTestImage(400, 400);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/image.jpg',
+          mimeType: 'image/jpeg',
+          size: testImage.length,
+          fileName: 'image.jpg',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts[0].mimeType).toBe('image/png');
+      expect(result.artifacts[0].storageKey).toContain('.png');
+    });
+
+    it('should include metadata in artifact output', async () => {
+      const processor = createThumbnailProcessor({
+        sizes: [{ name: 'small', width: 150, height: 150 }],
+        quality: 75,
+        format: 'jpeg',
+      });
+
+      const testImage = await createTestImage(600, 400);
+      const getData = vi.fn().mockResolvedValue(testImage);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/photo.jpg',
+          mimeType: 'image/jpeg',
+          size: testImage.length,
+          fileName: 'photo.jpg',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      const artifact = result.artifacts[0];
+      expect(artifact.metadata).toMatchObject({
+        width: 150,
+        height: 150,
+        quality: 75,
+        format: 'jpeg',
+        sourceFileId: 'file_001',
+        sourceVersionId: 'ver_001',
+      });
+      expect(artifact.metadata?.originalSize).toBe(testImage.length);
+      expect(artifact.metadata?.thumbnailSize).toBe(artifact.data.length);
+    });
+  });
+
+  describe('CompressionProcessor', () => {
+    it('should compress data using gzip by default', async () => {
+      const processor = createCompressionProcessor();
+
+      const testData = new Uint8Array(1000);
+      testData.fill(65);
+      const getData = vi.fn().mockResolvedValue(testData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/data.txt',
+          mimeType: 'text/plain',
+          size: testData.length,
+          fileName: 'data.txt',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts.length).toBe(1);
+      expect(result.artifacts[0].kind).toBe('compressed-gzip');
+      expect(result.artifacts[0].mimeType).toBe('application/gzip');
+      expect(result.artifacts[0].storageKey).toBe('test/data.txt.gz');
+      expect(result.artifacts[0].data.length).toBeLessThan(testData.length);
+
+      expect(result.artifacts[0].metadata).toMatchObject({
+        algorithm: 'gzip',
+        originalSize: 1000,
+      });
+      expect(result.artifacts[0].metadata?.compressedSize).toBe(result.artifacts[0].data.length);
+    });
+
+    it('should skip compression if ratio is too low (incompressible data)', async () => {
+      const processor = createCompressionProcessor();
+
+      const randomData = new Uint8Array(100);
+      for (let i = 0; i < randomData.length; i++) {
+        randomData[i] = Math.floor(Math.random() * 256);
+      }
+      const getData = vi.fn().mockResolvedValue(randomData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/random.bin',
+          mimeType: 'application/octet-stream',
+          size: randomData.length,
+          fileName: 'random.bin',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should use deflate when configured', async () => {
+      const processor = createCompressionProcessor({ algorithm: 'deflate' });
+
+      const testData = new Uint8Array(1000);
+      testData.fill(66);
+      const getData = vi.fn().mockResolvedValue(testData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/data.txt',
+          mimeType: 'text/plain',
+          size: testData.length,
+          fileName: 'data.txt',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts.length).toBe(1);
+      expect(result.artifacts[0].kind).toBe('compressed-deflate');
+      expect(result.artifacts[0].storageKey).toBe('test/data.txt.deflate');
+    });
+
+    it('should respect compression level', async () => {
+      const lowCompression = createCompressionProcessor({ level: 1 });
+      const highCompression = createCompressionProcessor({ level: 9 });
+
+      const testData = new Uint8Array(10000);
+      for (let i = 0; i < testData.length; i++) {
+        testData[i] = i % 100;
+      }
+
+      const lowResult = await lowCompression.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/data.bin',
+          mimeType: 'application/octet-stream',
+          size: testData.length,
+          fileName: 'data.bin',
+        },
+        async () => testData
+      );
+
+      const highResult = await highCompression.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/data.bin',
+          mimeType: 'application/octet-stream',
+          size: testData.length,
+          fileName: 'data.bin',
+        },
+        async () => testData
+      );
+
+      expect(lowResult.success).toBe(true);
+      expect(highResult.success).toBe(true);
+      expect(lowResult.artifacts).toHaveLength(1);
+      expect(highResult.artifacts).toHaveLength(1);
+      expect(highResult.artifacts[0].data.length).toBeLessThanOrEqual(lowResult.artifacts[0].data.length);
+    });
+  });
+
+  describe('PdfPreviewProcessor', () => {
+    it('should reject unsupported MIME types with a stable error code', async () => {
+      const processor = createPdfPreviewProcessor();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_002',
+          versionId: 'ver_002',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: 128,
+          fileName: 'image.png',
+        },
+        vi.fn(),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('FILEFN_PROCESSING_UNSUPPORTED_MIME_TYPE');
+    });
+
+    it('should emit canonical PDF preview kinds even when rasterization falls back to placeholders', async () => {
+      const processor = createPdfPreviewProcessor();
+      const invalidPdf = new TextEncoder().encode('not-a-real-pdf');
+      const getData = vi.fn().mockResolvedValue(invalidPdf);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_pdf_001',
+          versionId: 'ver_pdf_001',
+          storageKey: 'test/report.pdf',
+          mimeType: 'application/pdf',
+          size: invalidPdf.length,
+          fileName: 'report.pdf',
+        },
+        getData,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts.map((artifact) => artifact.kind)).toEqual([
+        'pdf-preview-page-1-small',
+        'pdf-preview-page-1-medium',
+        'pdf-preview-page-1-large',
+      ]);
+      expect(result.artifacts.every((artifact) => artifact.mimeType === 'image/png')).toBe(true);
+      expect(result.artifacts.every((artifact) => artifact.storageKey.includes('-pdf-preview-page-1-'))).toBe(true);
+      expect(result.artifacts.every((artifact) => artifact.metadata?.pageNumber === 1)).toBe(true);
+      expect(result.artifacts.every((artifact) => artifact.metadata?.renderMode)).toBe(true);
+      expect(result.artifacts.every((artifact) => artifact.data.length > 0)).toBe(true);
+      expect(getData).toHaveBeenCalledOnce();
+    });
+
+    it('should surface a stable error code when input retrieval fails', async () => {
+      const processor = createPdfPreviewProcessor();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_pdf_002',
+          versionId: 'ver_pdf_002',
+          storageKey: 'test/broken.pdf',
+          mimeType: 'application/pdf',
+          size: 0,
+          fileName: 'broken.pdf',
+        },
+        vi.fn().mockRejectedValue(new Error('boom')),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('FILEFN_PROCESSING_PDF_PREVIEW_FAILED');
+    });
+  });
+});

--- a/filefn/processing/tests/video-audio.test.ts
+++ b/filefn/processing/tests/video-audio.test.ts
@@ -1,0 +1,867 @@
+import sharp from 'sharp';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createVideoProcessor,
+  createAudioProcessor,
+  supportsProcessor,
+  VIDEO_SUPPORTED_MIME_TYPES,
+  AUDIO_SUPPORTED_MIME_TYPES,
+  type AudioProcessorProvider,
+  type VideoProcessorProvider,
+} from '../src/index.js';
+
+function createMockVideoData(size: number = 1000): Uint8Array {
+  const data = new Uint8Array(size);
+  const header = new TextEncoder().encode('VIDEO_SOURCE_DATA');
+  data.set(header, 0);
+  for (let i = header.length; i < size; i++) {
+    data[i] = i % 251;
+  }
+  return data;
+}
+
+function createMockVideoProvider(): VideoProcessorProvider {
+  return {
+    async generatePoster(request) {
+      const buffer = await sharp({
+        create: {
+          width: request.width,
+          height: request.height,
+          channels: 3,
+          background: { r: 24, g: 28, b: 40 },
+        },
+      })
+        .composite([
+          {
+            input: Buffer.from(
+              `<svg width="${request.width}" height="${request.height}">
+                <rect width="100%" height="100%" fill="#181c28"/>
+                <circle cx="${request.width / 2}" cy="${request.height / 2}" r="72" fill="#f8fafc" opacity="0.82"/>
+                <polygon points="${request.width / 2 - 22},${request.height / 2 - 32} ${request.width / 2 - 22},${request.height / 2 + 32} ${request.width / 2 + 30},${request.height / 2}" fill="#181c28"/>
+              </svg>`,
+            ),
+          },
+        ]);
+
+      if (request.format === 'png') {
+        return new Uint8Array(await buffer.png().toBuffer());
+      }
+      if (request.format === 'webp') {
+        return new Uint8Array(await buffer.webp({ quality: request.quality }).toBuffer());
+      }
+      return new Uint8Array(await buffer.jpeg({ quality: request.quality }).toBuffer());
+    },
+    async transcode(request) {
+      const mimeType = request.codec === 'vp9' || request.codec === 'av1' ? 'video/webm' : 'video/mp4';
+      const extension = mimeType === 'video/webm' ? 'webm' : 'mp4';
+      const payload = new TextEncoder().encode(
+        `TRANSCODED:${request.codec}:${request.resolution}:${request.bitrate}:${request.fps}`,
+      );
+      return {
+        data: payload,
+        mimeType,
+        extension,
+      };
+    },
+    async extractMetadata(request) {
+      return {
+        duration: 1.25,
+        width: 320,
+        height: 240,
+        codec: 'h264',
+        fps: '24/1',
+        bitrate: '220000',
+        audioCodec: null,
+        audioSampleRate: null,
+        audioChannels: null,
+        fileSize: request.videoData.length,
+        container: 'mov,mp4,m4a,3gp,3g2,mj2',
+        creationTime: '2026-04-02T00:00:00.000Z',
+      };
+    },
+  };
+}
+
+function createMockAudioData(size: number = 500): Uint8Array {
+  const data = new Uint8Array(size);
+  const header = new TextEncoder().encode('MOCK_AUDIO_DATA');
+  data.set(header, 0);
+  for (let i = header.length; i < size; i++) {
+    data[i] = i % 251;
+  }
+  return data;
+}
+
+function createMockAudioProvider(): AudioProcessorProvider {
+  return {
+    async transcode(request) {
+      const payloadSize = Math.max(
+        1,
+        Math.floor(
+          request.audioData.length *
+            Math.max(0.2, Math.min(1, Number.parseInt(request.bitrate.replace(/[^0-9]/g, ''), 10) / 320 || 0.4)),
+        ),
+      );
+      const payload = new Uint8Array(payloadSize);
+      payload.set(
+        new TextEncoder().encode(`AUDIO:${request.codec}:${request.bitrate}:${request.sampleRate}:${request.channels}`),
+      );
+      const extensionMap = {
+        mp3: 'mp3',
+        aac: 'm4a',
+        opus: 'opus',
+        vorbis: 'ogg',
+        flac: 'flac',
+      } as const;
+      const mimeTypeMap = {
+        mp3: 'audio/mpeg',
+        aac: 'audio/mp4',
+        opus: 'audio/opus',
+        vorbis: 'audio/ogg',
+        flac: 'audio/flac',
+      } as const;
+      return {
+        data: payload,
+        extension: extensionMap[request.codec],
+        mimeType: mimeTypeMap[request.codec],
+      };
+    },
+    async extractMetadata(request) {
+      return {
+        duration: 245.8,
+        codec: 'aac',
+        bitrate: '192000',
+        sampleRate: 44100,
+        channels: 2,
+        fileSize: request.audioData.length,
+        format: 'mp4',
+        title: 'Audio Track',
+        artist: 'Unknown Artist',
+        album: 'Unknown Album',
+        year: '2024',
+        genre: 'Unknown',
+        creationTime: '2026-04-02T00:00:00.000Z',
+      };
+    },
+    async generateWaveform(request) {
+      const sampleCount = request.samples ?? 100;
+      const samples = Array.from({ length: sampleCount }, (_, index) => {
+        const offset = Math.min(
+          request.audioData.length - 1,
+          Math.floor((index / sampleCount) * request.audioData.length),
+        );
+        return Number(((request.audioData[offset] ?? 0) / 255).toFixed(4));
+      });
+      return {
+        samples,
+        peakAmplitude: Math.max(...samples),
+        duration: 245.8,
+      };
+    },
+  };
+}
+
+describe('Video Processor', () => {
+  describe('Contract compliance', () => {
+    it('should export Processor-compatible video processor', () => {
+      const processor = createVideoProcessor();
+      expect(processor).toBeDefined();
+      expect(processor.name).toBe('video');
+      expect(processor.supportedMimeTypes).toEqual(VIDEO_SUPPORTED_MIME_TYPES);
+      expect(typeof processor.process).toBe('function');
+    });
+
+    it('should support correct MIME types', () => {
+      const processor = createVideoProcessor();
+      expect(supportsProcessor(processor, 'video/mp4')).toBe(true);
+      expect(supportsProcessor(processor, 'video/webm')).toBe(true);
+      expect(supportsProcessor(processor, 'video/ogg')).toBe(true);
+      expect(supportsProcessor(processor, 'video/quicktime')).toBe(true);
+      expect(supportsProcessor(processor, 'video/x-matroska')).toBe(true);
+      expect(supportsProcessor(processor, 'image/png')).toBe(false);
+      expect(supportsProcessor(processor, 'audio/mpeg')).toBe(false);
+    });
+  });
+
+  describe('Video processing', () => {
+    it('should reject unsupported MIME types', async () => {
+      const processor = createVideoProcessor();
+      const getData = vi.fn();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: 1000,
+          fileName: 'image.png',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unsupported MIME type');
+      expect(getData).not.toHaveBeenCalled();
+    });
+
+    it('should generate poster thumbnail by default', async () => {
+      const processor = createVideoProcessor({
+        provider: createMockVideoProvider(),
+        generatePoster: true,
+        posterOptions: {
+          timestamp: 2.5,
+          width: 1280,
+          height: 720,
+          format: 'jpeg',
+          quality: 85,
+        },
+        transcode: false,
+      });
+
+      const videoData = createMockVideoData(5000);
+      const getData = vi.fn().mockResolvedValue(videoData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'test/video.mp4',
+          mimeType: 'video/mp4',
+          size: videoData.length,
+          fileName: 'video.mp4',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('video-poster');
+      expect(result.artifacts[0].mimeType).toBe('image/jpeg');
+      expect(result.artifacts[0].storageKey).toBe('test/video-poster.jpg');
+
+      expect(result.artifacts[0].metadata).toMatchObject({
+        timestamp: 2.5,
+        width: 1280,
+        height: 720,
+        format: 'jpeg',
+        quality: 85,
+        sourceFileId: 'file_001',
+        sourceVersionId: 'ver_001',
+      });
+
+      expect(result.artifacts[0].data.length).toBeGreaterThan(0);
+      const posterMetadata = await sharp(result.artifacts[0].data).metadata();
+      expect(posterMetadata.width).toBe(1280);
+      expect(posterMetadata.height).toBe(720);
+    });
+
+    it('should generate poster in PNG format', async () => {
+      const processor = createVideoProcessor({
+        provider: createMockVideoProvider(),
+        generatePoster: true,
+        posterOptions: {
+          format: 'png',
+          width: 640,
+          height: 360,
+        },
+        transcode: false,
+      });
+
+      const videoData = createMockVideoData(5000);
+      const getData = vi.fn().mockResolvedValue(videoData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_002',
+          versionId: 'ver_001',
+          storageKey: 'test/video.webm',
+          mimeType: 'video/webm',
+          size: videoData.length,
+          fileName: 'video.webm',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts[0].kind).toBe('video-poster');
+      expect(result.artifacts[0].mimeType).toBe('image/png');
+      expect(result.artifacts[0].storageKey).toBe('test/video-poster.png');
+      const posterMetadata = await sharp(result.artifacts[0].data).metadata();
+      expect(posterMetadata.width).toBe(640);
+      expect(posterMetadata.height).toBe(360);
+    });
+
+    it('should transcode video', async () => {
+      const processor = createVideoProcessor({
+        provider: createMockVideoProvider(),
+        generatePoster: false,
+        transcode: true,
+        transcodeOptions: {
+          codec: 'h264',
+          resolution: '720p',
+          bitrate: '2M',
+          fps: 30,
+        },
+      });
+
+      const videoData = createMockVideoData(10000);
+      const getData = vi.fn().mockResolvedValue(videoData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_003',
+          versionId: 'ver_001',
+          storageKey: 'test/original.mp4',
+          mimeType: 'video/mp4',
+          size: videoData.length,
+          fileName: 'original.mp4',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('video-transcoded-720p');
+      expect(result.artifacts[0].mimeType).toBe('video/mp4');
+      expect(result.artifacts[0].storageKey).toBe('test/original-720p.mp4');
+
+      expect(result.artifacts[0].metadata).toMatchObject({
+        codec: 'h264',
+        resolution: '720p',
+        bitrate: '2M',
+        fps: 30,
+        sourceFileId: 'file_003',
+        sourceVersionId: 'ver_001',
+      });
+
+      expect(result.artifacts[0].data.length).toBeGreaterThan(0);
+    });
+
+    it('should transcode to VP9/WebM', async () => {
+      const processor = createVideoProcessor({
+        provider: createMockVideoProvider(),
+        generatePoster: false,
+        transcode: true,
+        transcodeOptions: {
+          codec: 'vp9',
+          resolution: '1080p',
+        },
+      });
+
+      const videoData = createMockVideoData(10000);
+      const getData = vi.fn().mockResolvedValue(videoData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_004',
+          versionId: 'ver_001',
+          storageKey: 'test/video.mp4',
+          mimeType: 'video/mp4',
+          size: videoData.length,
+          fileName: 'video.mp4',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts[0].kind).toBe('video-transcoded-1080p');
+      expect(result.artifacts[0].mimeType).toBe('video/webm');
+      expect(result.artifacts[0].storageKey).toBe('test/video-1080p.webm');
+    });
+
+    it('should extract video metadata', async () => {
+      const processor = createVideoProcessor({
+        provider: createMockVideoProvider(),
+        generatePoster: false,
+        transcode: false,
+        extractMetadata: true,
+      });
+
+      const videoData = createMockVideoData(5000);
+      const getData = vi.fn().mockResolvedValue(videoData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_005',
+          versionId: 'ver_001',
+          storageKey: 'test/video.mp4',
+          mimeType: 'video/mp4',
+          size: videoData.length,
+          fileName: 'video.mp4',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('video-metadata');
+      expect(result.artifacts[0].mimeType).toBe('application/json');
+      expect(result.artifacts[0].storageKey).toBe('test/video-metadata.json');
+
+      const metadata = JSON.parse(new TextDecoder().decode(result.artifacts[0].data));
+      expect(metadata.duration).toBeGreaterThan(0);
+      expect(metadata.width).toBe(320);
+      expect(metadata.height).toBe(240);
+      expect(typeof metadata.codec).toBe('string');
+      expect(metadata).toHaveProperty('fps');
+      expect(metadata).toHaveProperty('bitrate');
+      expect(metadata).toHaveProperty('audioCodec');
+    });
+
+    it('should generate all artifacts when all options enabled', async () => {
+      const processor = createVideoProcessor({
+        provider: createMockVideoProvider(),
+        generatePoster: true,
+        transcode: true,
+        extractMetadata: true,
+      });
+
+      const videoData = createMockVideoData(10000);
+      const getData = vi.fn().mockResolvedValue(videoData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_006',
+          versionId: 'ver_001',
+          storageKey: 'test/complete.mp4',
+          mimeType: 'video/mp4',
+          size: videoData.length,
+          fileName: 'complete.mp4',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(3);
+
+      const kinds = result.artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['video-metadata', 'video-poster', 'video-transcoded-720p']);
+    });
+
+    it('should handle getData errors gracefully', async () => {
+      const processor = createVideoProcessor();
+      const getData = vi.fn().mockRejectedValue(new Error('Storage failure'));
+
+      const result = await processor.process(
+        {
+          fileId: 'file_007',
+          versionId: 'ver_001',
+          storageKey: 'test/error.mp4',
+          mimeType: 'video/mp4',
+          size: 1000,
+          fileName: 'error.mp4',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Storage failure');
+      expect(result.artifacts).toHaveLength(0);
+    });
+  });
+});
+
+describe('Audio Processor', () => {
+  describe('Contract compliance', () => {
+    it('should export Processor-compatible audio processor', () => {
+      const processor = createAudioProcessor();
+      expect(processor).toBeDefined();
+      expect(processor.name).toBe('audio');
+      expect(processor.supportedMimeTypes).toEqual(AUDIO_SUPPORTED_MIME_TYPES);
+      expect(typeof processor.process).toBe('function');
+    });
+
+    it('should support correct MIME types', () => {
+      const processor = createAudioProcessor();
+      expect(supportsProcessor(processor, 'audio/mpeg')).toBe(true);
+      expect(supportsProcessor(processor, 'audio/mp3')).toBe(true);
+      expect(supportsProcessor(processor, 'audio/mp4')).toBe(true);
+      expect(supportsProcessor(processor, 'audio/aac')).toBe(true);
+      expect(supportsProcessor(processor, 'audio/ogg')).toBe(true);
+      expect(supportsProcessor(processor, 'audio/opus')).toBe(true);
+      expect(supportsProcessor(processor, 'audio/wav')).toBe(true);
+      expect(supportsProcessor(processor, 'audio/flac')).toBe(true);
+      expect(supportsProcessor(processor, 'video/mp4')).toBe(false);
+      expect(supportsProcessor(processor, 'image/jpeg')).toBe(false);
+    });
+  });
+
+  describe('Audio processing', () => {
+    it('should reject unsupported MIME types', async () => {
+      const processor = createAudioProcessor();
+      const getData = vi.fn();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_008',
+          versionId: 'ver_001',
+          storageKey: 'test/video.mp4',
+          mimeType: 'video/mp4',
+          size: 1000,
+          fileName: 'video.mp4',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unsupported MIME type');
+      expect(getData).not.toHaveBeenCalled();
+    });
+
+    it('should transcode audio by default', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: true,
+        transcodeOptions: {
+          codec: 'aac',
+          bitrate: '128k',
+          sampleRate: 44100,
+          channels: 2,
+        },
+      });
+
+      const audioData = createMockAudioData(5000);
+      const getData = vi.fn().mockResolvedValue(audioData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_009',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.mp3',
+          mimeType: 'audio/mpeg',
+          size: audioData.length,
+          fileName: 'audio.mp3',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('audio-transcoded-aac');
+      expect(result.artifacts[0].mimeType).toBe('audio/mp4');
+      expect(result.artifacts[0].storageKey).toBe('test/audio-aac.m4a');
+
+      expect(result.artifacts[0].metadata).toMatchObject({
+        codec: 'aac',
+        bitrate: '128k',
+        sampleRate: 44100,
+        channels: 2,
+        sourceFileId: 'file_009',
+        sourceVersionId: 'ver_001',
+      });
+
+      expect(result.artifacts[0].data.length).toBeGreaterThan(0);
+    });
+
+    it('should transcode to MP3', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: true,
+        transcodeOptions: {
+          codec: 'mp3',
+          bitrate: '192k',
+        },
+      });
+
+      const audioData = createMockAudioData(5000);
+      const getData = vi.fn().mockResolvedValue(audioData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_010',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.flac',
+          mimeType: 'audio/flac',
+          size: audioData.length,
+          fileName: 'audio.flac',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts[0].kind).toBe('audio-transcoded-mp3');
+      expect(result.artifacts[0].mimeType).toBe('audio/mpeg');
+      expect(result.artifacts[0].storageKey).toBe('test/audio-mp3.mp3');
+    });
+
+    it('should transcode to Opus', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: true,
+        transcodeOptions: {
+          codec: 'opus',
+          bitrate: '96k',
+        },
+      });
+
+      const audioData = createMockAudioData(5000);
+      const getData = vi.fn().mockResolvedValue(audioData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_011',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.wav',
+          mimeType: 'audio/wav',
+          size: audioData.length,
+          fileName: 'audio.wav',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts[0].kind).toBe('audio-transcoded-opus');
+      expect(result.artifacts[0].mimeType).toBe('audio/opus');
+      expect(result.artifacts[0].storageKey).toBe('test/audio-opus.opus');
+    });
+
+    it('should extract audio metadata', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: false,
+        extractMetadata: true,
+      });
+
+      const audioData = createMockAudioData(5000);
+      const getData = vi.fn().mockResolvedValue(audioData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_012',
+          versionId: 'ver_001',
+          storageKey: 'test/song.mp3',
+          mimeType: 'audio/mpeg',
+          size: audioData.length,
+          fileName: 'song.mp3',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('audio-metadata');
+      expect(result.artifacts[0].mimeType).toBe('application/json');
+      expect(result.artifacts[0].storageKey).toBe('test/song-metadata.json');
+
+      const metadata = JSON.parse(new TextDecoder().decode(result.artifacts[0].data));
+      expect(metadata).toHaveProperty('duration');
+      expect(metadata).toHaveProperty('codec');
+      expect(metadata).toHaveProperty('bitrate');
+      expect(metadata).toHaveProperty('sampleRate');
+      expect(metadata).toHaveProperty('channels');
+      expect(metadata).toHaveProperty('title');
+      expect(metadata).toHaveProperty('artist');
+      expect(metadata).toHaveProperty('album');
+    });
+
+    it('should generate waveform data', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: false,
+        generateWaveform: true,
+      });
+
+      const audioData = createMockAudioData(5000);
+      const getData = vi.fn().mockResolvedValue(audioData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_013',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.mp3',
+          mimeType: 'audio/mpeg',
+          size: audioData.length,
+          fileName: 'audio.mp3',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].kind).toBe('audio-waveform');
+      expect(result.artifacts[0].mimeType).toBe('application/json');
+      expect(result.artifacts[0].storageKey).toBe('test/audio-waveform.json');
+
+      const waveform = JSON.parse(new TextDecoder().decode(result.artifacts[0].data));
+      expect(waveform).toHaveProperty('samples');
+      expect(waveform).toHaveProperty('peakAmplitude');
+      expect(waveform).toHaveProperty('duration');
+      expect(Array.isArray(waveform.samples)).toBe(true);
+      expect(waveform.samples.length).toBeGreaterThan(0);
+    });
+
+    it('should generate deterministic waveform output for the same input', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: false,
+        generateWaveform: true,
+      });
+
+      const audioData = createMockAudioData(5000);
+      const input = {
+        fileId: 'file_013_repeat',
+        versionId: 'ver_001',
+        storageKey: 'test/audio-repeat.mp3',
+        mimeType: 'audio/mpeg',
+        size: audioData.length,
+        fileName: 'audio-repeat.mp3',
+      };
+
+      const first = await processor.process(input, vi.fn().mockResolvedValue(audioData));
+      const second = await processor.process(input, vi.fn().mockResolvedValue(audioData));
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      expect(first.artifacts[0].data).toEqual(second.artifacts[0].data);
+    });
+
+    it('should generate all artifacts when all options enabled', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: true,
+        extractMetadata: true,
+        generateWaveform: true,
+      });
+
+      const audioData = createMockAudioData(5000);
+      const getData = vi.fn().mockResolvedValue(audioData);
+
+      const result = await processor.process(
+        {
+          fileId: 'file_014',
+          versionId: 'ver_001',
+          storageKey: 'test/complete.mp3',
+          mimeType: 'audio/mpeg',
+          size: audioData.length,
+          fileName: 'complete.mp3',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts).toHaveLength(3);
+
+      const kinds = result.artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['audio-metadata', 'audio-transcoded-aac', 'audio-waveform']);
+    });
+
+    it('should handle different bitrates correctly', async () => {
+      const lowBitrate = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: true,
+        transcodeOptions: { codec: 'aac', bitrate: '64k' },
+      });
+
+      const highBitrate = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: true,
+        transcodeOptions: { codec: 'aac', bitrate: '256k' },
+      });
+
+      const audioData = createMockAudioData(10000);
+      const getDataLow = vi.fn().mockResolvedValue(audioData);
+      const getDataHigh = vi.fn().mockResolvedValue(audioData);
+
+      const resultLow = await lowBitrate.process(
+        {
+          fileId: 'file_015',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.mp3',
+          mimeType: 'audio/mpeg',
+          size: audioData.length,
+          fileName: 'audio.mp3',
+        },
+        getDataLow
+      );
+
+      const resultHigh = await highBitrate.process(
+        {
+          fileId: 'file_016',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.mp3',
+          mimeType: 'audio/mpeg',
+          size: audioData.length,
+          fileName: 'audio.mp3',
+        },
+        getDataHigh
+      );
+
+      expect(resultLow.success).toBe(true);
+      expect(resultHigh.success).toBe(true);
+
+      expect(resultLow.artifacts[0].data.length).toBeLessThan(resultHigh.artifacts[0].data.length);
+    });
+
+    it('falls back safely when bitrate is malformed', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: true,
+        transcodeOptions: { codec: 'aac', bitrate: 'oops' },
+      });
+
+      const audioData = createMockAudioData(10000);
+      const result = await processor.process(
+        {
+          fileId: 'file_016_bad_bitrate',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.wav',
+          mimeType: 'audio/wav',
+          size: audioData.length,
+          fileName: 'audio.wav',
+        },
+        vi.fn().mockResolvedValue(audioData),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.artifacts[0].metadata).toMatchObject({ bitrate: 'oops' });
+      expect(result.artifacts[0].data.length).toBeGreaterThan(0);
+    });
+
+    it('should handle getData errors gracefully', async () => {
+      const processor = createAudioProcessor({ provider: createMockAudioProvider() });
+      const getData = vi.fn().mockRejectedValue(new Error('Download failed'));
+
+      const result = await processor.process(
+        {
+          fileId: 'file_017',
+          versionId: 'ver_001',
+          storageKey: 'test/error.mp3',
+          mimeType: 'audio/mpeg',
+          size: 1000,
+          fileName: 'error.mp3',
+        },
+        getData
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Download failed');
+      expect(result.artifacts).toHaveLength(0);
+    });
+
+    it('skips loading source bytes when every audio operation is disabled', async () => {
+      const processor = createAudioProcessor({
+        provider: createMockAudioProvider(),
+        transcode: false,
+        extractMetadata: false,
+        generateWaveform: false,
+      });
+      const getData = vi.fn();
+
+      const result = await processor.process(
+        {
+          fileId: 'file_audio_disabled',
+          versionId: 'ver_001',
+          storageKey: 'test/audio.mp3',
+          mimeType: 'audio/mpeg',
+          size: 1000,
+          fileName: 'audio.mp3',
+        },
+        getData,
+      );
+
+      expect(result).toEqual({ success: true, artifacts: [] });
+      expect(getData).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/filefn/processing/tsconfig.json
+++ b/filefn/processing/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/filefn/processing/vitest.config.ts
+++ b/filefn/processing/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2567,6 +2567,20 @@
         }
       }
     },
+    "filefn/processing": {
+      "name": "@filefn/processing",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "sharp": "^0.33.5",
+        "tesseract.js": "^7.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^3.2.4"
+      }
+    },
     "filefn/viewer": {
       "name": "@filefn/viewer",
       "version": "0.1.0",
@@ -2575,6 +2589,16 @@
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
         "vitest": "^3.2.4"
+      }
+    },
+    "filefn/processing/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "filefn/viewer/node_modules/@types/node": {
@@ -4106,6 +4130,10 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@filefn/processing": {
+      "resolved": "filefn/processing",
+      "link": true
+    },
     "node_modules/@filefn/viewer": {
       "resolved": "filefn/viewer",
       "link": true
@@ -4217,7 +4245,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4238,7 +4265,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6983,6 +7009,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "dev": true,
@@ -7434,7 +7466,6 @@
     },
     "node_modules/color": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1",
@@ -7460,7 +7491,6 @@
     },
     "node_modules/color-string": {
       "version": "1.9.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
@@ -9941,6 +9971,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "funding": [
@@ -10059,7 +10095,6 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-decimal": {
@@ -10144,6 +10179,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -12128,6 +12169,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "dev": true,
@@ -12241,6 +12302,15 @@
         "oniguruma-parser": "^0.12.1",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -12973,6 +13043,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "license": "MIT",
@@ -13358,7 +13434,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.3",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13541,7 +13616,6 @@
     },
     "node_modules/sharp": {
       "version": "0.33.5",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13736,7 +13810,6 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
@@ -14132,6 +14205,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "dev": true,
@@ -14306,6 +14403,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -15292,6 +15395,28 @@
       "version": "3.1.0",
       "license": "MIT"
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "license": "ISC",
@@ -15670,6 +15795,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",


### PR DESCRIPTION
## Summary
- add the `@filefn/processing` package with image, PDF, OCR, audio, and video processors
- include the minimal root workspace wiring for `filefn/*`
- keep `.conduct` excluded for the `origin/dev` target

## Testing
- `cd filefn/processing && npm run build`
- `cd filefn/processing && npm run typecheck`
- `cd filefn/processing && npm test -- --run`

## Notes
- `.conduct` was intentionally excluded from this PR
- `.gitignore` was not changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the new `@filefn/processing` package: a pluggable pipeline for thumbnails, image transforms, PDF previews, OCR, audio, video, and compression. Wires `filefn/*` into the workspace to fulfill SF-14.

- **New Features**
  - Pipeline utilities: types, `createPipeline`, and `supportsProcessor`.
  - Processors: thumbnails; PDF previews; image transforms (resize/crop/rotate); OCR; audio/video (posters, transcodes, metadata/waveform); compression.
  - Providers: OCR defaults to `tesseract.js`; audio/video require providers; exports `createCommandVideoProvider` and `createCommandAudioProvider`.
  - Exports `*_SUPPORTED_MIME_TYPES`; artifacts include storage keys and metadata.

- **Dependencies**
  - Runtime: `sharp`, `tesseract.js`.
  - Dev: `vitest`, `typescript`, `@types/node`.
  - Adds `filefn/*` to the workspace.

<sup>Written for commit 15ef7d36765348e98024ba2631fcc576db8d0841. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new media processing package providing thumbnail generation, PDF previews, compression, OCR, image transforms (resize/crop/rotate), video (poster, transcode, metadata) and audio (transcode, waveform, metadata).
* **Types**
  * Public TypeScript types and interfaces for processors, jobs, configs and artifacts.
* **Tests**
  * Comprehensive test suites covering processors and providers.
* **Chores**
  * New package manifest with build, test and typecheck scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->