### PR TITLE
SF-14: feat(filefn): add server package

### DIFF
--- a/filefn/server/package.json
+++ b/filefn/server/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@filefn/server",
+  "version": "0.1.0",
+  "description": "FileFn server SDK for file upload/download handling",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": ["file", "upload", "server", "filefn"],
+  "author": "21n",
+  "license": "MIT",
+  "bugs": { "url": "https://github.com/21nCo/super-functions/issues" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "filefn/server"
+  },
+  "publishConfig": { "access": "public" },
+  "dependencies": {
+    "@superfunctions/storage": "*",
+    "@superfunctions/files": "*",
+    "@superfunctions/db": "*",
+    "@superfunctions/http": "*",
+    "@superfunctions/middleware": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/filefn/server/src/__tests__/artifact-authz.test.ts
+++ b/filefn/server/src/__tests__/artifact-authz.test.ts
@@ -1,0 +1,582 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFileFn, type FileFn } from '../index.js';
+import { createSharesService } from '../shares/service.js';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createDb(seed: Record<string, any[]> = {}): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let seq = 1;
+
+  function idFor(record: any): string {
+    return (
+      record.uploadSessionId ||
+      record.artifactId ||
+      record.fileId ||
+      record.versionId ||
+      record.permissionId ||
+      record.tokenHash ||
+      `id_${seq++}`
+    );
+  }
+
+  for (const [model, rows] of Object.entries(seed)) {
+    const table = new Map<string, any>();
+    for (const row of rows) table.set(idFor(row), { ...row });
+    tables.set(model, table);
+  }
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matches(record: any, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+      if (clause.operator === 'in' && !clause.value.includes(value)) return false;
+    }
+    return true;
+  }
+
+  return {
+    id: 'phase0-artifacts-db',
+    name: 'phase0-artifacts-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const table = getTable(params.model);
+      const row = { ...params.data };
+      table.set(idFor(row), row);
+      return row;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const row of table.values()) {
+        if (matches(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const rows = Array.from(table.values()).filter((row) => matches(row, params.where));
+      if (params.orderBy?.some((item: any) => item.field === 'createdAt' && item.direction === 'desc')) {
+        rows.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      }
+      return rows;
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          const next = { ...row, ...params.data };
+          table.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) {
+      const table = getTable(params.model);
+      let deleted = 0;
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          table.delete(id);
+          deleted += 1;
+        }
+      }
+      return deleted;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+describe('PHASE_03 PROCESS-002/FILE-002 share and artifact authz + proxy descriptors', () => {
+  let fileFn: FileFn;
+  let db: Adapter;
+
+  beforeEach(() => {
+    db = createDb({
+      files: [
+        {
+          fileId: 'file_0001',
+          currentVersionId: 'ver_0001',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 10,
+          name: 'one.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          fileId: 'file_0002',
+          currentVersionId: 'ver_0002',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 10,
+          name: 'two.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      fileVersions: [
+        {
+          versionId: 'ver_0001',
+          fileId: 'file_0001',
+          storageKey: 'files/file_0001/ver_0001',
+          mimeType: 'image/png',
+          size: 10,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          versionId: 'ver_0002',
+          fileId: 'file_0002',
+          storageKey: 'files/file_0002/ver_0002',
+          mimeType: 'image/png',
+          size: 10,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      fileArtifacts: [
+        {
+          artifactId: 'art_0001',
+          fileId: 'file_0002',
+          versionId: 'ver_0002',
+          kind: 'thumbnail-small',
+          storageKey: 'artifacts/file_0002/thumb',
+          mimeType: 'image/webp',
+          size: 123,
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          artifactId: 'art_pdf_0001',
+          fileId: 'file_0002',
+          versionId: 'ver_0002',
+          kind: 'pdf-preview-page-1-small',
+          storageKey: 'artifacts/file_0002/pdf-preview-page-1-small.png',
+          mimeType: 'image/png',
+          size: 456,
+          metadata: { pageNumber: 1 },
+          createdAt: '2026-03-20T12:01:00.000Z',
+        },
+      ],
+    });
+
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: false,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      },
+    });
+
+    fileFn = createFileFn({
+      db,
+      storage,
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      auth: {
+        required: false,
+        resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+      },
+    });
+  });
+
+  it('TV-ACCESS-NEG-001: artifact download should 404 for cross-file binding mismatch', async () => {
+    const res = await fileFn.router.handle(
+      new Request('http://localhost/file_0001/artifacts/art_0001/download', { method: 'GET' })
+    );
+    const body = await res!.json();
+
+    expect(res!.status).toBe(404);
+    expect(body.error.code).toBe('FILEFN_NOT_FOUND');
+  });
+
+  it('TV-DOWNLOAD-FALLBACK-001: artifact descriptor should be an HTTP proxy route, never proxy://', async () => {
+    const res = await fileFn.router.handle(
+      new Request('http://localhost/file_0002/artifacts/art_0001/download', { method: 'GET' })
+    );
+    const body = await res!.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.data.url).toMatch(/^\/proxy\/files\/file_0002\/artifacts\/art_0001\/download$/);
+    expect(body.data.url).not.toMatch(/^proxy:\/\//);
+  });
+
+  it('TV-PROCESS-002: artifact listing should include canonical thumbnail and PDF preview kinds', async () => {
+    const res = await fileFn.router.handle(
+      new Request('http://localhost/file_0002/artifacts', {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_artifact_list' },
+      }),
+    );
+    const body = await res!.json();
+
+    expect(res!.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.requestId).toBe('req_artifact_list');
+    expect(body.data.artifacts.map((artifact: any) => artifact.kind)).toEqual([
+      'pdf-preview-page-1-small',
+      'thumbnail-small',
+    ]);
+  });
+
+  it('TV-PROCESS-002: PDF preview artifact descriptors should stay on HTTP proxy routes', async () => {
+    const res = await fileFn.router.handle(
+      new Request('http://localhost/file_0002/artifacts/art_pdf_0001/download', { method: 'GET' }),
+    );
+    const body = await res!.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.data.url).toMatch(/^\/proxy\/files\/file_0002\/artifacts\/art_pdf_0001\/download$/);
+    expect(body.data.url).not.toMatch(/^proxy:\/\//);
+  });
+
+  it('TV-PROCESS-002: PDF preview artifact proxy routes should stream image bytes', async () => {
+    const descriptorRes = await fileFn.router.handle(
+      new Request('http://localhost/file_0002/artifacts/art_pdf_0001/download', { method: 'GET' }),
+    );
+    const descriptorBody = await descriptorRes!.json();
+
+    const proxyRes = await fileFn.router.handle(
+      new Request(`http://localhost${descriptorBody.data.url}`, { method: 'GET' }),
+    );
+
+    expect(proxyRes!.status).toBe(200);
+    expect(proxyRes!.headers.get('content-type')).toBe('image/png');
+  });
+
+  it('TV-DOWNLOAD-FALLBACK-001: artifact proxy data-plane route should stream authorized bytes', async () => {
+    const descriptorRes = await fileFn.router.handle(
+      new Request('http://localhost/file_0002/artifacts/art_0001/download', { method: 'GET' }),
+    );
+    const descriptorBody = await descriptorRes!.json();
+
+    const proxyRes = await fileFn.router.handle(
+      new Request(`http://localhost${descriptorBody.data.url}`, { method: 'GET' }),
+    );
+
+    expect(proxyRes!.status).toBe(200);
+    expect(proxyRes!.headers.get('content-type')).toBe('image/webp');
+  });
+
+  it('TV-PROCESS-NEG-001: unauthorized artifact download should return 403 FILEFN_FORBIDDEN', async () => {
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: false,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      },
+    });
+    const fileFnUnauthorized = createFileFn({
+      db,
+      storage,
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      auth: {
+        required: false,
+        resolveSession: async () => ({ principalId: 'user_999', tenantId: 'org_999' }),
+      },
+    });
+
+    const res = await fileFnUnauthorized.router.handle(
+      new Request('http://localhost/file_0002/artifacts/art_0001/download', { method: 'GET' }),
+    );
+    const body = await res!.json();
+
+    expect(res!.status).toBe(403);
+    expect(body.error.code).toBe('FILEFN_FORBIDDEN');
+  });
+
+  it('TV-PROCESS-NEG-002: artifact routes enforce auth by default when auth is required', async () => {
+    const authRequiredFileFn = createFileFn({
+      db,
+      storage: createFakeStorageAdapter({
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: false,
+          multipart: true,
+          proxyStreamingUpload: true,
+          proxyStreamingDownload: true,
+        },
+      }),
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      auth: {
+        required: true,
+        resolveSession: async () => null,
+      },
+    });
+
+    const res = await authRequiredFileFn.router.handle(
+      new Request('http://localhost/file_0002/artifacts', { method: 'GET' }),
+    );
+    const body = await res!.json();
+
+    expect(res!.status).toBe(401);
+    expect(body.error.code).toBe('FILEFN_AUTH_REQUIRED');
+  });
+
+  it('TV-PROCESS-TRIGGER-001: triggerProcessing uses the stored current version when versionId is omitted', async () => {
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: false,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      },
+    });
+
+    const events: any[] = [];
+    const fileFnWithProcessing = createFileFn({
+      db,
+      storage,
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      auth: {
+        required: false,
+        resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+      },
+      processing: {
+        enabled: true,
+        processors: [{
+          name: 'test-processor',
+          supportedMimeTypes: ['image/png'],
+          process: async (input: any) => {
+            events.push(input);
+            return { success: true, artifacts: [] };
+          },
+        }],
+      },
+    });
+
+    const res = await fileFnWithProcessing.router.handle(
+      new Request('http://localhost/file_0002/process', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      }),
+    );
+    const body = await res!.json();
+
+    expect(res!.status).toBe(200);
+    expect(body.ok).toBe(true);
+    await vi.waitFor(() => {
+      expect(events).toHaveLength(1);
+    });
+    expect(events[0]).toEqual(expect.objectContaining({
+      fileId: 'file_0002',
+      versionId: 'ver_0002',
+      storageKey: 'files/file_0002/ver_0002',
+      mimeType: 'image/png',
+      size: 10,
+      fileName: 'two.png',
+    }));
+  });
+
+  it('TV-DOWNLOAD-FALLBACK-001: share download descriptor should be an HTTP proxy route, never proxy://', async () => {
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: false,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      },
+    });
+
+    const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+    const { token } = await sharesService.createShareLink(
+      { fileId: 'file_0001' },
+      { principalId: 'user_123', tenantId: 'org_123' }
+    );
+
+    const descriptor = await sharesService.downloadViaShareLink(token, {
+      principalId: 'anonymous',
+      tenantId: 'org_123',
+      isAuthenticated: false,
+    });
+
+    expect(descriptor.url).toMatch(/^\/proxy\/share-links\//);
+    expect(descriptor.url).not.toMatch(/^proxy:\/\//);
+  });
+
+  it('TV-DOWNLOAD-FALLBACK-001: share proxy data-plane route should stream bytes', async () => {
+    const sharesService = createSharesService({
+      db,
+      storage: createFakeStorageAdapter({
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: false,
+          multipart: true,
+          proxyStreamingUpload: true,
+          proxyStreamingDownload: true,
+        },
+      }),
+      namespace: 'filefn',
+    });
+
+    const { token } = await sharesService.createShareLink(
+      { fileId: 'file_0001' },
+      { principalId: 'user_123', tenantId: 'org_123' },
+    );
+
+    const descriptorRes = await fileFn.router.handle(
+      new Request(`http://localhost/share-links/${token}/download`, { method: 'GET' }),
+    );
+    const descriptorBody = await descriptorRes!.json();
+
+    const proxyRes = await fileFn.router.handle(
+      new Request(`http://localhost${descriptorBody.data.url}`, { method: 'GET' }),
+    );
+
+    expect(proxyRes!.status).toBe(200);
+    expect(proxyRes!.headers.get('content-type')).toBe('image/png');
+  });
+
+  it('TV-RATE-001: shareDownload category rate limit should return FILEFN_RATE_LIMITED with ISO resetAt', async () => {
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: false,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      },
+    });
+
+    const fileFnWithShareRate = createFileFn({
+      db,
+      storage,
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      rateLimit: {
+        limits: {
+          shareDownload: { windowSeconds: 60, maxRequests: 1 },
+        },
+      },
+      auth: {
+        required: false,
+        resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+      },
+    });
+
+    const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+    const { token } = await sharesService.createShareLink(
+      { fileId: 'file_0001' },
+      { principalId: 'user_123', tenantId: 'org_123' }
+    );
+
+    const first = await fileFnWithShareRate.router.handle(
+      new Request(`http://localhost/share-links/${token}/download`, { method: 'GET' })
+    );
+    expect(first!.status).toBe(200);
+
+    const second = await fileFnWithShareRate.router.handle(
+      new Request(`http://localhost/share-links/${token}/download`, { method: 'GET' })
+    );
+    expect(second!.status).toBe(429);
+    const body = await second!.json();
+    expect(body.error.code).toBe('FILEFN_RATE_LIMITED');
+    expect(typeof body.error.details?.resetAt).toBe('string');
+    expect(Number.isNaN(Date.parse(body.error.details.resetAt))).toBe(false);
+  });
+
+  it('TV-RATE-001: artifactDownload category rate limit should apply to artifact control-plane downloads', async () => {
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: false,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      },
+    });
+
+    const fileFnWithArtifactRate = createFileFn({
+      db,
+      storage,
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      rateLimit: {
+        limits: {
+          artifactDownload: { windowSeconds: 60, maxRequests: 1 },
+        },
+      },
+      auth: {
+        required: false,
+        resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+      },
+    });
+
+    const first = await fileFnWithArtifactRate.router.handle(
+      new Request('http://localhost/file_0002/artifacts/art_0001/download', { method: 'GET' })
+    );
+    expect(first!.status).toBe(200);
+
+    const second = await fileFnWithArtifactRate.router.handle(
+      new Request('http://localhost/file_0002/artifacts/art_0001/download', { method: 'GET' })
+    );
+    expect(second!.status).toBe(429);
+    const body = await second!.json();
+    expect(body.error.code).toBe('FILEFN_RATE_LIMITED');
+    expect(typeof body.error.details?.resetAt).toBe('string');
+    expect(Number.isNaN(Date.parse(body.error.details.resetAt))).toBe(false);
+  });
+});

--- a/filefn/server/src/__tests__/delete-cascade.test.ts
+++ b/filefn/server/src/__tests__/delete-cascade.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, it } from 'vitest';
+import { createFileService } from '../files/service.js';
+import { createEventEmitter } from '../events.js';
+import { createPolicyRegistry } from '../policies.js';
+import { createRoutedStorageAdapter, type StorageAdapter, type StorageAdapterCapabilities } from '@superfunctions/storage';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createDb(seed: Record<string, any[]>) {
+  const tables = new Map<string, Map<string, any>>();
+  let seq = 1;
+
+  function keyFor(row: any): string {
+    return (
+      row.versionId ||
+      row.permissionId ||
+      row.artifactId ||
+      row.tokenHash ||
+      (row.uploadSessionId && row.partNumber !== undefined ? `${row.uploadSessionId}:${row.partNumber}` : undefined) ||
+      row.uploadSessionId ||
+      row.fileId ||
+      `id_${seq++}`
+    );
+  }
+
+  for (const [model, rows] of Object.entries(seed)) {
+    const t = new Map<string, any>();
+    for (const row of rows) t.set(keyFor(row), { ...row });
+    tables.set(model, t);
+  }
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matches(row: any, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = row?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+      if (clause.operator === 'in' && !clause.value.includes(value)) return false;
+    }
+    return true;
+  }
+
+  const adapter: Adapter = {
+    id: 'phase0-delete-db',
+    name: 'phase0-delete-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const t = getTable(params.model);
+      const row = { ...params.data };
+      t.set(keyFor(row), row);
+      return row;
+    },
+    async findOne(params) {
+      const t = getTable(params.model);
+      for (const row of t.values()) {
+        if (matches(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const t = getTable(params.model);
+      return Array.from(t.values()).filter((row) => matches(row, params.where));
+    },
+    async update(params) {
+      const t = getTable(params.model);
+      for (const [id, row] of t.entries()) {
+        if (matches(row, params.where)) {
+          const next = { ...row, ...params.data };
+          t.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const t = getTable(params.model);
+      for (const [id, row] of t.entries()) {
+        if (matches(row, params.where)) {
+          t.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) {
+      const t = getTable(params.model);
+      let deleted = 0;
+      for (const [id, row] of t.entries()) {
+        if (matches(row, params.where)) {
+          t.delete(id);
+          deleted += 1;
+        }
+      }
+      return deleted;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+
+  return {
+    adapter,
+    rows(model: string) {
+      return Array.from(getTable(model).values());
+    },
+  };
+}
+
+describe('PHASE_05 FILE-004 delete cascade semantics', () => {
+  it('TV-DELETE-CASCADE-001: delete removes related metadata, cleans artifacts/temp parts, and keeps shared storage alive', async () => {
+    const db = createDb({
+      files: [
+        {
+          fileId: 'file_0001',
+          currentVersionId: 'ver_0001',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 100,
+          name: 'one.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          fileId: 'file_0002',
+          currentVersionId: 'ver_0002',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 100,
+          name: 'two.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      fileVersions: [
+        {
+          versionId: 'ver_0001',
+          fileId: 'file_0001',
+          storageKey: 'shared/storage-key',
+          mimeType: 'image/png',
+          size: 100,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          versionId: 'ver_0003',
+          fileId: 'file_0001',
+          storageKey: 'unique/storage-key',
+          mimeType: 'image/png',
+          size: 25,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:01.000Z',
+        },
+        {
+          versionId: 'ver_0002',
+          fileId: 'file_0002',
+          storageKey: 'shared/storage-key',
+          mimeType: 'image/png',
+          size: 100,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      filePermissions: [
+        {
+          permissionId: 'perm_0001',
+          fileId: 'file_0001',
+          principalId: 'user_456',
+          canRead: true,
+          canWrite: false,
+          canDelete: false,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      fileShares: [
+        {
+          tokenHash: 'hash_0001',
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          expiresAt: null,
+          requiresAuth: false,
+          maxDownloads: null,
+          downloads: 0,
+          revokedAt: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      fileArtifacts: [
+        {
+          artifactId: 'art_0001',
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          kind: 'thumbnail',
+          storageKey: 'artifact/storage-key',
+          mimeType: 'image/webp',
+          size: 11,
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      uploadSessions: [
+        {
+          uploadSessionId: 'upl_0001',
+          status: 'pending',
+          policy: 'user-avatar',
+          fileId: 'file_0001',
+          fileName: 'stale.png',
+          mimeType: 'image/png',
+          size: 55,
+          uploadMode: 'proxy',
+          chunkSizeBytes: 8,
+          totalParts: 7,
+          storageKey: 'tmp/session-key',
+          storageUploadId: null,
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          expiresAt: '2026-03-21T12:00:00.000Z',
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          uploadSessionId: 'upl_0002',
+          status: 'in_progress',
+          policy: 'user-avatar',
+          fileId: 'file_0001',
+          fileName: 'stale-multipart.png',
+          mimeType: 'image/png',
+          size: 77,
+          uploadMode: 'multipart-signed-url',
+          chunkSizeBytes: 8,
+          totalParts: 10,
+          storageKey: 'tmp/multipart-key',
+          storageUploadId: 'mp_0001',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          expiresAt: '2026-03-21T12:00:00.000Z',
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      uploadParts: [
+        {
+          uploadSessionId: 'upl_0001',
+          partNumber: 1,
+          etag: 'etag_1',
+          size: 8,
+          checksumSha256Base64: null,
+        },
+        {
+          uploadSessionId: 'upl_0002',
+          partNumber: 1,
+          etag: 'etag_2',
+          size: 8,
+          checksumSha256Base64: null,
+        },
+      ],
+    });
+
+    const deletedKeys: string[] = [];
+    const abortedMultipart: Array<{ key: string; uploadId: string }> = [];
+    const quotaDeltas: Array<{ principalId?: string; tenantId?: string; bytes: number }> = [];
+
+    const service = createFileService({
+      db: db.adapter,
+      storage: {
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: true,
+          multipart: true,
+          proxyStreamingUpload: true,
+          proxyStreamingDownload: true,
+        },
+        async deleteObject(input: { key: string }) {
+          deletedKeys.push(input.key);
+        },
+        async abortMultipartUpload(input: { key: string; uploadId: string }) {
+          abortedMultipart.push(input);
+        },
+      } as any,
+      events: createEventEmitter(),
+      quota: {
+        async checkQuota() {
+          return { allowed: true, current: 0, limit: Number.MAX_SAFE_INTEGER };
+        },
+        async recordUsage(input) {
+          quotaDeltas.push(input);
+        },
+      },
+      namespace: 'filefn',
+    });
+
+    await service.deleteFile('file_0001', {
+      principalId: 'user_123',
+      tenantId: 'org_123',
+      requestId: 'req_delete_001',
+    });
+
+    expect(db.rows('filePermissions').filter((row) => row.fileId === 'file_0001')).toHaveLength(0);
+    expect(db.rows('fileShares').filter((row) => row.fileId === 'file_0001')).toHaveLength(0);
+    expect(db.rows('fileArtifacts').filter((row) => row.fileId === 'file_0001')).toHaveLength(0);
+    expect(db.rows('fileVersions').filter((row) => row.fileId === 'file_0001')).toHaveLength(0);
+    expect(db.rows('files').find((row) => row.fileId === 'file_0001')).toBeUndefined();
+    expect(db.rows('uploadSessions').filter((row) => row.fileId === 'file_0001')).toHaveLength(0);
+    expect(db.rows('uploadParts').filter((row) => row.uploadSessionId === 'upl_0001')).toHaveLength(0);
+    expect(db.rows('uploadParts').filter((row) => row.uploadSessionId === 'upl_0002')).toHaveLength(0);
+
+    expect(abortedMultipart).toEqual([{ key: 'tmp/multipart-key', target: 'durable', uploadId: 'mp_0001' }]);
+    expect(deletedKeys).toContain('tmp/session-key.part1');
+    expect(deletedKeys).toContain('artifact/storage-key');
+    expect(deletedKeys).toContain('unique/storage-key');
+    expect(deletedKeys).not.toContain('shared/storage-key');
+    expect(quotaDeltas).toEqual([{ principalId: 'user_123', tenantId: 'org_123', bytes: -25 }]);
+  });
+
+  it('TV-DELETE-CASCADE-NEG-001: deleting one of two files with a shared key does not physically delete shared storage', async () => {
+    const db = createDb({
+      files: [
+        {
+          fileId: 'file_0001',
+          currentVersionId: 'ver_0001',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 100,
+          name: 'one.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          fileId: 'file_0002',
+          currentVersionId: 'ver_0002',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 100,
+          name: 'two.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      fileVersions: [
+        {
+          versionId: 'ver_0001',
+          fileId: 'file_0001',
+          storageKey: 'shared/storage-key',
+          mimeType: 'image/png',
+          size: 100,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          versionId: 'ver_0002',
+          fileId: 'file_0002',
+          storageKey: 'shared/storage-key',
+          mimeType: 'image/png',
+          size: 100,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      filePermissions: [],
+      fileShares: [],
+      fileArtifacts: [],
+      uploadSessions: [],
+      uploadParts: [],
+    });
+
+    const deletedKeys: string[] = [];
+    const quotaDeltas: Array<{ principalId?: string; tenantId?: string; bytes: number }> = [];
+
+    const service = createFileService({
+      db: db.adapter,
+      storage: {
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: true,
+          multipart: true,
+          proxyStreamingUpload: true,
+          proxyStreamingDownload: true,
+        },
+        async deleteObject(input: { key: string }) {
+          deletedKeys.push(input.key);
+        },
+      } as any,
+      events: createEventEmitter(),
+      quota: {
+        async checkQuota() {
+          return { allowed: true, current: 0, limit: Number.MAX_SAFE_INTEGER };
+        },
+        async recordUsage(input) {
+          quotaDeltas.push(input);
+        },
+      },
+      namespace: 'filefn',
+    });
+
+    await service.deleteFile('file_0001', {
+      principalId: 'user_123',
+      tenantId: 'org_123',
+      requestId: 'req_delete_002',
+    });
+
+    expect(deletedKeys).toEqual([]);
+    expect(quotaDeltas).toEqual([]);
+    expect(db.rows('files').map((row) => row.fileId)).toEqual(['file_0002']);
+  });
+
+  it('TV-STORAGE-001: delete treats the same storage key in different logical targets as different physical objects', async () => {
+    const db = createDb({
+      files: [
+        {
+          fileId: 'file_durable',
+          currentVersionId: 'ver_durable',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'durable-policy',
+          mimeType: 'image/png',
+          size: 100,
+          name: 'one.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          fileId: 'file_temporary',
+          currentVersionId: 'ver_temporary',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'temporary-policy',
+          mimeType: 'image/png',
+          size: 100,
+          name: 'two.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+      fileVersions: [
+        {
+          versionId: 'ver_durable',
+          fileId: 'file_durable',
+          storageKey: 'shared/object.png',
+          mimeType: 'image/png',
+          size: 100,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          versionId: 'ver_temporary',
+          fileId: 'file_temporary',
+          storageKey: 'shared/object.png',
+          mimeType: 'image/png',
+          size: 100,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T12:00:00.000Z',
+        },
+      ],
+    });
+
+    const deleteCalls: string[] = [];
+    function makeAdapter(name: string): StorageAdapter {
+      const capabilities: StorageAdapterCapabilities = {
+        signedUploadUrls: true,
+        signedDownloadUrls: true,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      };
+      return {
+        name,
+        capabilities,
+        async statObject({ key }) {
+          return { key, size: 100 };
+        },
+        async deleteObject({ key }) {
+          deleteCalls.push(`${name}:${key}`);
+        },
+        async createMultipartUpload() {
+          return { uploadId: `${name}-upload` };
+        },
+        async signMultipartUploadPartUrl({ key, partNumber }) {
+          return { url: `https://${name}.local/${key}/${partNumber}` };
+        },
+        async completeMultipartUpload() {},
+        async abortMultipartUpload() {},
+        async signDownloadUrl({ key }) {
+          return { url: `https://${name}.local/${key}` };
+        },
+        async openUploadStream() {
+          return new WritableStream();
+        },
+        async openDownloadStream() {
+          return new ReadableStream();
+        },
+      };
+    }
+
+    const service = createFileService({
+      db: db.adapter,
+      storage: createRoutedStorageAdapter({
+        adapters: {
+          durable: makeAdapter('durable-bucket'),
+          temporary: makeAdapter('temporary-bucket'),
+        },
+      }),
+      policies: createPolicyRegistry([
+        { name: 'durable-policy', storageTarget: 'durable' },
+        { name: 'temporary-policy', storageTarget: 'temporary' },
+      ]),
+      events: createEventEmitter(),
+      namespace: 'filefn',
+    });
+
+    await service.deleteFile('file_durable', { principalId: 'user_123', tenantId: 'org_123' });
+    expect(deleteCalls).toContain('durable-bucket:shared/object.png');
+    expect(deleteCalls).not.toContain('temporary-bucket:shared/object.png');
+
+    await service.deleteFile('file_temporary', { principalId: 'user_123', tenantId: 'org_123' });
+    expect(deleteCalls).toContain('temporary-bucket:shared/object.png');
+  });
+});

--- a/filefn/server/src/__tests__/file-download-proxy.test.ts
+++ b/filefn/server/src/__tests__/file-download-proxy.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createFileRoutes } from '../files/routes.js';
+import { createFileService } from '../files/service.js';
+
+describe('Proxy Download', () => {
+  const mockDb = {
+    findOne: vi.fn(),
+  };
+
+  const mockStorage = {
+    capabilities: {
+      signedDownloadUrls: false, // Force proxy
+    },
+    signDownloadUrl: vi.fn(),
+    openDownloadStream: vi.fn(),
+  };
+
+  const mockAuthorizer = {
+    canRead: vi.fn().mockResolvedValue(true),
+  };
+
+  const service = createFileService({
+    db: mockDb as any,
+    storage: mockStorage as any,
+    events: {} as any,
+    authorizer: mockAuthorizer as any,
+  });
+
+  const routes = createFileRoutes({
+    service,
+    auth: { required: false },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getDownloadUrl returns proxy URL when signed URLs unsupported', async () => {
+    mockDb.findOne
+      .mockResolvedValueOnce({ fileId: 'f1', currentVersionId: 'v1' }) // getFile
+      .mockResolvedValueOnce({ versionId: 'v1', storageKey: 'k1', fileId: 'f1' }); // getVersion
+
+    const req = new Request('http://localhost/f1/download', { method: 'GET' });
+    const res = await routes.downloadFile(req, 'f1');
+    
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.url).toMatch(/\/proxy\/files\/f1\/download$/);
+  });
+
+  it('getDownloadUrl returns version proxy URL when versionId is provided', async () => {
+    mockDb.findOne
+      .mockResolvedValueOnce({ fileId: 'f1', currentVersionId: 'v1' }) // getFile
+      .mockResolvedValueOnce({ versionId: 'v2', storageKey: 'k2', fileId: 'f1' }); // getVersionChecked(v2)
+
+    const req = new Request('http://localhost/f1/versions/v2/download', { method: 'GET' });
+    const res = await routes.downloadFile(req, 'f1', 'v2');
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.url).toMatch(/\/proxy\/files\/f1\/versions\/v2\/download$/);
+    expect(body.data.url).not.toMatch(/^proxy:\/\//);
+  });
+});

--- a/filefn/server/src/__tests__/files-list-accessible.test.ts
+++ b/filefn/server/src/__tests__/files-list-accessible.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest';
+import { createFileService, type FileRecord } from '../files/service.js';
+import { createEventEmitter } from '../events.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+type Row = Record<string, any>;
+
+function createDb(seed: { files?: Row[]; permissions?: Row[] }): Adapter {
+  const tables = new Map<string, Map<string, Row>>();
+
+  tables.set('files', new Map((seed.files || []).map((file) => [file.fileId, file])));
+  tables.set(
+    'filePermissions',
+    new Map((seed.permissions || []).map((permission, idx) => [`perm_${idx + 1}`, permission])),
+  );
+
+  function table(model: string): Map<string, Row> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function match(record: Row, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'in' && !clause.value.includes(value)) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+      if (clause.operator === 'gt' && !(value > clause.value)) return false;
+    }
+    return true;
+  }
+
+  return {
+    id: 'file-list-db',
+    name: 'file-list-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const t = table(params.model);
+      const id = params.data.fileId || params.data.versionId || params.data.uploadSessionId || `id_${t.size + 1}`;
+      const row = { ...params.data, _id: id };
+      t.set(id, row);
+      return row;
+    },
+    async findOne(params) {
+      for (const row of table(params.model).values()) {
+        if (match(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      let rows = Array.from(table(params.model).values()).filter((row) => match(row, params.where));
+      const orderBy = params.orderBy;
+      if (orderBy && orderBy.length > 0) {
+        rows = rows.sort((a, b) => {
+          for (const clause of orderBy) {
+            const aValue = a[clause.field];
+            const bValue = b[clause.field];
+            if (aValue === bValue) continue;
+            if (clause.direction === 'asc') return aValue < bValue ? -1 : 1;
+            return aValue > bValue ? -1 : 1;
+          }
+          return 0;
+        });
+      }
+      return params.limit ? rows.slice(0, params.limit) : rows;
+    },
+    async update(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          const next = { ...row, ...params.data };
+          t.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany() { return 0; },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+function buildFile(input: Partial<FileRecord> & Pick<FileRecord, 'fileId' | 'ownerId' | 'updatedAt'>): FileRecord {
+  return {
+    fileId: input.fileId,
+    currentVersionId: input.currentVersionId || `ver_${input.fileId}`,
+    ownerId: input.ownerId,
+    tenantId: input.tenantId ?? 'org_123',
+    visibility: input.visibility || 'private',
+    policy: input.policy || 'user-avatar',
+    mimeType: input.mimeType || 'image/png',
+    size: input.size ?? 10,
+    name: input.name || `${input.fileId}.png`,
+    metadata: input.metadata || {},
+    createdAt: input.createdAt || '2026-03-20T10:00:00.000Z',
+    updatedAt: input.updatedAt,
+  };
+}
+
+describe('PHASE_03 FILE-001 deterministic list semantics', () => {
+  it('TV-FILE-LIST-001: returns readable set in deterministic order with stable cursor pagination', async () => {
+    const db = createDb({
+      files: [
+        buildFile({ fileId: 'file_003', ownerId: 'user_123', updatedAt: '2026-03-20T15:00:00.000Z' }),
+        buildFile({ fileId: 'file_001', ownerId: 'user_123', updatedAt: '2026-03-20T14:00:00.000Z' }),
+        buildFile({ fileId: 'file_004', ownerId: 'user_999', updatedAt: '2026-03-20T13:00:00.000Z', tenantId: 'org_999' }),
+        buildFile({ fileId: 'file_002', ownerId: 'user_999', updatedAt: '2026-03-20T16:00:00.000Z', tenantId: 'org_999' }),
+      ],
+      permissions: [
+        {
+          fileId: 'file_004',
+          principalId: 'user_123',
+          canRead: true,
+          tenantId: 'org_123',
+        },
+      ],
+    });
+
+    const service = createFileService({
+      db,
+      storage: { capabilities: { signedDownloadUrls: true } } as any,
+      events: createEventEmitter(),
+      namespace: 'filefn',
+    });
+
+    const ctx = { principalId: 'user_123', tenantId: 'org_123' };
+
+    const firstRun = await service.listFiles(ctx, { limit: 2 });
+    const secondRun = await service.listFiles(ctx, { limit: 2 });
+
+    expect(firstRun.files.map((f) => f.fileId)).toEqual(['file_003', 'file_001']);
+    expect(secondRun.files.map((f) => f.fileId)).toEqual(['file_003', 'file_001']);
+    expect(firstRun.nextCursor).toBeDefined();
+
+    const page2 = await service.listFiles(ctx, { limit: 2, cursor: firstRun.nextCursor });
+    expect(page2.files.map((f) => f.fileId)).toEqual(['file_004']);
+
+    const allReturned = [...firstRun.files, ...page2.files].map((f) => f.fileId);
+    expect(allReturned).not.toContain('file_002');
+  });
+
+  it('FILE-001: default limit is 20 and max limit is capped at 100', async () => {
+    const files: FileRecord[] = [];
+    for (let i = 1; i <= 120; i++) {
+      files.push(
+        buildFile({
+          fileId: `file_${i.toString().padStart(3, '0')}`,
+          ownerId: 'user_123',
+          updatedAt: `2026-03-20T12:${(i % 60).toString().padStart(2, '0')}:00.000Z`,
+        }),
+      );
+    }
+
+    const service = createFileService({
+      db: createDb({ files }),
+      storage: { capabilities: { signedDownloadUrls: true } } as any,
+      events: createEventEmitter(),
+      namespace: 'filefn',
+    });
+
+    const ctx = { principalId: 'user_123', tenantId: 'org_123' };
+
+    const defaultPage = await service.listFiles(ctx);
+    expect(defaultPage.files).toHaveLength(20);
+
+    const cappedPage = await service.listFiles(ctx, { limit: 999 });
+    expect(cappedPage.files).toHaveLength(100);
+  });
+
+  it('TV-FILE-LIST-002: cursor tie-breaking stays consistent for mixed-case file IDs', async () => {
+    const db = createDb({
+      files: [
+        buildFile({ fileId: 'file_a', ownerId: 'user_123', updatedAt: '2026-03-20T15:00:00.000Z' }),
+        buildFile({ fileId: 'file_B', ownerId: 'user_123', updatedAt: '2026-03-20T15:00:00.000Z' }),
+        buildFile({ fileId: 'file_c', ownerId: 'user_123', updatedAt: '2026-03-20T14:00:00.000Z' }),
+      ],
+    });
+
+    const service = createFileService({
+      db,
+      storage: { capabilities: { signedDownloadUrls: true } } as any,
+      events: createEventEmitter(),
+      namespace: 'filefn',
+    });
+
+    const page1 = await service.listFiles({ principalId: 'user_123', tenantId: 'org_123' }, { limit: 2 });
+    const page2 = await service.listFiles({ principalId: 'user_123', tenantId: 'org_123' }, { limit: 2, cursor: page1.nextCursor });
+
+    expect(page1.files.map((file) => file.fileId)).toEqual(['file_a', 'file_B']);
+    expect(page2.files.map((file) => file.fileId)).toEqual(['file_c']);
+  });
+});

--- a/filefn/server/src/__tests__/files.test.ts
+++ b/filefn/server/src/__tests__/files.test.ts
@@ -1,0 +1,922 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createFileFn, type FileFn } from '../index.js';
+import { createEventEmitter } from '../events.js';
+import { createPolicyRegistry } from '../policies.js';
+import { createProcessingService } from '../processing/service.js';
+import { createFakeStorageAdapter, createRoutedStorageAdapter, type StorageAdapter, type StorageAdapterCapabilities } from '@superfunctions/storage';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const FAKE_CAPABILITIES: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createFakeDbAdapter(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let idCounter = 1;
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matchesWhere(record: any, where: any[]): boolean {
+    for (const clause of where) {
+      const value = record[clause.field];
+      switch (clause.operator) {
+        case 'eq': if (value !== clause.value) return false; break;
+        case 'ne': if (value === clause.value) return false; break;
+        default: break;
+      }
+    }
+    return true;
+  }
+
+  return {
+    id: 'fake',
+    name: 'fake',
+    version: '1.0.0',
+    capabilities: FAKE_CAPABILITIES,
+    async create(params) {
+      const table = getTable(params.model);
+      const id = params.data.uploadSessionId || params.data.versionId || params.data.fileId || params.data.permissionId || `id_${idCounter++}`;
+      const record = { ...params.data, _id: id };
+      table.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const record of table.values()) {
+        if (matchesWhere(record, params.where)) return record;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const results: any[] = [];
+      for (const record of table.values()) {
+        if (!params.where || params.where.length === 0 || matchesWhere(record, params.where)) {
+          results.push(record);
+        }
+      }
+      // Sort by createdAt desc if orderBy specified
+      if (params.orderBy?.some((o: any) => o.field === 'createdAt' && o.direction === 'desc')) {
+        results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      }
+      return results.slice(0, params.limit || results.length);
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          const updated = { ...record, ...params.data };
+          table.set(id, updated);
+          return updated;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany(params) { return []; },
+    async updateMany(params) { return 0; },
+    async deleteMany(params) {
+      const table = getTable(params.model);
+      let count = 0;
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          table.delete(id);
+          count++;
+        }
+      }
+      return count;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return await this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return await this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count(params) { return 0; },
+    async transaction(callback) { return callback(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+async function createFileViaUpload(
+  fileFn: FileFn,
+  db: Adapter,
+  storageSizes: Map<string, number>,
+  principalId: string,
+  tenantId?: string,
+  inputOverrides: Partial<{
+    fileName: string;
+    size: number;
+    mimeType: string;
+    fileId: string;
+    metadata: Record<string, unknown>;
+  }> = {},
+): Promise<{ fileId: string; versionId: string }> {
+  const uploadInput = {
+    policy: 'user-avatar',
+    fileName: 'avatar.png',
+    size: 2097152,
+    mimeType: 'image/png',
+    ...inputOverrides,
+  };
+
+  const { uploadSessionId } = await fileFn.createUploadSession(
+    uploadInput,
+    { principalId, tenantId }
+  );
+
+  // Helper to get storageKey
+  const session = await db.findOne<any>({ model: 'uploadSessions', where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }] });
+  if (session) {
+    storageSizes.set(session.storageKey, uploadInput.size);
+  }
+  
+  await fileFn.completeUploadPart(
+    { uploadSessionId, partNumber: 1, etag: 'etag1', size: uploadInput.size },
+    { principalId, tenantId }
+  );
+  
+  return fileFn.completeUploadSession({ uploadSessionId }, { principalId, tenantId });
+}
+
+describe('@filefn/server files', () => {
+  let fileFn: FileFn;
+  let db: Adapter;
+  let storageSizes: Map<string, number>;
+
+  beforeEach(() => {
+    db = createFakeDbAdapter();
+    storageSizes = new Map();
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: true,
+        multipart: true,
+        proxyStreamingUpload: false,
+        proxyStreamingDownload: true,
+      },
+      async statObject(input) {
+        return { key: input.key, size: storageSizes.get(input.key) ?? 1024 };
+      }
+    });
+
+    fileFn = createFileFn({
+      db,
+      storage,
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png', 'image/jpeg'], maxSizeBytes: 10485760 }],
+      auth: { required: false },
+    });
+  });
+
+  describe('TV-FILE-GET-001: Get file metadata', () => {
+    it('should return file metadata for owner', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123', 'org_123');
+
+      const file = await fileFn.getFile({ fileId }, { principalId: 'user_123', tenantId: 'org_123' }) as any;
+
+      expect(file.fileId).toBe(fileId);
+      expect(file.ownerId).toBe('user_123');
+      expect(file.mimeType).toBe('image/png');
+    });
+
+    it('should persist upload metadata on the resulting file record', async () => {
+      const metadata = {
+        source: 'camera',
+        tags: ['avatar', 'profile'],
+        nested: { draft: true },
+      };
+
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123', 'org_123', { metadata });
+
+      const file = await fileFn.getFile({ fileId }, { principalId: 'user_123', tenantId: 'org_123' }) as any;
+
+      expect(file.metadata).toEqual(metadata);
+    });
+
+    it('TV-API-001: getFile route uses the canonical success envelope and echoes requestId', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123', 'org_123');
+
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+          async statObject(input) {
+            return { key: input.key, size: storageSizes.get(input.key) ?? 1024 };
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png', 'image/jpeg'] }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+        },
+      });
+
+      const response = await fileFnWithAuth.router.handle(
+        new Request(`http://localhost/${fileId}`, {
+          method: 'GET',
+          headers: { 'x-request-id': 'req_file_get' },
+        }),
+      );
+
+      expect(response!.status).toBe(200);
+      const body = await response!.json();
+      expect(body).toMatchObject({
+        ok: true,
+        warnings: [],
+        requestId: 'req_file_get',
+        data: {
+          fileId,
+          ownerId: 'user_123',
+          mimeType: 'image/png',
+        },
+      });
+    });
+  });
+
+  describe('TV-FILE-GET-NEG-001: Get file forbidden', () => {
+    it('should deny access for non-owner on private file', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123', 'org_123');
+
+      await expect(
+        fileFn.getFile({ fileId }, { principalId: 'other_user', tenantId: 'org_123' })
+      ).rejects.toMatchObject({ code: 'FILEFN_FORBIDDEN' });
+    });
+  });
+
+  describe('TV-FILE-DOWNLOAD-001: Download file', () => {
+    it('should return download URL for owner', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      // Create a new instance with resolveSession that returns the file owner
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123' }),
+        },
+      });
+
+      const request = new Request(`http://localhost/${fileId}/download`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_015' },
+      });
+
+      // Use router for full integration test
+      const response = await fileFnWithAuth.router.handle(request);
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(200);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(true);
+      expect(body.data.url).toBeDefined();
+    });
+  });
+
+  describe('TV-FILE-DOWNLOAD-NEG-001: Download forbidden', () => {
+    it('should deny download for non-owner on private file', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      // Create new instance with auth that resolves to different user
+      const fileFnOther = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'other_user' }),
+        },
+      });
+
+      const request = new Request(`http://localhost/${fileId}/download`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_016' },
+      });
+
+      const response = await fileFnOther.router.handle(request);
+      expect(response!.status).toBe(403);
+
+      const body = await response!.json();
+      expect(body.error.code).toBe('FILEFN_FORBIDDEN');
+    });
+  });
+
+  describe('TV-VERSION-LIST-001: List versions', () => {
+    it('should list versions newest-first', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      // Create another version (with a small delay to ensure different timestamps)
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 1000, mimeType: 'image/png', fileId },
+        { principalId: 'user_123' }
+      );
+      // Mock size for this session too
+      const session = await db.findOne<any>({ model: 'uploadSessions', where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }] });
+      if (session) storageSizes.set(session.storageKey, 1000);
+
+      await fileFn.completeUploadPart(
+        { uploadSessionId, partNumber: 1, etag: 'etag2', size: 1000 },
+        { principalId: 'user_123' }
+      );
+      await fileFn.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' });
+
+      // Create a new instance with resolveSession that returns the file owner
+      // Must use the same DB instance to see the versions
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123' }),
+        },
+      });
+
+      const request = new Request(`http://localhost/${fileId}/versions`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_021' },
+      });
+
+      const response = await fileFnWithAuth.router.handle(request);
+      expect(response!.status).toBe(200);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(true);
+      expect(body.data.versions.length).toBe(2);
+    });
+  });
+
+  describe('TV-FILE-DELETE-001: Delete file', () => {
+    it('should delete file for owner', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      await fileFn.deleteFile({ fileId }, { principalId: 'user_123' });
+
+      await expect(
+        fileFn.getFile({ fileId }, { principalId: 'user_123' })
+      ).rejects.toMatchObject({ code: 'FILEFN_NOT_FOUND' });
+    });
+  });
+
+  describe('TV-FILE-DELETE-NEG-001: Delete forbidden', () => {
+    it('should deny delete for non-owner', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      await expect(
+        fileFn.deleteFile({ fileId }, { principalId: 'other_user' })
+      ).rejects.toMatchObject({ code: 'FILEFN_FORBIDDEN' });
+    });
+  });
+
+  describe('TV-VERSION-REPLACE-001: Replace file', () => {
+    it('should allow owner to replace file with new version', async () => {
+      const { fileId, versionId: v1 } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 500, mimeType: 'image/png', fileId },
+        { principalId: 'user_123' }
+      );
+      
+      const session = await db.findOne<any>({ model: 'uploadSessions', where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }] });
+      if (session) storageSizes.set(session.storageKey, 500);
+
+      await fileFn.completeUploadPart(
+        { uploadSessionId, partNumber: 1, etag: 'etag_new', size: 500 },
+        { principalId: 'user_123' }
+      );
+
+      const { versionId: v2 } = await fileFn.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' });
+
+      expect(v2).not.toBe(v1);
+      
+      const file = await fileFn.getFile({ fileId }, { principalId: 'user_123' }) as any;
+      expect(file.currentVersionId).toBe(v2);
+    });
+
+    it('should update file metadata when a replacement upload carries new metadata', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+      const replacementMetadata = { source: 'editor', crop: 'square' };
+
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        {
+          policy: 'user-avatar',
+          fileName: 'avatar.png',
+          size: 500,
+          mimeType: 'image/png',
+          fileId,
+          metadata: replacementMetadata,
+        },
+        { principalId: 'user_123' }
+      );
+
+      const session = await db.findOne<any>({ model: 'uploadSessions', where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }] });
+      if (session) storageSizes.set(session.storageKey, 500);
+
+      await fileFn.completeUploadPart(
+        { uploadSessionId, partNumber: 1, etag: 'etag_replacement', size: 500 },
+        { principalId: 'user_123' }
+      );
+
+      await fileFn.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' });
+
+      const file = await fileFn.getFile({ fileId }, { principalId: 'user_123' }) as any;
+      expect(file.metadata).toEqual(replacementMetadata);
+    });
+  });
+
+  describe('List files', () => {
+    it('should list files owned by principal', async () => {
+      await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+      await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+      await createFileViaUpload(fileFn, db, storageSizes, 'other_user');
+
+      const result = await fileFn.listFiles({}, { principalId: 'user_123' }) as any;
+      expect(result.files.length).toBe(2);
+    });
+  });
+
+  describe('TV-STORAGE-001: artifact routing can differ from original file routing', () => {
+    function createTargetAdapter(
+      name: string,
+      storageCalls: string[],
+      objects: Map<string, Uint8Array>,
+    ): StorageAdapter {
+      const capabilities: StorageAdapterCapabilities = {
+        signedUploadUrls: true,
+        signedDownloadUrls: true,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      };
+
+      return {
+        name,
+        capabilities,
+        async statObject({ key }) {
+          return { key, size: objects.get(`${name}:${key}`)?.length ?? 0 };
+        },
+        async deleteObject({ key }) {
+          storageCalls.push(`${name}:delete:${key}`);
+          objects.delete(`${name}:${key}`);
+        },
+        async createMultipartUpload({ key }) {
+          storageCalls.push(`${name}:multipart:${key}`);
+          return { uploadId: `${name}-upload` };
+        },
+        async signMultipartUploadPartUrl({ key, partNumber }) {
+          return { url: `https://${name}.local/${key}/${partNumber}` };
+        },
+        async completeMultipartUpload() {},
+        async abortMultipartUpload() {},
+        async signDownloadUrl({ key }) {
+          storageCalls.push(`${name}:download:${key}`);
+          return { url: `https://${name}.local/${key}` };
+        },
+        async openUploadStream({ key }) {
+          storageCalls.push(`${name}:upload-stream:${key}`);
+          const chunks: Uint8Array[] = [];
+          return new WritableStream<Uint8Array>({
+            write(chunk) {
+              chunks.push(chunk);
+            },
+            close() {
+              const size = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+              const combined = new Uint8Array(size);
+              let offset = 0;
+              for (const chunk of chunks) {
+                combined.set(chunk, offset);
+                offset += chunk.byteLength;
+              }
+              objects.set(`${name}:${key}`, combined);
+            },
+          });
+        },
+        async openDownloadStream({ key }) {
+          storageCalls.push(`${name}:download-stream:${key}`);
+          const payload = objects.get(`${name}:${key}`) ?? new TextEncoder().encode('abc');
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(payload);
+              controller.close();
+            },
+          });
+        },
+      };
+    }
+
+    it('reads originals from the file target and writes artifacts to the artifact target', async () => {
+      const storageCalls: string[] = [];
+      const objects = new Map<string, Uint8Array>([
+        ['durable-bucket:uploads/file_001/ver_001-image.png', new TextEncoder().encode('abc')],
+      ]);
+      const storage = createRoutedStorageAdapter({
+        adapters: {
+          durable: createTargetAdapter('durable-bucket', storageCalls, objects),
+          temporary: createTargetAdapter('temporary-bucket', storageCalls, objects),
+        },
+      });
+
+      await db.create({
+        model: 'files',
+        data: {
+          fileId: 'file_001',
+          currentVersionId: 'ver_001',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'artifact-offload',
+          mimeType: 'image/png',
+          size: 3,
+          name: 'image.png',
+          metadata: {},
+          createdAt: '2026-03-22T00:00:00.000Z',
+          updatedAt: '2026-03-22T00:00:00.000Z',
+        },
+      });
+
+      const processing = createProcessingService({
+        db,
+        storage,
+        policies: createPolicyRegistry([
+          {
+            name: 'artifact-offload',
+            contentTypes: ['image/png'],
+            storageTarget: 'durable',
+            artifactStorageTarget: 'temporary',
+          },
+        ]),
+        events: createEventEmitter(),
+        processors: [
+          {
+            name: 'thumbnail',
+            supportedMimeTypes: ['image/png'],
+            async process(input, getData) {
+              return {
+                success: true,
+                artifacts: [
+                  {
+                    kind: 'thumbnail',
+                    data: await getData(),
+                    mimeType: 'image/png',
+                    storageKey: `${input.storageKey}.thumb.png`,
+                  },
+                ],
+              };
+            },
+          },
+        ],
+        namespace: 'filefn',
+      });
+
+      const result = await processing.runProcessing(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'uploads/file_001/ver_001-image.png',
+          mimeType: 'image/png',
+          size: 3,
+          fileName: 'image.png',
+          tenantId: 'org_123',
+        },
+        { principalId: 'user_123', tenantId: 'org_123', requestId: 'req_artifact_route' },
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+      expect(storageCalls).toContain('durable-bucket:download-stream:uploads/file_001/ver_001-image.png');
+      expect(storageCalls).toContain('temporary-bucket:upload-stream:uploads/file_001/ver_001-image.png.thumb.png');
+    });
+  });
+
+  describe('Download rate limiting', () => {
+    it('should enforce rate limits on download (TV-RATE-NEG-001 download variant)', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      const rateLimiter = {
+        async check(_input: any) {
+          return { allowed: false, remaining: 0, resetAt: new Date(Date.now() + 60000).toISOString(), total: 10 };
+        },
+        async reset(_key: string) {},
+      };
+
+      const fileFnWithRateLimit = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        rateLimiter,
+        auth: { required: false },
+      });
+
+      const request = new Request(`http://localhost/${fileId}/download`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_rate' },
+      });
+
+      const response = await fileFnWithRateLimit.router.handle(request);
+      expect(response!.status).toBe(429);
+
+      const body = await response!.json();
+      expect(body.error.code).toBe('FILEFN_RATE_LIMITED');
+    });
+
+    it('TV-RATE-001: should enforce download category rate limits from config', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      const fileFnWithCategoryRateLimit = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        rateLimit: {
+          limits: {
+            download: { windowSeconds: 60, maxRequests: 1 },
+          },
+        },
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123' }),
+        },
+      });
+
+      const first = await fileFnWithCategoryRateLimit.router.handle(
+        new Request(`http://localhost/${fileId}/download`, {
+          method: 'GET',
+          headers: { 'x-request-id': 'req_rate_cat_1' },
+        })
+      );
+      expect(first!.status).toBe(200);
+
+      const second = await fileFnWithCategoryRateLimit.router.handle(
+        new Request(`http://localhost/${fileId}/download`, {
+          method: 'GET',
+          headers: { 'x-request-id': 'req_rate_cat_2' },
+        })
+      );
+      expect(second!.status).toBe(429);
+
+      const body = await second!.json();
+      expect(body.error.code).toBe('FILEFN_RATE_LIMITED');
+      expect(typeof body.error.details?.resetAt).toBe('string');
+      expect(Number.isNaN(Date.parse(body.error.details.resetAt))).toBe(false);
+    });
+  });
+
+  describe('Render descriptors', () => {
+    it('TV-API-001 / TV-VIEW-001: render route returns a canonical artifact descriptor envelope', async () => {
+      const pdfFileFn = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+          async statObject(input) {
+            return { key: input.key, size: storageSizes.get(input.key) ?? 1024 };
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png', 'image/jpeg', 'application/pdf'] }],
+        auth: { required: false },
+      });
+
+      const { fileId, versionId } = await createFileViaUpload(
+        pdfFileFn,
+        db,
+        storageSizes,
+        'user_123',
+        'org_123',
+        {
+          fileName: 'note.pdf',
+          mimeType: 'application/pdf',
+          size: 4096,
+        },
+      );
+
+      await db.create({
+        model: 'fileArtifacts',
+        namespace: 'filefn',
+        data: {
+          artifactId: 'art_pdf_large_001',
+          fileId,
+          versionId,
+          kind: 'pdf-preview-page-1-large',
+          storageKey: `artifacts/${fileId}/preview-large.png`,
+          mimeType: 'image/png',
+          size: 1024,
+          metadata: {},
+          createdAt: '2026-03-22T00:00:00.000Z',
+        },
+      });
+
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: false,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png', 'application/pdf'] }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+        },
+      });
+
+      const response = await fileFnWithAuth.router.handle(
+        new Request(`http://localhost/${fileId}/render?intent=preview`, {
+          method: 'GET',
+          headers: { 'x-request-id': 'req_api_001' },
+        }),
+      );
+
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(200);
+
+      const body = await response!.json();
+      expect(body).toMatchObject({
+        ok: true,
+        warnings: [],
+        requestId: 'req_api_001',
+        data: {
+          fileId,
+          versionId,
+          intent: 'preview',
+          state: 'ready',
+          mimeType: 'image/png',
+          source: {
+            mode: 'artifact',
+            artifactId: 'art_pdf_large_001',
+            artifactKind: 'pdf-preview-page-1-large',
+          },
+        },
+      });
+      expect(body.data.source.url).toMatch(/^\/proxy\/files\//);
+      expect(body.data.source.url.startsWith('proxy://')).toBe(false);
+    });
+
+    it('TV-FILE-002: render route returns deterministic PDF placeholder when preview artifacts are unavailable', async () => {
+      const pdfFileFn = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+          async statObject(input) {
+            return { key: input.key, size: storageSizes.get(input.key) ?? 1024 };
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png', 'image/jpeg', 'application/pdf'] }],
+        auth: { required: false },
+      });
+
+      const { fileId, versionId } = await createFileViaUpload(
+        pdfFileFn,
+        db,
+        storageSizes,
+        'user_123',
+        'org_123',
+        {
+          fileName: 'waiting.pdf',
+          mimeType: 'application/pdf',
+          size: 2048,
+        },
+      );
+
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png', 'application/pdf'] }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+        },
+      });
+
+      const response = await fileFnWithAuth.router.handle(
+        new Request(`http://localhost/${fileId}/render?intent=preview&versionId=${versionId}`, {
+          method: 'GET',
+        }),
+      );
+
+      expect(response!.status).toBe(200);
+      const body = await response!.json();
+      expect(body.data).toMatchObject({
+        fileId,
+        versionId,
+        intent: 'preview',
+        state: 'processing',
+        source: {
+          mode: 'placeholder',
+          placeholderKind: 'pdf-processing',
+        },
+      });
+      expect(body.data.warnings).toEqual(['PDF preview artifact is not available yet.']);
+    });
+
+    it('TV-API-001 negative: unknown render target returns FILEFN_NOT_FOUND and echoes requestId', async () => {
+      const response = await fileFn.router.handle(
+        new Request('http://localhost/file_missing/render?intent=thumbnail', {
+          method: 'GET',
+          headers: { 'x-request-id': 'req_render_missing' },
+        }),
+      );
+
+      expect(response!.status).toBe(404);
+      const body = await response!.json();
+      expect(body).toMatchObject({
+        ok: false,
+        requestId: 'req_render_missing',
+        error: {
+          code: 'FILEFN_NOT_FOUND',
+        },
+      });
+    });
+
+    it('returns a stable invalid-render-intent error code', async () => {
+      const { fileId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123', 'org_123');
+
+      const response = await fileFn.router.handle(
+        new Request(`http://localhost/${fileId}/render?intent=poster`, {
+          method: 'GET',
+          headers: { 'x-request-id': 'req_render_invalid' },
+        }),
+      );
+
+      expect(response!.status).toBe(400);
+      const body = await response!.json();
+      expect(body).toMatchObject({
+        ok: false,
+        requestId: 'req_render_invalid',
+        error: {
+          code: 'FILEFN_INVALID_RENDER_INTENT',
+          details: {
+            intent: 'poster',
+          },
+        },
+      });
+    });
+  });
+});

--- a/filefn/server/src/__tests__/idempotency-complete.test.ts
+++ b/filefn/server/src/__tests__/idempotency-complete.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createUploadSessionService } from '../upload-sessions/service.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+type Row = Record<string, any>;
+
+function createMemoryDb(): Adapter {
+  const tables = new Map<string, Map<string, Row>>();
+  let idCounter = 1;
+
+  function table(model: string): Map<string, Row> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function match(record: Row, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+      if (clause.operator === 'gt' && !(value > clause.value)) return false;
+    }
+    return true;
+  }
+
+  return {
+    id: 'mem-db',
+    name: 'mem-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const t = table(params.model);
+      const id =
+        (params.model === 'uploadParts' ? `${params.data.uploadSessionId}:${params.data.partNumber}` : undefined) ||
+        (params.model === 'uploadSessions' ? params.data.uploadSessionId : undefined) ||
+        (params.model === 'files' ? params.data.fileId : undefined) ||
+        (params.model === 'fileVersions' ? params.data.versionId : undefined) ||
+        params.data.permissionId ||
+        params.data.artifactId ||
+        `id_${idCounter++}`;
+      const row = { ...params.data, _id: id };
+      t.set(id, row);
+      return row;
+    },
+    async findOne(params) {
+      for (const row of table(params.model).values()) {
+        if (match(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      return Array.from(table(params.model).values()).filter((row) => match(row, params.where));
+    },
+    async update(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          const next = { ...row, ...params.data };
+          t.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) {
+      const t = table(params.model);
+      let deleted = 0;
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          deleted += 1;
+        }
+      }
+      return deleted;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+function createMultipartStorage() {
+  return {
+    capabilities: {
+      signedUploadUrls: true,
+      signedDownloadUrls: true,
+      multipart: true,
+      proxyStreamingUpload: false,
+      proxyStreamingDownload: true,
+    },
+    createMultipartUpload: vi.fn(async () => ({ uploadId: 'up_1' })),
+    completeMultipartUpload: vi.fn(async () => {}),
+    signMultipartUploadPartUrl: vi.fn(async () => ({ url: 'https://signed.example/upload', headers: {} })),
+  };
+}
+
+function createHarness() {
+  const db = createMemoryDb();
+  const service = createUploadSessionService({
+    db,
+    storage: createMultipartStorage() as any,
+    policies: {
+      get: vi.fn(() => ({ maxSizeBytes: 100 * 1024 * 1024, contentTypes: ['text/plain'], visibility: 'private' })),
+    } as any,
+    events: { emit: vi.fn() } as any,
+  });
+
+  return { db, service };
+}
+
+function createService() {
+  return createHarness().service;
+}
+
+describe('PHASE_00 idempotency and completion semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('TV-IDEMPOTENCY-001: identical init idempotency key returns original success result', async () => {
+    const service = createService();
+    const input = {
+      policy: 'p1',
+      fileName: 'a.txt',
+      size: 3,
+      mimeType: 'text/plain',
+      idempotencyKey: 'idem_001',
+    };
+    const ctx = { principalId: 'user_1', tenantId: 'org_1', requestId: 'req_1' };
+
+    const first = await service.createSession(input, ctx);
+    const second = await service.createSession(input, ctx);
+
+    expect(second.uploadSessionId).toBe(first.uploadSessionId);
+    expect(second.uploadMode).toBe(first.uploadMode);
+    expect(second.totalParts).toBe(first.totalParts);
+  });
+
+  it('TV-AUTH-001: anonymous init replay returns the original upload session token', async () => {
+    const { service } = createHarness();
+    const input = {
+      policy: 'p1',
+      fileName: 'anon.txt',
+      size: 3,
+      mimeType: 'text/plain',
+      idempotencyKey: 'idem_anon_service_001',
+    };
+    const ctx = { requestId: 'req_anon_service_1' };
+
+    const first = await service.createSession(input, ctx);
+    const replay = await service.createSession(input, { requestId: 'req_anon_service_2' });
+
+    expect(first.uploadSessionId).toBe(replay.uploadSessionId);
+    expect(first.uploadSessionToken).toBeDefined();
+    expect(replay.uploadSessionToken).toBe(first.uploadSessionToken);
+  });
+
+  it('TV-IDEMPOTENCY-NEG-001: idempotency-key mismatch returns FILEFN_IDEMPOTENCY_CONFLICT', async () => {
+    const service = createService();
+    const ctx = { principalId: 'user_1', tenantId: 'org_1', requestId: 'req_2' };
+
+    await service.createSession(
+      {
+        policy: 'p1',
+        fileName: 'a.txt',
+        size: 3,
+        mimeType: 'text/plain',
+        idempotencyKey: 'idem_002',
+      },
+      ctx,
+    );
+
+    await expect(
+      service.createSession(
+        {
+          policy: 'p1',
+          fileName: 'b.txt',
+          size: 3,
+          mimeType: 'text/plain',
+          idempotencyKey: 'idem_002',
+        },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ code: 'FILEFN_IDEMPOTENCY_CONFLICT' });
+  });
+
+  it('TV-IDEMPOTENCY-001: part recording is tuple-idempotent and conflicting tuple returns FILEFN_PART_CONFLICT', async () => {
+    const service = createService();
+    const ctx = { principalId: 'user_1', tenantId: 'org_1', requestId: 'req_3' };
+
+    const session = await service.createSession(
+      { policy: 'p1', fileName: 'part.txt', size: 3, mimeType: 'text/plain' },
+      ctx,
+    );
+
+    await service.completePart(session.uploadSessionId, 1, 'etag_1', 3, ctx);
+    await expect(service.completePart(session.uploadSessionId, 1, 'etag_1', 3, ctx)).resolves.toBeUndefined();
+
+    await expect(service.completePart(session.uploadSessionId, 1, 'etag_1', 4, ctx)).rejects.toMatchObject({
+      code: 'FILEFN_PART_CONFLICT',
+    });
+  });
+
+  it('TV-IDEMPOTENCY-001: repeated complete returns stable { fileId, versionId }', async () => {
+    const service = createService();
+    const ctx = { principalId: 'user_1', tenantId: 'org_1', requestId: 'req_4' };
+
+    const session = await service.createSession(
+      { policy: 'p1', fileName: 'complete.txt', size: 3, mimeType: 'text/plain' },
+      ctx,
+    );
+
+    await service.completePart(session.uploadSessionId, 1, 'etag_1', 3, ctx);
+    const first = await service.completeSession(session.uploadSessionId, ctx);
+    const second = await service.completeSession(session.uploadSessionId, ctx);
+
+    expect(second).toEqual(first);
+  });
+
+  it('TV-META-001: completion persists init metadata onto the file row', async () => {
+    const { db, service } = createHarness();
+    const metadata = {
+      source: 'import',
+      category: 'note',
+      nested: { reviewed: false },
+    };
+    const ctx = { principalId: 'user_1', tenantId: 'org_1', requestId: 'req_meta_1' };
+
+    const session = await service.createSession(
+      {
+        policy: 'p1',
+        fileName: 'meta.txt',
+        size: 3,
+        mimeType: 'text/plain',
+        metadata,
+      },
+      ctx,
+    );
+
+    await service.completePart(session.uploadSessionId, 1, 'etag_meta_1', 3, ctx);
+    const completed = await service.completeSession(session.uploadSessionId, ctx);
+    const file = await db.findOne({
+      model: 'files',
+      where: [{ field: 'fileId', operator: 'eq', value: completed.fileId }],
+      namespace: 'filefn',
+    });
+
+    expect(file?.metadata).toEqual(metadata);
+  });
+
+  it('TV-IDEMPOTENCY-NEG-001: incomplete upload completion fails with FILEFN_UPLOAD_INCOMPLETE', async () => {
+    const service = createService();
+    const ctx = { principalId: 'user_1', tenantId: 'org_1', requestId: 'req_5' };
+
+    const twoPartUpload = await service.createSession(
+      { policy: 'p1', fileName: 'large.txt', size: 9 * 1024 * 1024, mimeType: 'text/plain' },
+      ctx,
+    );
+
+    await service.completePart(twoPartUpload.uploadSessionId, 1, 'etag_1', 8 * 1024 * 1024, ctx);
+
+    await expect(service.completeSession(twoPartUpload.uploadSessionId, ctx)).rejects.toMatchObject({
+      code: 'FILEFN_UPLOAD_INCOMPLETE',
+    });
+  });
+});

--- a/filefn/server/src/__tests__/list-determinism.test.ts
+++ b/filefn/server/src/__tests__/list-determinism.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { createFileService } from '../files/service.js';
+import { createEventEmitter } from '../events.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createDb(files: any[]): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  tables.set('files', new Map(files.map((file) => [file.fileId, file])));
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matches(row: any, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = row?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+      if (clause.operator === 'in' && !clause.value.includes(value)) return false;
+    }
+    return true;
+  }
+
+  return {
+    id: 'phase0-list-db',
+    name: 'phase0-list-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const table = getTable(params.model);
+      const row = { ...params.data };
+      table.set(row.fileId || `id_${table.size + 1}`, row);
+      return row;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const row of table.values()) {
+        if (matches(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const rows = Array.from(table.values()).filter((row) => matches(row, params.where));
+      return params.limit ? rows.slice(0, params.limit) : rows;
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          const next = { ...row, ...params.data };
+          table.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany() { return 0; },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+describe('PHASE_03 FILE-001 deterministic list semantics', () => {
+  it('TV-FILE-LIST-001: listFiles should enforce stable sort and cursor-based pagination', async () => {
+    const service = createFileService({
+      db: createDb([
+        {
+          fileId: 'file_002',
+          currentVersionId: 'ver_002',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 20,
+          name: 'older.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T12:00:00.000Z',
+        },
+        {
+          fileId: 'file_003',
+          currentVersionId: 'ver_003',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 30,
+          name: 'newer-b.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T15:00:00.000Z',
+        },
+        {
+          fileId: 'file_001',
+          currentVersionId: 'ver_001',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'user-avatar',
+          mimeType: 'image/png',
+          size: 10,
+          name: 'newer-a.png',
+          metadata: {},
+          createdAt: '2026-03-20T12:00:00.000Z',
+          updatedAt: '2026-03-20T15:00:00.000Z',
+        },
+      ]),
+      storage: { capabilities: { signedDownloadUrls: true } } as any,
+      events: createEventEmitter(),
+      namespace: 'filefn',
+    });
+
+    const firstPage = await service.listFiles(
+      { principalId: 'user_123', tenantId: 'org_123' },
+      { limit: 2 }
+    );
+
+    expect(firstPage.files.map((file) => file.fileId)).toEqual(['file_001', 'file_003']);
+
+    const secondPage = await service.listFiles(
+      { principalId: 'user_123', tenantId: 'org_123' },
+      { limit: 2, cursor: firstPage.nextCursor }
+    );
+
+    expect(secondPage.files.map((file) => file.fileId)).toEqual(['file_002']);
+  });
+});

--- a/filefn/server/src/__tests__/observability-redaction.test.ts
+++ b/filefn/server/src/__tests__/observability-redaction.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Test vectors for observability and redaction (OBS-001)
+ * 
+ * These tests encode the audit gap for correlation ID preservation:
+ * - TV-OBS-REDACTION-001: Correlation IDs like requestId are preserved (NOT redacted)
+ * - TV-OBS-LOG-001: Logs contain correlation IDs
+ * - TV-OBS-LOG-NEG-001: Signed URLs are NOT logged
+ */
+
+import { describe, it, expect } from 'vitest';
+import { redactSecrets, type LogContext } from '../index.js';
+
+describe('@filefn/server observability redaction', () => {
+  describe('TV-OBS-REDACTION-001: Correlation IDs are preserved', () => {
+    it('should preserve short requestId values', () => {
+      const context: LogContext = {
+        requestId: 'req_001',
+        uploadSessionId: 'upl_0001',
+        fileId: 'file_0001',
+        versionId: 'ver_0001',
+      };
+
+      const redacted = redactSecrets(context);
+
+      // These should NOT be redacted - this is the audit gap
+      // Current implementation redacts these which is wrong
+      expect(redacted.requestId).toBe('req_001');
+      expect(redacted.uploadSessionId).toBe('upl_0001');
+      expect(redacted.fileId).toBe('file_0001');
+      expect(redacted.versionId).toBe('ver_0001');
+    });
+
+    it('should preserve requestId in log context with other fields', () => {
+      const context: LogContext = {
+        requestId: 'req_001',
+        fileName: 'avatar.png',
+        size: 1024,
+        mimeType: 'image/png',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.requestId).toBe('req_001');
+      expect(redacted.fileName).toBe('avatar.png');
+      expect(redacted.size).toBe(1024);
+      expect(redacted.mimeType).toBe('image/png');
+    });
+
+    it('should mark redacted field as false for correlation IDs', () => {
+      const context: LogContext = {
+        requestId: 'req_001',
+      };
+
+      const redacted = redactSecrets(context);
+
+      // The test vector expects this specific shape
+      // This verifies correlation IDs are not redacted
+      expect(redacted.requestId).toBe('req_001');
+      expect(redacted.requestId).not.toBe('[REDACTED]');
+    });
+  });
+
+  describe('TV-OBS-LOG-001: Logs contain correlation IDs', () => {
+    it('should preserve all correlation IDs together', () => {
+      const context: LogContext = {
+        requestId: 'req_001',
+        uploadSessionId: 'upl_0001',
+        fileId: 'file_0001',
+        versionId: 'ver_0001',
+        operation: 'upload.init',
+      };
+
+      const redacted = redactSecrets(context);
+
+      // All correlation IDs should be preserved
+      expect(redacted.requestId).toBe('req_001');
+      expect(redacted.uploadSessionId).toBe('upl_0001');
+      expect(redacted.fileId).toBe('file_0001');
+      expect(redacted.versionId).toBe('ver_0001');
+      expect(redacted.operation).toBe('upload.init');
+    });
+  });
+
+  describe('TV-OBS-LOG-NEG-001: Signed URLs are NOT logged', () => {
+    it('should still redact signed URLs while preserving correlation IDs', () => {
+      const context: LogContext = {
+        requestId: 'req_001',
+        signedUrl: 'https://storage.test/upload/stor_upl_0001/part/1?X-Amz-Signature=secret',
+      };
+
+      const redacted = redactSecrets(context);
+
+      // requestId should be preserved
+      expect(redacted.requestId).toBe('req_001');
+      // signedUrl should be redacted
+      expect(redacted.signedUrl).toBe('[REDACTED]');
+    });
+
+    it('should redact URLs containing X-Amz-Signature', () => {
+      const context: LogContext = {
+        requestId: 'req_005',
+        url: 'https://s3.amazonaws.com/bucket/key?X-Amz-Signature=abc123',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.requestId).toBe('req_005');
+      expect(redacted.url).toBe('[REDACTED]');
+    });
+
+    it('should redact URLs containing token parameter', () => {
+      const context: LogContext = {
+        requestId: 'req_006',
+        downloadUrl: 'https://storage.example.com/file?token=jwt.token.here',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.requestId).toBe('req_006');
+      expect(redacted.downloadUrl).toBe('[REDACTED]');
+    });
+  });
+
+  describe('Upload session token redaction', () => {
+    it('should redact upload session token fields while preserving safe IDs', () => {
+      const context: LogContext = {
+        requestId: 'req_001',
+        uploadSessionToken: 'upls_live_0001_secret',
+        uploadSessionId: 'upl_0001',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.requestId).toBe('req_001');
+      expect(redacted.uploadSessionId).toBe('upl_0001');
+      expect(redacted.uploadSessionToken).toBe('[REDACTED]');
+    });
+
+    it('should recurse into arrays and nested objects for token redaction', () => {
+      const context: LogContext = {
+        requestId: 'req_001',
+        nested: {
+          values: ['safe', 'upls_live_abc123'],
+        },
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.requestId).toBe('req_001');
+      expect((redacted.nested as any).values).toEqual(['safe', '[REDACTED]']);
+    });
+  });
+
+  describe('Correlation ID patterns', () => {
+    it('should recognize standard correlation ID patterns', () => {
+      const patterns = [
+        { requestId: 'req_001' },
+        { requestId: 'req_010' },
+        { requestId: 'req_100' },
+        { uploadSessionId: 'upl_0001' },
+        { uploadSessionId: 'upl_expired_1' },
+        { fileId: 'file_0001' },
+        { fileId: 'file_pub_0001' },
+        { versionId: 'ver_0001' },
+        { versionId: 'ver_other_file' },
+      ];
+
+      for (const context of patterns) {
+        const redacted = redactSecrets(context as LogContext);
+        const key = Object.keys(context)[0];
+        const value = Object.values(context)[0];
+        
+        // All these should be preserved
+        expect(redacted[key]).toBe(value);
+      }
+    });
+  });
+});

--- a/filefn/server/src/__tests__/observability.test.ts
+++ b/filefn/server/src/__tests__/observability.test.ts
@@ -1,0 +1,619 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createLogger, redactSecrets, type LogContext, createFileFn, type FileFn, type Logger } from '../index.js';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+import { createUploadStartedEvent, type FileUploadedEvent, type FileDeletedEvent } from '../events.js';
+
+const FAKE_CAPABILITIES: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createFakeDbAdapter(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let idCounter = 1;
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matchesWhere(record: any, where: any[]): boolean {
+    for (const clause of where) {
+      const value = record[clause.field];
+      switch (clause.operator) {
+        case 'eq': if (value !== clause.value) return false; break;
+        case 'ne': if (value === clause.value) return false; break;
+        default: break;
+      }
+    }
+    return true;
+  }
+
+  return {
+    id: 'fake',
+    name: 'fake',
+    version: '1.0.0',
+    capabilities: FAKE_CAPABILITIES,
+    async create(params) {
+      const table = getTable(params.model);
+      const id = params.data.uploadSessionId || params.data.fileId || params.data.versionId || params.data.permissionId || `id_${idCounter++}`;
+      const record = { ...params.data, _id: id };
+      table.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const record of table.values()) {
+        if (matchesWhere(record, params.where)) return record;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const results: any[] = [];
+      for (const record of table.values()) {
+        if (!params.where || params.where.length === 0 || matchesWhere(record, params.where)) {
+          results.push(record);
+        }
+      }
+      return results;
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          const updated = { ...record, ...params.data };
+          table.set(id, updated);
+          return updated;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) { 
+        const table = getTable(params.model);
+        let count = 0;
+        for (const [id, record] of table.entries()) {
+            if (matchesWhere(record, params.where)) {
+                table.delete(id);
+                count++;
+            }
+        }
+        return count;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return await this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return await this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(callback) { return callback(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+describe('@filefn/server observability', () => {
+  describe('TV-OBS-LOG-NEG-001: Signed URLs are redacted in logs', () => {
+    it('should redact AWS signed URLs with X-Amz-Signature', () => {
+      const context: LogContext = {
+        url: 'https://my-bucket.s3.amazonaws.com/files/file_123/ver_456?X-Amz-Signature=abc123def456',
+        requestId: 'req_001',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.url).toBe('[REDACTED]');
+      expect(redacted.requestId).toBe('req_001');
+    });
+
+    it('should redact URLs containing Signature parameter', () => {
+      const context: LogContext = {
+        downloadUrl: 'https://storage.example.com/path?Signature=secret123&expires=12345',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.downloadUrl).toBe('[REDACTED]');
+    });
+
+    it('should redact URLs containing token parameter', () => {
+      const context: LogContext = {
+        signedUrl: 'https://cdn.example.com/files/test.pdf?token=eyJhbGciOiJIUzI1NiJ9',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.signedUrl).toBe('[REDACTED]');
+    });
+
+    it('should preserve non-secret callback urls', () => {
+      const context: LogContext = {
+        callbackUrl: 'https://app.example.com/files/file_123',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.callbackUrl).toBe('https://app.example.com/files/file_123');
+    });
+  });
+
+  describe('Logger redacts share tokens', () => {
+    it('should redact keys containing "token"', () => {
+      const context: LogContext = {
+        shareToken: 'shr_abc123def456xyz',
+        accessToken: 'jwt_token_here',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.shareToken).toBe('[REDACTED]');
+      expect(redacted.accessToken).toBe('[REDACTED]');
+    });
+
+    it('should redact keys containing "secret"', () => {
+      const context: LogContext = {
+        apiSecret: 'my-secret-key',
+        secretKey: 'another-secret',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.apiSecret).toBe('[REDACTED]');
+      expect(redacted.secretKey).toBe('[REDACTED]');
+    });
+
+    it('should redact keys containing "password"', () => {
+      const context: LogContext = {
+        password: 'hunter2',
+        userPassword: 'secret123',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.password).toBe('[REDACTED]');
+      expect(redacted.userPassword).toBe('[REDACTED]');
+    });
+
+    it('should redact Bearer tokens in string values', () => {
+      const context: LogContext = {
+        authHeader: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.authHeader).toBe('[REDACTED]');
+    });
+  });
+
+  describe('Logger redacts long identifiers for safety', () => {
+    it('should redact long requestId strings that could be secrets', () => {
+      const context: LogContext = {
+        requestId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.requestId).toBe('[REDACTED]');
+    });
+
+    it('should redact long fileId strings that could be secrets', () => {
+      const context: LogContext = {
+        fileId: 'f1234567-89ab-cdef-0123-456789abcdef',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.fileId).toBe('[REDACTED]');
+    });
+
+    it('should preserve non-UUID values for known ID fields', () => {
+      const context: LogContext = {
+        fileId: 'file_123',
+        uploadSessionId: 'upl_456',
+        versionId: 'ver_789',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.fileId).toBe('file_123');
+      expect(redacted.uploadSessionId).toBe('upl_456');
+      expect(redacted.versionId).toBe('ver_789');
+    });
+  });
+
+  describe('Logger handles nested objects', () => {
+    it('should redact secrets in nested objects', () => {
+      const context: LogContext = {
+        request: {
+          url: 'https://s3.amazonaws.com/bucket/key?X-Amz-Signature=secret',
+          headers: {
+            authorization: 'Bearer jwt.token.here',
+          },
+        },
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect((redacted.request as any).url).toBe('[REDACTED]');
+      expect((redacted.request as any).headers.authorization).toBe('[REDACTED]');
+    });
+  });
+
+  describe('Logger handles null and undefined', () => {
+    it('should skip null values', () => {
+      const context: LogContext = {
+        fileId: null as any,
+        requestId: undefined,
+        value: 'test',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.fileId).toBeUndefined();
+      expect(redacted.requestId).toBeUndefined();
+      expect(redacted.value).toBe('test');
+    });
+  });
+
+  describe('Logger preserves non-string values', () => {
+    it('should preserve numbers', () => {
+      const context: LogContext = {
+        size: 1024,
+        downloads: 5,
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.size).toBe(1024);
+      expect(redacted.downloads).toBe(5);
+    });
+
+    it('should preserve booleans', () => {
+      const context: LogContext = {
+        authenticated: true,
+        expired: false,
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.authenticated).toBe(true);
+      expect(redacted.expired).toBe(false);
+    });
+
+    it('should preserve arrays', () => {
+      const context: LogContext = {
+        roles: ['admin', 'user'],
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.roles).toEqual(['admin', 'user']);
+    });
+  });
+
+  describe('createLogger', () => {
+    it('should log with redacted secrets', () => {
+      const outputs: Array<{ level: string; message: string; context: LogContext }> = [];
+
+      const logger = createLogger({
+        level: 'info',
+        output: (level, message, context) => {
+          outputs.push({ level, message, context });
+        },
+      });
+
+      logger.info('File downloaded', {
+        fileName: 'test.png',
+        url: 'https://s3.amazonaws.com/bucket/key?X-Amz-Signature=secret',
+      });
+
+      expect(outputs.length).toBe(1);
+      expect(outputs[0].level).toBe('info');
+      expect(outputs[0].message).toBe('File downloaded');
+      expect(outputs[0].context.url).toBe('[REDACTED]');
+      expect(outputs[0].context.fileName).toBe('test.png');
+    });
+
+    it('should respect log level', () => {
+      const outputs: string[] = [];
+
+      const logger = createLogger({
+        level: 'warn',
+        output: (level, message) => {
+          outputs.push(`${level}: ${message}`);
+        },
+      });
+
+      logger.debug('debug message');
+      logger.info('info message');
+      logger.warn('warn message');
+      logger.error('error message');
+
+      expect(outputs).not.toContain('debug: debug message');
+      expect(outputs).not.toContain('info: info message');
+      expect(outputs).toContain('warn: warn message');
+      expect(outputs).toContain('error: error message');
+    });
+
+    it('should include timestamp in logs', () => {
+      let capturedContext: LogContext = {};
+
+      const logger = createLogger({
+        level: 'info',
+        output: (level, message, context) => {
+          capturedContext = context;
+        },
+      });
+
+      logger.info('Test message');
+
+      expect(capturedContext.timestamp).toBeDefined();
+      expect(typeof capturedContext.timestamp).toBe('string');
+    });
+
+    it('should use console output by default', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const logger = createLogger({ level: 'info' });
+      logger.info('Test message', { requestId: 'req_001' });
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const loggedJson = consoleSpy.mock.calls[0][0];
+      expect(loggedJson).toContain('Test message');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should use console.error for error level', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const logger = createLogger({ level: 'error' });
+      logger.error('Error occurred');
+
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should use console.warn for warn level', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const logger = createLogger({ level: 'warn' });
+      logger.warn('Warning message');
+
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Redaction patterns', () => {
+    it('should redact long random strings (potential secrets)', () => {
+      const context: LogContext = {
+        unknownField: 'this-is-a-very-long-random-string-that-looks-like-a-secret-key-abc123',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.unknownField).toBe('[REDACTED]');
+    });
+
+    it('should preserve short strings', () => {
+      const context: LogContext = {
+        fileName: 'test.png',
+        mimeType: 'image/png',
+        policy: 'user-avatar',
+      };
+
+      const redacted = redactSecrets(context);
+
+      expect(redacted.fileName).toBe('test.png');
+      expect(redacted.mimeType).toBe('image/png');
+      expect(redacted.policy).toBe('user-avatar');
+    });
+  });
+
+  describe('Logger methods', () => {
+    it('should have all required log methods', () => {
+      const logger = createLogger();
+
+      expect(typeof logger.debug).toBe('function');
+      expect(typeof logger.info).toBe('function');
+      expect(typeof logger.warn).toBe('function');
+      expect(typeof logger.error).toBe('function');
+    });
+
+    it('should handle empty context', () => {
+      const outputs: LogContext[] = [];
+
+      const logger = createLogger({
+        level: 'debug',
+        output: (level, message, context) => {
+          outputs.push(context);
+        },
+      });
+
+      logger.debug('No context');
+
+      expect(outputs.length).toBe(1);
+      expect(outputs[0].timestamp).toBeDefined();
+    });
+  });
+
+  describe('Event payload redaction', () => {
+    it('should redact secret-bearing event fields while preserving safe IDs', () => {
+      const event = createUploadStartedEvent({
+        uploadSessionId: 'upl_0001',
+        fileName: 'avatar.png',
+        size: 3,
+        mimeType: 'image/png',
+        policy: 'user-avatar',
+        principalId: 'user_123',
+        tenantId: 'org_123',
+        signedUrl: 'https://storage.example.com/upload?token=secret',
+        uploadSessionToken: 'upls_live_super_secret_token',
+      } as any, 'req_001');
+
+      expect(event.requestId).toBe('req_001');
+      expect(event.uploadSessionId).toBe('upl_0001');
+      expect((event as any).signedUrl).toBe('[REDACTED]');
+      expect((event as any).uploadSessionToken).toBe('[REDACTED]');
+    });
+
+    it('should preserve safe callback urls while still redacting signed urls', () => {
+      const event = createUploadStartedEvent({
+        uploadSessionId: 'upl_0002',
+        fileName: 'avatar.png',
+        size: 3,
+        mimeType: 'image/png',
+        policy: 'user-avatar',
+        callbackUrl: 'https://app.example.com/files/file_123',
+        signedUrl: 'https://storage.example.com/download?X-Amz-Signature=secret',
+      } as any, 'req_002');
+
+      expect((event as any).callbackUrl).toBe('https://app.example.com/files/file_123');
+      expect((event as any).signedUrl).toBe('[REDACTED]');
+    });
+  });
+
+  describe('Integration: Events and Logging', () => {
+    let fileFn: FileFn;
+    let logger: Logger;
+    let logOutput: Array<{ level: string; message: string; context: LogContext }>;
+    let events: Array<any>;
+
+    beforeEach(() => {
+        logOutput = [];
+        events = [];
+        logger = createLogger({
+            level: 'info',
+            output: (level, message, context) => {
+                logOutput.push({ level, message, context });
+            }
+        });
+
+        fileFn = createFileFn({
+            db: createFakeDbAdapter(),
+            storage: createFakeStorageAdapter({
+                capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+                // Mock statObject for size validation
+                async statObject(input) { return { key: input.key, size: 100 }; }
+            }),
+            policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 10485760 }],
+            auth: { required: false },
+            logger
+        });
+
+        // Listen for events
+        fileFn.events.on('file:uploaded', (e) => events.push(e));
+        fileFn.events.on('file:deleted', (e) => events.push(e));
+    });
+
+    it('TV-OBS-001: should emit file:uploaded with requestId', async () => {
+        const { uploadSessionId } = await fileFn.createUploadSession(
+            { policy: 'user-avatar', fileName: 'test.png', size: 100, mimeType: 'image/png' },
+            { principalId: 'user_123', requestId: 'req_001' }
+        );
+
+        await fileFn.completeUploadPart(
+            { uploadSessionId, partNumber: 1, etag: 'etag1', size: 100 },
+            { principalId: 'user_123', requestId: 'req_001' }
+        );
+
+        await fileFn.completeUploadSession(
+            { uploadSessionId },
+            { principalId: 'user_123', requestId: 'req_001' }
+        );
+
+        const uploadedEvent = events.find(e => e.type === 'file:uploaded');
+        expect(uploadedEvent).toBeDefined();
+        expect(uploadedEvent.requestId).toBe('req_001');
+        expect(uploadedEvent.fileId).toBeDefined();
+    });
+
+    it('should emit file:deleted with requestId', async () => {
+        // Create file first
+        const { uploadSessionId } = await fileFn.createUploadSession(
+            { policy: 'user-avatar', fileName: 'test.png', size: 100, mimeType: 'image/png' },
+            { principalId: 'user_123', requestId: 'req_init' }
+        );
+        await fileFn.completeUploadPart({ uploadSessionId, partNumber: 1, etag: 'etag1', size: 100 }, { principalId: 'user_123' });
+        const { fileId } = await fileFn.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' });
+
+        // Clear events
+        events.length = 0;
+
+        // Delete
+        await fileFn.deleteFile({ fileId }, { principalId: 'user_123', requestId: 'req_del' });
+
+        const deletedEvent = events.find(e => e.type === 'file:deleted');
+        expect(deletedEvent).toBeDefined();
+        expect(deletedEvent.requestId).toBe('req_del');
+        expect(deletedEvent.fileId).toBe(fileId);
+    });
+
+    it('TV-OBS-LOG-001: should log structured entries for lifecycle', async () => {
+        const { uploadSessionId } = await fileFn.createUploadSession(
+            { policy: 'user-avatar', fileName: 'test.png', size: 100, mimeType: 'image/png' },
+            { principalId: 'user_123', requestId: 'req_lifecycle' }
+        );
+
+        const initLog = logOutput.find(l => l.message === 'Upload session created');
+        expect(initLog).toBeDefined();
+        expect(initLog!.context.uploadSessionId).toBe(uploadSessionId);
+        expect(initLog!.context.requestId).toBe('req_lifecycle');
+
+        await fileFn.completeUploadPart(
+            { uploadSessionId, partNumber: 1, etag: 'etag1', size: 100 },
+            { principalId: 'user_123', requestId: 'req_lifecycle' }
+        );
+
+        const { fileId } = await fileFn.completeUploadSession(
+            { uploadSessionId },
+            { principalId: 'user_123', requestId: 'req_lifecycle' }
+        );
+
+        const completeLog = logOutput.find(l => l.message === 'Upload session completed');
+        expect(completeLog).toBeDefined();
+        expect(completeLog!.context.fileId).toBe(fileId);
+        expect(completeLog!.context.requestId).toBe('req_lifecycle');
+
+        await fileFn.deleteFile({ fileId }, { principalId: 'user_123', requestId: 'req_lifecycle' });
+
+        const deleteLog = logOutput.find(l => l.message === 'File deleted');
+        expect(deleteLog).toBeDefined();
+        expect(deleteLog!.context.fileId).toBe(fileId);
+        expect(deleteLog!.context.requestId).toBe('req_lifecycle');
+    });
+  });
+});

--- a/filefn/server/src/__tests__/permissions.test.ts
+++ b/filefn/server/src/__tests__/permissions.test.ts
@@ -1,0 +1,642 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  composeAuthorizers,
+  createDefaultAuthorizer,
+  createGrantsService,
+  type FilePermissionRecord,
+} from '../index.js';
+import { createUploadSessionService } from '../upload-sessions/service.js';
+import type { FileRecord, Authorizer } from '../files/service.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+import type { FileProviderContext } from '@superfunctions/files';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+
+const FAKE_CAPABILITIES: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createFakeDbAdapter(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let idCounter = 1;
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matchesWhere(record: any, where: any[]): boolean {
+    for (const clause of where) {
+      const value = record[clause.field];
+      switch (clause.operator) {
+        case 'eq': if (value !== clause.value) return false; break;
+        case 'ne': if (value === clause.value) return false; break;
+        default: break;
+      }
+    }
+    return true;
+  }
+
+  return {
+    id: 'fake',
+    name: 'fake',
+    version: '1.0.0',
+    capabilities: FAKE_CAPABILITIES,
+    async create(params) {
+      const table = getTable(params.model);
+      const id = params.data.permissionId || params.data.fileId || `id_${idCounter++}`;
+      const record = { ...params.data, _id: id };
+      table.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const record of table.values()) {
+        if (matchesWhere(record, params.where)) return record;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const results: any[] = [];
+      for (const record of table.values()) {
+        if (!params.where || params.where.length === 0 || matchesWhere(record, params.where)) {
+          results.push(record);
+        }
+      }
+      return results;
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          const updated = { ...record, ...params.data };
+          table.set(id, updated);
+          return updated;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany(params) { return []; },
+    async updateMany(params) { return 0; },
+    async deleteMany(params) { return 0; },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return await this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return await this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count(params) { return 0; },
+    async transaction(callback) { return callback(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+function createMockFile(overrides: Partial<FileRecord> = {}): FileRecord {
+  return {
+    fileId: 'file_123',
+    name: 'test.png',
+    mimeType: 'image/png',
+    size: 1000,
+    ownerId: 'user_123',
+    tenantId: null,
+    visibility: 'private',
+    policy: 'user-avatar',
+    currentVersionId: 'ver_123',
+    metadata: {},
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createMockAuthorizer(allow: boolean): Authorizer {
+  return {
+    async canRead() { return allow; },
+    async canWrite() { return allow; },
+    async canDelete() { return allow; },
+  };
+}
+
+describe('@filefn/server permissions', () => {
+  let db: Adapter;
+
+  beforeEach(() => {
+    db = createFakeDbAdapter();
+  });
+
+  describe('TV-AUTHZ-COMPOSE-001: composeAuthorizers with first-allow strategy', () => {
+    it('should return allow if any authorizer allows', async () => {
+      const denyAuth = createMockAuthorizer(false);
+      const allowAuth = createMockAuthorizer(true);
+
+      // Uses audited spec signature: composeAuthorizers([a, b], { strategy: 'first-allow' })
+      const composed = composeAuthorizers([denyAuth, allowAuth], { strategy: 'first-allow' });
+
+      const file = createMockFile();
+      const ctx: FileProviderContext = { principalId: 'other_user' };
+
+      expect(await composed.canRead(file, ctx)).toBe(true);
+      expect(await composed.canWrite(file, ctx)).toBe(true);
+      expect(await composed.canDelete(file, ctx)).toBe(true);
+    });
+
+    it('should return deny if all authorizers deny', async () => {
+      const denyAuth1 = createMockAuthorizer(false);
+      const denyAuth2 = createMockAuthorizer(false);
+
+      const composed = composeAuthorizers([denyAuth1, denyAuth2], { strategy: 'first-allow' });
+
+      const file = createMockFile();
+      const ctx: FileProviderContext = { principalId: 'other_user' };
+
+      expect(await composed.canRead(file, ctx)).toBe(false);
+    });
+  });
+
+  describe('TV-AUTHZ-COMPOSE-NEG-001: composeAuthorizers with all-must-allow strategy', () => {
+    it('should deny if any authorizer denies', async () => {
+      const allowAuth = createMockAuthorizer(true);
+      const denyAuth = createMockAuthorizer(false);
+
+      // Uses audited spec signature: composeAuthorizers([a, b], { strategy: 'all-must-allow' })
+      const composed = composeAuthorizers([allowAuth, denyAuth], { strategy: 'all-must-allow' });
+
+      const file = createMockFile();
+      const ctx: FileProviderContext = { principalId: 'other_user' };
+
+      expect(await composed.canRead(file, ctx)).toBe(false);
+      expect(await composed.canWrite(file, ctx)).toBe(false);
+      expect(await composed.canDelete(file, ctx)).toBe(false);
+    });
+
+    it('should allow if all authorizers allow', async () => {
+      const allowAuth1 = createMockAuthorizer(true);
+      const allowAuth2 = createMockAuthorizer(true);
+
+      const composed = composeAuthorizers([allowAuth1, allowAuth2], { strategy: 'all-must-allow' });
+
+      const file = createMockFile();
+      const ctx: FileProviderContext = { principalId: 'other_user' };
+
+      expect(await composed.canRead(file, ctx)).toBe(true);
+    });
+  });
+
+  describe('TV-PERM-GRANT-001: Create permission grant and authorizer respects it', () => {
+    it('should allow access when valid grant exists', async () => {
+      const file = createMockFile({ fileId: 'file_456', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const grantsService = createGrantsService({ db, namespace: 'filefn' });
+
+      await grantsService.createGrant(
+        {
+          fileId: 'file_456',
+          userId: 'grantee_user',
+          canRead: true,
+          canWrite: true,
+          canDelete: false,
+        },
+        { principalId: 'owner_user' }
+      );
+
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'grantee_user' };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(true);
+      expect(await authorizer.canWrite(file, ctx)).toBe(true);
+      expect(await authorizer.canDelete(file, ctx)).toBe(false);
+    });
+  });
+
+  describe('TV-PERM-GRANT-NEG-001: Expired grant is ignored', () => {
+    it('should deny access when grant is expired', async () => {
+      const file = createMockFile({ fileId: 'file_789', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const expiredGrant: FilePermissionRecord = {
+        permissionId: 'perm_expired',
+        fileId: 'file_789',
+        userId: 'grantee_user',
+        role: null,
+        tenantId: null,
+        canRead: true,
+        canWrite: true,
+        canDelete: true,
+        canShare: false,
+        expiresAt: new Date(Date.now() - 10000).toISOString(),
+        createdAt: new Date().toISOString(),
+      };
+
+      await db.create({
+        model: 'filePermissions',
+        data: expiredGrant,
+        namespace: 'filefn',
+      });
+
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'grantee_user' };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(false);
+      expect(await authorizer.canWrite(file, ctx)).toBe(false);
+      expect(await authorizer.canDelete(file, ctx)).toBe(false);
+    });
+  });
+
+  describe('TV-PERM-GRANT-NEG-002: Malformed grant expiry is ignored', () => {
+    it('should deny access when expiresAt is invalid', async () => {
+      const file = createMockFile({ fileId: 'file_invalid_expiry', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const invalidGrant: FilePermissionRecord = {
+        permissionId: 'perm_invalid_expiry',
+        fileId: 'file_invalid_expiry',
+        userId: 'grantee_user',
+        role: null,
+        tenantId: null,
+        canRead: true,
+        canWrite: true,
+        canDelete: false,
+        canShare: false,
+        expiresAt: 'not-a-timestamp',
+        createdAt: new Date().toISOString(),
+      };
+
+      await db.create({
+        model: 'filePermissions',
+        data: invalidGrant,
+        namespace: 'filefn',
+      });
+
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'grantee_user' };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(false);
+      expect(await authorizer.canWrite(file, ctx)).toBe(false);
+      expect(await authorizer.canDelete(file, ctx)).toBe(false);
+    });
+  });
+
+  describe('TV-VISIBILITY-001: Public file is readable without grants', () => {
+    it('should allow read access to public files', async () => {
+      const file = createMockFile({
+        fileId: 'file_public',
+        ownerId: 'owner_user',
+        visibility: 'public',
+      });
+
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'random_user' };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(true);
+      expect(await authorizer.canWrite(file, ctx)).toBe(false);
+      expect(await authorizer.canDelete(file, ctx)).toBe(false);
+    });
+  });
+
+  describe('TV-VISIBILITY-NEG-001: Private file without grant is denied', () => {
+    it('should deny access to private file without grant', async () => {
+      const file = createMockFile({
+        fileId: 'file_private',
+        ownerId: 'owner_user',
+        visibility: 'private',
+      });
+
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'random_user' };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(false);
+      expect(await authorizer.canWrite(file, ctx)).toBe(false);
+      expect(await authorizer.canDelete(file, ctx)).toBe(false);
+    });
+  });
+
+  describe('createDefaultAuthorizer', () => {
+    it('should allow owner full access', async () => {
+      const file = createMockFile({ ownerId: 'owner_user' });
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'owner_user' };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(true);
+      expect(await authorizer.canWrite(file, ctx)).toBe(true);
+      expect(await authorizer.canDelete(file, ctx)).toBe(true);
+    });
+
+    it('should allow admin full access', async () => {
+      const file = createMockFile({ ownerId: 'owner_user' });
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn', adminRoles: ['admin'] });
+      const ctx = { principalId: 'admin_user', roles: ['admin'] };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(true);
+      expect(await authorizer.canWrite(file, ctx)).toBe(true);
+      expect(await authorizer.canDelete(file, ctx)).toBe(true);
+    });
+
+    it('should allow read for shared visibility within tenant', async () => {
+      const file = createMockFile({
+        ownerId: 'owner_user',
+        visibility: 'shared',
+        tenantId: 'org_123',
+      });
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'coworker', tenantId: 'org_123' };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(true);
+      expect(await authorizer.canWrite(file, ctx)).toBe(false);
+    });
+
+    it('should respect role-based grants', async () => {
+      const file = createMockFile({ fileId: 'file_role', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const roleGrant: FilePermissionRecord = {
+        permissionId: 'perm_role',
+        fileId: 'file_role',
+        userId: null,
+        role: 'editor',
+        tenantId: null,
+        canRead: true,
+        canWrite: true,
+        canDelete: false,
+        canShare: false,
+        expiresAt: null,
+        createdAt: new Date().toISOString(),
+      };
+
+      await db.create({
+        model: 'filePermissions',
+        data: roleGrant,
+        namespace: 'filefn',
+      });
+
+      const authorizer = createDefaultAuthorizer({ db, namespace: 'filefn' });
+      const ctx = { principalId: 'editor_user', roles: ['editor'] };
+
+      expect(await authorizer.canRead(file, ctx)).toBe(true);
+      expect(await authorizer.canWrite(file, ctx)).toBe(true);
+      expect(await authorizer.canDelete(file, ctx)).toBe(false);
+    });
+  });
+
+  describe('GrantsService', () => {
+    it('should create grant for file owner', async () => {
+      const file = createMockFile({ fileId: 'file_grant', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const grantsService = createGrantsService({ db, namespace: 'filefn' });
+
+      const grant = await grantsService.createGrant(
+        {
+          fileId: 'file_grant',
+          userId: 'grantee_user',
+          canRead: true,
+        },
+        { principalId: 'owner_user' }
+      );
+
+      expect(grant.permissionId).toBeDefined();
+      expect(grant.fileId).toBe('file_grant');
+      expect(grant.userId).toBe('grantee_user');
+      expect(grant.canRead).toBe(true);
+    });
+
+    it('should list grants for file owner', async () => {
+      const file = createMockFile({ fileId: 'file_list', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const grantsService = createGrantsService({ db, namespace: 'filefn' });
+
+      await grantsService.createGrant(
+        { fileId: 'file_list', userId: 'user1', canRead: true },
+        { principalId: 'owner_user' }
+      );
+      await grantsService.createGrant(
+        { fileId: 'file_list', userId: 'user2', canRead: true },
+        { principalId: 'owner_user' }
+      );
+
+      const grants = await grantsService.listGrants('file_list', { principalId: 'owner_user' });
+
+      expect(grants.length).toBe(2);
+    });
+
+    it('should revoke grant for file owner', async () => {
+      const file = createMockFile({ fileId: 'file_revoke', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const grantsService = createGrantsService({ db, namespace: 'filefn' });
+
+      const grant = await grantsService.createGrant(
+        { fileId: 'file_revoke', userId: 'grantee_user', canRead: true },
+        { principalId: 'owner_user' }
+      );
+
+      await grantsService.revokeGrant('file_revoke', grant.permissionId, { principalId: 'owner_user' });
+
+      const grants = await grantsService.listGrants('file_revoke', { principalId: 'owner_user' });
+      expect(grants.length).toBe(0);
+    });
+
+    it('should deny grant creation for non-owner', async () => {
+      const file = createMockFile({ fileId: 'file_deny', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const grantsService = createGrantsService({ db, namespace: 'filefn' });
+
+      await expect(
+        grantsService.createGrant(
+          { fileId: 'file_deny', userId: 'grantee_user', canRead: true },
+          { principalId: 'other_user' }
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_FORBIDDEN' });
+    });
+
+    it('should require at least one target (userId, role, or tenantId)', async () => {
+      const file = createMockFile({ fileId: 'file_target', ownerId: 'owner_user' });
+
+      await db.create({
+        model: 'files',
+        data: file,
+        namespace: 'filefn',
+      });
+
+      const grantsService = createGrantsService({ db, namespace: 'filefn' });
+
+      await expect(
+        grantsService.createGrant(
+          { fileId: 'file_target', canRead: true },
+          { principalId: 'owner_user' }
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_INVALID_GRANT' });
+    });
+  });
+
+  describe('TV-AUTH-002: Replace completion re-checks authorization', () => {
+    it('should reject replacement completion after write access is revoked', async () => {
+      const storageSizes = new Map<string, number>();
+      const canWriteState = { current: true };
+      const storage = createFakeStorageAdapter({
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: true,
+          multipart: true,
+          proxyStreamingUpload: false,
+          proxyStreamingDownload: true,
+        },
+        async createMultipartUpload() {
+          return { uploadId: 'up_replace_1' };
+        },
+        async completeMultipartUpload() {},
+        async signMultipartUploadPartUrl() {
+          return { url: 'https://signed.example/upload', headers: {} };
+        },
+        async statObject(input) {
+          return { key: input.key, size: storageSizes.get(input.key) ?? 1000 };
+        },
+      });
+
+      await db.create({
+        model: 'files',
+        data: createMockFile({ fileId: 'file_replace', ownerId: 'user_123', currentVersionId: 'ver_old' }),
+        namespace: 'filefn',
+      });
+
+      const service = createUploadSessionService({
+        db,
+        storage,
+        policies: {
+          get: vi.fn(() => ({
+            visibility: 'private',
+            contentTypes: ['image/png'],
+            maxSizeBytes: 10 * 1024 * 1024,
+          })),
+        } as any,
+        events: { emit: vi.fn() } as any,
+        fileWriteChecker: {
+          async canWriteFile() {
+            return canWriteState.current;
+          },
+        },
+        namespace: 'filefn',
+      });
+
+      const ctx: FileProviderContext = { principalId: 'user_123', requestId: 'req_replace_auth_001' };
+      const { uploadSessionId } = await service.createSession(
+        {
+          policy: 'user-avatar',
+          fileName: 'avatar.png',
+          size: 1000,
+          mimeType: 'image/png',
+          fileId: 'file_replace',
+        },
+        ctx,
+      );
+
+      const session = await db.findOne<any>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace: 'filefn',
+      });
+      storageSizes.set(session.storageKey, 1000);
+
+      await service.completePart(uploadSessionId, 1, 'etag_replace_1', 1000, ctx);
+      canWriteState.current = false;
+
+      await expect(service.completeSession(uploadSessionId, ctx)).rejects.toMatchObject({
+        code: 'FILEFN_FORBIDDEN',
+      });
+    });
+  });
+
+  describe('composeAuthorizers edge cases', () => {
+    it('should return deny-all for empty authorizers list', async () => {
+      const composed = composeAuthorizers([], { strategy: 'first-allow' });
+
+      const file = createMockFile();
+      const ctx: FileProviderContext = { principalId: 'any_user' };
+
+      expect(await composed.canRead(file, ctx)).toBe(false);
+      expect(await composed.canWrite(file, ctx)).toBe(false);
+      expect(await composed.canDelete(file, ctx)).toBe(false);
+    });
+
+    it('should work with single authorizer', async () => {
+      const allowAuth = createMockAuthorizer(true);
+
+      const composed = composeAuthorizers([allowAuth], { strategy: 'first-allow' });
+
+      const file = createMockFile();
+      const ctx: FileProviderContext = { principalId: 'any_user' };
+
+      expect(await composed.canRead(file, ctx)).toBe(true);
+    });
+  });
+});

--- a/filefn/server/src/__tests__/policies.test.ts
+++ b/filefn/server/src/__tests__/policies.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { computeStoragePath } from '../policies.js';
+
+describe('policy storage paths', () => {
+  it('TV-POLICY-001: sanitizes user-controlled path segments before joining', () => {
+    const path = computeStoragePath(
+      { name: 'user-avatar' },
+      {
+        tenantId: '../tenant',
+        principalId: 'user/123',
+        fileId: 'file\\id',
+        versionId: 'ver/001',
+        fileName: '../../avatar.png',
+      },
+    );
+
+    expect(path).toBe('_tenant/user_123/file_id/ver_001-_avatar.png');
+    expect(path).not.toContain('..');
+    expect(path).not.toContain('\\');
+  });
+});

--- a/filefn/server/src/__tests__/processing.test.ts
+++ b/filefn/server/src/__tests__/processing.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createFileFn } from '../index.js';
+import { createProcessingService, type Processor } from '../processing/service.js';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+import { createEventEmitter } from '../events.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+function createFakeDbAdapter() {
+  return {
+    create: vi.fn().mockResolvedValue({ artifactId: 'art_1' }),
+    findOne: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue({}),
+    findMany: vi.fn().mockResolvedValue([]),
+  } as any;
+}
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createStructuredDb(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let seq = 1;
+
+  function idFor(record: any): string {
+    return record.uploadSessionId || record.fileId || record.versionId || record.artifactId || `id_${seq++}`;
+  }
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) {
+      tables.set(model, new Map());
+    }
+    return tables.get(model)!;
+  }
+
+  function matches(record: any, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'in' && !clause.value.includes(value)) return false;
+    }
+    return true;
+  }
+
+  return {
+    id: 'processing-phase3-db',
+    name: 'processing-phase3-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const row = { ...params.data };
+      getTable(params.model).set(idFor(row), row);
+      return row;
+    },
+    async findOne(params) {
+      for (const row of getTable(params.model).values()) {
+        if (matches(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const rows = Array.from(getTable(params.model).values()).filter((row) => matches(row, params.where));
+      if (params.orderBy?.some((item: any) => item.field === 'createdAt' && item.direction === 'desc')) {
+        rows.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      }
+      return rows;
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          const updated = { ...row, ...params.data };
+          table.set(id, updated);
+          return updated;
+        }
+      }
+      return null;
+    },
+    async delete() {},
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) {
+      const table = getTable(params.model);
+      let removed = 0;
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          table.delete(id);
+          removed += 1;
+        }
+      }
+      return removed;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+async function createFileViaUpload(fileFn: ReturnType<typeof createFileFn>, db: Adapter, storageSizes: Map<string, number>) {
+  const session = await fileFn.createUploadSession(
+    {
+      policy: 'user-avatar',
+      fileName: 'avatar.png',
+      size: 2048,
+      mimeType: 'image/png',
+    },
+    { principalId: 'user_123', tenantId: 'org_123', requestId: 'req_upload' },
+  );
+
+  const storedSession = await db.findOne<any>({
+    model: 'uploadSessions',
+    where: [{ field: 'uploadSessionId', operator: 'eq', value: session.uploadSessionId }],
+    namespace: 'filefn',
+  });
+  storageSizes.set(storedSession.storageKey, 2048);
+
+  await fileFn.completeUploadPart(
+    { uploadSessionId: session.uploadSessionId, partNumber: 1, etag: 'etag-1', size: 2048 },
+    { principalId: 'user_123', tenantId: 'org_123', requestId: 'req_upload' },
+  );
+
+  return fileFn.completeUploadSession(
+    { uploadSessionId: session.uploadSessionId },
+    { principalId: 'user_123', tenantId: 'org_123', requestId: 'req_upload' },
+  );
+}
+
+describe('ProcessingService', () => {
+  let db: ReturnType<typeof createFakeDbAdapter>;
+  let service: ReturnType<typeof createProcessingService>;
+  let events: any;
+
+  beforeEach(() => {
+    db = createFakeDbAdapter();
+    events = createEventEmitter();
+    service = createProcessingService({
+      db,
+      storage: createFakeStorageAdapter({
+        capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: true, proxyStreamingDownload: true },
+        async openDownloadStream() {
+            return new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                    controller.close();
+                }
+            }) as any;
+        },
+        async openUploadStream() {
+            return new WritableStream() as any;
+        }
+      }),
+      events,
+      processors: [{
+        name: 'test-processor',
+        supportedMimeTypes: ['image/png'],
+        process: async () => ({
+          success: true,
+          artifacts: [{
+            kind: 'thumbnail-small',
+            data: new Uint8Array([1]),
+            mimeType: 'image/png',
+            storageKey: 'thumb/key'
+          }]
+        })
+      }]
+    });
+  });
+
+  it('should create artifact if not exists', async () => {
+    const input = {
+      fileId: 'f1',
+      versionId: 'v1',
+      storageKey: 'k1',
+      mimeType: 'image/png',
+      size: 100,
+      fileName: 'test.png',
+    };
+    const ctx = { requestId: 'req1' };
+
+    db.findOne.mockResolvedValue(null); // Not found
+
+    await service.runProcessing(input, ctx);
+
+    expect(db.create).toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('should update artifact if exists (idempotency)', async () => {
+    const input = {
+      fileId: 'f1',
+      versionId: 'v1',
+      storageKey: 'k1',
+      mimeType: 'image/png',
+      size: 100,
+      fileName: 'test.png',
+    };
+    const ctx = { requestId: 'req1' };
+
+    db.findOne.mockResolvedValue({ artifactId: 'art_existing', kind: 'thumbnail-small' }); // Found
+
+    await service.runProcessing(input, ctx);
+
+    expect(db.create).not.toHaveBeenCalled();
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it('should propagate request IDs in processing completion events', async () => {
+    const completed = vi.fn();
+    events.on('processing.completed', completed);
+
+    await service.runProcessing(
+      {
+        fileId: 'f1',
+        versionId: 'v1',
+        storageKey: 'k1',
+        mimeType: 'image/png',
+        size: 100,
+        fileName: 'test.png',
+      },
+      { requestId: 'req_phase3' },
+    );
+
+    expect(completed).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: 'req_phase3',
+      fileId: 'f1',
+      versionId: 'v1',
+      artifactsCreated: 1,
+    }));
+  });
+
+  it('should build queue idempotency keys from file, version, and processor set', async () => {
+    const queue = {
+      add: vi.fn().mockResolvedValue({ jobId: 'job_1' }),
+    };
+
+    service = createProcessingService({
+      db,
+      storage: createFakeStorageAdapter({
+        capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: true, proxyStreamingDownload: true },
+      }),
+      events,
+      processors: [
+        {
+          name: 'zeta',
+          supportedMimeTypes: ['image/png'],
+          process: async () => ({ success: true, artifacts: [] }),
+        },
+        {
+          name: 'alpha',
+          supportedMimeTypes: ['image/png'],
+          process: async () => ({ success: true, artifacts: [] }),
+        },
+      ],
+      flowFn: {
+        getQueue(name: string) {
+          return name === 'filefn.processing' ? (queue as any) : undefined;
+        },
+      },
+    });
+
+    const result = await service.triggerProcessing(
+      {
+        fileId: 'file_proc_1',
+        versionId: 'ver_proc_1',
+        storageKey: 'uploads/file_proc_1/ver_proc_1-image.png',
+        mimeType: 'image/png',
+        size: 10,
+        fileName: 'image.png',
+      },
+      { requestId: 'req_queue' },
+    );
+
+    expect(result).toEqual({ enqueued: true, jobId: 'job_1' });
+    expect(queue.add).toHaveBeenCalledWith(expect.objectContaining({
+      idempotencyKey: 'processing:file_proc_1:ver_proc_1:alpha,zeta',
+    }));
+  });
+
+  it('should trigger processing automatically when createFileFn completes an upload session', async () => {
+    const structuredDb = createStructuredDb();
+    const storageSizes = new Map<string, number>();
+    const processingCompleted = vi.fn();
+
+    const fileFn = createFileFn({
+      db: structuredDb,
+      storage: createFakeStorageAdapter({
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: true,
+          multipart: true,
+          proxyStreamingUpload: true,
+          proxyStreamingDownload: true,
+        },
+        async statObject(input) {
+          return { key: input.key, size: storageSizes.get(input.key) ?? 2048 };
+        },
+      }),
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 4096 }],
+      auth: { required: false },
+      processing: {
+        enabled: true,
+        processors: [
+          {
+            name: 'thumbnail',
+            supportedMimeTypes: ['image/png'],
+            async process(input: any) {
+              return {
+                success: true,
+                artifacts: [
+                  {
+                    kind: 'thumbnail-small',
+                    data: new Uint8Array([1, 2, 3]),
+                    mimeType: 'image/png',
+                    storageKey: `${input.storageKey}.thumb.png`,
+                  },
+                ],
+              };
+            },
+          },
+        ],
+      },
+    });
+
+    fileFn.events.on('processing.completed', processingCompleted);
+
+    const uploadResult = await createFileViaUpload(fileFn, structuredDb, storageSizes);
+    expect(uploadResult.fileId).toMatch(/^file_/);
+    expect(uploadResult.versionId).toMatch(/^ver_/);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const artifacts = await structuredDb.findMany<any>({
+      model: 'fileArtifacts',
+      where: [{ field: 'fileId', operator: 'eq', value: uploadResult.fileId }],
+      namespace: 'filefn',
+    });
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].kind).toBe('thumbnail-small');
+    expect(processingCompleted).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: 'req_upload',
+      fileId: uploadResult.fileId,
+      versionId: uploadResult.versionId,
+      artifactsCreated: 1,
+    }));
+  });
+});

--- a/filefn/server/src/__tests__/router.test.ts
+++ b/filefn/server/src/__tests__/router.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRouter } from '../router.js';
+
+function createMockRoutes() {
+  return {
+    uploadRoutes: {
+      initSession: vi.fn(async () => new Response('upload-init')),
+      getStatus: vi.fn(async () => new Response('upload-status')),
+      signPart: vi.fn(async () => new Response('upload-sign')),
+      completePart: vi.fn(async () => new Response('upload-complete-part')),
+      uploadPartBytes: vi.fn(async () => new Response('upload-part')),
+      completeSession: vi.fn(async () => new Response('upload-complete')),
+      abortSession: vi.fn(async () => new Response('upload-abort')),
+    },
+    fileRoutes: {
+      listFiles: vi.fn(async () => new Response('list-files')),
+      getFile: vi.fn(async () => new Response('get-file')),
+      deleteFile: vi.fn(async () => new Response('delete-file')),
+      downloadFile: vi.fn(async () => new Response('download-file')),
+      renderFile: vi.fn(async () => new Response('render-file')),
+      listVersions: vi.fn(async () => new Response('list-versions')),
+      getVersion: vi.fn(async () => new Response('get-version')),
+      proxyDownloadFile: vi.fn(async () => new Response('proxy-download-file')),
+    },
+    policyRoutes: {
+      listPolicies: vi.fn(async () => new Response('policies')),
+    },
+    quotaRoutes: {
+      getStorageQuota: vi.fn(async () => new Response('quota')),
+    },
+    grantsRoutes: {
+      createGrant: vi.fn(async () => new Response('create-grant')),
+      listGrants: vi.fn(async () => new Response('list-grants')),
+      revokeGrant: vi.fn(async () => new Response('revoke-grant')),
+    },
+    sharesRoutes: {
+      createShareLink: vi.fn(async () => new Response('create-share')),
+      listShareLinks: vi.fn(async () => new Response('list-share')),
+      downloadViaShareLink: vi.fn(async () => new Response('share-download')),
+      revokeShareLink: vi.fn(async () => new Response('revoke-share')),
+      proxyDownloadViaShareLink: vi.fn(async () => new Response('proxy-share-download')),
+    },
+    processingRoutes: {
+      listArtifacts: vi.fn(async () => new Response('list-artifacts')),
+      downloadArtifact: vi.fn(async () => new Response('download-artifact')),
+      proxyDownloadArtifact: vi.fn(async () => new Response('proxy-download-artifact')),
+      triggerProcessing: vi.fn(async () => new Response('trigger-processing')),
+    },
+  };
+}
+
+describe('createRouter', () => {
+  it('does not let reserved top-level routes shadow explicit handlers', async () => {
+    const routes = createMockRoutes();
+    const router = createRouter(routes as any);
+
+    const response = await router.handle(new Request('https://example.com/policies', { method: 'GET' }));
+
+    expect(await response?.text()).toBe('policies');
+    expect(routes.policyRoutes.listPolicies).toHaveBeenCalledTimes(1);
+    expect(routes.fileRoutes.getFile).not.toHaveBeenCalled();
+  });
+});

--- a/filefn/server/src/__tests__/shares.test.ts
+++ b/filefn/server/src/__tests__/shares.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createSharesService, type FileShareRecord } from '../index.js';
+import type { FileRecord, FileVersionRecord } from '../files/service.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+import type { StorageAdapter } from '@superfunctions/storage';
+
+const FAKE_CAPABILITIES: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createFakeDbAdapter(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let idCounter = 1;
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matchesWhere(record: any, where: any[]): boolean {
+    for (const clause of where) {
+      const value = record[clause.field];
+      switch (clause.operator) {
+        case 'eq': if (value !== clause.value) return false; break;
+        case 'ne': if (value === clause.value) return false; break;
+        default: break;
+      }
+    }
+    return true;
+  }
+
+  return {
+    id: 'fake',
+    name: 'fake',
+    version: '1.0.0',
+    capabilities: FAKE_CAPABILITIES,
+    async create(params) {
+      const table = getTable(params.model);
+      const id = params.data.tokenHash || params.data.fileId || params.data.versionId || `id_${idCounter++}`;
+      const record = { ...params.data, _id: id };
+      table.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const record of table.values()) {
+        if (matchesWhere(record, params.where)) return record;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const results: any[] = [];
+      for (const record of table.values()) {
+        if (!params.where || params.where.length === 0 || matchesWhere(record, params.where)) {
+          results.push(record);
+        }
+      }
+      return results;
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          const updated = { ...record, ...params.data };
+          table.set(id, updated);
+          return updated;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany(params) { return []; },
+    async updateMany(params) { return 0; },
+    async deleteMany(params) { return 0; },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return await this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return await this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count(params) { return 0; },
+    async transaction(callback) { return callback(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+function createFakeStorageAdapter(): StorageAdapter {
+  return {
+    id: 'fake-storage',
+    name: 'fake-storage',
+    version: '1.0.0',
+    capabilities: {
+      signedUploadUrls: true,
+      signedDownloadUrls: true,
+      multipart: true,
+      proxyStreamingUpload: false,
+      proxyStreamingDownload: true,
+    },
+    async signDownloadUrl({ key }: { key: string }) {
+      return { url: `https://fake-bucket.s3.amazonaws.com/${key}?X-Amz-Signature=fake` };
+    },
+    async signUploadUrl({ key }: { key: string }) {
+      return { url: `https://fake-bucket.s3.amazonaws.com/${key}?X-Amz-Signature=fake` };
+    },
+    async openDownloadStream() {
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+    },
+    async put() { return { key: 'test-key', size: 100 }; },
+    async get() { return { stream: new ReadableStream(), contentType: 'application/octet-stream', size: 100 }; },
+    async delete() {},
+    async copy() { return { key: 'copied-key' }; },
+    async exists() { return true; },
+    async list() { return { objects: [], continuationToken: undefined }; },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+  } as unknown as StorageAdapter;
+}
+
+async function seedFileAndVersion(db: Adapter, fileId: string, ownerId: string): Promise<{ file: FileRecord; version: FileVersionRecord }> {
+  const file: FileRecord = {
+    fileId,
+    name: 'test.png',
+    mimeType: 'image/png',
+    size: 1000,
+    ownerId,
+    tenantId: null,
+    visibility: 'private',
+    policy: 'user-avatar',
+    currentVersionId: `ver_${fileId}`,
+    metadata: {},
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const version: FileVersionRecord = {
+    versionId: `ver_${fileId}`,
+    fileId,
+    storageKey: `files/${fileId}/ver_${fileId}`,
+    mimeType: 'image/png',
+    size: 1000,
+    checksumSha256Base64: null,
+    createdAt: new Date().toISOString(),
+  };
+
+  await db.create({ model: 'files', data: file, namespace: 'filefn' });
+  await db.create({ model: 'fileVersions', data: version, namespace: 'filefn' });
+
+  return { file, version };
+}
+
+describe('@filefn/server shares', () => {
+  let db: Adapter;
+  let storage: StorageAdapter;
+
+  beforeEach(() => {
+    db = createFakeDbAdapter();
+    storage = createFakeStorageAdapter();
+  });
+
+  describe('TV-SHARE-CREATE-001: Create share link returns token once', () => {
+    it('should create share link and return plaintext token', async () => {
+      await seedFileAndVersion(db, 'file_share', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const result = await sharesService.createShareLink(
+        { fileId: 'file_share' },
+        { principalId: 'owner_user' }
+      );
+
+      expect(result.token).toBeDefined();
+      expect(typeof result.token).toBe('string');
+      expect(result.token.length).toBeGreaterThan(20);
+    });
+
+    it('should store token as hash (not plaintext)', async () => {
+      await seedFileAndVersion(db, 'file_hash', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const result = await sharesService.createShareLink(
+        { fileId: 'file_hash' },
+        { principalId: 'owner_user' }
+      );
+
+      const shares = await db.findMany<FileShareRecord>({
+        model: 'fileShares',
+        where: [{ field: 'fileId', operator: 'eq', value: 'file_hash' }],
+        namespace: 'filefn',
+      });
+
+      expect(shares.length).toBe(1);
+      expect(shares[0].tokenHash).toBeDefined();
+      expect(shares[0].tokenHash).not.toBe(result.token);
+    });
+  });
+
+  describe('Download via share link', () => {
+    it('should return download URL for valid share', async () => {
+      await seedFileAndVersion(db, 'file_download', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_download' },
+        { principalId: 'owner_user' }
+      );
+
+      const result = await sharesService.downloadViaShareLink(token, {
+        principalId: 'anonymous',
+        isAuthenticated: false,
+      });
+
+      expect(result.url).toBeDefined();
+      expect(result.fileName).toBe('test.png');
+      expect(result.mimeType).toBe('image/png');
+    });
+  });
+
+  describe('TV-SHARE-DOWNLOAD-NEG-001: Expired share fails', () => {
+    it('should fail with FILEFN_SHARE_EXPIRED for expired share', async () => {
+      await seedFileAndVersion(db, 'file_expired', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        {
+          fileId: 'file_expired',
+          expiresAt: new Date(Date.now() - 10000).toISOString(),
+        },
+        { principalId: 'owner_user' }
+      );
+
+      await expect(
+        sharesService.downloadViaShareLink(token, { principalId: 'anonymous' })
+      ).rejects.toMatchObject({ code: 'FILEFN_SHARE_EXPIRED' });
+    });
+  });
+
+  describe('Revoked share fails', () => {
+    it('should fail with FILEFN_SHARE_REVOKED for revoked share', async () => {
+      await seedFileAndVersion(db, 'file_revoked', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_revoked' },
+        { principalId: 'owner_user' }
+      );
+
+      await sharesService.revokeShareLink('file_revoked', token, { principalId: 'owner_user' });
+
+      await expect(
+        sharesService.downloadViaShareLink(token, { principalId: 'anonymous' })
+      ).rejects.toMatchObject({ code: 'FILEFN_SHARE_REVOKED' });
+    });
+  });
+
+  describe('Max downloads exceeded fails', () => {
+    it('should fail with FILEFN_SHARE_DOWNLOADS_EXCEEDED after max downloads', async () => {
+      await seedFileAndVersion(db, 'file_max', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_max', maxDownloads: 2 },
+        { principalId: 'owner_user' }
+      );
+
+      await sharesService.downloadViaShareLink(token, { principalId: 'user1' });
+      await sharesService.downloadViaShareLink(token, { principalId: 'user2' });
+
+      await expect(
+        sharesService.downloadViaShareLink(token, { principalId: 'user3' })
+      ).rejects.toMatchObject({ code: 'FILEFN_SHARE_DOWNLOADS_EXCEEDED' });
+    });
+  });
+
+  describe('requiresAuth enforcement', () => {
+    it('should fail with FILEFN_AUTH_REQUIRED when requiresAuth=true and not authenticated', async () => {
+      await seedFileAndVersion(db, 'file_auth', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_auth', requiresAuth: true },
+        { principalId: 'owner_user' }
+      );
+
+      await expect(
+        sharesService.downloadViaShareLink(token, {
+          principalId: 'anonymous',
+          isAuthenticated: false,
+        })
+      ).rejects.toMatchObject({ code: 'FILEFN_AUTH_REQUIRED' });
+    });
+
+    it('should allow download when requiresAuth=true and authenticated', async () => {
+      await seedFileAndVersion(db, 'file_auth_ok', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_auth_ok', requiresAuth: true },
+        { principalId: 'owner_user' }
+      );
+
+      const result = await sharesService.downloadViaShareLink(token, {
+        principalId: 'authenticated_user',
+        isAuthenticated: true,
+      });
+
+      expect(result.url).toBeDefined();
+    });
+  });
+
+  describe('Share link not found', () => {
+    it('should fail with FILEFN_SHARE_NOT_FOUND for invalid token', async () => {
+      await seedFileAndVersion(db, 'file_notfound', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      await expect(
+        sharesService.downloadViaShareLink('invalid_token_abc123', { principalId: 'anonymous' })
+      ).rejects.toMatchObject({ code: 'FILEFN_SHARE_NOT_FOUND' });
+    });
+  });
+
+  describe('listShareLinks', () => {
+    it('should list share links for file owner', async () => {
+      await seedFileAndVersion(db, 'file_list', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      await sharesService.createShareLink({ fileId: 'file_list' }, { principalId: 'owner_user' });
+      await sharesService.createShareLink({ fileId: 'file_list' }, { principalId: 'owner_user' });
+
+      const shares = await sharesService.listShareLinks('file_list', { principalId: 'owner_user' });
+
+      expect(shares.length).toBe(2);
+      expect(shares[0].tokenHashPrefix).toBeDefined();
+      expect(shares[0].tokenHashPrefix.length).toBe(8);
+    });
+
+    it('should deny listing for non-owner', async () => {
+      await seedFileAndVersion(db, 'file_list_deny', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      await expect(
+        sharesService.listShareLinks('file_list_deny', { principalId: 'other_user' })
+      ).rejects.toMatchObject({ code: 'FILEFN_FORBIDDEN' });
+    });
+  });
+
+  describe('revokeShareLink', () => {
+    it('should deny revocation for non-owner', async () => {
+      await seedFileAndVersion(db, 'file_revoke_deny', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_revoke_deny' },
+        { principalId: 'owner_user' }
+      );
+
+      await expect(
+        sharesService.revokeShareLink('file_revoke_deny', token, { principalId: 'other_user' })
+      ).rejects.toMatchObject({ code: 'FILEFN_FORBIDDEN' });
+    });
+
+    it('should fail for non-existent token', async () => {
+      await seedFileAndVersion(db, 'file_revoke_404', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      await expect(
+        sharesService.revokeShareLink('file_revoke_404', 'invalid_token', { principalId: 'owner_user' })
+      ).rejects.toMatchObject({ code: 'FILEFN_SHARE_NOT_FOUND' });
+    });
+  });
+
+  describe('createShareLink', () => {
+    it('should deny creation for non-owner', async () => {
+      await seedFileAndVersion(db, 'file_create_deny', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      await expect(
+        sharesService.createShareLink({ fileId: 'file_create_deny' }, { principalId: 'other_user' })
+      ).rejects.toMatchObject({ code: 'FILEFN_FORBIDDEN' });
+    });
+
+    it('should fail for non-existent file', async () => {
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      await expect(
+        sharesService.createShareLink({ fileId: 'non_existent' }, { principalId: 'any_user' })
+      ).rejects.toMatchObject({ code: 'FILEFN_NOT_FOUND' });
+    });
+
+    it('should support version-specific share links', async () => {
+      await seedFileAndVersion(db, 'file_version', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_version', versionId: 'ver_file_version' },
+        { principalId: 'owner_user' }
+      );
+
+      expect(token).toBeDefined();
+
+      const shares = await db.findMany<FileShareRecord>({
+        model: 'fileShares',
+        where: [{ field: 'fileId', operator: 'eq', value: 'file_version' }],
+        namespace: 'filefn',
+      });
+
+      expect(shares[0].versionId).toBe('ver_file_version');
+    });
+
+    it('should support expiresAt configuration', async () => {
+      await seedFileAndVersion(db, 'file_expires', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const expiresAt = new Date(Date.now() + 86400000).toISOString();
+
+      const result = await sharesService.createShareLink(
+        { fileId: 'file_expires', expiresAt },
+        { principalId: 'owner_user' }
+      );
+
+      expect(result.expiresAt).toBe(expiresAt);
+    });
+
+    it('should allow delegated canShare grants to create share links', async () => {
+      await seedFileAndVersion(db, 'file_delegate', 'owner_user');
+      await db.create({
+        model: 'filePermissions',
+        data: {
+          permissionId: 'perm_delegate',
+          fileId: 'file_delegate',
+          userId: 'delegate_user',
+          role: null,
+          tenantId: null,
+          canRead: true,
+          canWrite: false,
+          canDelete: false,
+          canShare: true,
+          expiresAt: null,
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+      const result = await sharesService.createShareLink(
+        { fileId: 'file_delegate' },
+        { principalId: 'delegate_user' },
+      );
+
+      expect(result.token).toBeDefined();
+      expect(typeof result.token).toBe('string');
+    });
+  });
+
+  describe('Download increments counter', () => {
+    it('should increment download count on each download', async () => {
+      await seedFileAndVersion(db, 'file_count', 'owner_user');
+
+      const sharesService = createSharesService({ db, storage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_count' },
+        { principalId: 'owner_user' }
+      );
+
+      await sharesService.downloadViaShareLink(token, { principalId: 'user1' });
+      await sharesService.downloadViaShareLink(token, { principalId: 'user2' });
+
+      const shares = await db.findMany<FileShareRecord>({
+        model: 'fileShares',
+        where: [{ field: 'fileId', operator: 'eq', value: 'file_count' }],
+        namespace: 'filefn',
+      });
+
+      expect(shares[0].downloads).toBe(2);
+    });
+
+    it('should defer counter increment for proxy descriptors until proxy stream starts', async () => {
+      await seedFileAndVersion(db, 'file_proxy_count', 'owner_user');
+
+      const proxyOnlyStorage = createFakeStorageAdapter();
+      (proxyOnlyStorage.capabilities as any).signedDownloadUrls = false;
+
+      const sharesService = createSharesService({ db, storage: proxyOnlyStorage, namespace: 'filefn' });
+
+      const { token } = await sharesService.createShareLink(
+        { fileId: 'file_proxy_count' },
+        { principalId: 'owner_user' },
+      );
+
+      const descriptor = await sharesService.downloadViaShareLink(token, {
+        principalId: 'anonymous',
+        isAuthenticated: false,
+      });
+      expect(descriptor.url).toMatch(/^\/proxy\/share-links\//);
+
+      let shares = await db.findMany<FileShareRecord>({
+        model: 'fileShares',
+        where: [{ field: 'fileId', operator: 'eq', value: 'file_proxy_count' }],
+        namespace: 'filefn',
+      });
+      expect(shares[0].downloads).toBe(0);
+
+      const streamResult = await sharesService.getDownloadStreamViaShareLink(token, {
+        principalId: 'anonymous',
+        isAuthenticated: false,
+      });
+      expect(streamResult.contentType).toBe('image/png');
+
+      shares = await db.findMany<FileShareRecord>({
+        model: 'fileShares',
+        where: [{ field: 'fileId', operator: 'eq', value: 'file_proxy_count' }],
+        namespace: 'filefn',
+      });
+      expect(shares[0].downloads).toBe(1);
+    });
+  });
+});

--- a/filefn/server/src/__tests__/upload-gc.test.ts
+++ b/filefn/server/src/__tests__/upload-gc.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createUploadSessionService } from '../upload-sessions/service.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+type Row = Record<string, any>;
+
+type MemoryDb = {
+  db: Adapter;
+  all(model: string): Row[];
+};
+
+function createMemoryDb(): MemoryDb {
+  const tables = new Map<string, Map<string, Row>>();
+  let idCounter = 1;
+
+  function table(model: string): Map<string, Row> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function match(record: Row, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+      if (clause.operator === 'gt' && !(value > clause.value)) return false;
+    }
+    return true;
+  }
+
+  const db: Adapter = {
+    id: 'mem-db',
+    name: 'mem-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const t = table(params.model);
+      const id =
+        (params.model === 'uploadParts' ? `${params.data.uploadSessionId}:${params.data.partNumber}` : undefined) ||
+        (params.model === 'uploadSessions' ? params.data.uploadSessionId : undefined) ||
+        (params.model === 'files' ? params.data.fileId : undefined) ||
+        (params.model === 'fileVersions' ? params.data.versionId : undefined) ||
+        params.data.permissionId ||
+        params.data.artifactId ||
+        `id_${idCounter++}`;
+      const row = { ...params.data, _id: id };
+      t.set(id, row);
+      return row;
+    },
+    async findOne(params) {
+      for (const row of table(params.model).values()) {
+        if (match(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const rows = Array.from(table(params.model).values()).filter((row) => match(row, params.where));
+      if (params.select && params.select.length > 0) {
+        return rows.map((row) => {
+          const projected: Row = {};
+          for (const key of params.select!) projected[key] = row[key];
+          return projected;
+        });
+      }
+      return rows;
+    },
+    async update(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          const next = { ...row, ...params.data };
+          t.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) {
+      const t = table(params.model);
+      let deleted = 0;
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          deleted += 1;
+        }
+      }
+      return deleted;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+
+  return {
+    db,
+    all(model: string) {
+      return Array.from(table(model).values());
+    },
+  };
+}
+
+function createStorage() {
+  const objects = new Map<string, Uint8Array>();
+  return {
+    objects,
+    adapter: {
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: true,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      },
+      abortMultipartUpload: vi.fn(async () => {}),
+      deleteObject: vi.fn(async ({ key }: { key: string }) => {
+        objects.delete(key);
+      }),
+    },
+  };
+}
+
+describe('PHASE_02 upload cleanup semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('TV-UPLOAD-GC-001: cleanup removes expired incomplete sessions, aborts multipart, and deletes proxy temp parts + uploadPart rows', async () => {
+    const db = createMemoryDb();
+    const storage = createStorage();
+    const service = createUploadSessionService({
+      db: db.db,
+      storage: storage.adapter as any,
+      policies: { get: vi.fn(() => ({ maxSizeBytes: 10 * 1024 * 1024 })) } as any,
+      events: { emit: vi.fn() } as any,
+    });
+
+    const old = new Date(Date.now() - 60_000).toISOString();
+
+    await db.db.create({ model: 'uploadSessions', data: {
+      uploadSessionId: 's_proxy',
+      status: 'pending',
+      uploadMode: 'proxy',
+      storageKey: 'k_proxy',
+      storageUploadId: null,
+      ownerId: 'user_1',
+      tenantId: null,
+      totalParts: 2,
+      size: 3,
+      mimeType: 'text/plain',
+      fileName: 'a.txt',
+      policy: 'p1',
+      chunkSizeBytes: 8 * 1024 * 1024,
+      fileId: null,
+      expiresAt: old,
+      createdAt: old,
+    }, namespace: 'filefn' });
+
+    await db.db.create({ model: 'uploadSessions', data: {
+      uploadSessionId: 's_multipart',
+      status: 'in_progress',
+      uploadMode: 'multipart-signed-url',
+      storageKey: 'k_mp',
+      storageUploadId: 'up_mp',
+      ownerId: 'user_1',
+      tenantId: null,
+      totalParts: 1,
+      size: 3,
+      mimeType: 'text/plain',
+      fileName: 'b.txt',
+      policy: 'p1',
+      chunkSizeBytes: 8 * 1024 * 1024,
+      fileId: null,
+      expiresAt: old,
+      createdAt: old,
+    }, namespace: 'filefn' });
+
+    await db.db.create({ model: 'uploadSessions', data: {
+      uploadSessionId: 's_done',
+      status: 'completed',
+      uploadMode: 'proxy',
+      storageKey: 'k_done',
+      storageUploadId: null,
+      ownerId: 'user_1',
+      tenantId: null,
+      totalParts: 1,
+      size: 3,
+      mimeType: 'text/plain',
+      fileName: 'c.txt',
+      policy: 'p1',
+      chunkSizeBytes: 8 * 1024 * 1024,
+      fileId: 'file_done',
+      expiresAt: old,
+      createdAt: old,
+    }, namespace: 'filefn' });
+
+    await db.db.create({ model: 'uploadParts', data: { uploadSessionId: 's_proxy', partNumber: 1, etag: 'e1', size: 1 }, namespace: 'filefn' });
+    await db.db.create({ model: 'uploadParts', data: { uploadSessionId: 's_proxy', partNumber: 2, etag: 'e2', size: 2 }, namespace: 'filefn' });
+    await db.db.create({ model: 'uploadParts', data: { uploadSessionId: 's_multipart', partNumber: 1, etag: 'e3', size: 3 }, namespace: 'filefn' });
+    await db.db.create({ model: 'uploadParts', data: { uploadSessionId: 's_done', partNumber: 1, etag: 'e4', size: 3 }, namespace: 'filefn' });
+
+    storage.objects.set('k_proxy.part1', new TextEncoder().encode('a'));
+    storage.objects.set('k_proxy.part2', new TextEncoder().encode('bc'));
+
+    const result = await service.cleanupExpiredSessions();
+
+    expect(result.deletedSessions).toBe(2);
+    expect(result.abortedMultipart).toBe(1);
+    expect(storage.adapter.abortMultipartUpload).toHaveBeenCalledWith({ key: 'k_mp', target: 'durable', uploadId: 'up_mp' });
+
+    const remainingSessions = db.all('uploadSessions').map((s) => s.uploadSessionId);
+    expect(remainingSessions).toEqual(['s_done']);
+
+    const remainingParts = db.all('uploadParts').map((p) => p.uploadSessionId);
+    expect(remainingParts).toEqual(['s_done']);
+
+    expect(storage.adapter.deleteObject).toHaveBeenCalledWith({ key: 'k_proxy.part1', target: 'durable' });
+    expect(storage.adapter.deleteObject).toHaveBeenCalledWith({ key: 'k_proxy.part2', target: 'durable' });
+
+    const secondRun = await service.cleanupExpiredSessions();
+    expect(secondRun.deletedSessions).toBe(0);
+    expect(secondRun.abortedMultipart).toBe(0);
+  });
+
+  it('TV-UPLOAD-GC-001: abort removes proxy temp part objects and uploadPart rows', async () => {
+    const db = createMemoryDb();
+    const storage = createStorage();
+    const service = createUploadSessionService({
+      db: db.db,
+      storage: storage.adapter as any,
+      policies: { get: vi.fn(() => ({ maxSizeBytes: 10 * 1024 * 1024 })) } as any,
+      events: { emit: vi.fn() } as any,
+    });
+
+    const future = new Date(Date.now() + 60_000).toISOString();
+
+    await db.db.create({ model: 'uploadSessions', data: {
+      uploadSessionId: 's_abort',
+      status: 'in_progress',
+      uploadMode: 'proxy',
+      storageKey: 'k_abort',
+      storageUploadId: null,
+      ownerId: 'user_1',
+      tenantId: null,
+      totalParts: 2,
+      size: 3,
+      mimeType: 'text/plain',
+      fileName: 'abort.txt',
+      policy: 'p1',
+      chunkSizeBytes: 8 * 1024 * 1024,
+      fileId: null,
+      expiresAt: future,
+      createdAt: new Date().toISOString(),
+    }, namespace: 'filefn' });
+
+    await db.db.create({ model: 'uploadParts', data: { uploadSessionId: 's_abort', partNumber: 1, etag: 'e1', size: 1 }, namespace: 'filefn' });
+    await db.db.create({ model: 'uploadParts', data: { uploadSessionId: 's_abort', partNumber: 2, etag: 'e2', size: 2 }, namespace: 'filefn' });
+
+    storage.objects.set('k_abort.part1', new TextEncoder().encode('a'));
+    storage.objects.set('k_abort.part2', new TextEncoder().encode('bc'));
+
+    await service.abortSession('s_abort', { principalId: 'user_1', requestId: 'req_abort' });
+
+    const aborted = await db.db.findOne({
+      model: 'uploadSessions',
+      where: [{ field: 'uploadSessionId', operator: 'eq', value: 's_abort' }],
+      namespace: 'filefn',
+    });
+    expect(aborted?.status).toBe('aborted');
+
+    const parts = await db.db.findMany({
+      model: 'uploadParts',
+      where: [{ field: 'uploadSessionId', operator: 'eq', value: 's_abort' }],
+      namespace: 'filefn',
+    });
+    expect(parts).toHaveLength(0);
+
+    expect(storage.adapter.deleteObject).toHaveBeenCalledWith({ key: 'k_abort.part1', target: 'durable' });
+    expect(storage.adapter.deleteObject).toHaveBeenCalledWith({ key: 'k_abort.part2', target: 'durable' });
+  });
+});

--- a/filefn/server/src/__tests__/upload-proxy.test.ts
+++ b/filefn/server/src/__tests__/upload-proxy.test.ts
@@ -1,0 +1,440 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createUploadSessionRoutes } from '../upload-sessions/routes.js';
+import { createUploadSessionService } from '../upload-sessions/service.js';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+type Row = Record<string, any>;
+
+type MemoryDb = {
+  db: Adapter;
+  all(model: string): Row[];
+};
+
+function createMemoryDb(): MemoryDb {
+  const tables = new Map<string, Map<string, Row>>();
+  let idCounter = 1;
+
+  function table(model: string): Map<string, Row> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function match(record: Row, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+      if (clause.operator === 'gt' && !(value > clause.value)) return false;
+    }
+    return true;
+  }
+
+  const db: Adapter = {
+    id: 'mem-db',
+    name: 'mem-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const t = table(params.model);
+      const id =
+        (params.model === 'uploadParts' ? `${params.data.uploadSessionId}:${params.data.partNumber}` : undefined) ||
+        (params.model === 'uploadSessions' ? params.data.uploadSessionId : undefined) ||
+        (params.model === 'files' ? params.data.fileId : undefined) ||
+        (params.model === 'fileVersions' ? params.data.versionId : undefined) ||
+        params.data.permissionId ||
+        params.data.artifactId ||
+        `id_${idCounter++}`;
+      const row = { ...params.data, _id: id };
+      t.set(id, row);
+      return row;
+    },
+    async findOne(params) {
+      for (const row of table(params.model).values()) {
+        if (match(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const rows = Array.from(table(params.model).values()).filter((row) => match(row, params.where));
+      if (params.select && params.select.length > 0) {
+        return rows.map((row) => {
+          const projected: Row = {};
+          for (const key of params.select!) projected[key] = row[key];
+          return projected;
+        });
+      }
+      return rows;
+    },
+    async update(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          const next = { ...row, ...params.data };
+          t.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) {
+      const t = table(params.model);
+      let deleted = 0;
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          deleted += 1;
+        }
+      }
+      return deleted;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+
+  return {
+    db,
+    all(model: string) {
+      return Array.from(table(model).values());
+    },
+  };
+}
+
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((acc, c) => acc + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function createMemoryStorage(capabilities: {
+  signedUploadUrls: boolean;
+  multipart: boolean;
+  proxyStreamingUpload: boolean;
+}) {
+  const objects = new Map<string, Uint8Array>();
+
+  return {
+    objects,
+    adapter: {
+      capabilities: {
+        ...capabilities,
+        signedDownloadUrls: true,
+        proxyStreamingDownload: true,
+      },
+      createMultipartUpload: vi.fn(async () => ({ uploadId: 'up_1' })),
+      signMultipartUploadPartUrl: vi.fn(async () => ({ url: 'https://signed.example/upload', headers: { 'x-test': '1' } })),
+      completeMultipartUpload: vi.fn(async () => {}),
+      openUploadStream: vi.fn(async ({ key }: { key: string }) => {
+        const chunks: Uint8Array[] = [];
+        return new WritableStream<Uint8Array>({
+          write(chunk) {
+            chunks.push(new Uint8Array(chunk));
+          },
+          close() {
+            objects.set(key, concatChunks(chunks));
+          },
+        });
+      }),
+      openDownloadStream: vi.fn(async ({ key }: { key: string }) => {
+        const bytes = objects.get(key);
+        if (!bytes) throw new Error(`Object not found: ${key}`);
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        });
+      }),
+      deleteObject: vi.fn(async ({ key }: { key: string }) => {
+        objects.delete(key);
+      }),
+      statObject: vi.fn(async ({ key }: { key: string }) => {
+        const bytes = objects.get(key) || new Uint8Array();
+        return { key, size: bytes.byteLength };
+      }),
+    },
+  };
+}
+
+function policyRegistry() {
+  return {
+    get: vi.fn(() => ({
+      maxSizeBytes: 10 * 1024 * 1024,
+      contentTypes: ['text/plain'],
+      visibility: 'private',
+    })),
+  };
+}
+
+function jsonBody(input: unknown): string {
+  return JSON.stringify(input);
+}
+
+describe('PHASE_02 upload mode and proxy semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('TV-UPLOAD-MODE-001: selects only canonical upload modes', async () => {
+    const dbA = createMemoryDb();
+    const storageA = createMemoryStorage({ signedUploadUrls: true, multipart: true, proxyStreamingUpload: false });
+    const serviceA = createUploadSessionService({
+      db: dbA.db,
+      storage: storageA.adapter as any,
+      policies: policyRegistry() as any,
+      events: { emit: vi.fn() } as any,
+    });
+
+    const a = await serviceA.createSession(
+      { policy: 'p1', fileName: 'a.txt', size: 3, mimeType: 'text/plain' },
+      { principalId: 'u1', requestId: 'req_a' },
+    );
+    expect(a.uploadMode).toBe('multipart-signed-url');
+
+    const dbB = createMemoryDb();
+    const storageB = createMemoryStorage({ signedUploadUrls: false, multipart: false, proxyStreamingUpload: true });
+    const serviceB = createUploadSessionService({
+      db: dbB.db,
+      storage: storageB.adapter as any,
+      policies: policyRegistry() as any,
+      events: { emit: vi.fn() } as any,
+    });
+
+    const b = await serviceB.createSession(
+      { policy: 'p1', fileName: 'b.txt', size: 3, mimeType: 'text/plain' },
+      { principalId: 'u1', requestId: 'req_b' },
+    );
+    expect(b.uploadMode).toBe('proxy');
+    expect(b.uploadMode).not.toBe('signed-url');
+  });
+
+  it('TV-UPLOAD-MODE-NEG-001: init fails with FILEFN_NO_SUPPORTED_UPLOAD_MODE when no valid mode exists', async () => {
+    const db = createMemoryDb();
+    const storage = createMemoryStorage({ signedUploadUrls: true, multipart: false, proxyStreamingUpload: false });
+    const service = createUploadSessionService({
+      db: db.db,
+      storage: storage.adapter as any,
+      policies: policyRegistry() as any,
+      events: { emit: vi.fn() } as any,
+    });
+
+    await expect(
+      service.createSession(
+        { policy: 'p1', fileName: 'c.txt', size: 3, mimeType: 'text/plain' },
+        { principalId: 'u1', requestId: 'req_c' },
+      ),
+    ).rejects.toMatchObject({ code: 'FILEFN_NO_SUPPORTED_UPLOAD_MODE' });
+  });
+
+  it('TV-UPLOAD-PROXY-001: proxy PUT records durable part, status shows recordedParts, and complete succeeds', async () => {
+    const db = createMemoryDb();
+    const storage = createMemoryStorage({ signedUploadUrls: false, multipart: false, proxyStreamingUpload: true });
+    const service = createUploadSessionService({
+      db: db.db,
+      storage: storage.adapter as any,
+      policies: policyRegistry() as any,
+      events: { emit: vi.fn() } as any,
+    });
+    const routes = createUploadSessionRoutes({ service, auth: { required: false } });
+
+    const initReq = new Request('http://localhost/upload/init', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: jsonBody({ policy: 'p1', fileName: 'proxy.txt', size: 3, mimeType: 'text/plain' }),
+    });
+    const initRes = await routes.initSession(initReq);
+    const initBody = await initRes.json();
+    expect(initRes.status).toBe(200);
+    expect(initBody.data.uploadMode).toBe('proxy');
+
+    const uploadSessionId = initBody.data.uploadSessionId as string;
+    const uploadSessionToken = initBody.data.uploadSessionToken as string;
+
+    const signReq = new Request(`http://localhost/upload/${uploadSessionId}/parts/1/sign`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-upload-session-token': uploadSessionToken,
+      },
+      body: jsonBody({ contentLength: 3 }),
+    });
+    const signRes = await routes.signPart(signReq, uploadSessionId, 1);
+    const signBody = await signRes.json();
+    expect(signRes.status).toBe(200);
+    expect(signBody.data.url).toBe(`/upload/${uploadSessionId}/parts/1`);
+
+    const putReq = new Request(`http://localhost/upload/${uploadSessionId}/parts/1`, {
+      method: 'PUT',
+      headers: {
+        'content-length': '3',
+        'content-type': 'text/plain',
+        'x-upload-session-token': uploadSessionToken,
+      },
+      body: 'abc',
+      duplex: 'half' as any,
+    } as any);
+    const putRes = await routes.uploadPartBytes(putReq, uploadSessionId, 1);
+    const putBody = await putRes.json();
+    expect(putRes.status).toBe(200);
+    expect(putBody.data.recorded).toBe(true);
+    expect(putBody.data.size).toBe(3);
+    expect(putBody.data.etag).toMatch(/^proxy-sha256-/);
+
+    const statusReq = new Request(`http://localhost/upload/${uploadSessionId}/status`, {
+      method: 'GET',
+      headers: { 'x-upload-session-token': uploadSessionToken },
+    });
+    const statusRes = await routes.getStatus(statusReq, uploadSessionId);
+    const statusBody = await statusRes.json();
+    expect(statusRes.status).toBe(200);
+    expect(statusBody.data.recordedParts).toEqual([1]);
+
+    const completeReq = new Request(`http://localhost/upload/${uploadSessionId}/complete`, {
+      method: 'POST',
+      headers: { 'x-upload-session-token': uploadSessionToken },
+    });
+    const completeRes = await routes.completeSession(completeReq, uploadSessionId);
+    const completeBody = await completeRes.json();
+    expect(completeRes.status).toBe(200);
+    expect(completeBody.data.fileId).toBeDefined();
+    expect(completeBody.data.versionId).toBeDefined();
+
+    const uploadSession = db.all('uploadSessions').find((s) => s.uploadSessionId === uploadSessionId)!;
+    expect(storage.objects.get(uploadSession.storageKey)).toEqual(new TextEncoder().encode('abc'));
+    expect(storage.objects.has(`${uploadSession.storageKey}.part1`)).toBe(false);
+  });
+
+  it('TV-UPLOAD-PROXY-NEG-001: conflicting bytes for a recorded proxy part returns FILEFN_PART_CONFLICT', async () => {
+    const db = createMemoryDb();
+    const storage = createMemoryStorage({ signedUploadUrls: false, multipart: false, proxyStreamingUpload: true });
+    const service = createUploadSessionService({
+      db: db.db,
+      storage: storage.adapter as any,
+      policies: policyRegistry() as any,
+      events: { emit: vi.fn() } as any,
+    });
+    const routes = createUploadSessionRoutes({ service, auth: { required: false } });
+
+    const initReq = new Request('http://localhost/upload/init', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: jsonBody({ policy: 'p1', fileName: 'proxy.txt', size: 3, mimeType: 'text/plain' }),
+    });
+    const initRes = await routes.initSession(initReq);
+    const initBody = await initRes.json();
+    const uploadSessionId = initBody.data.uploadSessionId as string;
+    const uploadSessionToken = initBody.data.uploadSessionToken as string;
+
+    const firstPutReq = new Request(`http://localhost/upload/${uploadSessionId}/parts/1`, {
+      method: 'PUT',
+      headers: {
+        'content-length': '3',
+        'content-type': 'text/plain',
+        'x-upload-session-token': uploadSessionToken,
+      },
+      body: 'abc',
+      duplex: 'half' as any,
+    } as any);
+    const firstPutRes = await routes.uploadPartBytes(firstPutReq, uploadSessionId, 1);
+    expect(firstPutRes.status).toBe(200);
+
+    const conflictingPutReq = new Request(`http://localhost/upload/${uploadSessionId}/parts/1`, {
+      method: 'PUT',
+      headers: {
+        'content-length': '3',
+        'content-type': 'text/plain',
+        'x-upload-session-token': uploadSessionToken,
+      },
+      body: 'abd',
+      duplex: 'half' as any,
+    } as any);
+    const conflictingPutRes = await routes.uploadPartBytes(conflictingPutReq, uploadSessionId, 1);
+    const conflictBody = await conflictingPutRes.json();
+
+    expect(conflictingPutRes.status).toBe(409);
+    expect(conflictBody.error.code).toBe('FILEFN_PART_CONFLICT');
+  });
+
+  it('TV-UPLOAD-PROXY-NEG-002: missing proxy PUT body returns a structured 400 error', async () => {
+    const db = createMemoryDb();
+    const storage = createMemoryStorage({ signedUploadUrls: false, multipart: false, proxyStreamingUpload: true });
+    const service = createUploadSessionService({
+      db: db.db,
+      storage: storage.adapter as any,
+      policies: policyRegistry() as any,
+      events: { emit: vi.fn() } as any,
+    });
+    const routes = createUploadSessionRoutes({ service, auth: { required: false } });
+
+    const initReq = new Request('http://localhost/upload/init', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: jsonBody({ policy: 'p1', fileName: 'proxy.txt', size: 3, mimeType: 'text/plain' }),
+    });
+    const initRes = await routes.initSession(initReq);
+    const initBody = await initRes.json();
+    const uploadSessionId = initBody.data.uploadSessionId as string;
+    const uploadSessionToken = initBody.data.uploadSessionToken as string;
+
+    const putReq = new Request(`http://localhost/upload/${uploadSessionId}/parts/1`, {
+      method: 'PUT',
+      headers: {
+        'content-length': '3',
+        'content-type': 'text/plain',
+        'x-upload-session-token': uploadSessionToken,
+      },
+    });
+
+    const putRes = await routes.uploadPartBytes(putReq, uploadSessionId, 1);
+    const putBody = await putRes.json();
+
+    expect(putRes.status).toBe(400);
+    expect(putBody.error.code).toBe('FILEFN_INVALID_REQUEST');
+  });
+});

--- a/filefn/server/src/__tests__/upload-session-authz.test.ts
+++ b/filefn/server/src/__tests__/upload-session-authz.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createFileFn, type FileFn } from '../index.js';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createDb(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let i = 1;
+
+  function table(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function match(record: any, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+      if (clause.operator === 'lt' && !(value < clause.value)) return false;
+    }
+    return true;
+  }
+
+  return {
+    id: 'phase0-db',
+    name: 'phase0-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const t = table(params.model);
+      const id =
+        params.data.uploadSessionId ||
+        params.data.fileId ||
+        params.data.versionId ||
+        params.data.permissionId ||
+        `id_${i++}`;
+      const record = { ...params.data, _id: id };
+      t.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const t = table(params.model);
+      for (const row of t.values()) {
+        if (match(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const t = table(params.model);
+      const rows = Array.from(t.values()).filter((row) => match(row, params.where));
+      return rows;
+    },
+    async update(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          const next = { ...row, ...params.data };
+          t.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const t = table(params.model);
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany(params) {
+      const t = table(params.model);
+      let deleted = 0;
+      for (const [id, row] of t.entries()) {
+        if (match(row, params.where)) {
+          t.delete(id);
+          deleted += 1;
+        }
+      }
+      return deleted;
+    },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+function json(data: unknown) {
+  return JSON.stringify(data);
+}
+
+describe('PHASE_00 AUTH-001 upload-session binding tests', () => {
+  let fileFn: FileFn;
+
+  beforeEach(() => {
+    fileFn = createFileFn({
+      db: createDb(),
+      storage: createFakeStorageAdapter({
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: true,
+          multipart: true,
+          proxyStreamingUpload: true,
+          proxyStreamingDownload: true,
+        },
+        async statObject() {
+          return { key: 'k', size: 3 };
+        },
+      }),
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      auth: {
+        required: false,
+        resolveSession: async (request) => {
+          const principalId = request.headers.get('x-user-id');
+          const tenantId = request.headers.get('x-tenant-id') || undefined;
+          if (!principalId) return null;
+          return { principalId, tenantId };
+        },
+      },
+    });
+  });
+
+  it('TV-UPLOAD-AUTH-NEG-001: cross-principal follow-up should be forbidden', async () => {
+    const initReq = new Request('http://localhost/upload/init', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-user-id': 'user_123',
+        'x-tenant-id': 'org_123',
+      },
+      body: json({
+        policy: 'user-avatar',
+        fileName: 'avatar.png',
+        size: 3,
+        mimeType: 'image/png',
+      }),
+    });
+
+    const initRes = await fileFn.router.handle(initReq);
+    const initBody = await initRes!.json();
+    const uploadSessionId = initBody.data.uploadSessionId as string;
+
+    const statusReq = new Request(`http://localhost/upload/${uploadSessionId}/status`, {
+      method: 'GET',
+      headers: { 'x-user-id': 'user_999', 'x-tenant-id': 'org_123' },
+    });
+
+    const statusRes = await fileFn.router.handle(statusReq);
+    const statusBody = await statusRes!.json();
+
+    expect(statusRes!.status).toBe(403);
+    expect(statusBody.error.code).toBe('FILEFN_FORBIDDEN');
+  });
+
+  it('TV-UPLOAD-AUTH-001: anonymous init should mint uploadSessionToken', async () => {
+    const initReq = new Request('http://localhost/upload/init', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: json({
+        policy: 'user-avatar',
+        fileName: 'anonymous.png',
+        size: 3,
+        mimeType: 'image/png',
+      }),
+    });
+
+    const initRes = await fileFn.router.handle(initReq);
+    const initBody = await initRes!.json();
+
+    expect(initBody.data.uploadSessionToken).toMatch(/^upls_/);
+  });
+});

--- a/filefn/server/src/__tests__/upload-sessions.test.ts
+++ b/filefn/server/src/__tests__/upload-sessions.test.ts
@@ -1,0 +1,784 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { createFileFn, createNucleusPolicies, type FileFn, type QuotaProvider } from '../index.js';
+import { createFakeStorageAdapter, createRoutedStorageAdapter, type StorageAdapter, type StorageAdapterCapabilities } from '@superfunctions/storage';
+import type { Adapter, TableSchema, AdapterCapabilities } from '@superfunctions/db';
+
+const FAKE_CAPABILITIES: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+// Fake in-memory DB adapter
+function createFakeDbAdapter(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let idCounter = 1;
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matchesWhere(record: any, where: any[]): boolean {
+    for (const clause of where) {
+      const value = record[clause.field];
+      switch (clause.operator) {
+        case 'eq': if (value !== clause.value) return false; break;
+        case 'ne': if (value === clause.value) return false; break;
+        default: break;
+      }
+    }
+    return true;
+  }
+
+  return {
+    id: 'fake',
+    name: 'fake',
+    version: '1.0.0',
+    capabilities: FAKE_CAPABILITIES,
+    async create(params) {
+      const table = getTable(params.model);
+      const id = params.data.uploadSessionId || params.data.fileId || params.data.versionId || params.data.permissionId || `id_${idCounter++}`;
+      const record = { ...params.data, _id: id };
+      table.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const record of table.values()) {
+        if (matchesWhere(record, params.where)) return record;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const results: any[] = [];
+      for (const record of table.values()) {
+        if (matchesWhere(record, params.where)) results.push(record);
+      }
+      return results;
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          const updated = { ...record, ...params.data };
+          table.set(id, updated);
+          return updated;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany(params) { return []; },
+    async updateMany(params) { return 0; },
+    async deleteMany(params) { return 0; },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return await this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return await this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count(params) { return 0; },
+    async transaction(callback) { return callback(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+describe('@filefn/server upload sessions', () => {
+  let fileFn: FileFn;
+  let db: Adapter;
+  let storageSizes: Map<string, number>;
+
+  beforeEach(() => {
+    db = createFakeDbAdapter();
+    storageSizes = new Map();
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: true,
+        multipart: true,
+        proxyStreamingUpload: false,
+        proxyStreamingDownload: true,
+      },
+      async statObject(input) {
+        return { key: input.key, size: storageSizes.get(input.key) ?? 1024 };
+      }
+    });
+
+    fileFn = createFileFn({
+      db,
+      storage,
+      policies: [
+        {
+          name: 'user-avatar',
+          contentTypes: ['image/png', 'image/jpeg'],
+          maxSizeBytes: 10485760, // 10 MiB
+          visibility: 'private',
+        },
+      ],
+      auth: { required: false },
+    });
+  });
+
+  describe('TV-UPLOAD-INIT-001: Create upload session', () => {
+    it('should create upload session successfully', async () => {
+      const result = await fileFn.createUploadSession(
+        {
+          policy: 'user-avatar',
+          fileName: 'avatar.png',
+          size: 2097152,
+          mimeType: 'image/png',
+          metadata: { userId: 'user_123' },
+        },
+        { principalId: 'user_123', tenantId: 'org_123', requestId: 'req_001' }
+      );
+
+      expect(result.uploadSessionId).toBeDefined();
+      expect(result.uploadSessionId).toMatch(/^upl_/);
+    });
+  });
+
+  describe('TV-STORAGE-001 / TV-POLICY-001: routed targets and Nucleus policies', () => {
+    function createTargetAdapter(
+      name: string,
+      calls: string[],
+      objects: Map<string, Uint8Array>,
+    ): StorageAdapter {
+      const capabilities: StorageAdapterCapabilities = {
+        signedUploadUrls: true,
+        signedDownloadUrls: true,
+        multipart: true,
+        proxyStreamingUpload: true,
+        proxyStreamingDownload: true,
+      };
+
+      return {
+        name,
+        capabilities,
+        async statObject({ key }) {
+          return { key, size: objects.get(`${name}:${key}`)?.length ?? 1024 };
+        },
+        async deleteObject({ key }) {
+          calls.push(`${name}:delete:${key}`);
+          objects.delete(`${name}:${key}`);
+        },
+        async createMultipartUpload({ key }) {
+          calls.push(`${name}:multipart:${key}`);
+          return { uploadId: `${name}-upload` };
+        },
+        async signMultipartUploadPartUrl({ key, partNumber }) {
+          calls.push(`${name}:sign-part:${key}:${partNumber}`);
+          return { url: `https://${name}.local/${key}/${partNumber}` };
+        },
+        async completeMultipartUpload({ key }) {
+          calls.push(`${name}:complete:${key}`);
+          if (!objects.has(`${name}:${key}`)) {
+            objects.set(`${name}:${key}`, new TextEncoder().encode('same-bytes'));
+          }
+        },
+        async abortMultipartUpload({ key }) {
+          calls.push(`${name}:abort:${key}`);
+        },
+        async signDownloadUrl({ key }) {
+          calls.push(`${name}:download:${key}`);
+          return { url: `https://${name}.local/download/${key}` };
+        },
+        async openUploadStream({ key }) {
+          calls.push(`${name}:upload-stream:${key}`);
+          const chunks: Uint8Array[] = [];
+          return new WritableStream<Uint8Array>({
+            write(chunk) {
+              chunks.push(chunk);
+            },
+            close() {
+              const size = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+              const combined = new Uint8Array(size);
+              let offset = 0;
+              for (const chunk of chunks) {
+                combined.set(chunk, offset);
+                offset += chunk.byteLength;
+              }
+              objects.set(`${name}:${key}`, combined);
+            },
+          });
+        },
+        async openDownloadStream({ key }) {
+          calls.push(`${name}:download-stream:${key}`);
+          const payload = objects.get(`${name}:${key}`) ?? new TextEncoder().encode('same-bytes');
+          return new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(payload);
+              controller.close();
+            },
+          });
+        },
+      };
+    }
+
+    it('routes durable and temporary policies to different physical adapters', async () => {
+      const calls: string[] = [];
+      const objects = new Map<string, Uint8Array>();
+      const storage = createRoutedStorageAdapter({
+        adapters: {
+          durable: createTargetAdapter('durable-bucket', calls, objects),
+          temporary: createTargetAdapter('temporary-bucket', calls, objects),
+        },
+      });
+
+      const routedFileFn = createFileFn({
+        db,
+        storage,
+        policies: [
+          { name: 'durable-policy', contentTypes: ['image/png'], storageTarget: 'durable' },
+          { name: 'temporary-policy', contentTypes: ['image/png'], storageTarget: 'temporary' },
+        ],
+        auth: { required: false },
+      });
+
+      await routedFileFn.createUploadSession(
+        { policy: 'durable-policy', fileName: 'a.png', size: 1024, mimeType: 'image/png' },
+        { principalId: 'user_123', tenantId: 'org_123' },
+      );
+      await routedFileFn.createUploadSession(
+        { policy: 'temporary-policy', fileName: 'b.png', size: 1024, mimeType: 'image/png' },
+        { principalId: 'user_123', tenantId: 'org_123' },
+      );
+
+      expect(calls).toContainEqual(expect.stringMatching(/^durable-bucket:multipart:/));
+      expect(calls).toContainEqual(expect.stringMatching(/^temporary-bucket:multipart:/));
+    });
+
+    it('does not dedupe across different routed storage targets', async () => {
+      const storageObjects = new Map<string, Uint8Array>([
+        ['durable-bucket:existing/shared.png', new TextEncoder().encode('same-bytes')],
+      ]);
+      const calls: string[] = [];
+      const storage = createRoutedStorageAdapter({
+        adapters: {
+          durable: createTargetAdapter('durable-bucket', calls, storageObjects),
+          temporary: createTargetAdapter('temporary-bucket', calls, storageObjects),
+        },
+      });
+
+      const checksum = createHash('sha256').update('same-bytes').digest('base64');
+      await db.create({
+        model: 'files',
+        data: {
+          fileId: 'file_existing',
+          currentVersionId: 'ver_existing',
+          ownerId: 'user_123',
+          tenantId: 'org_123',
+          visibility: 'private',
+          policy: 'durable-policy',
+          mimeType: 'image/png',
+          size: 10,
+          name: 'existing.png',
+          metadata: {},
+          createdAt: '2026-03-22T00:00:00.000Z',
+          updatedAt: '2026-03-22T00:00:00.000Z',
+        },
+      });
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_existing',
+          fileId: 'file_existing',
+          storageKey: 'existing/shared.png',
+          mimeType: 'image/png',
+          size: 10,
+          checksumSha256Base64: checksum,
+          tenantId: 'org_123',
+          createdAt: '2026-03-22T00:00:00.000Z',
+        },
+      });
+
+      const routedFileFn = createFileFn({
+        db,
+        storage,
+        policies: [
+          { name: 'durable-policy', contentTypes: ['image/png'], storageTarget: 'durable' },
+          { name: 'temporary-policy', contentTypes: ['image/png'], storageTarget: 'temporary' },
+        ],
+        dedup: { enabled: true },
+        auth: { required: false },
+      });
+
+      const { uploadSessionId } = await routedFileFn.createUploadSession(
+        { policy: 'temporary-policy', fileName: 'shared.png', size: 10, mimeType: 'image/png' },
+        { principalId: 'user_123', tenantId: 'org_123' },
+      );
+
+      const session = await db.findOne<any>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+      });
+      storageObjects.set(`temporary-bucket:${session.storageKey}`, new TextEncoder().encode('same-bytes'));
+
+      await routedFileFn.completeUploadPart(
+        { uploadSessionId, partNumber: 1, etag: 'etag_1', size: 10 },
+        { principalId: 'user_123', tenantId: 'org_123' },
+      );
+
+      const completed = await routedFileFn.completeUploadSession(
+        { uploadSessionId },
+        { principalId: 'user_123', tenantId: 'org_123' },
+      );
+
+      const version = await db.findOne<any>({
+        model: 'fileVersions',
+        where: [{ field: 'versionId', operator: 'eq', value: completed.versionId }],
+      });
+      expect(version.storageKey).toBe(session.storageKey);
+      expect(version.storageKey).not.toBe('existing/shared.png');
+    });
+
+    it('ships Nucleus policies with wildcard mime support and a 100 MiB cap', async () => {
+      const nucleusFileFn = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: createNucleusPolicies(),
+        auth: { required: false },
+      });
+
+      const ok = await nucleusFileFn.createUploadSession(
+        {
+          policy: 'nucleus-durable-default',
+          fileName: 'document.pdf',
+          size: 104857600,
+          mimeType: 'application/pdf',
+        },
+        { principalId: 'user_123' },
+      );
+      expect(ok.uploadSessionId).toBeDefined();
+
+      await expect(
+        nucleusFileFn.createUploadSession(
+          {
+            policy: 'nucleus-durable-default',
+            fileName: 'too-big.pdf',
+            size: 104857601,
+            mimeType: 'application/pdf',
+          },
+          { principalId: 'user_123' },
+        ),
+      ).rejects.toMatchObject({ code: 'FILEFN_POLICY_MAX_SIZE_EXCEEDED' });
+
+      await expect(
+        nucleusFileFn.createUploadSession(
+          {
+            policy: 'nucleus-temporary-default',
+            fileName: 'notes.zip',
+            size: 100,
+            mimeType: 'application/zip',
+          },
+          { principalId: 'user_123' },
+        ),
+      ).rejects.toMatchObject({ code: 'FILEFN_POLICY_CONTENT_TYPE_NOT_ALLOWED' });
+    });
+  });
+
+  describe('TV-UPLOAD-INIT-NEG-001: Disallowed content type', () => {
+    it('should reject disallowed content type', async () => {
+      await expect(
+        fileFn.createUploadSession(
+          { policy: 'user-avatar', fileName: 'avatar.gif', size: 100, mimeType: 'image/gif' },
+          { principalId: 'user_123', requestId: 'req_002' }
+        )
+      ).rejects.toMatchObject({
+        code: 'FILEFN_POLICY_CONTENT_TYPE_NOT_ALLOWED',
+        details: { policy: 'user-avatar', mimeType: 'image/gif' },
+      });
+    });
+  });
+
+  describe('TV-UPLOAD-INIT-NEG-002: Size exceeds policy max', () => {
+    it('should reject file exceeding max size', async () => {
+      await expect(
+        fileFn.createUploadSession(
+          { policy: 'user-avatar', fileName: 'big.png', size: 10485761, mimeType: 'image/png' },
+          { principalId: 'user_123', requestId: 'req_003' }
+        )
+      ).rejects.toMatchObject({
+        code: 'FILEFN_POLICY_MAX_SIZE_EXCEEDED',
+        details: { policy: 'user-avatar', maxSizeBytes: 10485760, size: 10485761 },
+      });
+    });
+  });
+
+  describe('TV-QUOTA-NEG-001: Quota exceeded', () => {
+    it('should reject when quota is exceeded', async () => {
+      const quotaProvider: QuotaProvider = {
+        async checkQuota() {
+          return { allowed: false, current: 100, limit: 100 };
+        },
+        async recordUsage() {},
+      };
+
+      const fileFnWithQuota = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 10485760 }],
+        quota: quotaProvider,
+        auth: { required: false },
+      });
+
+      await expect(
+        fileFnWithQuota.createUploadSession(
+          { policy: 'user-avatar', fileName: 'avatar.png', size: 1, mimeType: 'image/png' },
+          { principalId: 'user_123', requestId: 'req_004' }
+        )
+      ).rejects.toMatchObject({
+        code: 'FILEFN_QUOTA_EXCEEDED',
+        details: { current: 100, limit: 100, requested: 1 },
+      });
+    });
+  });
+
+  describe('TV-IDEMPOTENCY-001: Idempotent upload init', () => {
+    it('should return same session for same idempotency key', async () => {
+      const input = {
+        policy: 'user-avatar',
+        fileName: 'avatar.png',
+        size: 2097152,
+        mimeType: 'image/png',
+        idempotencyKey: 'idem_001',
+      };
+      const ctx = { principalId: 'user_123', requestId: 'req_001' };
+
+      const result1 = await fileFn.createUploadSession(input, ctx);
+      const result2 = await fileFn.createUploadSession(input, ctx);
+
+      expect(result1.uploadSessionId).toBe(result2.uploadSessionId);
+    });
+
+    it('should replay the original anonymous upload session token for identical input', async () => {
+      const input = {
+        policy: 'user-avatar',
+        fileName: 'avatar.png',
+        size: 2097152,
+        mimeType: 'image/png',
+        idempotencyKey: 'idem_anon_001',
+      };
+
+      const first = await fileFn.createUploadSession(input, { requestId: 'req_anon_001' }) as any;
+      const replay = await fileFn.createUploadSession(input, { requestId: 'req_anon_002' }) as any;
+
+      expect(first.uploadSessionId).toBe(replay.uploadSessionId);
+      expect(first.uploadSessionToken).toBeDefined();
+      expect(replay.uploadSessionToken).toBe(first.uploadSessionToken);
+    });
+  });
+
+  describe('TV-IDEMPOTENCY-NEG-001: Idempotency conflict', () => {
+    it('should reject idempotency key reuse with different payload', async () => {
+      const ctx = { principalId: 'user_123', requestId: 'req_001' };
+
+      await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png', idempotencyKey: 'idem_001' },
+        ctx
+      );
+
+      await expect(
+        fileFn.createUploadSession(
+          { policy: 'user-avatar', fileName: 'different.png', size: 2, mimeType: 'image/png', idempotencyKey: 'idem_001' },
+          ctx
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_IDEMPOTENCY_CONFLICT' });
+    });
+  });
+
+  describe('TV-UPLOAD-PART-SIGN-NEG-001: Invalid part number', () => {
+    it('should reject invalid part number', async () => {
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png' },
+        { principalId: 'user_123' }
+      );
+
+      await expect(
+        fileFn.signUploadPart(
+          { uploadSessionId, partNumber: 0, contentLength: 1 },
+          { principalId: 'user_123' }
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_INVALID_PART_NUMBER' });
+    });
+  });
+
+  describe('TV-AUTH-001: Anonymous follow-up routes stay bound to the original session token', () => {
+    it('should require the session token for anonymous follow-up routes and reject a wrong token', async () => {
+      const { uploadSessionId, uploadSessionToken } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png', idempotencyKey: 'anon_followup_001' },
+        { requestId: 'req_anon_followup_001' }
+      ) as any;
+
+      expect(uploadSessionToken).toBeDefined();
+
+      await expect(
+        fileFn.getUploadSessionStatus(
+          { uploadSessionId },
+          { requestId: 'req_anon_followup_missing' }
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_SESSION_TOKEN_REQUIRED' });
+
+      await expect(
+        fileFn.getUploadSessionStatus(
+          { uploadSessionId },
+          { requestId: 'req_anon_followup_wrong', uploadSessionToken: 'upls_live_wrong' } as any
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_SESSION_TOKEN_INVALID' });
+
+      const status = await fileFn.getUploadSessionStatus(
+        { uploadSessionId },
+        { requestId: 'req_anon_followup_ok', uploadSessionToken } as any
+      ) as any;
+
+      expect(status.uploadSessionId).toBe(uploadSessionId);
+      expect(status.fileId).toMatch(/^file_/);
+      expect(status.recordedParts).toEqual([]);
+    });
+  });
+
+  describe('TV-UPLOAD-PART-COMPLETE-NEG-001: Invalid etag', () => {
+    it('should reject empty etag', async () => {
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png' },
+        { principalId: 'user_123' }
+      );
+
+      await expect(
+        fileFn.completeUploadPart(
+          { uploadSessionId, partNumber: 1, etag: '', size: 2097152 },
+          { principalId: 'user_123' }
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_INVALID_ETAG' });
+    });
+  });
+
+  describe('TV-UPLOAD-COMPLETE-NEG-001: Upload incomplete', () => {
+    it('should reject completion with missing parts', async () => {
+      // Create a fileFn with a larger size limit for this test
+      const fileFnLarge = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 50000000 }],
+        auth: { required: false },
+      });
+
+      const { uploadSessionId } = await fileFnLarge.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 20000000, mimeType: 'image/png' }, // ~20MB = 3 parts
+        { principalId: 'user_123' }
+      );
+
+      // Only complete 1 part
+      await fileFnLarge.completeUploadPart(
+        { uploadSessionId, partNumber: 1, etag: 'etag1', size: 8388608 },
+        { principalId: 'user_123' }
+      );
+
+      await expect(
+        fileFnLarge.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' })
+      ).rejects.toMatchObject({ code: 'FILEFN_UPLOAD_INCOMPLETE' });
+    });
+  });
+
+  describe('TV-UPLOAD-COMPLETE-001: Complete upload session', () => {
+    it('should complete upload session after all parts recorded', async () => {
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png' },
+        { principalId: 'user_123' }
+      );
+
+      const session = await db.findOne<any>({ model: 'uploadSessions', where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }] });
+      if (session) storageSizes.set(session.storageKey, 2097152);
+
+      await fileFn.completeUploadPart(
+        { uploadSessionId, partNumber: 1, etag: 'etag_part_1', size: 2097152 },
+        { principalId: 'user_123' }
+      );
+
+      const result = await fileFn.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' });
+
+      expect(result.fileId).toBeDefined();
+      expect(result.versionId).toBeDefined();
+      expect(result.fileId).toMatch(/^file_/);
+      expect(result.versionId).toMatch(/^ver_/);
+    });
+  });
+
+  describe('TV-UPLOAD-EXPIRE-001: Expired session', () => {
+    it('should reject completion of expired session', async () => {
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png' },
+        { principalId: 'user_123' }
+      );
+
+      // Manually expire the session
+      await db.update({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        data: { expiresAt: new Date(Date.now() - 1000).toISOString() },
+        namespace: 'filefn',
+      });
+
+      await expect(
+        fileFn.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' })
+      ).rejects.toMatchObject({ code: 'FILEFN_UPLOAD_EXPIRED' });
+    });
+  });
+
+  describe('Abort then complete', () => {
+    it('should reject completion after abort', async () => {
+      const { uploadSessionId } = await fileFn.createUploadSession(
+        { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png' },
+        { principalId: 'user_123' }
+      );
+
+      await fileFn.abortUploadSession({ uploadSessionId }, { principalId: 'user_123' });
+
+      await expect(
+        fileFn.completeUploadSession({ uploadSessionId }, { principalId: 'user_123' })
+      ).rejects.toMatchObject({ code: 'FILEFN_UPLOAD_ABORTED' });
+    });
+  });
+
+  describe('getSchema', () => {
+    it('should return all required schemas (TV-DB-SCHEMA-001)', () => {
+      const { version, schemas } = fileFn.getSchema();
+
+      expect(version).toBe(1);
+
+      const modelNames = schemas.map(s => s.modelName);
+      expect(modelNames).toContain('files');
+      expect(modelNames).toContain('fileVersions');
+      expect(modelNames).toContain('uploadSessions');
+      expect(modelNames).toContain('uploadParts');
+      expect(modelNames).toContain('filePermissions');
+      expect(modelNames).toContain('fileShares');
+      expect(modelNames).toContain('fileArtifacts');
+    });
+  });
+
+  describe('Rate limiting (TV-RATE-NEG-001)', () => {
+    it('should enforce rate limits on upload init', async () => {
+      const rateLimiter = {
+        async check(_input: any) {
+          return { allowed: false, remaining: 0, resetAt: new Date(Date.now() + 60000).toISOString(), total: 10 };
+        },
+        async reset(_key: string) {},
+      };
+
+      const fileFnWithRateLimit = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        rateLimiter,
+        auth: { required: false },
+      });
+
+      const request = new Request('http://localhost/upload/init', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req_rate' },
+        body: JSON.stringify({ policy: 'user-avatar', fileName: 'test.png', size: 100, mimeType: 'image/png' }),
+      });
+
+      const response = await fileFnWithRateLimit.router.handle(request);
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(429);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('FILEFN_RATE_LIMITED');
+    });
+
+    it('TV-RATE-001: should enforce uploadInit category limits with ISO8601 resetAt', async () => {
+      const fileFnWithCategoryRateLimit = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        rateLimit: {
+          limits: {
+            uploadInit: { windowSeconds: 60, maxRequests: 1 },
+          },
+        },
+        auth: { required: false },
+      });
+
+      const request1 = new Request('http://localhost/upload/init', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req_rate_1' },
+        body: JSON.stringify({ policy: 'user-avatar', fileName: 'a.png', size: 100, mimeType: 'image/png' }),
+      });
+      const response1 = await fileFnWithCategoryRateLimit.router.handle(request1);
+      expect(response1!.status).toBe(200);
+
+      const request2 = new Request('http://localhost/upload/init', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req_rate_2' },
+        body: JSON.stringify({ policy: 'user-avatar', fileName: 'b.png', size: 100, mimeType: 'image/png' }),
+      });
+      const response2 = await fileFnWithCategoryRateLimit.router.handle(request2);
+      expect(response2!.status).toBe(429);
+
+      const body2 = await response2!.json();
+      expect(body2.error.code).toBe('FILEFN_RATE_LIMITED');
+      expect(typeof body2.error.details?.resetAt).toBe('string');
+      expect(Number.isNaN(Date.parse(body2.error.details.resetAt))).toBe(false);
+    });
+
+    it('TV-RATE-NEG-001: should reject legacy non-category rateLimit config', () => {
+      expect(() => createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: { signedUploadUrls: true, signedDownloadUrls: true, multipart: true, proxyStreamingUpload: false, proxyStreamingDownload: true },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'] }],
+        rateLimit: {
+          limits: {},
+        },
+        auth: { required: false },
+      })).toThrow(/RATE_LIMIT_CONFIG_INVALID/);
+    });
+  });
+});

--- a/filefn/server/src/__tests__/upload-size-validate.test.ts
+++ b/filefn/server/src/__tests__/upload-size-validate.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createUploadSessionRoutes } from '../upload-sessions/routes.js';
+import { createUploadSessionService } from '../upload-sessions/service.js';
+
+describe('Completion Size Validation', () => {
+  const mockDb = {
+    findOne: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
+  };
+
+  const mockStorage = {
+    capabilities: { multipart: true },
+    completeMultipartUpload: vi.fn(),
+    statObject: vi.fn(), // We will use this
+  };
+
+  const service = createUploadSessionService({
+    db: mockDb as any,
+    storage: mockStorage as any,
+    policies: { get: () => ({}) } as any,
+    events: { emit: vi.fn() } as any,
+  });
+
+  const routes = createUploadSessionRoutes({ service, auth: { required: false } });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // TV-UPLOAD-COMPLETE-VALIDATE-SIZE-NEG-001
+  it('fails completion if storage size does not match session size', async () => {
+    mockDb.findOne.mockResolvedValue({
+      uploadSessionId: 'sess_1',
+      status: 'in_progress',
+      uploadMode: 'multipart-signed-url',
+      totalParts: 1,
+      size: 100, // Expected
+      expiresAt: new Date(Date.now() + 10000).toISOString(),
+      storageKey: 'key',
+      storageUploadId: 'uid'
+    });
+    
+    mockDb.findMany.mockResolvedValue([{ partNumber: 1, etag: 'e1' }]);
+
+    // Storage reports different size
+    mockStorage.statObject.mockResolvedValue({ size: 99 });
+
+    const req = new Request('http://localhost/upload/sess_1/complete', { method: 'POST' });
+    
+    const res = await routes.completeSession(req, 'sess_1');
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe('FILEFN_UPLOAD_SIZE_MISMATCH');
+    expect(body.error.details).toEqual({ expected: 100, actual: 99 });
+    expect(mockStorage.completeMultipartUpload).toHaveBeenCalled();
+    expect(mockStorage.statObject).toHaveBeenCalledWith({ key: 'key', target: 'durable' });
+  });
+});

--- a/filefn/server/src/__tests__/upload-status-contract.test.ts
+++ b/filefn/server/src/__tests__/upload-status-contract.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createFileFn, type FileFn } from '../index.js';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const CAPS: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createDb(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let seq = 1;
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matches(record: any, where: any[] = []): boolean {
+    for (const clause of where) {
+      const value = record?.[clause.field];
+      if (clause.operator === 'eq' && value !== clause.value) return false;
+      if (clause.operator === 'ne' && value === clause.value) return false;
+    }
+    return true;
+  }
+
+  return {
+    id: 'phase0-upload-status-db',
+    name: 'phase0-upload-status-db',
+    version: '1.0.0',
+    capabilities: CAPS,
+    async create(params) {
+      const table = getTable(params.model);
+      const id =
+        params.data.uploadSessionId ||
+        params.data.fileId ||
+        params.data.versionId ||
+        params.data.permissionId ||
+        `id_${seq++}`;
+      const record = { ...params.data, _id: id };
+      table.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const row of table.values()) {
+        if (matches(row, params.where)) return row;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      return Array.from(table.values()).filter((row) => matches(row, params.where));
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          const next = { ...row, ...params.data };
+          table.set(id, next);
+          return next;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, row] of table.entries()) {
+        if (matches(row, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany() { return 0; },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(cb) { return cb(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+describe('PHASE_00 UPLOAD-001/API-001 upload status contract', () => {
+  let fileFn: FileFn;
+
+  beforeEach(() => {
+    fileFn = createFileFn({
+      db: createDb(),
+      storage: createFakeStorageAdapter({
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: true,
+          multipart: true,
+          proxyStreamingUpload: false,
+          proxyStreamingDownload: true,
+        },
+      }),
+      policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 1024 * 1024 }],
+      auth: {
+        required: false,
+        resolveSession: async () => ({ principalId: 'user_123', tenantId: 'org_123' }),
+      },
+    });
+  });
+
+  it('TV-UPLOAD-STATUS-001: status response should expose canonical resumability fields', async () => {
+    const initRes = await fileFn.router.handle(
+      new Request('http://localhost/upload/init', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req_004' },
+        body: JSON.stringify({
+          policy: 'user-avatar',
+          fileName: 'photo.png',
+          size: 9,
+          mimeType: 'image/png',
+        }),
+      })
+    );
+
+    const initBody = await initRes!.json();
+    const uploadSessionId = initBody.data.uploadSessionId as string;
+
+    const statusRes = await fileFn.router.handle(
+      new Request(`http://localhost/upload/${uploadSessionId}/status`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_004' },
+      })
+    );
+
+    const statusBody = await statusRes!.json();
+
+    expect(statusBody.ok).toBe(true);
+    expect(statusBody.requestId).toBe('req_004');
+    expect(statusBody.data).toMatchObject({
+      uploadSessionId,
+      fileId: expect.any(String),
+      status: expect.any(String),
+      totalParts: expect.any(Number),
+      recordedParts: expect.any(Array),
+      chunkSizeBytes: expect.any(Number),
+      fileSize: expect.any(Number),
+      expiresAt: expect.any(String),
+    });
+  });
+
+  it('TV-ENVELOPE-NEG-001: not-found should still use canonical error envelope', async () => {
+    const res = await fileFn.router.handle(
+      new Request('http://localhost/upload/upl_missing/status', {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_002' },
+      })
+    );
+
+    const body = await res!.json();
+
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe('FILEFN_SESSION_NOT_FOUND');
+    expect(body.requestId).toBe('req_002');
+  });
+});

--- a/filefn/server/src/__tests__/versions-metadata.test.ts
+++ b/filefn/server/src/__tests__/versions-metadata.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Test vectors for version metadata and binding (VERSION-001, SERVER-002)
+ * 
+ * These tests encode the audit gaps for version operations:
+ * - TV-VERSION-GET-001: Get version metadata
+ * - TV-VERSION-DOWNLOAD-BINDING-NEG-001: Version download rejects when versionId doesn't belong to fileId
+ * - TV-POLICY-LIST-001: GET /policies returns policy constraints
+ * - TV-QUOTA-GET-001: GET /quota/storage returns quota usage
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createFileFn, type FileFn, type QuotaProvider } from '../index.js';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+import type { Adapter, AdapterCapabilities } from '@superfunctions/db';
+
+const FAKE_CAPABILITIES: AdapterCapabilities = {
+  types: { json: true, dates: true, booleans: true, bigint: false, uuid: false, enum: false },
+  operations: { batch: false, upsert: true, streaming: false, fulltext: false, returning: false },
+  transactions: { supported: false, nested: false },
+  performance: { supportsJoins: false, supportsPreparedStatements: false },
+  schema: { migrations: false, constraints: false, indexes: false },
+  advanced: { customIdGeneration: false, numericIds: false, schemaNamespaces: false, customTypes: false },
+};
+
+function createFakeDbAdapter(): Adapter {
+  const tables = new Map<string, Map<string, any>>();
+  let idCounter = 1;
+
+  function getTable(model: string): Map<string, any> {
+    if (!tables.has(model)) tables.set(model, new Map());
+    return tables.get(model)!;
+  }
+
+  function matchesWhere(record: any, where: any[]): boolean {
+    for (const clause of where) {
+      const value = record[clause.field];
+      switch (clause.operator) {
+        case 'eq': if (value !== clause.value) return false; break;
+        case 'ne': if (value === clause.value) return false; break;
+        default: break;
+      }
+    }
+    return true;
+  }
+
+  return {
+    id: 'fake',
+    name: 'fake',
+    version: '1.0.0',
+    capabilities: FAKE_CAPABILITIES,
+    async create(params) {
+      const table = getTable(params.model);
+      const id = params.model === 'fileVersions'
+        ? (params.data.versionId || params.data.fileId || params.data.uploadSessionId || params.data.permissionId || `id_${idCounter++}`)
+        : (params.data.uploadSessionId || params.data.fileId || params.data.versionId || params.data.permissionId || `id_${idCounter++}`);
+      const record = { ...params.data, _id: id };
+      table.set(id, record);
+      return record;
+    },
+    async findOne(params) {
+      const table = getTable(params.model);
+      for (const record of table.values()) {
+        if (matchesWhere(record, params.where)) return record;
+      }
+      return null;
+    },
+    async findMany(params) {
+      const table = getTable(params.model);
+      const results: any[] = [];
+      for (const record of table.values()) {
+        if (!params.where || params.where.length === 0 || matchesWhere(record, params.where)) {
+          results.push(record);
+        }
+      }
+      if (params.orderBy?.some((o: any) => o.field === 'createdAt' && o.direction === 'desc')) {
+        results.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      }
+      return results.slice(0, params.limit || results.length);
+    },
+    async update(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          const updated = { ...record, ...params.data };
+          table.set(id, updated);
+          return updated;
+        }
+      }
+      return null;
+    },
+    async delete(params) {
+      const table = getTable(params.model);
+      for (const [id, record] of table.entries()) {
+        if (matchesWhere(record, params.where)) {
+          table.delete(id);
+          return;
+        }
+      }
+    },
+    async createMany() { return []; },
+    async updateMany() { return 0; },
+    async deleteMany() { return 0; },
+    async upsert(params) {
+      const existing = await this.findOne({ model: params.model, where: params.where, namespace: params.namespace });
+      if (existing) {
+        return await this.update({ model: params.model, where: params.where, data: params.update, namespace: params.namespace });
+      }
+      return await this.create({ model: params.model, data: params.create, namespace: params.namespace });
+    },
+    async count() { return 0; },
+    async transaction(callback) { return callback(this as any); },
+    async initialize() {},
+    async isHealthy() { return { healthy: true, uptime: 0 }; },
+    async close() {},
+    async getSchemaVersion() { return 0; },
+    async setSchemaVersion() {},
+    async validateSchema() { return { valid: true }; },
+    internal: {
+      async ensureTable() {},
+      async create() { return {}; },
+      async findOne() { return null; },
+      async findMany() { return []; },
+      async update() { return 0; },
+      async delete() { return 0; },
+    },
+  } as Adapter;
+}
+
+async function createFileViaUpload(fileFn: FileFn, db: Adapter, storageSizes: Map<string, number>, principalId: string, tenantId?: string): Promise<{ fileId: string; versionId: string }> {
+  const { uploadSessionId } = await fileFn.createUploadSession(
+    { policy: 'user-avatar', fileName: 'avatar.png', size: 2097152, mimeType: 'image/png' },
+    { principalId, tenantId }
+  );
+
+  const session = await db.findOne<any>({ model: 'uploadSessions', where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }] });
+  if (session) storageSizes.set(session.storageKey, 2097152);
+  
+  await fileFn.completeUploadPart(
+    { uploadSessionId, partNumber: 1, etag: 'etag1', size: 2097152 },
+    { principalId, tenantId }
+  );
+  
+  return fileFn.completeUploadSession({ uploadSessionId }, { principalId, tenantId });
+}
+
+describe('@filefn/server version metadata', () => {
+  let db: Adapter;
+  let fileFn: FileFn;
+  let storageSizes: Map<string, number>;
+
+  beforeEach(() => {
+    db = createFakeDbAdapter();
+    storageSizes = new Map();
+    const storage = createFakeStorageAdapter({
+      capabilities: {
+        signedUploadUrls: true,
+        signedDownloadUrls: true,
+        multipart: true,
+        proxyStreamingUpload: false,
+        proxyStreamingDownload: true,
+      },
+      async statObject(input) {
+        return { key: input.key, size: storageSizes.get(input.key) ?? 1024 };
+      }
+    });
+
+    fileFn = createFileFn({
+      db,
+      storage,
+      policies: [
+        {
+          name: 'user-avatar',
+          contentTypes: ['image/png', 'image/jpeg'],
+          maxSizeBytes: 10485760,
+          visibility: 'private',
+        },
+      ],
+      auth: { required: false },
+    });
+  });
+
+  describe('TV-VERSION-GET-001: Get version metadata', () => {
+    it('should return version metadata when versionId belongs to fileId', async () => {
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 10485760 }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123' }),
+        },
+      });
+
+      const { fileId, versionId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      const request = new Request(`http://localhost/${fileId}/versions/${versionId}`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_070' },
+      });
+
+      const response = await fileFnWithAuth.router.handle(request);
+      
+      // This will fail until version metadata route is implemented
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(200);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(true);
+      expect(body.data.versionId).toBe(versionId);
+      expect(body.data.fileId).toBe(fileId);
+      expect(body.data.size).toBeDefined();
+      expect(body.data.mimeType).toBe('image/png');
+      expect(body.data.createdAt).toBeDefined();
+      expect(body.requestId).toBe('req_070');
+    });
+  });
+
+  describe('TV-VERSION-001: provider getFile({ versionId }) semantics', () => {
+    it('returns metadata for the requested non-current version', async () => {
+      const { fileId, versionId: oldVersionId } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+      const newVersionId = 'ver_new_manual';
+
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: newVersionId,
+          fileId,
+          storageKey: `uploads/${fileId}/${newVersionId}`,
+          mimeType: 'image/jpeg',
+          size: 4096,
+          checksumSha256Base64: null,
+          createdAt: '2026-03-20T16:00:00.000Z',
+        },
+      });
+
+      await db.update({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        data: {
+          currentVersionId: newVersionId,
+          mimeType: 'image/jpeg',
+          size: 4096,
+          updatedAt: '2026-03-20T16:00:00.000Z',
+        },
+      });
+
+      const result = await fileFn.getFile(
+        { fileId, versionId: oldVersionId },
+        { principalId: 'user_123' },
+      ) as any;
+
+      expect(result.fileId).toBe(fileId);
+      expect(result.versionId).toBe(oldVersionId);
+      expect(result.currentVersionId).toBe(oldVersionId);
+      expect(result.mimeType).toBe('image/png');
+    });
+
+    it('throws FILEFN_NOT_FOUND for cross-file version binding mismatch', async () => {
+      const { fileId: fileId1 } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+      const { versionId: versionId2 } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      await expect(
+        fileFn.getFile(
+          { fileId: fileId1, versionId: versionId2 },
+          { principalId: 'user_123' },
+        ),
+      ).rejects.toMatchObject({ code: 'FILEFN_NOT_FOUND' });
+    });
+  });
+
+  describe('TV-VERSION-DOWNLOAD-BINDING-NEG-001: Version binding check', () => {
+    it('should reject download when versionId does not belong to fileId', async () => {
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 10485760 }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123' }),
+        },
+      });
+
+      // Create two files
+      const { fileId: fileId1 } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+      const { versionId: versionId2 } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      // Try to download fileId1 with versionId2 (wrong binding)
+      const request = new Request(`http://localhost/${fileId1}/versions/${versionId2}/download`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_071' },
+      });
+
+      const response = await fileFnWithAuth.router.handle(request);
+      
+      // This will fail until version binding check is implemented
+      expect(response!.status).toBe(404);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('FILEFN_NOT_FOUND');
+      expect(body.requestId).toBe('req_071');
+    });
+
+    it('should reject version metadata when versionId does not belong to fileId', async () => {
+      const fileFnWithAuth = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 10485760 }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123' }),
+        },
+      });
+
+      const { fileId: fileId1 } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+      const { versionId: versionId2 } = await createFileViaUpload(fileFn, db, storageSizes, 'user_123');
+
+      const request = new Request(`http://localhost/${fileId1}/versions/${versionId2}`, {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_072' },
+      });
+
+      const response = await fileFnWithAuth.router.handle(request);
+      
+      // This will fail until version binding check is implemented
+      expect(response!.status).toBe(404);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('FILEFN_NOT_FOUND');
+    });
+  });
+});
+
+describe('@filefn/server missing routes', () => {
+  let db: Adapter;
+
+  beforeEach(() => {
+    db = createFakeDbAdapter();
+  });
+
+  describe('TV-POLICY-LIST-001: GET /policies', () => {
+    it('should list policy constraints', async () => {
+      const fileFn = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: [
+          {
+            name: 'user-avatar',
+            contentTypes: ['image/png', 'image/jpeg'],
+            maxSizeBytes: 10485760,
+            visibility: 'private',
+          },
+          {
+            name: 'documents',
+            contentTypes: ['application/pdf'],
+            maxSizeBytes: 52428800,
+            visibility: 'shared',
+          },
+        ],
+        auth: { required: false },
+      });
+
+      const request = new Request('http://localhost/policies', {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_030' },
+      });
+
+      const response = await fileFn.router.handle(request);
+      
+      // This will fail until /policies route is implemented
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(200);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(true);
+      expect(body.data.policies).toBeDefined();
+      expect(body.data.policies.length).toBe(2);
+      
+      const avatarPolicy = body.data.policies.find((p: any) => p.name === 'user-avatar');
+      expect(avatarPolicy).toBeDefined();
+      expect(avatarPolicy.maxSizeBytes).toBe(10485760);
+      expect(avatarPolicy.contentTypes).toContain('image/png');
+      expect(avatarPolicy.contentTypes).toContain('image/jpeg');
+      expect(body.requestId).toBe('req_030');
+    });
+  });
+
+  describe('TV-QUOTA-GET-001: GET /quota/storage', () => {
+    it('should return storage quota usage when quota provider exists', async () => {
+      const quotaProvider: QuotaProvider = {
+        async checkQuota() {
+          return { allowed: true, current: 5, limit: 10 };
+        },
+        async recordUsage() {},
+        async getUsage(principalId: string) {
+          return { current: 5, limit: 10 };
+        },
+      };
+
+      const fileFn = createFileFn({
+        db,
+        storage: createFakeStorageAdapter({
+          capabilities: {
+            signedUploadUrls: true,
+            signedDownloadUrls: true,
+            multipart: true,
+            proxyStreamingUpload: false,
+            proxyStreamingDownload: true,
+          },
+        }),
+        policies: [{ name: 'user-avatar', contentTypes: ['image/png'], maxSizeBytes: 10485760 }],
+        auth: {
+          required: false,
+          resolveSession: async () => ({ principalId: 'user_123' }),
+        },
+        quota: quotaProvider,
+      });
+
+      const request = new Request('http://localhost/quota/storage', {
+        method: 'GET',
+        headers: { 'x-request-id': 'req_080' },
+      });
+
+      const response = await fileFn.router.handle(request);
+      
+      // This will fail until /quota/storage route is implemented
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(200);
+
+      const body = await response!.json();
+      expect(body.ok).toBe(true);
+      expect(body.data.current).toBe(5);
+      expect(body.data.limit).toBe(10);
+      expect(body.requestId).toBe('req_080');
+    });
+  });
+});

--- a/filefn/server/src/auth.ts
+++ b/filefn/server/src/auth.ts
@@ -1,0 +1,59 @@
+export interface FileFnPrincipal {
+  principalId: string;
+  tenantId?: string;
+  roles?: string[];
+}
+
+export interface AuthProvider {
+  authenticate?(request: Request): Promise<{ principalId: string; tenantId?: string; roles?: string[] } | null>;
+  getSession?(request: Request): Promise<{ principalId: string; tenantId?: string; roles?: string[] } | null>;
+}
+
+export interface AuthConfig {
+  provider?: AuthProvider;
+  resolveSession?: (request: Request) => Promise<FileFnPrincipal | null>;
+  required?: boolean;
+}
+
+export async function resolvePrincipal(
+  request: Request,
+  config: AuthConfig
+): Promise<FileFnPrincipal | null> {
+  // 1. Try custom resolveSession first
+  if (config.resolveSession) {
+    const principal = await config.resolveSession(request);
+    if (principal) return principal;
+  }
+
+  // 2. Try provider.getSession (cached session lookup)
+  if (config.provider?.getSession) {
+    const session = await config.provider.getSession(request);
+    if (session) {
+      return {
+        principalId: session.principalId,
+        tenantId: session.tenantId,
+        roles: session.roles,
+      };
+    }
+  }
+
+  // 3. Try provider.authenticate (full authentication)
+  if (config.provider?.authenticate) {
+    const session = await config.provider.authenticate(request);
+    if (session) {
+      return {
+        principalId: session.principalId,
+        tenantId: session.tenantId,
+        roles: session.roles,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function isAnonymousPrincipal(
+  principal: FileFnPrincipal | null | undefined
+): boolean {
+  return !principal || !principal.principalId || principal.principalId === 'anonymous';
+}

--- a/filefn/server/src/authz/authorizer.ts
+++ b/filefn/server/src/authz/authorizer.ts
@@ -1,0 +1,175 @@
+import type { Adapter } from '@superfunctions/db';
+import type { FileProviderContext } from '@superfunctions/files';
+import type { FileRecord, Authorizer } from '../files/service.js';
+
+export type AuthorizerStrategy = 'first-allow' | 'all-must-allow';
+
+export interface ComposeAuthorizersOptions {
+  strategy: AuthorizerStrategy;
+}
+
+/**
+ * Compose multiple authorizers into a single authorizer.
+ * 
+ * @param authorizers - Array of authorizers to compose
+ * @param options - Composition options including strategy
+ * @returns A composed authorizer
+ * 
+ * Strategies:
+ * - 'first-allow': Allow if ANY authorizer allows (OR logic)
+ * - 'all-must-allow': Allow only if ALL authorizers allow (AND logic)
+ */
+export function composeAuthorizers(
+  authorizers: Authorizer[],
+  options?: ComposeAuthorizersOptions
+): Authorizer {
+  const strategy = options?.strategy ?? 'first-allow';
+
+  if (authorizers.length === 0) {
+    return {
+      async canRead() { return false; },
+      async canWrite() { return false; },
+      async canDelete() { return false; },
+    };
+  }
+
+  if (strategy === 'first-allow') {
+    return {
+      async canRead(file, ctx) {
+        for (const auth of authorizers) {
+          if (await auth.canRead(file, ctx)) return true;
+        }
+        return false;
+      },
+      async canWrite(file, ctx) {
+        for (const auth of authorizers) {
+          if (await auth.canWrite(file, ctx)) return true;
+        }
+        return false;
+      },
+      async canDelete(file, ctx) {
+        for (const auth of authorizers) {
+          if (await auth.canDelete(file, ctx)) return true;
+        }
+        return false;
+      },
+    };
+  }
+
+  return {
+    async canRead(file, ctx) {
+      for (const auth of authorizers) {
+        if (!(await auth.canRead(file, ctx))) return false;
+      }
+      return true;
+    },
+    async canWrite(file, ctx) {
+      for (const auth of authorizers) {
+        if (!(await auth.canWrite(file, ctx))) return false;
+      }
+      return true;
+    },
+    async canDelete(file, ctx) {
+      for (const auth of authorizers) {
+        if (!(await auth.canDelete(file, ctx))) return false;
+      }
+      return true;
+    },
+  };
+}
+
+export interface FilePermissionRecord {
+  permissionId: string;
+  fileId: string;
+  userId: string | null;
+  role: string | null;
+  tenantId: string | null;
+  canRead: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+  canShare: boolean;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export interface DefaultAuthorizerConfig {
+  db: Adapter;
+  namespace?: string;
+  adminRoles?: string[];
+}
+
+export interface DefaultAuthorizerContext extends FileProviderContext {
+  roles?: string[];
+}
+
+export function createDefaultAuthorizer(config: DefaultAuthorizerConfig): Authorizer {
+  const { db, namespace = 'filefn', adminRoles = ['admin'] } = config;
+
+  function isGrantExpired(expiresAt: string | null): boolean {
+    if (!expiresAt) {
+      return false;
+    }
+    const expiresAtMs = Date.parse(expiresAt);
+    if (Number.isNaN(expiresAtMs)) {
+      return true;
+    }
+    return expiresAtMs <= Date.now();
+  }
+
+  async function getApplicableGrants(
+    fileId: string,
+    ctx: DefaultAuthorizerContext
+  ): Promise<FilePermissionRecord[]> {
+    const grants = await db.findMany<FilePermissionRecord>({
+      model: 'filePermissions',
+      where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+      namespace,
+    });
+
+    return grants.filter(grant => {
+      if (isGrantExpired(grant.expiresAt)) return false;
+
+      if (grant.userId && grant.userId === ctx.principalId) return true;
+      if (grant.role && ctx.roles?.includes(grant.role)) return true;
+      if (grant.tenantId && grant.tenantId === ctx.tenantId) return true;
+
+      return false;
+    });
+  }
+
+  function isAdmin(ctx: DefaultAuthorizerContext): boolean {
+    return ctx.roles?.some(role => adminRoles.includes(role)) ?? false;
+  }
+
+  function isOwner(file: FileRecord, ctx: FileProviderContext): boolean {
+    return file.ownerId === ctx.principalId;
+  }
+
+  return {
+    async canRead(file, ctx) {
+      if (isOwner(file, ctx)) return true;
+      if (isAdmin(ctx as DefaultAuthorizerContext)) return true;
+      if (file.visibility === 'public') return true;
+      if (file.visibility === 'shared' && file.tenantId && file.tenantId === ctx.tenantId) return true;
+
+      const grants = await getApplicableGrants(file.fileId, ctx as DefaultAuthorizerContext);
+      return grants.some(g => g.canRead);
+    },
+
+    async canWrite(file, ctx) {
+      if (isOwner(file, ctx)) return true;
+      if (isAdmin(ctx as DefaultAuthorizerContext)) return true;
+
+      const grants = await getApplicableGrants(file.fileId, ctx as DefaultAuthorizerContext);
+      return grants.some(g => g.canWrite);
+    },
+
+    async canDelete(file, ctx) {
+      if (isOwner(file, ctx)) return true;
+      if (isAdmin(ctx as DefaultAuthorizerContext)) return true;
+
+      const grants = await getApplicableGrants(file.fileId, ctx as DefaultAuthorizerContext);
+      return grants.some(g => g.canDelete);
+    },
+  };
+}

--- a/filefn/server/src/authz/grants.routes.ts
+++ b/filefn/server/src/authz/grants.routes.ts
@@ -1,0 +1,112 @@
+import type { GrantsService } from './grants.service.js';
+import type { FileFnPrincipal, AuthConfig } from '../auth.js';
+import { resolvePrincipal } from '../auth.js';
+import { FileFnError, authRequired } from '../errors.js';
+
+export interface GrantsRouteContext {
+  service: GrantsService;
+  auth: AuthConfig;
+}
+
+function getRequestId(request: Request): string | undefined {
+  return request.headers.get('x-request-id') || undefined;
+}
+
+function successResponse(data: unknown, requestId?: string): Response {
+  return Response.json({ ok: true, data, requestId }, { status: 200 });
+}
+
+function createdResponse(data: unknown, requestId?: string): Response {
+  return Response.json({ ok: true, data, requestId }, { status: 201 });
+}
+
+function errorResponse(error: FileFnError, requestId?: string): Response {
+  return Response.json({ ok: false, error: error.toJSON(), requestId }, { status: error.statusCode });
+}
+
+export function createGrantsRoutes(ctx: GrantsRouteContext) {
+  const { service, auth } = ctx;
+
+  async function requireAuth(request: Request): Promise<FileFnPrincipal> {
+    const principal = await resolvePrincipal(request, auth);
+    if (!principal && auth.required !== false) {
+      throw authRequired();
+    }
+    return principal || { principalId: 'anonymous' };
+  }
+
+  return {
+    async createGrant(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const body = await request.json() as {
+          userId?: string;
+          role?: string;
+          tenantId?: string;
+          canRead?: boolean;
+          canWrite?: boolean;
+          canDelete?: boolean;
+          canShare?: boolean;
+          expiresAt?: string;
+        };
+
+        const grant = await service.createGrant(
+          {
+            fileId,
+            userId: body.userId,
+            role: body.role,
+            tenantId: body.tenantId,
+            canRead: body.canRead,
+            canWrite: body.canWrite,
+            canDelete: body.canDelete,
+            canShare: body.canShare,
+            expiresAt: body.expiresAt,
+          },
+          { principalId: principal.principalId, tenantId: principal.tenantId, requestId }
+        );
+
+        return createdResponse(grant, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async listGrants(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const grants = await service.listGrants(fileId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({ permissions: grants }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async revokeGrant(request: Request, fileId: string, permissionId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        await service.revokeGrant(fileId, permissionId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({ revoked: true }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+  };
+}
+
+export type GrantsRoutes = ReturnType<typeof createGrantsRoutes>;

--- a/filefn/server/src/authz/grants.service.ts
+++ b/filefn/server/src/authz/grants.service.ts
@@ -1,0 +1,130 @@
+import type { Adapter } from '@superfunctions/db';
+import type { FileProviderContext } from '@superfunctions/files';
+import type { FileRecord } from '../files/service.js';
+import type { FilePermissionRecord } from './authorizer.js';
+import { randomUUID } from 'crypto';
+import * as errors from '../errors.js';
+
+export interface GrantsServiceConfig {
+  db: Adapter;
+  namespace?: string;
+}
+
+export interface CreateGrantInput {
+  fileId: string;
+  userId?: string;
+  role?: string;
+  tenantId?: string;
+  canRead?: boolean;
+  canWrite?: boolean;
+  canDelete?: boolean;
+  canShare?: boolean;
+  expiresAt?: string;
+}
+
+export function createGrantsService(config: GrantsServiceConfig) {
+  const { db, namespace = 'filefn' } = config;
+
+  async function getFile(fileId: string): Promise<FileRecord | null> {
+    return db.findOne<FileRecord>({
+      model: 'files',
+      where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+      namespace,
+    });
+  }
+
+  async function canManagePermissions(file: FileRecord, ctx: FileProviderContext): Promise<boolean> {
+    return file.ownerId === ctx.principalId;
+  }
+
+  return {
+    async createGrant(input: CreateGrantInput, ctx: FileProviderContext): Promise<FilePermissionRecord> {
+      const file = await getFile(input.fileId);
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const canManage = await canManagePermissions(file, ctx);
+      if (!canManage) {
+        throw errors.forbidden();
+      }
+
+      if (!input.userId && !input.role && !input.tenantId) {
+        throw new errors.FileFnError('FILEFN_INVALID_GRANT', 'Grant must specify userId, role, or tenantId', 400);
+      }
+
+      const permission: FilePermissionRecord = {
+        permissionId: randomUUID(),
+        fileId: input.fileId,
+        userId: input.userId || null,
+        role: input.role || null,
+        tenantId: input.tenantId || null,
+        canRead: input.canRead ?? true,
+        canWrite: input.canWrite ?? false,
+        canDelete: input.canDelete ?? false,
+        canShare: input.canShare ?? false,
+        expiresAt: input.expiresAt || null,
+        createdAt: new Date().toISOString(),
+      };
+
+      await db.create({
+        model: 'filePermissions',
+        data: permission,
+        namespace,
+      });
+
+      return permission;
+    },
+
+    async listGrants(fileId: string, ctx: FileProviderContext): Promise<FilePermissionRecord[]> {
+      const file = await getFile(fileId);
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const canManage = await canManagePermissions(file, ctx);
+      if (!canManage) {
+        throw errors.forbidden();
+      }
+
+      return db.findMany<FilePermissionRecord>({
+        model: 'filePermissions',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+    },
+
+    async revokeGrant(fileId: string, permissionId: string, ctx: FileProviderContext): Promise<void> {
+      const file = await getFile(fileId);
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const canManage = await canManagePermissions(file, ctx);
+      if (!canManage) {
+        throw errors.forbidden();
+      }
+
+      const permission = await db.findOne<FilePermissionRecord>({
+        model: 'filePermissions',
+        where: [
+          { field: 'permissionId', operator: 'eq', value: permissionId },
+          { field: 'fileId', operator: 'eq', value: fileId },
+        ],
+        namespace,
+      });
+
+      if (!permission) {
+        throw errors.permissionNotFound();
+      }
+
+      await db.delete({
+        model: 'filePermissions',
+        where: [{ field: 'permissionId', operator: 'eq', value: permissionId }],
+        namespace,
+      });
+    },
+  };
+}
+
+export type GrantsService = ReturnType<typeof createGrantsService>;

--- a/filefn/server/src/dedup/service.ts
+++ b/filefn/server/src/dedup/service.ts
@@ -1,0 +1,228 @@
+import type { Adapter } from '@superfunctions/db';
+import { createHash } from 'node:crypto';
+import { type StorageAdapter, type StorageTargetName } from '@superfunctions/storage';
+import { resolveStorageTarget, type PolicyRegistry } from '../policies.js';
+
+export interface DeduplicationServiceConfig {
+  db: Adapter;
+  policies?: Pick<PolicyRegistry, 'get'>;
+  namespace?: string;
+  enabled?: boolean;
+}
+
+export interface FileVersionRecord {
+  versionId: string;
+  fileId: string;
+  storageKey: string;
+  mimeType: string;
+  size: number;
+  checksumSha256Base64?: string | null;
+  tenantId?: string | null;
+  createdAt: string;
+}
+
+export interface DeduplicationResult {
+  isDuplicate: boolean;
+  existingVersionId?: string;
+  existingStorageKey?: string;
+  checksumSha256Base64: string;
+}
+
+interface FileRecord {
+  fileId: string;
+  policy: string;
+}
+
+export function createDeduplicationService(config: DeduplicationServiceConfig) {
+  const { db, policies, namespace = 'filefn', enabled = true } = config;
+
+  async function resolveVersionStorageTarget(version: Pick<FileVersionRecord, 'fileId'>): Promise<string> {
+    const file = await db.findOne<FileRecord>({
+      model: 'files',
+      where: [{ field: 'fileId', operator: 'eq', value: version.fileId }],
+      namespace,
+    });
+    const policy = file ? policies?.get(file.policy) : undefined;
+    return resolveStorageTarget(policy ?? {});
+  }
+
+  function computeHash(data: Uint8Array): string {
+    const hash = createHash('sha256');
+    hash.update(data);
+    return hash.digest('base64');
+  }
+
+  async function computeHashFromStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+    const hash = createHash('sha256');
+    const reader = stream.getReader();
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          hash.update(value);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return hash.digest('base64');
+  }
+
+  async function checkForDuplicate(
+    checksumSha256Base64: string,
+    tenantId: string | null,
+    storageTarget?: StorageTargetName | null,
+  ): Promise<DeduplicationResult> {
+    if (!enabled) {
+      return {
+        isDuplicate: false,
+        checksumSha256Base64,
+      };
+    }
+
+    const whereConditions: Array<{
+      field: string;
+      operator: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'not_in' | 'contains' | 'starts_with' | 'ends_with';
+      value: any;
+    }> = [{ field: 'checksumSha256Base64', operator: 'eq', value: checksumSha256Base64 }];
+
+    if (tenantId !== null) {
+      whereConditions.push({ field: 'tenantId', operator: 'eq', value: tenantId });
+    } else {
+      whereConditions.push({ field: 'tenantId', operator: 'eq', value: null });
+    }
+
+    if (!storageTarget) {
+      const existingVersion = await db.findOne<FileVersionRecord>({
+        model: 'fileVersions',
+        where: whereConditions,
+        namespace,
+      });
+
+      if (existingVersion) {
+        return {
+          isDuplicate: true,
+          existingVersionId: existingVersion.versionId,
+          existingStorageKey: existingVersion.storageKey,
+          checksumSha256Base64,
+        };
+      }
+
+      return {
+        isDuplicate: false,
+        checksumSha256Base64,
+      };
+    }
+
+    const existingVersions = await db.findMany<FileVersionRecord>({
+      model: 'fileVersions',
+      where: whereConditions,
+      namespace,
+    });
+
+    for (const existingVersion of existingVersions) {
+      if (storageTarget) {
+        const existingTarget = await resolveVersionStorageTarget(existingVersion);
+        if (existingTarget !== storageTarget) {
+          continue;
+        }
+      }
+
+      return {
+        isDuplicate: true,
+        existingVersionId: existingVersion.versionId,
+        existingStorageKey: existingVersion.storageKey,
+        checksumSha256Base64,
+      };
+    }
+
+    return {
+      isDuplicate: false,
+      checksumSha256Base64,
+    };
+  }
+
+  return {
+    isEnabled(): boolean {
+      return enabled;
+    },
+
+    /**
+     * Computes SHA-256 hash of the provided data.
+     * Returns base64-encoded hash.
+     */
+    computeHash,
+
+    /**
+     * Computes SHA-256 hash from a readable stream.
+     * Returns base64-encoded hash.
+     */
+    computeHashFromStream,
+
+    /**
+     * Checks if a version with the given hash already exists in the same tenant.
+     * Returns deduplication result with existing version info if found.
+     */
+    checkForDuplicate,
+
+    /**
+     * Computes hash from stored content and checks for duplicates.
+     * This is used during upload completion.
+     */
+    async computeAndCheckDuplicate(
+      storageKey: string,
+      tenantId: string | null,
+      storageTargetOrStorage: StorageTargetName | null | Pick<StorageAdapter, 'openDownloadStream'>,
+      maybeStorage?: Pick<StorageAdapter, 'openDownloadStream'>
+    ): Promise<DeduplicationResult> {
+      const storageTarget =
+        maybeStorage === undefined
+          ? null
+          : storageTargetOrStorage as StorageTargetName | null;
+      const storage =
+        maybeStorage ??
+        (storageTargetOrStorage as Pick<StorageAdapter, 'openDownloadStream'>);
+
+      if (!storage.openDownloadStream) {
+        throw new Error('Storage adapter does not support streaming downloads required for deduplication');
+      }
+
+      const stream = await storage.openDownloadStream({ key: storageKey, target: storageTarget ?? undefined });
+      const checksumSha256Base64 = await computeHashFromStream(stream);
+
+      if (!enabled) {
+        return {
+          isDuplicate: false,
+          checksumSha256Base64,
+        };
+      }
+
+      return checkForDuplicate(checksumSha256Base64, tenantId, storageTarget);
+    },
+
+    /**
+     * Verifies that a hash matches the content at the given storage key.
+     * Used for integrity verification.
+     */
+    async verifyHash(
+      storageKey: string,
+      expectedHash: string,
+      storage: Pick<StorageAdapter, 'openDownloadStream'>,
+      storageTarget?: StorageTargetName | null,
+    ): Promise<boolean> {
+      if (!storage.openDownloadStream) {
+        return false;
+      }
+
+      const stream = await storage.openDownloadStream({ key: storageKey, target: storageTarget ?? undefined });
+      const actualHash = await computeHashFromStream(stream);
+
+      return actualHash === expectedHash;
+    },
+  };
+}
+
+export type DeduplicationService = ReturnType<typeof createDeduplicationService>;

--- a/filefn/server/src/errors.ts
+++ b/filefn/server/src/errors.ts
@@ -1,0 +1,223 @@
+export class FileFnError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly status: number = 400,
+    public readonly details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'FileFnError';
+  }
+
+  get statusCode(): number {
+    return this.status;
+  }
+
+  toJSON() {
+    return {
+      code: this.code,
+      message: this.message,
+      details: this.details,
+    };
+  }
+}
+
+export const ErrorCodes = {
+  AUTH_REQUIRED: 'FILEFN_AUTH_REQUIRED',
+  FORBIDDEN: 'FILEFN_FORBIDDEN',
+  NOT_FOUND: 'FILEFN_NOT_FOUND',
+  POLICY_CONTENT_TYPE_NOT_ALLOWED: 'FILEFN_POLICY_CONTENT_TYPE_NOT_ALLOWED',
+  POLICY_MAX_SIZE_EXCEEDED: 'FILEFN_POLICY_MAX_SIZE_EXCEEDED',
+  POLICY_NOT_FOUND: 'FILEFN_POLICY_NOT_FOUND',
+  QUOTA_EXCEEDED: 'FILEFN_QUOTA_EXCEEDED',
+  RATE_LIMITED: 'FILEFN_RATE_LIMITED',
+  INVALID_PART_NUMBER: 'FILEFN_INVALID_PART_NUMBER',
+  INVALID_ETAG: 'FILEFN_INVALID_ETAG',
+  UPLOAD_INCOMPLETE: 'FILEFN_UPLOAD_INCOMPLETE',
+  UPLOAD_EXPIRED: 'FILEFN_UPLOAD_EXPIRED',
+  UPLOAD_ABORTED: 'FILEFN_UPLOAD_ABORTED',
+  UPLOAD_ALREADY_COMPLETED: 'FILEFN_UPLOAD_ALREADY_COMPLETED',
+  IDEMPOTENCY_CONFLICT: 'FILEFN_IDEMPOTENCY_CONFLICT',
+  PART_CONFLICT: 'FILEFN_PART_CONFLICT',
+  UPLOAD_SIZE_MISMATCH: 'FILEFN_UPLOAD_SIZE_MISMATCH',
+  NO_SUPPORTED_UPLOAD_MODE: 'FILEFN_NO_SUPPORTED_UPLOAD_MODE',
+  OFFLINE_UNSUPPORTED: 'FILEFN_OFFLINE_UNSUPPORTED',
+  SESSION_NOT_FOUND: 'FILEFN_SESSION_NOT_FOUND',
+  SHARE_EXPIRED: 'FILEFN_SHARE_EXPIRED',
+  SHARE_REVOKED: 'FILEFN_SHARE_REVOKED',
+  SHARE_DOWNLOADS_EXCEEDED: 'FILEFN_SHARE_DOWNLOADS_EXCEEDED',
+  SHARE_NOT_FOUND: 'FILEFN_SHARE_NOT_FOUND',
+  PERMISSION_NOT_FOUND: 'FILEFN_PERMISSION_NOT_FOUND',
+  PROCESSING_ENQUEUE_FAILED: 'FILEFN_PROCESSING_ENQUEUE_FAILED',
+  INVALID_RENDER_INTENT: 'FILEFN_INVALID_RENDER_INTENT',
+  SESSION_TOKEN_REQUIRED: 'FILEFN_SESSION_TOKEN_REQUIRED',
+  SESSION_TOKEN_INVALID: 'FILEFN_SESSION_TOKEN_INVALID',
+} as const;
+
+export type ErrorCode = typeof ErrorCodes[keyof typeof ErrorCodes];
+
+export function authRequired(): FileFnError {
+  return new FileFnError(ErrorCodes.AUTH_REQUIRED, 'Authentication required', 401);
+}
+
+export function forbidden(details?: Record<string, unknown>): FileFnError {
+  return new FileFnError(ErrorCodes.FORBIDDEN, 'Access denied', 403, details);
+}
+
+export function notFound(resource: string): FileFnError {
+  return new FileFnError(ErrorCodes.NOT_FOUND, `${resource} not found`, 404);
+}
+
+export function policyContentTypeNotAllowed(policy: string, mimeType: string): FileFnError {
+  return new FileFnError(
+    ErrorCodes.POLICY_CONTENT_TYPE_NOT_ALLOWED,
+    'Content type not allowed',
+    400,
+    { policy, mimeType }
+  );
+}
+
+export function policyMaxSizeExceeded(policy: string, maxSizeBytes: number, size: number): FileFnError {
+  return new FileFnError(
+    ErrorCodes.POLICY_MAX_SIZE_EXCEEDED,
+    'File size exceeds policy max',
+    400,
+    { policy, maxSizeBytes, size }
+  );
+}
+
+export function policyNotFound(policy: string): FileFnError {
+  return new FileFnError(ErrorCodes.POLICY_NOT_FOUND, `Policy '${policy}' not found`, 400, { policy });
+}
+
+export function quotaExceeded(current: number, limit: number, requested: number): FileFnError {
+  return new FileFnError(
+    ErrorCodes.QUOTA_EXCEEDED,
+    'Storage quota exceeded',
+    402,
+    { current, limit, requested }
+  );
+}
+
+export function rateLimited(resetAt: string): FileFnError {
+  return new FileFnError(ErrorCodes.RATE_LIMITED, 'Rate limit exceeded', 429, { resetAt });
+}
+
+export function invalidPartNumber(): FileFnError {
+  return new FileFnError(ErrorCodes.INVALID_PART_NUMBER, 'Invalid partNumber', 400);
+}
+
+export function invalidEtag(): FileFnError {
+  return new FileFnError(ErrorCodes.INVALID_ETAG, 'Invalid etag', 400);
+}
+
+export function uploadIncomplete(): FileFnError {
+  return new FileFnError(ErrorCodes.UPLOAD_INCOMPLETE, 'Upload incomplete', 409);
+}
+
+export function uploadExpired(): FileFnError {
+  return new FileFnError(ErrorCodes.UPLOAD_EXPIRED, 'Upload session expired', 410);
+}
+
+export function uploadAborted(): FileFnError {
+  return new FileFnError(ErrorCodes.UPLOAD_ABORTED, 'Upload session was aborted', 410);
+}
+
+export function uploadAlreadyCompleted(): FileFnError {
+  return new FileFnError(ErrorCodes.UPLOAD_ALREADY_COMPLETED, 'Upload session already completed', 409);
+}
+
+export function idempotencyConflict(): FileFnError {
+  return new FileFnError(ErrorCodes.IDEMPOTENCY_CONFLICT, 'Idempotency key reuse with different payload', 409);
+}
+
+export function noSupportedUploadMode(): FileFnError {
+  return new FileFnError(
+    ErrorCodes.NO_SUPPORTED_UPLOAD_MODE,
+    'No supported upload mode for configured adapter',
+    500
+  );
+}
+
+export function sessionNotFound(): FileFnError {
+  return new FileFnError(ErrorCodes.SESSION_NOT_FOUND, 'Upload session not found', 404);
+}
+
+export function shareExpired(): FileFnError {
+  return new FileFnError(ErrorCodes.SHARE_EXPIRED, 'Share link has expired', 410);
+}
+
+export function shareRevoked(): FileFnError {
+  return new FileFnError(ErrorCodes.SHARE_REVOKED, 'Share link has been revoked', 410);
+}
+
+export function shareDownloadsExceeded(): FileFnError {
+  return new FileFnError(ErrorCodes.SHARE_DOWNLOADS_EXCEEDED, 'Share link download limit exceeded', 410);
+}
+
+export function shareNotFound(): FileFnError {
+  return new FileFnError(ErrorCodes.SHARE_NOT_FOUND, 'Share link not found', 404);
+}
+
+export function permissionNotFound(): FileFnError {
+  return new FileFnError(ErrorCodes.PERMISSION_NOT_FOUND, 'Permission not found', 404);
+}
+
+export function sessionTokenRequired(): FileFnError {
+  return new FileFnError(
+    ErrorCodes.SESSION_TOKEN_REQUIRED,
+    'Upload session token required',
+    401
+  );
+}
+
+export function sessionTokenInvalid(): FileFnError {
+  return new FileFnError(
+    ErrorCodes.SESSION_TOKEN_INVALID,
+    'Invalid upload session token',
+    403
+  );
+}
+
+export function processingEnqueueFailed(): FileFnError {
+  return new FileFnError(
+    ErrorCodes.PROCESSING_ENQUEUE_FAILED,
+    'Failed to enqueue processing',
+    503
+  );
+}
+
+export function invalidRenderIntent(intent?: string): FileFnError {
+  return new FileFnError(
+    ErrorCodes.INVALID_RENDER_INTENT,
+    'Invalid render intent',
+    400,
+    { intent }
+  );
+}
+
+export function partConflict(uploadSessionId: string, partNumber: number): FileFnError {
+  return new FileFnError(
+    ErrorCodes.PART_CONFLICT,
+    'Part already completed with a different etag',
+    409,
+    { uploadSessionId, partNumber }
+  );
+}
+
+export function uploadSizeMismatch(expected: number, actual: number): FileFnError {
+  return new FileFnError(
+    ErrorCodes.UPLOAD_SIZE_MISMATCH,
+    'Uploaded size does not match expected size',
+    409,
+    { expected, actual }
+  );
+}
+
+export function offlineUnsupported(): FileFnError {
+  return new FileFnError(
+    ErrorCodes.OFFLINE_UNSUPPORTED,
+    'OPFS unavailable',
+    400
+  );
+}

--- a/filefn/server/src/events.ts
+++ b/filefn/server/src/events.ts
@@ -1,0 +1,196 @@
+import { EventEmitter } from 'events';
+
+export interface FileFnEvent {
+  type: string;
+  timestamp: string;
+  requestId?: string;
+}
+
+const SECRET_EVENT_PATTERNS = [
+  /https?:\/\/[^\s"']+\?[^\s"']*(?:X-Amz-Signature|Signature|sig|token|key)=[^\s"'&]+/gi,
+  /[?&](?:X-Amz-Signature|Signature|sig|token|key)=[^\s"'&]+/gi,
+  /Bearer\s+[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+/gi,
+  /upls_live_[A-Za-z0-9\-_]+/g,
+];
+
+function shouldRedactEventKey(key: string): boolean {
+  const lowerKey = key.toLowerCase();
+  return (
+    lowerKey.includes('token') ||
+    lowerKey.includes('secret') ||
+    lowerKey.includes('password') ||
+    lowerKey.includes('signature') ||
+    lowerKey.includes('signedurl') ||
+    lowerKey.includes('signed_url') ||
+    lowerKey.includes('authorization')
+  );
+}
+
+function sanitizeEventValue(key: string, value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (shouldRedactEventKey(key)) return '[REDACTED]';
+
+  if (typeof value === 'string') {
+    let sanitized = value;
+    for (const pattern of SECRET_EVENT_PATTERNS) {
+      sanitized = sanitized.replace(pattern, '[REDACTED]');
+    }
+    return sanitized;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeEventValue(key, item));
+  }
+
+  if (typeof value === 'object') {
+    return sanitizeEventData(value as Record<string, unknown>);
+  }
+
+  return value;
+}
+
+function sanitizeEventData<T extends Record<string, unknown>>(data: T): T {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    sanitized[key] = sanitizeEventValue(key, value);
+  }
+  return sanitized as T;
+}
+
+export interface UploadStartedEvent extends FileFnEvent {
+  type: 'upload.started';
+  uploadSessionId: string;
+  fileName: string;
+  size: number;
+  mimeType: string;
+  policy: string;
+  principalId?: string;
+  tenantId?: string;
+}
+
+export interface PartRecordedEvent extends FileFnEvent {
+  type: 'part.recorded';
+  uploadSessionId: string;
+  partNumber: number;
+  size: number;
+}
+
+export interface FileUploadedEvent extends FileFnEvent {
+  type: 'file:uploaded';
+  fileId: string;
+  versionId: string;
+  fileName: string;
+  size: number;
+  mimeType: string;
+  ownerId: string;
+  tenantId?: string;
+}
+
+export interface FileDeletedEvent extends FileFnEvent {
+  type: 'file:deleted';
+  fileId: string;
+  ownerId: string;
+  tenantId?: string;
+}
+
+export interface ProcessingStartedEvent extends FileFnEvent {
+  type: 'processing.started';
+  fileId: string;
+  versionId: string;
+}
+
+export interface ProcessingCompletedEvent extends FileFnEvent {
+  type: 'processing.completed';
+  fileId: string;
+  versionId: string;
+  artifactsCreated: number;
+}
+
+export interface ProcessingFailedEvent extends FileFnEvent {
+  type: 'processing.failed';
+  fileId: string;
+  versionId: string;
+  error?: string;
+}
+
+export type FileFnEventTypes = {
+  'upload.started': UploadStartedEvent;
+  'part.recorded': PartRecordedEvent;
+  'file:uploaded': FileUploadedEvent;
+  'file:deleted': FileDeletedEvent;
+  'processing.started': ProcessingStartedEvent;
+  'processing.completed': ProcessingCompletedEvent;
+  'processing.failed': ProcessingFailedEvent;
+};
+
+export class FileFnEventEmitter extends EventEmitter {
+  emit<K extends keyof FileFnEventTypes>(event: K, payload: FileFnEventTypes[K]): boolean {
+    return super.emit(event, payload);
+  }
+
+  on<K extends keyof FileFnEventTypes>(event: K, listener: (payload: FileFnEventTypes[K]) => void): this {
+    return super.on(event, listener);
+  }
+
+  once<K extends keyof FileFnEventTypes>(event: K, listener: (payload: FileFnEventTypes[K]) => void): this {
+    return super.once(event, listener);
+  }
+}
+
+export function createUploadStartedEvent(
+  data: Omit<UploadStartedEvent, 'type' | 'timestamp' | 'requestId'>,
+  requestId?: string
+): UploadStartedEvent {
+  const sanitizedData = sanitizeEventData(data);
+  return {
+    type: 'upload.started',
+    timestamp: new Date().toISOString(),
+    requestId,
+    ...sanitizedData,
+  };
+}
+
+export function createPartRecordedEvent(
+  data: Omit<PartRecordedEvent, 'type' | 'timestamp' | 'requestId'>,
+  requestId?: string
+): PartRecordedEvent {
+  const sanitizedData = sanitizeEventData(data);
+  return {
+    type: 'part.recorded',
+    timestamp: new Date().toISOString(),
+    requestId,
+    ...sanitizedData,
+  };
+}
+
+export function createFileUploadedEvent(
+  data: Omit<FileUploadedEvent, 'type' | 'timestamp' | 'requestId'>,
+  requestId?: string
+): FileUploadedEvent {
+  const sanitizedData = sanitizeEventData(data);
+  return {
+    type: 'file:uploaded',
+    timestamp: new Date().toISOString(),
+    requestId,
+    ...sanitizedData,
+  };
+}
+
+export function createFileDeletedEvent(
+  data: Omit<FileDeletedEvent, 'type' | 'timestamp' | 'requestId'>,
+  requestId?: string
+): FileDeletedEvent {
+  const sanitizedData = sanitizeEventData(data);
+  return {
+    type: 'file:deleted',
+    timestamp: new Date().toISOString(),
+    requestId,
+    ...sanitizedData,
+  };
+}
+
+export function createEventEmitter(): FileFnEventEmitter {
+  return new FileFnEventEmitter();
+}
+
+export type FileFnEventType = keyof FileFnEventTypes;

--- a/filefn/server/src/files/routes.ts
+++ b/filefn/server/src/files/routes.ts
@@ -1,0 +1,256 @@
+import type { FileService } from './service.js';
+import type { FileFnPrincipal, AuthConfig } from '../auth.js';
+import type { RateLimiter } from '@superfunctions/middleware';
+import { resolvePrincipal } from '../auth.js';
+import { FileFnError, authRequired, invalidRenderIntent, rateLimited } from '../errors.js';
+
+export interface FileRouteContext {
+  service: FileService;
+  auth: AuthConfig;
+  rateLimiter?: RateLimiter;
+  rateLimits?: {
+    download?: {
+      windowSeconds: number;
+      maxRequests: number;
+    };
+  };
+  legacyGlobalRateLimit?: boolean;
+}
+
+function getRequestId(request: Request): string | undefined {
+  return request.headers.get('x-request-id') || undefined;
+}
+
+function successResponse(data: unknown, requestId?: string): Response {
+  return Response.json({ ok: true, data, warnings: [], requestId }, { status: 200 });
+}
+
+function errorResponse(error: FileFnError, requestId?: string): Response {
+  return Response.json({ ok: false, error: error.toJSON(), requestId }, { status: error.statusCode });
+}
+
+export function createFileRoutes(ctx: FileRouteContext) {
+  const { service, auth, rateLimiter, rateLimits, legacyGlobalRateLimit = false } = ctx;
+  const validRenderIntents = new Set(['thumbnail', 'preview', 'full', 'download']);
+
+  async function requireAuth(request: Request): Promise<FileFnPrincipal> {
+    const principal = await resolvePrincipal(request, auth);
+    if (!principal && auth.required !== false) {
+      throw authRequired();
+    }
+    return principal || { principalId: 'anonymous' };
+  }
+
+  async function checkRateLimit(
+    categoryKey: string,
+    principal: FileFnPrincipal,
+    categoryLimit?: { windowSeconds: number; maxRequests: number }
+  ): Promise<void> {
+    if (!rateLimiter) {
+      return;
+    }
+    if (!categoryLimit && !legacyGlobalRateLimit) {
+      return;
+    }
+
+    const result = await rateLimiter.check({
+      key: `${categoryKey}:${principal.tenantId || 'global'}:${principal.principalId}`,
+      windowSeconds: categoryLimit?.windowSeconds,
+      limit: categoryLimit?.maxRequests,
+    });
+    if (!result.allowed) {
+      throw rateLimited(result.resetAt);
+    }
+  }
+
+  return {
+    async listFiles(request: Request): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const url = new URL(request.url);
+        const cursor = url.searchParams.get('cursor') || undefined;
+        const rawLimit = url.searchParams.get('limit');
+        const parsedLimit = rawLimit ? parseInt(rawLimit, 10) : undefined;
+        const limit = typeof parsedLimit === 'number' && !Number.isNaN(parsedLimit) ? parsedLimit : undefined;
+
+        const result = await service.listFiles(
+          { principalId: principal.principalId, tenantId: principal.tenantId, requestId },
+          { cursor, limit }
+        );
+
+        return successResponse(result, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async getFile(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const file = await service.getFile(fileId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({
+          fileId: file.fileId,
+          currentVersionId: file.currentVersionId,
+          ownerId: file.ownerId,
+          tenantId: file.tenantId,
+          visibility: file.visibility,
+          mimeType: file.mimeType,
+          size: file.size,
+          name: file.name,
+          createdAt: file.createdAt,
+          updatedAt: file.updatedAt,
+        }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async downloadFile(request: Request, fileId: string, versionId?: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        await checkRateLimit('download', principal, rateLimits?.download);
+
+        const result = await service.getDownloadUrl(fileId, versionId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({ url: result.url, headers: result.headers }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async renderFile(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const url = new URL(request.url);
+        const intent = url.searchParams.get('intent') || undefined;
+        const versionId = url.searchParams.get('versionId') || undefined;
+
+        if (!intent || !validRenderIntents.has(intent)) {
+          throw invalidRenderIntent(intent);
+        }
+
+        const descriptor = await service.getRenderDescriptor(fileId, {
+          intent: intent as 'thumbnail' | 'preview' | 'full' | 'download',
+          versionId,
+        }, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse(descriptor, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async deleteFile(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        await service.deleteFile(fileId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({ deleted: true }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async listVersions(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const result = await service.listVersions(fileId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({
+          versions: result.versions.map(v => ({
+            versionId: v.versionId,
+            size: v.size,
+            mimeType: v.mimeType,
+            createdAt: v.createdAt,
+          })),
+        }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async getVersion(request: Request, fileId: string, versionId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const version = await service.getVersion(fileId, versionId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({
+          versionId: version.versionId,
+          fileId: version.fileId,
+          size: version.size,
+          mimeType: version.mimeType,
+          createdAt: version.createdAt,
+        }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async proxyDownloadFile(request: Request, fileId: string, versionId?: string): Promise<Response> {
+        const requestId = getRequestId(request);
+        try {
+            const principal = await requireAuth(request);
+            await checkRateLimit('download', principal, rateLimits?.download);
+
+            const result = await service.getDownloadStream(fileId, versionId, {
+                principalId: principal.principalId,
+                tenantId: principal.tenantId,
+                requestId
+            });
+
+            return new Response(result.stream, {
+                status: 200,
+                headers: {
+                    'Content-Type': result.contentType,
+                    'Content-Length': result.size.toString(),
+                    // 'Content-Disposition': `attachment; filename="file"` // Optional
+                }
+            });
+        } catch (err) {
+            if (err instanceof FileFnError) return errorResponse(err, requestId);
+            throw err;
+        }
+    }
+  };
+}
+
+export type FileRoutes = ReturnType<typeof createFileRoutes>;

--- a/filefn/server/src/files/service.ts
+++ b/filefn/server/src/files/service.ts
@@ -1,0 +1,883 @@
+import type { Adapter } from '@superfunctions/db';
+import { getStorageCapabilities, type StorageAdapter } from '@superfunctions/storage';
+import type { FileProviderContext } from '@superfunctions/files';
+import type { FileFnEventEmitter } from '../events.js';
+import type { Logger } from '../observability/logger.js';
+import type { QuotaProvider } from '../upload-sessions/service.js';
+import { resolveArtifactStorageTarget, resolveStorageTarget, type PolicyRegistry } from '../policies.js';
+import * as errors from '../errors.js';
+import { createFileDeletedEvent } from '../events.js';
+
+export interface FileRecord {
+  fileId: string;
+  currentVersionId: string;
+  ownerId: string;
+  tenantId: string | null;
+  visibility: 'private' | 'shared' | 'public';
+  policy: string;
+  mimeType: string;
+  size: number;
+  name: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FileVersionRecord {
+  versionId: string;
+  fileId: string;
+  storageKey: string;
+  mimeType: string;
+  size: number;
+  checksumSha256Base64: string | null;
+  createdAt: string;
+}
+
+interface FileArtifactRecord {
+  artifactId: string;
+  fileId: string;
+  versionId: string;
+  kind: string;
+  storageKey: string;
+  mimeType: string;
+  size?: number | null;
+  createdAt?: string;
+}
+
+interface UploadSessionRecord {
+  uploadSessionId: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'aborted' | 'expired';
+  policy: string;
+  uploadMode: string;
+  storageKey: string;
+  storageUploadId: string | null;
+}
+
+interface UploadPartRecord {
+  partNumber: number;
+}
+
+interface FilePermissionGrantRecord {
+  fileId: string;
+  userId?: string;
+  tenantId?: string | null;
+  canRead?: boolean;
+  canShare?: boolean;
+  expiresAt?: string | null;
+}
+
+export interface Authorizer {
+  canRead(file: FileRecord, ctx: FileProviderContext): Promise<boolean>;
+  canWrite(file: FileRecord, ctx: FileProviderContext): Promise<boolean>;
+  canDelete(file: FileRecord, ctx: FileProviderContext): Promise<boolean>;
+}
+
+export interface FileServiceConfig {
+  db: Adapter;
+  storage: StorageAdapter;
+  policies?: Pick<PolicyRegistry, 'get'>;
+  events: FileFnEventEmitter;
+  logger?: Logger;
+  quota?: QuotaProvider;
+  authorizer?: Authorizer;
+  namespace?: string;
+  signedUrlTtlSeconds?: number;
+}
+
+interface CursorTuple {
+  updatedAt: string;
+  fileId: string;
+}
+
+export type FileReadResult = FileRecord & {
+  versionId?: string;
+  versionCreatedAt?: string;
+  checksumSha256Base64?: string | null;
+  storageKey?: string;
+};
+
+type RenderIntent = 'thumbnail' | 'preview' | 'full' | 'download';
+type RenderState = 'ready' | 'processing' | 'pending-local' | 'unsupported';
+type RenderPlaceholderKind = 'generic-file' | 'pdf-processing' | 'unsupported-preview';
+
+interface RenderDescriptor {
+  fileId: string;
+  versionId: string;
+  intent: RenderIntent;
+  state: RenderState;
+  mimeType: string;
+  name: string;
+  size: number;
+  source:
+    | {
+        mode: 'artifact';
+        artifactId: string;
+        artifactKind: string;
+        url: string;
+        headers?: Record<string, string>;
+      }
+    | {
+        mode: 'original';
+        url: string;
+        headers?: Record<string, string>;
+      }
+    | {
+        mode: 'placeholder';
+        placeholderKind: RenderPlaceholderKind;
+      };
+  warnings?: string[];
+}
+
+function createDefaultAuthorizer(): Authorizer {
+  return {
+    async canRead(file, ctx) {
+      if (file.visibility === 'public') return true;
+      if (file.ownerId === ctx.principalId) return true;
+      if (file.visibility === 'shared' && file.tenantId && file.tenantId === ctx.tenantId) return true;
+      return false;
+    },
+    async canWrite(file, ctx) {
+      return file.ownerId === ctx.principalId;
+    },
+    async canDelete(file, ctx) {
+      return file.ownerId === ctx.principalId;
+    },
+  };
+}
+
+function fileSortComparator(a: FileRecord, b: FileRecord): number {
+  const aTs = Date.parse(a.updatedAt);
+  const bTs = Date.parse(b.updatedAt);
+  if (aTs !== bTs) {
+    return bTs - aTs; // updatedAt DESC
+  }
+  return a.fileId.localeCompare(b.fileId); // fileId ASC
+}
+
+function encodeCursor(tuple: CursorTuple): string {
+  return Buffer.from(JSON.stringify(tuple), 'utf8').toString('base64url');
+}
+
+function isAfterCursor(file: FileRecord, cursor: CursorTuple): boolean {
+  const fileTs = Date.parse(file.updatedAt);
+  const cursorTs = Date.parse(cursor.updatedAt);
+
+  if (fileTs < cursorTs) return true;
+  if (fileTs > cursorTs) return false;
+
+  return file.fileId.localeCompare(cursor.fileId) > 0;
+}
+
+function isGrantExpired(expiresAt: string | null | undefined): boolean {
+  if (!expiresAt) {
+    return false;
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiresAtMs)) {
+    return false;
+  }
+  return expiresAtMs <= Date.now();
+}
+
+function tryParseCursor(cursor: string): CursorTuple | null {
+  try {
+    const decoded = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Partial<CursorTuple>;
+    if (typeof decoded.updatedAt === 'string' && typeof decoded.fileId === 'string') {
+      return { updatedAt: decoded.updatedAt, fileId: decoded.fileId };
+    }
+  } catch {
+    // Fall through for legacy/plain cursor support.
+  }
+  return null;
+}
+
+function proxyPartKey(storageKey: string, partNumber: number): string {
+  return `${storageKey}.part${partNumber}`;
+}
+
+function isImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith('image/');
+}
+
+function isPdfMimeType(mimeType: string): boolean {
+  return mimeType === 'application/pdf';
+}
+
+function isMediaPreviewMimeType(mimeType: string): boolean {
+  return mimeType.startsWith('audio/') || mimeType.startsWith('video/');
+}
+
+function selectArtifactByKind(
+  artifacts: FileArtifactRecord[],
+  preferredKinds: string[],
+): FileArtifactRecord | null {
+  for (const kind of preferredKinds) {
+    const found = artifacts.find((artifact) => artifact.kind === kind);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+export function createFileService(config: FileServiceConfig) {
+  const {
+    db,
+    storage,
+    policies,
+    events,
+    logger,
+    quota,
+    authorizer = createDefaultAuthorizer(),
+    namespace = 'filefn',
+    signedUrlTtlSeconds = 900,
+  } = config;
+
+  async function getReadableGrantFileIds(ctx: FileProviderContext): Promise<Set<string>> {
+    if (!ctx.principalId) {
+      return new Set<string>();
+    }
+
+    const findMany = (db as Partial<Adapter>).findMany;
+    if (typeof findMany !== 'function') {
+      return new Set<string>();
+    }
+
+    const grants: FilePermissionGrantRecord[] = [];
+    grants.push(...await findMany.call(db, {
+      model: 'filePermissions',
+      where: [{ field: 'userId', operator: 'eq', value: ctx.principalId }],
+      namespace,
+    }) as FilePermissionGrantRecord[]);
+    if (ctx.tenantId) {
+      grants.push(...await findMany.call(db, {
+        model: 'filePermissions',
+        where: [{ field: 'tenantId', operator: 'eq', value: ctx.tenantId }],
+        namespace,
+      }) as FilePermissionGrantRecord[]);
+    }
+
+    const readable = new Set<string>();
+    for (const grant of grants) {
+      if (!grant?.canRead || isGrantExpired(grant.expiresAt)) continue;
+      if (
+        grant.userId === ctx.principalId ||
+        (grant.tenantId && grant.tenantId === ctx.tenantId)
+      ) {
+        readable.add(grant.fileId);
+      }
+    }
+
+    return readable;
+  }
+
+  async function canReadFile(
+    file: FileRecord,
+    ctx: FileProviderContext,
+    readableGrantFileIds?: Set<string>
+  ): Promise<boolean> {
+    if (await authorizer.canRead(file, ctx)) {
+      return true;
+    }
+
+    if (readableGrantFileIds?.has(file.fileId)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  async function getVersionChecked(fileId: string, versionId: string): Promise<FileVersionRecord> {
+    const version = await db.findOne<FileVersionRecord>({
+      model: 'fileVersions',
+      where: [{ field: 'versionId', operator: 'eq', value: versionId }],
+      namespace,
+    });
+
+    if (!version) {
+      throw errors.notFound('Version');
+    }
+
+    if (version.fileId !== fileId) {
+      throw errors.notFound('Version');
+    }
+
+    return version;
+  }
+
+  async function getArtifactDownloadUrl(
+    file: Pick<FileRecord, 'policy' | 'fileId'>,
+    artifact: FileArtifactRecord,
+  ): Promise<{ url: string; headers?: Record<string, string> }> {
+    const artifactStorageTarget = resolveArtifactStorageTarget(policies?.get(file.policy) ?? {});
+    if (getStorageCapabilities(storage, artifactStorageTarget).signedDownloadUrls && storage.signDownloadUrl) {
+      const result = await storage.signDownloadUrl({
+        key: artifact.storageKey,
+        target: artifactStorageTarget,
+        expiresInSeconds: signedUrlTtlSeconds,
+      });
+      return { url: result.url, headers: result.headers };
+    }
+
+    return { url: `/proxy/files/${file.fileId}/artifacts/${artifact.artifactId}/download` };
+  }
+
+  function createPlaceholderDescriptor(input: {
+    fileId: string;
+    versionId: string;
+    intent: RenderIntent;
+    state: 'processing' | 'unsupported';
+    mimeType: string;
+    name: string;
+    size: number;
+    placeholderKind: RenderPlaceholderKind;
+    warnings?: string[];
+  }): RenderDescriptor {
+    return {
+      fileId: input.fileId,
+      versionId: input.versionId,
+      intent: input.intent,
+      state: input.state,
+      mimeType: input.mimeType,
+      name: input.name,
+      size: input.size,
+      source: {
+        mode: 'placeholder',
+        placeholderKind: input.placeholderKind,
+      },
+      warnings: input.warnings,
+    };
+  }
+
+  return {
+    async getFile(fileId: string, ctx: FileProviderContext, versionId?: string): Promise<FileReadResult> {
+      const file = await db.findOne<FileRecord>({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const readableGrantFileIds = await getReadableGrantFileIds(ctx);
+      const canRead = await canReadFile(file, ctx, readableGrantFileIds);
+      if (!canRead) {
+        throw errors.forbidden();
+      }
+
+      if (!versionId) {
+        return file;
+      }
+
+      const version = await getVersionChecked(fileId, versionId);
+
+      return {
+        ...file,
+        currentVersionId: version.versionId,
+        mimeType: version.mimeType,
+        size: version.size,
+        versionId: version.versionId,
+        versionCreatedAt: version.createdAt,
+        checksumSha256Base64: version.checksumSha256Base64,
+        storageKey: version.storageKey,
+      };
+    },
+
+    async listFiles(ctx: FileProviderContext, options: { cursor?: string; limit?: number } = {}): Promise<{
+      files: FileRecord[];
+      nextCursor?: string;
+    }> {
+      const requested = typeof options.limit === 'number' && Number.isFinite(options.limit)
+        ? Math.floor(options.limit)
+        : 20;
+      const limit = Math.min(100, Math.max(1, requested));
+
+      const allFiles = await db.findMany<FileRecord>({
+        model: 'files',
+        where: [],
+        namespace,
+      });
+
+      const readableGrantFileIds = await getReadableGrantFileIds(ctx);
+      const readableFiles: FileRecord[] = [];
+      for (const file of allFiles) {
+        if (await canReadFile(file, ctx, readableGrantFileIds)) {
+          readableFiles.push(file);
+        }
+      }
+
+      readableFiles.sort(fileSortComparator);
+
+      let paged = readableFiles;
+      if (options.cursor) {
+        const tupleCursor = tryParseCursor(options.cursor);
+        if (tupleCursor) {
+          paged = readableFiles.filter((file) => isAfterCursor(file, tupleCursor));
+        } else {
+          // Legacy cursor support: plain fileId cursor from previous implementation.
+          const legacyAnchor = readableFiles.find((file) => file.fileId === options.cursor);
+          if (legacyAnchor) {
+            const legacyTuple: CursorTuple = {
+              updatedAt: legacyAnchor.updatedAt,
+              fileId: legacyAnchor.fileId,
+            };
+            paged = readableFiles.filter((file) => isAfterCursor(file, legacyTuple));
+          }
+        }
+      }
+
+      const files = paged.slice(0, limit);
+      const hasMore = paged.length > limit;
+
+      return {
+        files,
+        nextCursor: hasMore && files.length > 0
+          ? encodeCursor({ updatedAt: files[files.length - 1].updatedAt, fileId: files[files.length - 1].fileId })
+          : undefined,
+      };
+    },
+
+    async getDownloadUrl(fileId: string, versionId: string | undefined, ctx: FileProviderContext): Promise<{
+      url: string;
+      headers?: Record<string, string>;
+    }> {
+      const file = await this.getFile(fileId, ctx);
+      const targetVersionId = versionId || file.currentVersionId;
+      const version = await getVersionChecked(fileId, targetVersionId);
+      const storageTarget = resolveStorageTarget(policies?.get(file.policy) ?? {});
+
+      if (getStorageCapabilities(storage, storageTarget).signedDownloadUrls && storage.signDownloadUrl) {
+        const result = await storage.signDownloadUrl({
+          key: version.storageKey,
+          target: storageTarget,
+          expiresInSeconds: signedUrlTtlSeconds,
+        });
+        return { url: result.url, headers: result.headers };
+      }
+
+      const proxyUrl = versionId
+        ? `/proxy/files/${fileId}/versions/${versionId}/download`
+        : `/proxy/files/${fileId}/download`;
+
+      return { url: proxyUrl };
+    },
+
+    async getDownloadStream(fileId: string, versionId: string | undefined, ctx: FileProviderContext): Promise<{
+      stream: ReadableStream;
+      contentType: string;
+      size: number;
+    }> {
+      const file = await this.getFile(fileId, ctx);
+      const targetVersionId = versionId || file.currentVersionId;
+      const version = await getVersionChecked(fileId, targetVersionId);
+      const storageTarget = resolveStorageTarget(policies?.get(file.policy) ?? {});
+
+      if (!storage.openDownloadStream) {
+        throw new Error('Storage adapter does not support streaming');
+      }
+
+      const stream = await storage.openDownloadStream({ key: version.storageKey, target: storageTarget });
+      return {
+        stream: stream as unknown as ReadableStream,
+        contentType: version.mimeType,
+        size: version.size,
+      };
+    },
+
+    async getRenderDescriptor(
+      fileId: string,
+      options: { intent: RenderIntent; versionId?: string },
+      ctx: FileProviderContext,
+    ): Promise<RenderDescriptor> {
+      const file = await this.getFile(fileId, ctx);
+      const versionId = options.versionId || file.currentVersionId;
+      const version = await getVersionChecked(fileId, versionId);
+      const artifacts = await db.findMany<FileArtifactRecord>({
+        model: 'fileArtifacts',
+        where: [
+          { field: 'fileId', operator: 'eq', value: fileId },
+          { field: 'versionId', operator: 'eq', value: versionId },
+        ],
+        namespace,
+      });
+
+      const originalDescriptor = async (): Promise<RenderDescriptor> => {
+        const original = await this.getDownloadUrl(fileId, versionId, ctx);
+        return {
+          fileId,
+          versionId,
+          intent: options.intent,
+          state: 'ready',
+          mimeType: version.mimeType,
+          name: file.name,
+          size: version.size,
+          source: {
+            mode: 'original',
+            url: original.url,
+            headers: original.headers,
+          },
+        };
+      };
+
+      const artifactDescriptor = async (artifact: FileArtifactRecord): Promise<RenderDescriptor> => {
+        const resolved = await getArtifactDownloadUrl(file, artifact);
+        return {
+          fileId,
+          versionId,
+          intent: options.intent,
+          state: 'ready',
+          mimeType: artifact.mimeType,
+          name: file.name,
+          size: artifact.size ?? version.size,
+          source: {
+            mode: 'artifact',
+            artifactId: artifact.artifactId,
+            artifactKind: artifact.kind,
+            url: resolved.url,
+            headers: resolved.headers,
+          },
+        };
+      };
+
+      if (options.intent === 'full' || options.intent === 'download') {
+        return originalDescriptor();
+      }
+
+      if (options.intent === 'thumbnail') {
+        if (isImageMimeType(version.mimeType)) {
+          const artifact = selectArtifactByKind(artifacts, ['thumbnail-small', 'thumbnail-medium']);
+          if (artifact) {
+            return artifactDescriptor(artifact);
+          }
+          return originalDescriptor();
+        }
+
+        if (isPdfMimeType(version.mimeType)) {
+          const artifact = selectArtifactByKind(artifacts, ['pdf-preview-page-1-small', 'pdf-preview-page-1-medium']);
+          if (artifact) {
+            return artifactDescriptor(artifact);
+          }
+          return createPlaceholderDescriptor({
+            fileId,
+            versionId,
+            intent: options.intent,
+            state: 'processing',
+            mimeType: version.mimeType,
+            name: file.name,
+            size: version.size,
+            placeholderKind: 'pdf-processing',
+            warnings: ['PDF preview artifact is not available yet.'],
+          });
+        }
+
+        return createPlaceholderDescriptor({
+          fileId,
+          versionId,
+          intent: options.intent,
+          state: 'unsupported',
+          mimeType: version.mimeType,
+          name: file.name,
+          size: version.size,
+          placeholderKind: 'generic-file',
+        });
+      }
+
+      if (isImageMimeType(version.mimeType)) {
+        const artifact = selectArtifactByKind(artifacts, ['thumbnail-large']);
+        if (artifact) {
+          return artifactDescriptor(artifact);
+        }
+        return originalDescriptor();
+      }
+
+      if (isPdfMimeType(version.mimeType)) {
+        const artifact = selectArtifactByKind(artifacts, ['pdf-preview-page-1-large', 'pdf-preview-page-1-medium']);
+        if (artifact) {
+          return artifactDescriptor(artifact);
+        }
+        return createPlaceholderDescriptor({
+          fileId,
+          versionId,
+          intent: options.intent,
+          state: 'processing',
+          mimeType: version.mimeType,
+          name: file.name,
+          size: version.size,
+          placeholderKind: 'pdf-processing',
+          warnings: ['PDF preview artifact is not available yet.'],
+        });
+      }
+
+      if (isMediaPreviewMimeType(version.mimeType)) {
+        return originalDescriptor();
+      }
+
+      return createPlaceholderDescriptor({
+        fileId,
+        versionId,
+        intent: options.intent,
+        state: 'unsupported',
+        mimeType: version.mimeType,
+        name: file.name,
+        size: version.size,
+        placeholderKind: 'unsupported-preview',
+      });
+    },
+
+    async deleteFile(fileId: string, ctx: FileProviderContext): Promise<void> {
+      const file = await db.findOne<FileRecord>({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const canDelete = await authorizer.canDelete(file, ctx);
+      if (!canDelete) {
+        throw errors.forbidden();
+      }
+
+      const versions = await db.findMany<FileVersionRecord>({
+        model: 'fileVersions',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      const artifacts = await db.findMany<FileArtifactRecord>({
+        model: 'fileArtifacts',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      const pendingSessions = await db.findMany<UploadSessionRecord>({
+        model: 'uploadSessions',
+        where: [
+          { field: 'fileId', operator: 'eq', value: fileId },
+          { field: 'status', operator: 'ne', value: 'completed' },
+        ],
+        namespace,
+      });
+
+      for (const session of pendingSessions) {
+        const sessionPolicy = policies?.get(session.policy) ?? {};
+        const sessionStorageTarget = resolveStorageTarget(sessionPolicy);
+        if (session.storageUploadId && storage.abortMultipartUpload) {
+          try {
+            await storage.abortMultipartUpload({
+              key: session.storageKey,
+              target: sessionStorageTarget,
+              uploadId: session.storageUploadId,
+            });
+          } catch {
+            // Best-effort abort for stale multipart uploads.
+          }
+        }
+
+        const parts = await db.findMany<UploadPartRecord>({
+          model: 'uploadParts',
+          where: [{ field: 'uploadSessionId', operator: 'eq', value: session.uploadSessionId }],
+          select: ['partNumber'],
+          namespace,
+        });
+
+        if (session.uploadMode === 'proxy') {
+          for (const part of parts) {
+            try {
+              await storage.deleteObject({ key: proxyPartKey(session.storageKey, part.partNumber), target: sessionStorageTarget });
+            } catch {
+              // Best-effort cleanup for proxy temp parts.
+            }
+          }
+        }
+
+        await db.deleteMany({
+          model: 'uploadParts',
+          where: [{ field: 'uploadSessionId', operator: 'eq', value: session.uploadSessionId }],
+          namespace,
+        });
+      }
+
+      const versionBytesByStorageKey = new Map<string, number>();
+      const targetKeyFor = (target: string, key: string) => `${target}\u0000${key}`;
+      const fileStorageTarget = resolveStorageTarget(policies?.get(file.policy) ?? {});
+      const artifactStorageTarget = resolveArtifactStorageTarget(policies?.get(file.policy) ?? {});
+      for (const version of versions) {
+        const ref = targetKeyFor(fileStorageTarget, version.storageKey);
+        const existing = versionBytesByStorageKey.get(ref) ?? 0;
+        versionBytesByStorageKey.set(ref, Math.max(existing, version.size));
+      }
+
+      const candidateStorageKeys = new Set<string>();
+      for (const version of versions) {
+        candidateStorageKeys.add(targetKeyFor(fileStorageTarget, version.storageKey));
+      }
+      for (const artifact of artifacts) {
+        candidateStorageKeys.add(targetKeyFor(artifactStorageTarget, artifact.storageKey));
+      }
+
+      const storageKeysReferencedElsewhere = new Set<string>();
+      if (candidateStorageKeys.size > 0) {
+        const allVersions = await db.findMany<Pick<FileVersionRecord, 'fileId' | 'storageKey'>>({
+          model: 'fileVersions',
+          where: [],
+          select: ['fileId', 'storageKey'],
+          namespace,
+        });
+
+        const allFiles = await db.findMany<Pick<FileRecord, 'fileId' | 'policy'>>({
+          model: 'files',
+          where: [],
+          select: ['fileId', 'policy'],
+          namespace,
+        });
+        const policyByFileId = new Map(allFiles.map((entry) => [entry.fileId, entry.policy]));
+
+        for (const version of allVersions) {
+          const versionTarget = resolveStorageTarget(policies?.get(policyByFileId.get(version.fileId) ?? '') ?? {});
+          const ref = targetKeyFor(versionTarget, version.storageKey);
+          if (version.fileId !== fileId && candidateStorageKeys.has(ref)) {
+            storageKeysReferencedElsewhere.add(ref);
+          }
+        }
+
+        const allArtifacts = await db.findMany<Pick<FileArtifactRecord, 'fileId' | 'storageKey'>>({
+          model: 'fileArtifacts',
+          where: [],
+          select: ['fileId', 'storageKey'],
+          namespace,
+        });
+
+        for (const artifact of allArtifacts) {
+          const artifactTarget = resolveArtifactStorageTarget(policies?.get(policyByFileId.get(artifact.fileId) ?? '') ?? {});
+          const ref = targetKeyFor(artifactTarget, artifact.storageKey);
+          if (artifact.fileId !== fileId && candidateStorageKeys.has(ref)) {
+            storageKeysReferencedElsewhere.add(ref);
+          }
+        }
+      }
+
+      await db.deleteMany({
+        model: 'filePermissions',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      await db.deleteMany({
+        model: 'fileShares',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      await db.deleteMany({
+        model: 'fileArtifacts',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      await db.deleteMany({
+        model: 'fileVersions',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      await db.deleteMany({
+        model: 'uploadSessions',
+        where: [
+          { field: 'fileId', operator: 'eq', value: fileId },
+          { field: 'status', operator: 'ne', value: 'completed' },
+        ],
+        namespace,
+      });
+
+      await db.delete({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      let totalBytesFreed = 0;
+      for (const ref of candidateStorageKeys) {
+        if (storageKeysReferencedElsewhere.has(ref)) {
+          continue;
+        }
+        try {
+          const split = ref.indexOf('\u0000');
+          const target = ref.slice(0, split);
+          const key = ref.slice(split + 1);
+          await storage.deleteObject({ key, target });
+          totalBytesFreed += versionBytesByStorageKey.get(ref) ?? 0;
+        } catch {
+          // Continue on storage errors (object may already be deleted)
+        }
+      }
+
+      if (quota && totalBytesFreed > 0) {
+        await quota.recordUsage({
+          principalId: file.ownerId,
+          tenantId: file.tenantId ?? undefined,
+          bytes: -totalBytesFreed,
+        });
+      }
+
+      events.emit('file:deleted', createFileDeletedEvent({
+        fileId,
+        ownerId: file.ownerId,
+        tenantId: file.tenantId || undefined,
+      }, ctx.requestId));
+
+      logger?.info('File deleted', {
+        fileId,
+        ownerId: file.ownerId,
+        tenantId: file.tenantId,
+        requestId: ctx.requestId,
+      });
+    },
+
+    async listVersions(fileId: string, ctx: FileProviderContext): Promise<{ versions: FileVersionRecord[] }> {
+      await this.getFile(fileId, ctx);
+
+      const versions = await db.findMany<FileVersionRecord>({
+        model: 'fileVersions',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        orderBy: [{ field: 'createdAt', direction: 'desc' }],
+        namespace,
+      });
+
+      return { versions };
+    },
+
+    async canWriteFile(fileId: string, ctx: FileProviderContext): Promise<boolean> {
+      const file = await db.findOne<FileRecord>({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      if (!file) {
+        return true;
+      }
+
+      return authorizer.canWrite(file, ctx);
+    },
+
+    async getVersion(fileId: string, versionId: string, ctx: FileProviderContext): Promise<FileVersionRecord & { fileId: string }> {
+      await this.getFile(fileId, ctx);
+      const version = await getVersionChecked(fileId, versionId);
+      return { ...version, fileId };
+    },
+
+    async getDownloadUrlWithBinding(fileId: string, versionId: string, ctx: FileProviderContext): Promise<{
+      url: string;
+      headers?: Record<string, string>;
+    }> {
+      return this.getDownloadUrl(fileId, versionId, ctx);
+    },
+  };
+}
+
+export type FileService = ReturnType<typeof createFileService>;

--- a/filefn/server/src/index.test.ts
+++ b/filefn/server/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { createFileFn } from './index.js';
+
+describe('@filefn/server', () => {
+  it('should export createFileFn', () => {
+    expect(createFileFn).toBeDefined();
+  });
+});

--- a/filefn/server/src/index.ts
+++ b/filefn/server/src/index.ts
@@ -1,0 +1,364 @@
+import type { Adapter } from '@superfunctions/db';
+import type { StorageAdapter } from '@superfunctions/storage';
+import type { FileProvider } from '@superfunctions/files';
+import { type RateLimiter, createRateLimiter } from '@superfunctions/middleware';
+import { getSchema } from './schema.js';
+import { createNucleusPolicies, createPolicyRegistry, type Policy } from './policies.js';
+import { createEventEmitter, type FileFnEventEmitter } from './events.js';
+import { createUploadSessionService, type QuotaProvider } from './upload-sessions/service.js';
+import { createUploadSessionRoutes } from './upload-sessions/routes.js';
+import { createFileService, type Authorizer } from './files/service.js';
+import { createFileRoutes } from './files/routes.js';
+import { createDeduplicationService } from './dedup/service.js';
+import { createGrantsService } from './authz/grants.service.js';
+import { createGrantsRoutes } from './authz/grants.routes.js';
+import { createSharesService } from './shares/service.js';
+import { createSharesRoutes } from './shares/routes.js';
+import { createProcessingService, type Processor, type FlowFnProvider } from './processing/service.js';
+import { createProcessingRoutes } from './processing/routes.js';
+import { createPolicyRoutes } from './policies.routes.js';
+import { createQuotaRoutes } from './quota.routes.js';
+import { createRouter, type FileFnRouter } from './router.js';
+import type { AuthConfig } from './auth.js';
+import type { Logger } from './observability/logger.js';
+
+export interface RateLimitCategory {
+  windowSeconds: number;
+  maxRequests: number;
+}
+
+export interface FileFnRouteRateLimits {
+  uploadInit?: RateLimitCategory;
+  uploadSign?: RateLimitCategory;
+  uploadComplete?: RateLimitCategory;
+  download?: RateLimitCategory;
+  shareDownload?: RateLimitCategory;
+  artifactDownload?: RateLimitCategory;
+}
+
+export interface FileFnConfig {
+  db: Adapter;
+  storage: StorageAdapter;
+  policies?: Policy[];
+  auth?: AuthConfig;
+  quota?: QuotaProvider;
+  rateLimiter?: RateLimiter;
+  rateLimit?: {
+    persistence?: any;
+    algorithm?: 'fixed-window' | 'sliding-window' | 'token-bucket';
+    limits?: FileFnRouteRateLimits;
+  };
+  logger?: Logger;
+  authorizer?: Authorizer;
+  namespace?: string;
+  defaultChunkSizeBytes?: number;
+  uploadSessionTtlSeconds?: number;
+  signedUrlTtlSeconds?: number;
+  dedup?: {
+    enabled?: boolean;
+  };
+  processing?: {
+    enabled?: boolean;
+    processors?: Processor[];
+    flowFn?: FlowFnProvider;
+  };
+}
+
+export interface FileFn extends FileProvider {
+  router: FileFnRouter;
+  events: FileFnEventEmitter;
+  definePolicy(name: string, policy: Omit<Policy, 'name'>): void;
+  getSchema(): ReturnType<typeof getSchema>;
+}
+
+function hasConfiguredRouteRateLimits(limits?: FileFnRouteRateLimits): boolean {
+  if (!limits) return false;
+  return Boolean(
+    limits.uploadInit ||
+    limits.uploadSign ||
+    limits.uploadComplete ||
+    limits.download ||
+    limits.shareDownload ||
+    limits.artifactDownload
+  );
+}
+
+export function createFileFn(config: FileFnConfig): FileFn {
+  const {
+    db,
+    storage,
+    policies: initialPolicies = [],
+    auth = {},
+    quota,
+    rateLimiter,
+    rateLimit,
+    logger,
+    authorizer,
+    namespace = 'filefn',
+    defaultChunkSizeBytes,
+    uploadSessionTtlSeconds,
+    signedUrlTtlSeconds,
+    dedup,
+    processing: processingConfig,
+  } = config;
+
+  const policyRegistry = createPolicyRegistry(initialPolicies);
+  const events = createEventEmitter();
+  const deduplication = createDeduplicationService({
+    db,
+    policies: policyRegistry,
+    namespace,
+    enabled: dedup?.enabled ?? false,
+  });
+
+  const routeRateLimits = rateLimit?.limits;
+  const hasRouteRateLimits = hasConfiguredRouteRateLimits(routeRateLimits);
+
+  if (rateLimit && !hasRouteRateLimits) {
+    throw new Error('RATE_LIMIT_CONFIG_INVALID: Missing route-category limits');
+  }
+
+  let finalRateLimiter = rateLimiter;
+  if (!finalRateLimiter && rateLimit && routeRateLimits) {
+    const seedLimit =
+      routeRateLimits.uploadInit ||
+      routeRateLimits.uploadSign ||
+      routeRateLimits.uploadComplete ||
+      routeRateLimits.download ||
+      routeRateLimits.shareDownload ||
+      routeRateLimits.artifactDownload;
+
+    finalRateLimiter = createRateLimiter({
+      windowMs: (seedLimit?.windowSeconds || 60) * 1000,
+      maxRequests: seedLimit?.maxRequests || 100,
+      persistence: rateLimit.persistence,
+      algorithm: rateLimit.algorithm,
+    });
+  }
+
+  const legacyGlobalRateLimit = Boolean(rateLimiter && !rateLimit);
+
+  // Create file service first so we can use it for authorization checks
+  const fileService = createFileService({
+    db,
+    storage,
+    policies: policyRegistry,
+    events,
+    logger,
+    quota,
+    authorizer,
+    namespace,
+    signedUrlTtlSeconds,
+  });
+
+  const processingService = createProcessingService({
+    db,
+    storage,
+    policies: policyRegistry,
+    events,
+    processors: processingConfig?.processors,
+    flowFn: processingConfig?.flowFn,
+    logger,
+    namespace,
+    enabled: processingConfig?.enabled ?? false,
+  });
+
+  const uploadService = createUploadSessionService({
+    db,
+    storage,
+    policies: policyRegistry,
+    events,
+    logger,
+    quota,
+    dedup: deduplication,
+    fileWriteChecker: fileService,
+    processingService,
+    namespace,
+    defaultChunkSizeBytes,
+    uploadSessionTtlSeconds,
+    signedUrlTtlSeconds,
+  });
+
+  const uploadRoutes = createUploadSessionRoutes({
+    service: uploadService,
+    auth,
+    rateLimiter: finalRateLimiter,
+    rateLimits: {
+      uploadInit: routeRateLimits?.uploadInit,
+      uploadSign: routeRateLimits?.uploadSign,
+      uploadComplete: routeRateLimits?.uploadComplete,
+    },
+    legacyGlobalRateLimit,
+  });
+
+  const fileRoutes = createFileRoutes({
+    service: fileService,
+    auth,
+    rateLimiter: finalRateLimiter,
+    rateLimits: {
+      download: routeRateLimits?.download,
+    },
+    legacyGlobalRateLimit,
+  });
+
+  const grantsService = createGrantsService({
+    db,
+    namespace,
+  });
+
+  const grantsRoutes = createGrantsRoutes({
+    service: grantsService,
+    auth,
+  });
+
+  const sharesService = createSharesService({
+    db,
+    storage,
+    policies: policyRegistry,
+    namespace,
+    signedUrlTtlSeconds,
+  });
+
+  const sharesRoutes = createSharesRoutes({
+    service: sharesService,
+    auth,
+    rateLimiter: finalRateLimiter,
+    rateLimits: {
+      shareDownload: routeRateLimits?.shareDownload,
+    },
+  });
+
+  const processingRoutes = createProcessingRoutes({
+    service: processingService,
+    auth,
+    rateLimiter: finalRateLimiter,
+    rateLimits: {
+      artifactDownload: routeRateLimits?.artifactDownload,
+    },
+  });
+
+  const policyRoutes = createPolicyRoutes({
+    policyRegistry,
+    auth,
+  });
+
+  const quotaRoutes = createQuotaRoutes({
+    quota,
+    auth,
+  });
+
+  const router = createRouter({ uploadRoutes, fileRoutes, grantsRoutes, sharesRoutes, processingRoutes, policyRoutes, quotaRoutes });
+
+  return {
+    router,
+    events,
+
+    definePolicy(name: string, policy: Omit<Policy, 'name'>): void {
+      policyRegistry.define(name, policy);
+    },
+
+    getSchema() {
+      return getSchema({ namespace });
+    },
+
+    // FileProvider implementation
+    async createUploadSession(input, ctx) {
+      return uploadService.createSession(input, ctx);
+    },
+
+    async getUploadSessionStatus(input, ctx) {
+      const uploadSessionToken = (ctx as any)?.uploadSessionToken as string | undefined;
+      return uploadService.getSessionStatus(input.uploadSessionId, ctx, uploadSessionToken);
+    },
+
+    async signUploadPart(input, ctx) {
+      const uploadSessionToken = (ctx as any)?.uploadSessionToken as string | undefined;
+      return uploadService.signPart(input.uploadSessionId, input.partNumber, input.contentLength, ctx, uploadSessionToken);
+    },
+
+    async completeUploadPart(input, ctx) {
+      const uploadSessionToken = (ctx as any)?.uploadSessionToken as string | undefined;
+      await uploadService.completePart(input.uploadSessionId, input.partNumber, input.etag, input.size, ctx, uploadSessionToken);
+    },
+
+    async completeUploadSession(input, ctx) {
+      const uploadSessionToken = (ctx as any)?.uploadSessionToken as string | undefined;
+      return uploadService.completeSession(input.uploadSessionId, ctx, uploadSessionToken);
+    },
+
+    async abortUploadSession(input, ctx) {
+      const uploadSessionToken = (ctx as any)?.uploadSessionToken as string | undefined;
+      await uploadService.abortSession(input.uploadSessionId, ctx, uploadSessionToken);
+    },
+
+    async getFile(input, ctx) {
+      return fileService.getFile(input.fileId, ctx, input.versionId);
+    },
+
+    async listFiles(input, ctx) {
+      return fileService.listFiles(ctx, input);
+    },
+
+    async deleteFile(input, ctx) {
+      await fileService.deleteFile(input.fileId, ctx);
+    },
+  };
+}
+
+// Re-exports
+export { getSchema, getSchemaMap } from './schema.js';
+export {
+  DEFAULT_STORAGE_TARGET,
+  NUCLEUS_ALLOWED_CONTENT_TYPES,
+  NUCLEUS_MAX_SIZE_BYTES,
+  computeStoragePath,
+  createNucleusPolicies,
+  createPolicyRegistry,
+  matchesContentType,
+  resolveArtifactStorageTarget,
+  resolveStorageTarget,
+  validatePolicyConstraints,
+} from './policies.js';
+export type { Policy, PolicyRegistry, Visibility } from './policies.js';
+export { createEventEmitter } from './events.js';
+export type { FileFnEvent, FileFnEventTypes, FileFnEventEmitter } from './events.js';
+export { resolvePrincipal } from './auth.js';
+export type { AuthConfig, AuthProvider, FileFnPrincipal } from './auth.js';
+export type { QuotaProvider } from './upload-sessions/service.js';
+export { createFileService } from './files/service.js';
+export type { FileService, FileRecord, FileVersionRecord, Authorizer } from './files/service.js';
+export * from './errors.js';
+export type { FileFnRouter } from './router.js';
+
+// Authorization exports
+export { composeAuthorizers, createDefaultAuthorizer } from './authz/authorizer.js';
+export type { AuthorizerStrategy, ComposeAuthorizersOptions, FilePermissionRecord, DefaultAuthorizerConfig } from './authz/authorizer.js';
+export { createGrantsService } from './authz/grants.service.js';
+export type { GrantsService, CreateGrantInput } from './authz/grants.service.js';
+export { createGrantsRoutes } from './authz/grants.routes.js';
+export type { GrantsRoutes, GrantsRouteContext } from './authz/grants.routes.js';
+
+// Share link exports
+export { createSharesService } from './shares/service.js';
+export type { SharesService, FileShareRecord, CreateShareLinkInput } from './shares/service.js';
+export { createSharesRoutes } from './shares/routes.js';
+export type { SharesRoutes, SharesRouteContext } from './shares/routes.js';
+
+// Observability exports
+export { createLogger, redactSecrets } from './observability/logger.js';
+export type { Logger, LogContext, LoggerOptions } from './observability/logger.js';
+
+// Processing exports
+export { createProcessingService } from './processing/service.js';
+export type {
+  ProcessingService,
+  Processor,
+  ProcessorInput,
+  ProcessorOutputArtifact,
+  ProcessorResult,
+  FileArtifactRecord,
+  FlowFnProvider,
+  FlowFnQueue,
+} from './processing/service.js';
+export { createProcessingRoutes } from './processing/routes.js';
+export type { ProcessingRoutes, ProcessingRoutesConfig } from './processing/routes.js';

--- a/filefn/server/src/observability/logger.ts
+++ b/filefn/server/src/observability/logger.ts
@@ -1,0 +1,146 @@
+export interface LogContext {
+  requestId?: string;
+  fileId?: string;
+  uploadSessionId?: string;
+  [key: string]: unknown;
+}
+
+export interface Logger {
+  info(message: string, context?: LogContext): void;
+  warn(message: string, context?: LogContext): void;
+  error(message: string, context?: LogContext): void;
+  debug(message: string, context?: LogContext): void;
+}
+
+const REDACT_PATTERNS = [
+  /https?:\/\/[^\s"']+\?[^\s"']*(?:X-Amz-Signature|Signature|sig|token|key)=[^\s"'&]+/gi,
+  /[?&](?:X-Amz-Signature|Signature|sig|token|key)=[^\s"'&]+/gi,
+  /Bearer\s+[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+/gi,
+  /upls_live_[A-Za-z0-9\-_]+/g,
+  /shr_live_[A-Za-z0-9\-_]+/g,
+  /[A-Za-z0-9\-_]{32,}/g,
+];
+
+const SAFE_ID_PATTERN = /^[a-zA-Z0-9_\-]+$/;
+
+function isSafeValue(key: string, value: unknown): boolean {
+  if (typeof value !== 'string') return true;
+  if (['requestId', 'fileId', 'uploadSessionId', 'versionId', 'permissionId'].includes(key)) {
+    return SAFE_ID_PATTERN.test(value);
+  }
+  return true;
+}
+
+function shouldRedactKey(lowerKey: string): boolean {
+  return (
+    lowerKey.includes('token') ||
+    lowerKey.includes('secret') ||
+    lowerKey.includes('password') ||
+    lowerKey.includes('signedurl') ||
+    lowerKey.includes('signed_url') ||
+    lowerKey.includes('signature') ||
+    lowerKey.includes('authorization') ||
+    lowerKey.includes('credential') ||
+    lowerKey.includes('cookie')
+  );
+}
+
+function redactStringValue(key: string, value: string): string {
+  let redacted = value;
+  for (const pattern of REDACT_PATTERNS) {
+    redacted = redacted.replace(pattern, '[REDACTED]');
+  }
+  if (redacted !== value && /^https?:\/\//i.test(value)) {
+    return '[REDACTED]';
+  }
+  if (!isSafeValue(key, redacted)) {
+    return '[REDACTED]';
+  }
+  return redacted;
+}
+
+function redactValue(key: string, value: unknown): unknown {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const lowerKey = key.toLowerCase();
+  if (shouldRedactKey(lowerKey)) {
+    return '[REDACTED]';
+  }
+
+  if (typeof value === 'string') {
+    return redactStringValue(key, value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      if (typeof item === 'string') {
+        return redactStringValue(key, item);
+      }
+      if (item && typeof item === 'object') {
+        return redactSecrets(item as LogContext);
+      }
+      return item;
+    });
+  }
+
+  if (typeof value === 'object') {
+    return redactSecrets(value as LogContext);
+  }
+
+  return value;
+}
+
+function redactSecrets(context: LogContext): LogContext {
+  const result: LogContext = {};
+
+  for (const [key, value] of Object.entries(context)) {
+    const redactedValue = redactValue(key, value);
+    if (redactedValue !== undefined) {
+      result[key] = redactedValue;
+    }
+  }
+
+  return result;
+}
+
+export interface LoggerOptions {
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  output?: (level: string, message: string, context: LogContext) => void;
+}
+
+const LOG_LEVELS = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export function createLogger(options: LoggerOptions = {}): Logger {
+  const { level = 'info', output } = options;
+  const minLevel = LOG_LEVELS[level];
+
+  function log(logLevel: keyof typeof LOG_LEVELS, message: string, context: LogContext = {}): void {
+    if (LOG_LEVELS[logLevel] < minLevel) return;
+
+    const safeContext = redactSecrets(context);
+    const timestamp = new Date().toISOString();
+
+    if (output) {
+      output(logLevel, message, { timestamp, ...safeContext });
+    } else {
+      const logFn = logLevel === 'error' ? console.error : logLevel === 'warn' ? console.warn : console.log;
+      logFn(JSON.stringify({ timestamp, level: logLevel, message, ...safeContext }));
+    }
+  }
+
+  return {
+    debug: (message, context) => log('debug', message, context),
+    info: (message, context) => log('info', message, context),
+    warn: (message, context) => log('warn', message, context),
+    error: (message, context) => log('error', message, context),
+  };
+}
+
+export { redactSecrets };

--- a/filefn/server/src/policies.routes.ts
+++ b/filefn/server/src/policies.routes.ts
@@ -1,0 +1,36 @@
+import type { PolicyRegistry } from './policies.js';
+import type { AuthConfig } from './auth.js';
+
+export interface PolicyRoutesContext {
+  policyRegistry: PolicyRegistry;
+  auth: AuthConfig;
+}
+
+function getRequestId(request: Request): string | undefined {
+  return request.headers.get('x-request-id') || undefined;
+}
+
+function successResponse(data: unknown, requestId?: string): Response {
+  return Response.json({ ok: true, data, requestId }, { status: 200 });
+}
+
+export function createPolicyRoutes(ctx: PolicyRoutesContext) {
+  const { policyRegistry } = ctx;
+
+  return {
+    async listPolicies(request: Request): Promise<Response> {
+      const requestId = getRequestId(request);
+
+      const policies = policyRegistry.list().map((p) => ({
+        name: p.name,
+        maxSizeBytes: p.maxSizeBytes,
+        contentTypes: p.contentTypes,
+        visibility: p.visibility,
+      }));
+
+      return successResponse({ policies }, requestId);
+    },
+  };
+}
+
+export type PolicyRoutes = ReturnType<typeof createPolicyRoutes>;

--- a/filefn/server/src/policies.ts
+++ b/filefn/server/src/policies.ts
@@ -1,0 +1,160 @@
+export interface PolicyStoragePathContext {
+  fileName: string;
+  principalId?: string;
+  tenantId?: string;
+  fileId: string;
+  versionId: string;
+}
+
+export interface Policy {
+  name: string;
+  contentTypes?: string[];
+  maxSizeBytes?: number;
+  visibility?: 'public' | 'private' | 'shared';
+  storageTarget?: string;
+  artifactStorageTarget?: string;
+  lifecycle?: 'durable' | 'temporary';
+  renderProfile?: 'default' | 'nucleus';
+  storagePath?: (ctx: PolicyStoragePathContext) => string;
+}
+
+export interface PolicyRegistry {
+  get(name: string): Policy | undefined;
+  register(policy: Policy): void;
+  list(): Policy[];
+}
+
+export type Visibility = 'public' | 'private' | 'shared';
+export type RenderProfile = 'default' | 'nucleus';
+
+export const DEFAULT_STORAGE_TARGET = 'durable';
+export const NUCLEUS_MAX_SIZE_BYTES = 100 * 1024 * 1024;
+export const NUCLEUS_ALLOWED_CONTENT_TYPES = [
+  'image/*',
+  'audio/*',
+  'video/*',
+  'application/pdf',
+  'text/markdown',
+  'text/plain',
+] as const;
+
+export interface PolicyRegistryWithDefine extends PolicyRegistry {
+  define(name: string, policy: Omit<Policy, 'name'>): void;
+}
+
+export function createPolicyRegistry(initialPolicies: Policy[] = []): PolicyRegistryWithDefine {
+  const policies = new Map<string, Policy>();
+
+  for (const policy of initialPolicies) {
+    policies.set(policy.name, policy);
+  }
+
+  return {
+    get(name: string): Policy | undefined {
+      return policies.get(name);
+    },
+
+    register(policy: Policy): void {
+      policies.set(policy.name, policy);
+    },
+
+    define(name: string, policy: Omit<Policy, 'name'>): void {
+      policies.set(name, { name, ...policy });
+    },
+
+    list(): Policy[] {
+      return Array.from(policies.values());
+    },
+  };
+}
+
+export function validatePolicyConstraints(
+  policy: Policy,
+  mimeType: string,
+  size: number
+): { valid: boolean; error?: string } {
+  if (policy.contentTypes && policy.contentTypes.length > 0) {
+    if (!policy.contentTypes.some((pattern) => matchesContentType(pattern, mimeType))) {
+      return { valid: false, error: `Content type '${mimeType}' not allowed by policy '${policy.name}'` };
+    }
+  }
+
+  if (policy.maxSizeBytes !== undefined && size > policy.maxSizeBytes) {
+    return { valid: false, error: `Size ${size} exceeds max ${policy.maxSizeBytes} for policy '${policy.name}'` };
+  }
+
+  return { valid: true };
+}
+
+export function computeStoragePath(
+  policy: Policy,
+  ctx: PolicyStoragePathContext
+): string {
+  if (policy.storagePath) {
+    return policy.storagePath(ctx);
+  }
+  const sanitizePathSegment = (value: string): string =>
+    value
+      .replace(/[\\/]+/g, '_')
+      .replace(/\.\.+/g, '_')
+      .replace(/[\u0000-\u001f\u007f]+/g, '')
+      .replace(/_+/g, '_')
+      .trim() || '_';
+  const parts: string[] = [];
+  if (ctx.tenantId) parts.push(sanitizePathSegment(ctx.tenantId));
+  if (ctx.principalId) parts.push(sanitizePathSegment(ctx.principalId));
+  parts.push(sanitizePathSegment(ctx.fileId));
+  parts.push(`${sanitizePathSegment(ctx.versionId)}-${sanitizePathSegment(ctx.fileName)}`);
+  return parts.join('/');
+}
+
+export function resolveStorageTarget(policy: Pick<Policy, 'storageTarget'>): string {
+  return policy.storageTarget || DEFAULT_STORAGE_TARGET;
+}
+
+export function resolveArtifactStorageTarget(
+  policy: Pick<Policy, 'storageTarget' | 'artifactStorageTarget'>
+): string {
+  return policy.artifactStorageTarget || resolveStorageTarget(policy);
+}
+
+export function matchesContentType(pattern: string, mimeType: string): boolean {
+  const normalizedPattern = pattern.toLowerCase();
+  const normalizedMimeType = mimeType.toLowerCase();
+
+  if (normalizedPattern === '*/*') {
+    return true;
+  }
+
+  if (normalizedPattern.endsWith('/*')) {
+    const prefix = normalizedPattern.slice(0, normalizedPattern.length - 1);
+    return normalizedMimeType.startsWith(prefix);
+  }
+
+  return normalizedPattern === normalizedMimeType;
+}
+
+export function createNucleusPolicies(): Policy[] {
+  return [
+    {
+      name: 'nucleus-durable-default',
+      contentTypes: [...NUCLEUS_ALLOWED_CONTENT_TYPES],
+      maxSizeBytes: NUCLEUS_MAX_SIZE_BYTES,
+      visibility: 'private',
+      storageTarget: 'durable',
+      artifactStorageTarget: 'durable',
+      lifecycle: 'durable',
+      renderProfile: 'nucleus',
+    },
+    {
+      name: 'nucleus-temporary-default',
+      contentTypes: [...NUCLEUS_ALLOWED_CONTENT_TYPES],
+      maxSizeBytes: NUCLEUS_MAX_SIZE_BYTES,
+      visibility: 'private',
+      storageTarget: 'temporary',
+      artifactStorageTarget: 'temporary',
+      lifecycle: 'temporary',
+      renderProfile: 'nucleus',
+    },
+  ];
+}

--- a/filefn/server/src/processing/routes.ts
+++ b/filefn/server/src/processing/routes.ts
@@ -1,0 +1,230 @@
+import type { ProcessingService } from './service.js';
+import type { AuthConfig } from '../auth.js';
+import type { RateLimiter } from '@superfunctions/middleware';
+import { resolvePrincipal } from '../auth.js';
+import * as errors from '../errors.js';
+
+export interface ProcessingRoutesConfig {
+  service: ProcessingService;
+  auth: AuthConfig;
+  rateLimiter?: RateLimiter;
+  rateLimits?: {
+    artifactDownload?: {
+      windowSeconds: number;
+      maxRequests: number;
+    };
+  };
+}
+
+export interface ProcessingRouteContext {
+  requestId?: string;
+}
+
+function getRequestId(request: Request): string | undefined {
+  return request.headers.get('x-request-id') || undefined;
+}
+
+function jsonResponse(data: unknown, requestId?: string, status = 200): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      data,
+      warnings: [],
+      requestId,
+    }),
+    {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }
+  );
+}
+
+function errorResponse(error: errors.FileFnError, requestId?: string): Response {
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: {
+        code: error.code,
+        message: error.message,
+        details: error.details || {},
+      },
+      requestId,
+    }),
+    {
+      status: error.status,
+      headers: { 'content-type': 'application/json' },
+    }
+  );
+}
+
+export function createProcessingRoutes(config: ProcessingRoutesConfig) {
+  const { service, auth, rateLimiter, rateLimits } = config;
+
+  function requireAuth(principal: { principalId?: string; tenantId?: string } | null): void {
+    if (!principal && auth.required !== false) {
+      throw errors.authRequired();
+    }
+  }
+
+  async function checkArtifactDownloadRateLimit(
+    principal: { principalId?: string; tenantId?: string } | null
+  ): Promise<void> {
+    const categoryLimit = rateLimits?.artifactDownload;
+    if (!rateLimiter || !categoryLimit) {
+      return;
+    }
+
+    const result = await rateLimiter.check({
+      key: `artifact-download:${principal?.tenantId || 'global'}:${principal?.principalId || 'anonymous'}`,
+      windowSeconds: categoryLimit.windowSeconds,
+      limit: categoryLimit.maxRequests,
+    });
+    if (!result.allowed) {
+      throw errors.rateLimited(result.resetAt);
+    }
+  }
+
+  return {
+    async listArtifacts(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+
+      try {
+        const principal = await resolvePrincipal(request, auth);
+        requireAuth(principal);
+        await checkArtifactDownloadRateLimit(principal);
+        const ctx = {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        };
+
+        const artifacts = await service.listArtifactsForFile(fileId, ctx);
+
+        return jsonResponse(
+          {
+            artifacts: artifacts.map((a) => ({
+              artifactId: a.artifactId,
+              fileId: a.fileId,
+              versionId: a.versionId,
+              kind: a.kind,
+              mimeType: a.mimeType,
+              size: a.size,
+              createdAt: a.createdAt,
+            })),
+          },
+          requestId
+        );
+      } catch (error) {
+        if (error instanceof errors.FileFnError) {
+          return errorResponse(error, requestId);
+        }
+        throw error;
+      }
+    },
+
+    async downloadArtifact(request: Request, fileId: string, artifactId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+
+      try {
+        const principal = await resolvePrincipal(request, auth);
+        requireAuth(principal);
+        await checkArtifactDownloadRateLimit(principal);
+        const ctx = {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        };
+
+        const { url, headers } = await service.getArtifactDownloadUrlForFile(fileId, artifactId, ctx);
+
+        return jsonResponse({ url, headers }, requestId);
+      } catch (error) {
+        if (error instanceof errors.FileFnError) {
+          return errorResponse(error, requestId);
+        }
+        throw error;
+      }
+    },
+
+    async proxyDownloadArtifact(request: Request, fileId: string, artifactId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+
+      try {
+        const principal = await resolvePrincipal(request, auth);
+        requireAuth(principal);
+        await checkArtifactDownloadRateLimit(principal);
+        const ctx = {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        };
+
+        const result = await service.getArtifactDownloadStreamForFile(fileId, artifactId, ctx);
+
+        return new Response(result.stream, {
+          status: 200,
+          headers: {
+            'Content-Type': result.contentType,
+            'Content-Length': result.size.toString(),
+          },
+        });
+      } catch (error) {
+        if (error instanceof errors.FileFnError) {
+          return errorResponse(error, requestId);
+        }
+        throw error;
+      }
+    },
+
+    async triggerProcessing(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+
+      try {
+        const principal = await resolvePrincipal(request, auth);
+        requireAuth(principal);
+
+        const ctx = {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        };
+
+        const body = (await request.json()) as {
+          versionId?: string;
+        } | undefined;
+        const target = await service.getReadableVersionForFile(fileId, ctx, body?.versionId);
+
+        const result = await service.triggerProcessing(
+          {
+            fileId,
+            versionId: target.version.versionId,
+            storageKey: target.version.storageKey,
+            mimeType: target.version.mimeType,
+            size: target.version.size,
+            fileName: target.file.name,
+            tenantId: target.file.tenantId ?? ctx.tenantId,
+          },
+          ctx
+        );
+
+        return jsonResponse(
+          {
+            processing: {
+              started: true,
+              enqueued: result.enqueued,
+              jobId: result.jobId,
+            },
+          },
+          requestId
+        );
+      } catch (error) {
+        if (error instanceof errors.FileFnError) {
+          return errorResponse(error, requestId);
+        }
+        throw error;
+      }
+    },
+  };
+}
+
+export type ProcessingRoutes = ReturnType<typeof createProcessingRoutes>;

--- a/filefn/server/src/processing/service.ts
+++ b/filefn/server/src/processing/service.ts
@@ -1,0 +1,607 @@
+import type { Adapter } from '@superfunctions/db';
+import { getStorageCapabilities, type StorageAdapter } from '@superfunctions/storage';
+import type { FileProviderContext } from '@superfunctions/files';
+import type { FileFnEventEmitter } from '../events.js';
+import { resolveArtifactStorageTarget, resolveStorageTarget, type PolicyRegistry } from '../policies.js';
+import type { Logger } from '../observability/logger.js';
+import * as errors from '../errors.js';
+
+export interface Processor {
+  name: string;
+  supportedMimeTypes: string[];
+  process(
+    input: ProcessorInput,
+    getData: () => Promise<Uint8Array>
+  ): Promise<ProcessorResult>;
+}
+
+export interface ProcessorInput {
+  fileId: string;
+  versionId: string;
+  storageKey: string;
+  mimeType: string;
+  size: number;
+  fileName: string;
+  tenantId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProcessorOutputArtifact {
+  kind: string;
+  data: Uint8Array;
+  mimeType: string;
+  storageKey: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProcessorResult {
+  success: boolean;
+  artifacts: ProcessorOutputArtifact[];
+  error?: string;
+}
+
+export interface FlowFnQueue {
+  name: string;
+  add(job: unknown): Promise<{ jobId: string }>;
+}
+
+export interface FlowFnProvider {
+  getQueue(name: string): FlowFnQueue | undefined;
+}
+
+export interface ProcessingServiceConfig {
+  db: Adapter;
+  storage: StorageAdapter;
+  policies?: Pick<PolicyRegistry, 'get'>;
+  events: FileFnEventEmitter;
+  processors?: Processor[];
+  flowFn?: FlowFnProvider;
+  logger?: Logger;
+  namespace?: string;
+  enabled?: boolean;
+  maxFileBytes?: number;
+}
+
+export interface FileArtifactRecord {
+  artifactId: string;
+  fileId: string;
+  versionId: string;
+  kind: string;
+  storageKey: string;
+  mimeType: string;
+  size: number;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+}
+
+interface FileRecord {
+  fileId: string;
+  currentVersionId: string;
+  ownerId: string;
+  tenantId: string | null;
+  visibility: 'private' | 'shared' | 'public';
+  policy: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
+interface FilePermissionRecord {
+  fileId: string;
+  userId?: string;
+  tenantId?: string | null;
+  canRead?: boolean;
+  expiresAt?: string | null;
+}
+
+interface FileVersionRecord {
+  versionId: string;
+  fileId: string;
+  storageKey: string;
+  mimeType: string;
+  size: number;
+}
+
+function generateId(): string {
+  return `art_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function supportsProcessor(processor: Processor, mimeType: string): boolean {
+  if (processor.supportedMimeTypes.includes('*/*')) {
+    return true;
+  }
+  return processor.supportedMimeTypes.includes(mimeType);
+}
+
+function buildProcessingIdempotencyKey(fileId: string, versionId: string, processors: Processor[]): string {
+  const processorKey = processors.map((processor) => processor.name).sort().join(',');
+  return `processing:${fileId}:${versionId}:${processorKey}`;
+}
+
+function isGrantExpired(expiresAt: string | null | undefined): boolean {
+  if (!expiresAt) {
+    return false;
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiresAtMs)) {
+    return false;
+  }
+  return expiresAtMs <= Date.now();
+}
+
+export function createProcessingService(config: ProcessingServiceConfig) {
+  const {
+    db,
+    storage,
+    policies,
+    events,
+    processors = [],
+    flowFn,
+    logger,
+    namespace = 'filefn',
+    enabled = true,
+    maxFileBytes = 50 * 1024 * 1024,
+  } = config;
+
+  const QUEUE_NAME = 'filefn.processing';
+
+  async function getReadableGrantFileIds(ctx: FileProviderContext): Promise<Set<string>> {
+    if (!ctx.principalId) {
+      return new Set<string>();
+    }
+
+    const grants: FilePermissionRecord[] = [];
+    grants.push(...await db.findMany<FilePermissionRecord>({
+      model: 'filePermissions',
+      where: [{ field: 'userId', operator: 'eq', value: ctx.principalId }],
+      namespace,
+    }));
+    if (ctx.tenantId) {
+      grants.push(...await db.findMany<FilePermissionRecord>({
+        model: 'filePermissions',
+        where: [{ field: 'tenantId', operator: 'eq', value: ctx.tenantId }],
+        namespace,
+      }));
+    }
+
+    const readable = new Set<string>();
+    for (const grant of grants) {
+      if (!grant?.canRead || isGrantExpired(grant.expiresAt)) continue;
+      if (
+        grant.userId === ctx.principalId ||
+        (grant.tenantId && grant.tenantId === ctx.tenantId)
+      ) {
+        readable.add(grant.fileId);
+      }
+    }
+
+    return readable;
+  }
+
+  function canReadByVisibility(file: FileRecord, ctx: FileProviderContext): boolean {
+    if (file.visibility === 'public') return true;
+    if (file.ownerId === ctx.principalId) return true;
+    if (file.visibility === 'shared' && file.tenantId && file.tenantId === ctx.tenantId) return true;
+    return false;
+  }
+
+  async function requireReadableFile(fileId: string, ctx: FileProviderContext): Promise<FileRecord> {
+    const file = await db.findOne<FileRecord>({
+      model: 'files',
+      where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+      namespace,
+    });
+
+    if (!file) {
+      throw errors.notFound('File');
+    }
+
+    if (canReadByVisibility(file, ctx)) {
+      return file;
+    }
+
+    const grantFileIds = await getReadableGrantFileIds(ctx);
+    if (grantFileIds.has(fileId)) {
+      return file;
+    }
+
+    throw errors.forbidden();
+  }
+
+  async function getVersionChecked(fileId: string, versionId: string): Promise<FileVersionRecord> {
+    const version = await db.findOne<FileVersionRecord>({
+      model: 'fileVersions',
+      where: [{ field: 'versionId', operator: 'eq', value: versionId }],
+      namespace,
+    });
+
+    if (!version) {
+      throw errors.notFound('Version');
+    }
+
+    if (version.fileId !== fileId) {
+      throw errors.notFound('Version');
+    }
+
+    return version;
+  }
+
+  async function getReadableVersionForFile(
+    fileId: string,
+    ctx: FileProviderContext,
+    versionId?: string,
+  ): Promise<{ file: FileRecord; version: FileVersionRecord }> {
+    const file = await requireReadableFile(fileId, ctx);
+    const version = await getVersionChecked(fileId, versionId || file.currentVersionId);
+    return { file, version };
+  }
+
+  function getFileStorageTarget(file: Pick<FileRecord, 'policy'>): string {
+    return resolveStorageTarget(policies?.get(file.policy) ?? {});
+  }
+
+  function getArtifactStorageTarget(file: Pick<FileRecord, 'policy'>): string {
+    return resolveArtifactStorageTarget(policies?.get(file.policy) ?? {});
+  }
+
+  async function getBoundArtifact(fileId: string, artifactId: string): Promise<FileArtifactRecord> {
+    const artifact = await db.findOne<FileArtifactRecord>({
+      model: 'fileArtifacts',
+      where: [{ field: 'artifactId', operator: 'eq', value: artifactId }],
+      namespace,
+    });
+
+    if (!artifact) {
+      throw errors.notFound('Artifact');
+    }
+
+    if (artifact.fileId !== fileId) {
+      throw errors.notFound('Artifact');
+    }
+
+    return artifact;
+  }
+
+  return {
+    isEnabled(): boolean {
+      return enabled && processors.length > 0;
+    },
+
+    async triggerProcessing(
+      input: {
+        fileId: string;
+        versionId: string;
+        storageKey: string;
+        mimeType: string;
+        size: number;
+        fileName: string;
+        tenantId?: string;
+      },
+      ctx: FileProviderContext
+    ): Promise<{ enqueued: boolean; jobId?: string }> {
+      if (!enabled || processors.length === 0) {
+        return { enqueued: false };
+      }
+
+      events.emit('processing.started' as any, {
+        type: 'processing.started',
+        timestamp: new Date().toISOString(),
+        requestId: ctx.requestId,
+        fileId: input.fileId,
+        versionId: input.versionId,
+      });
+
+      if (flowFn) {
+        const queue = flowFn.getQueue(QUEUE_NAME);
+        if (queue) {
+          try {
+            const result = await queue.add({
+              fileId: input.fileId,
+              versionId: input.versionId,
+              storageKey: input.storageKey,
+              mimeType: input.mimeType,
+              size: input.size,
+              fileName: input.fileName,
+              tenantId: input.tenantId,
+              idempotencyKey: buildProcessingIdempotencyKey(input.fileId, input.versionId, processors),
+            });
+            return { enqueued: true, jobId: result.jobId };
+          } catch {
+            throw errors.processingEnqueueFailed();
+          }
+        }
+      }
+
+      setImmediate(async () => {
+        try {
+          await this.runProcessing(input, ctx);
+        } catch (error) {
+          logger?.error('processing failed', {
+            requestId: ctx.requestId,
+            fileId: input.fileId,
+            versionId: input.versionId,
+            error: error instanceof Error ? error.stack ?? error.message : String(error),
+          });
+          events.emit('processing.failed' as any, {
+            type: 'processing.failed',
+            timestamp: new Date().toISOString(),
+            requestId: ctx.requestId,
+            fileId: input.fileId,
+            versionId: input.versionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      });
+
+      return { enqueued: false };
+    },
+
+    async runProcessing(
+      input: ProcessorInput,
+      ctx: FileProviderContext
+    ): Promise<{ artifactsCreated: number; errors: string[] }> {
+      const applicableProcessors = processors.filter((p) =>
+        supportsProcessor(p, input.mimeType)
+      );
+
+      if (applicableProcessors.length === 0) {
+        return { artifactsCreated: 0, errors: [] };
+      }
+
+      const file = await db.findOne<FileRecord>({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: input.fileId }],
+        namespace,
+      });
+      const fileStorageTarget = getFileStorageTarget(file ?? { policy: '' });
+      const artifactStorageTarget = getArtifactStorageTarget(file ?? { policy: '' });
+
+      let dataCache: Uint8Array | null = null;
+      // Processing currently reads the source into memory once per run; reject overly large inputs early.
+      const getData = async (): Promise<Uint8Array> => {
+        if (dataCache) return dataCache;
+
+        if (storage.openDownloadStream) {
+          const stream = await storage.openDownloadStream({ key: input.storageKey, target: fileStorageTarget });
+          const reader = stream.getReader();
+          const chunks: Uint8Array[] = [];
+          let totalLength = 0;
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) {
+              totalLength += value.length;
+              if (totalLength > maxFileBytes) {
+                throw new Error(
+                  `Processing source exceeds ${maxFileBytes} bytes; increase maxFileBytes or use a streaming-friendly processor.`,
+                );
+              }
+              chunks.push(value);
+            }
+          }
+          dataCache = new Uint8Array(totalLength);
+          let offset = 0;
+          for (const chunk of chunks) {
+            dataCache.set(chunk, offset);
+            offset += chunk.length;
+          }
+        } else {
+          throw new Error('Storage adapter does not support streaming downloads');
+        }
+
+        return dataCache;
+      };
+
+      const processingErrors: string[] = [];
+      let artifactsCreated = 0;
+
+      for (const processor of applicableProcessors) {
+        try {
+          const result = await processor.process(input, getData);
+
+          if (!result.success) {
+            if (result.error) {
+              processingErrors.push(`${processor.name}: ${result.error}`);
+            }
+            continue;
+          }
+
+          for (const artifact of result.artifacts) {
+            if (storage.openUploadStream) {
+              const stream = await storage.openUploadStream({
+                key: artifact.storageKey,
+                target: artifactStorageTarget,
+                contentType: artifact.mimeType,
+              });
+              const writer = stream.getWriter();
+              await writer.write(artifact.data);
+              await writer.close();
+            } else {
+              throw new Error('Storage adapter does not support streaming uploads');
+            }
+
+            const existingArtifact = await db.findOne<FileArtifactRecord>({
+              model: 'fileArtifacts',
+              where: [
+                { field: 'fileId', operator: 'eq', value: input.fileId },
+                { field: 'versionId', operator: 'eq', value: input.versionId },
+                { field: 'kind', operator: 'eq', value: artifact.kind },
+              ],
+              namespace,
+            });
+
+            if (existingArtifact) {
+              await db.update({
+                model: 'fileArtifacts',
+                where: [{ field: 'artifactId', operator: 'eq', value: existingArtifact.artifactId }],
+                data: {
+                  storageKey: artifact.storageKey,
+                  mimeType: artifact.mimeType,
+                  size: artifact.data.length,
+                  metadata: artifact.metadata || {},
+                },
+                namespace,
+              });
+            } else {
+              const artifactId = generateId();
+              await db.create({
+                model: 'fileArtifacts',
+                data: {
+                  artifactId,
+                  fileId: input.fileId,
+                  versionId: input.versionId,
+                  kind: artifact.kind,
+                  storageKey: artifact.storageKey,
+                  mimeType: artifact.mimeType,
+                  size: artifact.data.length,
+                  metadata: artifact.metadata || {},
+                  createdAt: new Date().toISOString(),
+                },
+                namespace,
+              });
+            }
+
+            artifactsCreated++;
+          }
+        } catch (error) {
+          processingErrors.push(
+            `${processor.name}: ${error instanceof Error ? error.message : 'Unknown error'}`
+          );
+        }
+      }
+
+      events.emit('processing.completed' as any, {
+        type: 'processing.completed',
+        timestamp: new Date().toISOString(),
+        requestId: ctx.requestId,
+        fileId: input.fileId,
+        versionId: input.versionId,
+        artifactsCreated,
+      });
+
+      return { artifactsCreated, errors: processingErrors };
+    },
+
+    async listArtifacts(
+      fileId: string,
+      ctx: FileProviderContext
+    ): Promise<FileArtifactRecord[]> {
+      void ctx;
+
+      const artifacts = await db.findMany<FileArtifactRecord>({
+        model: 'fileArtifacts',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        orderBy: [{ field: 'createdAt', direction: 'desc' }],
+        namespace,
+      });
+
+      return artifacts;
+    },
+
+    async listArtifactsForFile(
+      fileId: string,
+      ctx: FileProviderContext,
+    ): Promise<FileArtifactRecord[]> {
+      await requireReadableFile(fileId, ctx);
+      return this.listArtifacts(fileId, ctx);
+    },
+
+    async getArtifactDownloadUrl(
+      artifactId: string,
+      ctx: FileProviderContext
+    ): Promise<{ url: string; headers?: Record<string, string> }> {
+      const artifact = await db.findOne<FileArtifactRecord>({
+        model: 'fileArtifacts',
+        where: [{ field: 'artifactId', operator: 'eq', value: artifactId }],
+        namespace,
+      });
+
+      if (!artifact) {
+        throw errors.notFound('Artifact');
+      }
+
+      const file = await db.findOne<FileRecord>({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: artifact.fileId }],
+        namespace,
+      });
+      if (file) {
+        await requireReadableFile(file.fileId, ctx);
+      }
+      const artifactStorageTarget = getArtifactStorageTarget(file ?? { policy: '' });
+
+      if (getStorageCapabilities(storage, artifactStorageTarget).signedDownloadUrls && storage.signDownloadUrl) {
+        const result = await storage.signDownloadUrl({
+          key: artifact.storageKey,
+          target: artifactStorageTarget,
+          expiresInSeconds: 900,
+        });
+        return { url: result.url, headers: result.headers };
+      }
+
+      return { url: `/proxy/files/${artifact.fileId}/artifacts/${artifact.artifactId}/download` };
+    },
+
+    async getArtifactDownloadUrlForFile(
+      fileId: string,
+      artifactId: string,
+      ctx: FileProviderContext,
+    ): Promise<{ url: string; headers?: Record<string, string> }> {
+      await requireReadableFile(fileId, ctx);
+      const artifact = await getBoundArtifact(fileId, artifactId);
+      const file = await db.findOne<FileRecord>({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+      const artifactStorageTarget = getArtifactStorageTarget(file ?? { policy: '' });
+
+      if (getStorageCapabilities(storage, artifactStorageTarget).signedDownloadUrls && storage.signDownloadUrl) {
+        const result = await storage.signDownloadUrl({
+          key: artifact.storageKey,
+          target: artifactStorageTarget,
+          expiresInSeconds: 900,
+        });
+        return { url: result.url, headers: result.headers };
+      }
+
+      return { url: `/proxy/files/${fileId}/artifacts/${artifactId}/download` };
+    },
+
+    async getArtifactDownloadStreamForFile(
+      fileId: string,
+      artifactId: string,
+      ctx: FileProviderContext,
+    ): Promise<{ stream: ReadableStream; contentType: string; size: number }> {
+      await requireReadableFile(fileId, ctx);
+      const artifact = await getBoundArtifact(fileId, artifactId);
+
+      if (!storage.openDownloadStream) {
+        throw new Error('Storage adapter does not support streaming');
+      }
+
+      const file = await db.findOne<FileRecord>({
+        model: 'files',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+      const artifactStorageTarget = getArtifactStorageTarget(file ?? { policy: '' });
+      const stream = await storage.openDownloadStream({ key: artifact.storageKey, target: artifactStorageTarget });
+      return {
+        stream: stream as unknown as ReadableStream,
+        contentType: artifact.mimeType,
+        size: artifact.size,
+      };
+    },
+
+    async getReadableVersionForFile(
+      fileId: string,
+      ctx: FileProviderContext,
+      versionId?: string,
+    ) {
+      return getReadableVersionForFile(fileId, ctx, versionId);
+    },
+  };
+}
+
+export type ProcessingService = ReturnType<typeof createProcessingService>;

--- a/filefn/server/src/quota.routes.ts
+++ b/filefn/server/src/quota.routes.ts
@@ -1,0 +1,54 @@
+import type { FileFnPrincipal, AuthConfig } from './auth.js';
+import type { QuotaProvider } from './upload-sessions/service.js';
+import { resolvePrincipal } from './auth.js';
+import { FileFnError, authRequired, notFound } from './errors.js';
+
+export interface QuotaRoutesContext {
+  quota?: QuotaProvider;
+  auth: AuthConfig;
+}
+
+function getRequestId(request: Request): string | undefined {
+  return request.headers.get('x-request-id') || undefined;
+}
+
+function successResponse(data: unknown, requestId?: string): Response {
+  return Response.json({ ok: true, data, requestId }, { status: 200 });
+}
+
+function errorResponse(error: FileFnError, requestId?: string): Response {
+  return Response.json({ ok: false, error: error.toJSON(), requestId }, { status: error.statusCode });
+}
+
+export function createQuotaRoutes(ctx: QuotaRoutesContext) {
+  const { quota, auth } = ctx;
+
+  async function requireAuth(request: Request): Promise<FileFnPrincipal> {
+    const principal = await resolvePrincipal(request, auth);
+    if (!principal && auth.required !== false) {
+      throw authRequired();
+    }
+    return principal || { principalId: 'anonymous' };
+  }
+
+  return {
+    async getStorageQuota(request: Request): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+
+        if (!quota?.getUsage) {
+          throw notFound('Quota');
+        }
+
+        const usage = await quota.getUsage(principal.principalId, principal.tenantId);
+        return successResponse(usage, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+  };
+}
+
+export type QuotaRoutes = ReturnType<typeof createQuotaRoutes>;

--- a/filefn/server/src/router.ts
+++ b/filefn/server/src/router.ts
@@ -1,0 +1,206 @@
+import type { UploadSessionRoutes } from './upload-sessions/routes.js';
+import type { FileRoutes } from './files/routes.js';
+import type { GrantsRoutes } from './authz/grants.routes.js';
+import type { SharesRoutes } from './shares/routes.js';
+import type { ProcessingRoutes } from './processing/routes.js';
+import type { PolicyRoutes } from './policies.routes.js';
+import type { QuotaRoutes } from './quota.routes.js';
+
+export interface FileFnRouterConfig {
+  uploadRoutes: UploadSessionRoutes;
+  fileRoutes: FileRoutes;
+  grantsRoutes?: GrantsRoutes;
+  sharesRoutes?: SharesRoutes;
+  processingRoutes?: ProcessingRoutes;
+  policyRoutes?: PolicyRoutes;
+  quotaRoutes?: QuotaRoutes;
+}
+
+export function createRouter(config: FileFnRouterConfig) {
+  const { uploadRoutes, fileRoutes, grantsRoutes, sharesRoutes, processingRoutes, policyRoutes, quotaRoutes } = config;
+  const reservedTopLevelPaths = new Set([
+    'upload',
+    'policies',
+    'quota',
+    'proxy',
+    'grants',
+    'shares',
+    'processing',
+  ]);
+
+  return {
+    async handle(request: Request): Promise<Response | null> {
+      const url = new URL(request.url);
+      const path = url.pathname;
+      const method = request.method;
+
+      // Upload session routes
+      if (path === '/upload/init' && method === 'POST') {
+        return uploadRoutes.initSession(request);
+      }
+
+      const statusMatch = path.match(/^\/upload\/([^/]+)\/status$/);
+      if (statusMatch && method === 'GET') {
+        return uploadRoutes.getStatus(request, statusMatch[1]);
+      }
+
+      const signMatch = path.match(/^\/upload\/([^/]+)\/parts\/(\d+)\/sign$/);
+      if (signMatch && method === 'POST') {
+        return uploadRoutes.signPart(request, signMatch[1], parseInt(signMatch[2], 10));
+      }
+
+      const completePartMatch = path.match(/^\/upload\/([^/]+)\/parts\/(\d+)\/complete$/);
+      if (completePartMatch && method === 'POST') {
+        return uploadRoutes.completePart(request, completePartMatch[1], parseInt(completePartMatch[2], 10));
+      }
+
+      const uploadPartMatch = path.match(/^\/upload\/([^/]+)\/parts\/(\d+)$/);
+      if (uploadPartMatch && method === 'PUT') {
+        return uploadRoutes.uploadPartBytes(request, uploadPartMatch[1], parseInt(uploadPartMatch[2], 10));
+      }
+
+      const completeMatch = path.match(/^\/upload\/([^/]+)\/complete$/);
+      if (completeMatch && method === 'POST') {
+        return uploadRoutes.completeSession(request, completeMatch[1]);
+      }
+
+      const abortMatch = path.match(/^\/upload\/([^/]+)\/abort$/);
+      if (abortMatch && method === 'POST') {
+        return uploadRoutes.abortSession(request, abortMatch[1]);
+      }
+
+      // Policy routes
+      if (policyRoutes && path === '/policies' && method === 'GET') {
+        return policyRoutes.listPolicies(request);
+      }
+
+      // Quota routes
+      if (quotaRoutes && path === '/quota/storage' && method === 'GET') {
+        return quotaRoutes.getStorageQuota(request);
+      }
+
+      // File routes
+      if (path === '/' && method === 'GET') {
+        return fileRoutes.listFiles(request);
+      }
+
+      // Keep reserved route prefixes above file-id routing so top-level resources never shadow explicit handlers.
+      const fileMatch = path.match(/^\/([^/]+)$/);
+      const isFileRoute = fileMatch && !reservedTopLevelPaths.has(fileMatch[1]);
+      if (isFileRoute && method === 'GET') {
+        return fileRoutes.getFile(request, fileMatch[1]);
+      }
+
+      if (isFileRoute && method === 'DELETE') {
+        return fileRoutes.deleteFile(request, fileMatch[1]);
+      }
+
+      const downloadMatch = path.match(/^\/([^/]+)\/download$/);
+      if (downloadMatch && method === 'GET') {
+        return fileRoutes.downloadFile(request, downloadMatch[1]);
+      }
+
+      const renderMatch = path.match(/^\/([^/]+)\/render$/);
+      if (renderMatch && method === 'GET') {
+        return fileRoutes.renderFile(request, renderMatch[1]);
+      }
+
+      const versionsMatch = path.match(/^\/([^/]+)\/versions$/);
+      if (versionsMatch && method === 'GET') {
+        return fileRoutes.listVersions(request, versionsMatch[1]);
+      }
+
+      const versionDownloadMatch = path.match(/^\/([^/]+)\/versions\/([^/]+)\/download$/);
+      if (versionDownloadMatch && method === 'GET') {
+        return fileRoutes.downloadFile(request, versionDownloadMatch[1], versionDownloadMatch[2]);
+      }
+
+      const versionMetadataMatch = path.match(/^\/([^/]+)\/versions\/([^/]+)$/);
+      if (versionMetadataMatch && method === 'GET') {
+        return fileRoutes.getVersion(request, versionMetadataMatch[1], versionMetadataMatch[2]);
+      }
+
+      // Proxy download routes
+      const proxyDownloadMatch = path.match(/^\/proxy\/files\/([^/]+)\/download$/);
+      if (proxyDownloadMatch && method === 'GET') {
+        return fileRoutes.proxyDownloadFile(request, proxyDownloadMatch[1]);
+      }
+
+      const proxyVersionDownloadMatch = path.match(/^\/proxy\/files\/([^/]+)\/versions\/([^/]+)\/download$/);
+      if (proxyVersionDownloadMatch && method === 'GET') {
+        return fileRoutes.proxyDownloadFile(request, proxyVersionDownloadMatch[1], proxyVersionDownloadMatch[2]);
+      }
+
+      if (sharesRoutes) {
+        const proxyShareDownloadMatch = path.match(/^\/proxy\/share-links\/([^/]+)\/download$/);
+        if (proxyShareDownloadMatch && method === 'GET') {
+          return sharesRoutes.proxyDownloadViaShareLink(request, proxyShareDownloadMatch[1]);
+        }
+      }
+
+      // Grant routes
+      if (grantsRoutes) {
+        const permissionsMatch = path.match(/^\/([^/]+)\/permissions$/);
+        if (permissionsMatch && method === 'POST') {
+          return grantsRoutes.createGrant(request, permissionsMatch[1]);
+        }
+        if (permissionsMatch && method === 'GET') {
+          return grantsRoutes.listGrants(request, permissionsMatch[1]);
+        }
+
+        const revokePermissionMatch = path.match(/^\/([^/]+)\/permissions\/([^/]+)$/);
+        if (revokePermissionMatch && method === 'DELETE') {
+          return grantsRoutes.revokeGrant(request, revokePermissionMatch[1], revokePermissionMatch[2]);
+        }
+      }
+
+      // Share link routes
+      if (sharesRoutes) {
+        const shareLinksMatch = path.match(/^\/([^/]+)\/share-links$/);
+        if (shareLinksMatch && method === 'POST') {
+          return sharesRoutes.createShareLink(request, shareLinksMatch[1]);
+        }
+        if (shareLinksMatch && method === 'GET') {
+          return sharesRoutes.listShareLinks(request, shareLinksMatch[1]);
+        }
+
+        const shareLinkDownloadMatch = path.match(/^\/share-links\/([^/]+)\/download$/);
+        if (shareLinkDownloadMatch && method === 'GET') {
+          return sharesRoutes.downloadViaShareLink(request, shareLinkDownloadMatch[1]);
+        }
+
+        const revokeShareMatch = path.match(/^\/([^/]+)\/share-links\/([^/]+)$/);
+        if (revokeShareMatch && method === 'DELETE') {
+          return sharesRoutes.revokeShareLink(request, revokeShareMatch[1], revokeShareMatch[2]);
+        }
+      }
+
+      // Processing routes
+      if (processingRoutes) {
+        const artifactsMatch = path.match(/^\/([^/]+)\/artifacts$/);
+        if (artifactsMatch && method === 'GET') {
+          return processingRoutes.listArtifacts(request, artifactsMatch[1]);
+        }
+
+        const artifactDownloadMatch = path.match(/^\/([^/]+)\/artifacts\/([^/]+)\/download$/);
+        if (artifactDownloadMatch && method === 'GET') {
+          return processingRoutes.downloadArtifact(request, artifactDownloadMatch[1], artifactDownloadMatch[2]);
+        }
+
+        const proxyArtifactDownloadMatch = path.match(/^\/proxy\/files\/([^/]+)\/artifacts\/([^/]+)\/download$/);
+        if (proxyArtifactDownloadMatch && method === 'GET') {
+          return processingRoutes.proxyDownloadArtifact(request, proxyArtifactDownloadMatch[1], proxyArtifactDownloadMatch[2]);
+        }
+
+        const processMatch = path.match(/^\/([^/]+)\/process$/);
+        if (processMatch && method === 'POST') {
+          return processingRoutes.triggerProcessing(request, processMatch[1]);
+        }
+      }
+
+      return null; // Route not found
+    },
+  };
+}
+
+export type FileFnRouter = ReturnType<typeof createRouter>;

--- a/filefn/server/src/schema.ts
+++ b/filefn/server/src/schema.ts
@@ -1,0 +1,166 @@
+import type { TableSchema, TableSchemaMap } from '@superfunctions/db';
+
+export interface FileFnSchemaOptions {
+  namespace?: string;
+}
+
+export function getSchema(options: FileFnSchemaOptions = {}): { version: number; schemas: TableSchema[] } {
+  const ns = options.namespace || 'filefn';
+
+  const files: TableSchema = {
+    modelName: 'files',
+    fields: {
+      fileId: { type: 'string', required: true, unique: true },
+      currentVersionId: { type: 'string', required: true },
+      ownerId: { type: 'string', required: true },
+      tenantId: { type: 'string', required: false },
+      visibility: { type: 'string', required: true },
+      policy: { type: 'string', required: true },
+      mimeType: { type: 'string', required: true },
+      size: { type: 'number', required: true },
+      name: { type: 'string', required: true },
+      metadata: { type: 'json', required: false },
+      createdAt: { type: 'string', required: true },
+      updatedAt: { type: 'string', required: true },
+    },
+    indexes: [
+      { name: `${ns}_files_owner_idx`, fields: ['ownerId'] },
+      { name: `${ns}_files_tenant_idx`, fields: ['tenantId'] },
+    ],
+  };
+
+  const fileVersions: TableSchema = {
+    modelName: 'fileVersions',
+    fields: {
+      versionId: { type: 'string', required: true, unique: true },
+      fileId: { type: 'string', required: true },
+      storageKey: { type: 'string', required: true },
+      mimeType: { type: 'string', required: true },
+      size: { type: 'number', required: true },
+      checksumSha256Base64: { type: 'string', required: false },
+      tenantId: { type: 'string', required: false },
+      createdAt: { type: 'string', required: true },
+    },
+    indexes: [
+      { name: `${ns}_versions_file_idx`, fields: ['fileId'] },
+      { name: `${ns}_versions_checksum_idx`, fields: ['checksumSha256Base64', 'tenantId'] },
+    ],
+  };
+
+  const uploadSessions: TableSchema = {
+    modelName: 'uploadSessions',
+    fields: {
+      uploadSessionId: { type: 'string', required: true, unique: true },
+      status: { type: 'string', required: true },
+      policy: { type: 'string', required: true },
+      fileId: { type: 'string', required: false },
+      fileName: { type: 'string', required: true },
+      mimeType: { type: 'string', required: true },
+      size: { type: 'number', required: true },
+      uploadMode: { type: 'string', required: true },
+      chunkSizeBytes: { type: 'number', required: true },
+      totalParts: { type: 'number', required: true },
+      storageKey: { type: 'string', required: true },
+      storageUploadId: { type: 'string', required: false },
+      ownerId: { type: 'string', required: true },
+      tenantId: { type: 'string', required: false },
+      metadata: { type: 'json', required: false },
+      idempotencyKey: { type: 'string', required: false },
+      idempotencyPayloadHash: { type: 'string', required: false },
+      completionVersionId: { type: 'string', required: false },
+      uploadSessionToken: { type: 'string', required: false },
+      uploadSessionTokenHash: { type: 'string', required: false },
+      expiresAt: { type: 'string', required: true },
+      createdAt: { type: 'string', required: true },
+    },
+    indexes: [
+      { name: `${ns}_sessions_idem_idx`, fields: ['idempotencyKey'], unique: true },
+      { name: `${ns}_sessions_expires_idx`, fields: ['expiresAt'] },
+    ],
+  };
+
+  const uploadParts: TableSchema = {
+    modelName: 'uploadParts',
+    fields: {
+      uploadSessionId: { type: 'string', required: true },
+      partNumber: { type: 'number', required: true },
+      etag: { type: 'string', required: true },
+      size: { type: 'number', required: true },
+      checksumSha256Base64: { type: 'string', required: false },
+    },
+    indexes: [
+      { name: `${ns}_parts_session_idx`, fields: ['uploadSessionId'] },
+    ],
+    constraints: [
+      { name: `${ns}_parts_unique`, type: 'unique', fields: ['uploadSessionId', 'partNumber'] },
+    ],
+  };
+
+  const filePermissions: TableSchema = {
+    modelName: 'filePermissions',
+    fields: {
+      permissionId: { type: 'string', required: true, unique: true },
+      fileId: { type: 'string', required: true },
+      userId: { type: 'string', required: false },
+      role: { type: 'string', required: false },
+      tenantId: { type: 'string', required: false },
+      canRead: { type: 'boolean', required: true },
+      canWrite: { type: 'boolean', required: true },
+      canDelete: { type: 'boolean', required: true },
+      canShare: { type: 'boolean', required: true },
+      expiresAt: { type: 'string', required: false },
+      createdAt: { type: 'string', required: true },
+    },
+    indexes: [
+      { name: `${ns}_perms_file_idx`, fields: ['fileId'] },
+      { name: `${ns}_perms_user_idx`, fields: ['userId'] },
+    ],
+  };
+
+  const fileShares: TableSchema = {
+    modelName: 'fileShares',
+    fields: {
+      tokenHash: { type: 'string', required: true, unique: true },
+      fileId: { type: 'string', required: true },
+      versionId: { type: 'string', required: false },
+      expiresAt: { type: 'string', required: false },
+      requiresAuth: { type: 'boolean', required: true },
+      maxDownloads: { type: 'number', required: false },
+      downloads: { type: 'number', required: true },
+      createdAt: { type: 'string', required: true },
+      revokedAt: { type: 'string', required: false },
+    },
+    indexes: [
+      { name: `${ns}_shares_file_idx`, fields: ['fileId'] },
+    ],
+  };
+
+  const fileArtifacts: TableSchema = {
+    modelName: 'fileArtifacts',
+    fields: {
+      artifactId: { type: 'string', required: true, unique: true },
+      fileId: { type: 'string', required: true },
+      versionId: { type: 'string', required: true },
+      kind: { type: 'string', required: true },
+      storageKey: { type: 'string', required: true },
+      mimeType: { type: 'string', required: true },
+      size: { type: 'number', required: false },
+      metadata: { type: 'json', required: false },
+      createdAt: { type: 'string', required: true },
+    },
+    indexes: [
+      { name: `${ns}_artifacts_file_idx`, fields: ['fileId'] },
+      { name: `${ns}_artifacts_version_idx`, fields: ['versionId'] },
+    ],
+  };
+
+  return {
+    version: 1,
+    schemas: [files, fileVersions, uploadSessions, uploadParts, filePermissions, fileShares, fileArtifacts],
+  };
+}
+
+export function getSchemaMap(options: FileFnSchemaOptions = {}): TableSchemaMap {
+  const { schemas } = getSchema(options);
+  return Object.fromEntries(schemas.map(s => [s.modelName, s]));
+}

--- a/filefn/server/src/shares/routes.ts
+++ b/filefn/server/src/shares/routes.ts
@@ -1,0 +1,185 @@
+import type { SharesService } from './service.js';
+import type { FileFnPrincipal, AuthConfig } from '../auth.js';
+import type { RateLimiter } from '@superfunctions/middleware';
+import { resolvePrincipal } from '../auth.js';
+import { FileFnError, authRequired, rateLimited } from '../errors.js';
+
+export interface SharesRouteContext {
+  service: SharesService;
+  auth: AuthConfig;
+  rateLimiter?: RateLimiter;
+  rateLimits?: {
+    shareDownload?: {
+      windowSeconds: number;
+      maxRequests: number;
+    };
+  };
+}
+
+function getRequestId(request: Request): string | undefined {
+  return request.headers.get('x-request-id') || undefined;
+}
+
+function successResponse(data: unknown, requestId?: string): Response {
+  return Response.json({ ok: true, data, requestId }, { status: 200 });
+}
+
+function createdResponse(data: unknown, requestId?: string): Response {
+  return Response.json({ ok: true, data, requestId }, { status: 201 });
+}
+
+function errorResponse(error: FileFnError, requestId?: string): Response {
+  return Response.json({ ok: false, error: error.toJSON(), requestId }, { status: error.statusCode });
+}
+
+export function createSharesRoutes(ctx: SharesRouteContext) {
+  const { service, auth, rateLimiter, rateLimits } = ctx;
+
+  async function requireAuth(request: Request): Promise<FileFnPrincipal> {
+    const principal = await resolvePrincipal(request, auth);
+    if (!principal && auth.required !== false) {
+      throw authRequired();
+    }
+    return principal || { principalId: 'anonymous' };
+  }
+
+  async function optionalAuth(request: Request): Promise<FileFnPrincipal | null> {
+    return resolvePrincipal(request, auth);
+  }
+
+  async function checkRateLimit(
+    principal: FileFnPrincipal | null,
+    categoryLimit?: { windowSeconds: number; maxRequests: number }
+  ): Promise<void> {
+    if (!rateLimiter || !categoryLimit) {
+      return;
+    }
+
+    const result = await rateLimiter.check({
+      key: `share-download:${principal?.tenantId || 'global'}:${principal?.principalId || 'anonymous'}`,
+      windowSeconds: categoryLimit.windowSeconds,
+      limit: categoryLimit.maxRequests,
+    });
+    if (!result.allowed) {
+      throw rateLimited(result.resetAt);
+    }
+  }
+
+  return {
+    async createShareLink(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const body = await request.json() as {
+          versionId?: string;
+          expiresAt?: string;
+          requiresAuth?: boolean;
+          maxDownloads?: number;
+        };
+
+        const result = await service.createShareLink(
+          {
+            fileId,
+            versionId: body.versionId,
+            expiresAt: body.expiresAt,
+            requiresAuth: body.requiresAuth,
+            maxDownloads: body.maxDownloads,
+          },
+          { principalId: principal.principalId, tenantId: principal.tenantId, requestId }
+        );
+
+        return createdResponse(result, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async downloadViaShareLink(request: Request, token: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await optionalAuth(request);
+        await checkRateLimit(principal, rateLimits?.shareDownload);
+
+        const result = await service.downloadViaShareLink(token, {
+          principalId: principal?.principalId || 'anonymous',
+          tenantId: principal?.tenantId,
+          isAuthenticated: !!principal,
+          requestId,
+        });
+
+        return successResponse({
+          url: result.url,
+          headers: result.headers,
+          fileName: result.fileName,
+          mimeType: result.mimeType,
+        }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async proxyDownloadViaShareLink(request: Request, token: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await optionalAuth(request);
+        await checkRateLimit(principal, rateLimits?.shareDownload);
+
+        const result = await service.getDownloadStreamViaShareLink(token, {
+          principalId: principal?.principalId || 'anonymous',
+          tenantId: principal?.tenantId,
+          isAuthenticated: !!principal,
+          requestId,
+        });
+
+        return new Response(result.stream, {
+          status: 200,
+          headers: {
+            'Content-Type': result.contentType,
+            'Content-Length': result.size.toString(),
+          },
+        });
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async revokeShareLink(request: Request, fileId: string, token: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        await service.revokeShareLink(fileId, token, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({ revoked: true }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+
+    async listShareLinks(request: Request, fileId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await requireAuth(request);
+        const shares = await service.listShareLinks(fileId, {
+          principalId: principal.principalId,
+          tenantId: principal.tenantId,
+          requestId,
+        });
+
+        return successResponse({ shares }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) return errorResponse(err, requestId);
+        throw err;
+      }
+    },
+  };
+}
+
+export type SharesRoutes = ReturnType<typeof createSharesRoutes>;

--- a/filefn/server/src/shares/service.ts
+++ b/filefn/server/src/shares/service.ts
@@ -1,0 +1,310 @@
+import type { Adapter } from '@superfunctions/db';
+import { getStorageCapabilities, type StorageAdapter } from '@superfunctions/storage';
+import type { FileProviderContext } from '@superfunctions/files';
+import type { FileRecord, FileVersionRecord } from '../files/service.js';
+import { resolveStorageTarget, type PolicyRegistry } from '../policies.js';
+import { createHash, randomBytes } from 'crypto';
+import * as errors from '../errors.js';
+
+export interface FileShareRecord {
+  tokenHash: string;
+  fileId: string;
+  versionId: string | null;
+  expiresAt: string | null;
+  requiresAuth: boolean;
+  maxDownloads: number | null;
+  downloads: number;
+  createdAt: string;
+  revokedAt: string | null;
+}
+
+interface FilePermissionRecord {
+  fileId: string;
+  userId?: string | null;
+  tenantId?: string | null;
+  canShare?: boolean;
+  expiresAt?: string | null;
+}
+
+export interface SharesServiceConfig {
+  db: Adapter;
+  storage: StorageAdapter;
+  policies?: Pick<PolicyRegistry, 'get'>;
+  namespace?: string;
+  signedUrlTtlSeconds?: number;
+}
+
+export interface CreateShareLinkInput {
+  fileId: string;
+  versionId?: string;
+  expiresAt?: string;
+  requiresAuth?: boolean;
+  maxDownloads?: number;
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function generateToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function isGrantExpired(expiresAt: string | null | undefined): boolean {
+  if (!expiresAt) {
+    return false;
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiresAtMs)) {
+    return false;
+  }
+  return expiresAtMs <= Date.now();
+}
+
+export function createSharesService(config: SharesServiceConfig) {
+  const { db, storage, policies, namespace = 'filefn', signedUrlTtlSeconds = 900 } = config;
+
+  async function getFile(fileId: string): Promise<FileRecord | null> {
+    return db.findOne<FileRecord>({
+      model: 'files',
+      where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+      namespace,
+    });
+  }
+
+  async function canShareFile(file: FileRecord, ctx: FileProviderContext): Promise<boolean> {
+    if (file.ownerId === ctx.principalId) {
+      return true;
+    }
+    if (!ctx.principalId) {
+      return false;
+    }
+
+    const grants = await db.findMany<FilePermissionRecord>({
+      model: 'filePermissions',
+      where: [{ field: 'fileId', operator: 'eq', value: file.fileId }],
+      namespace,
+    });
+
+    return grants.some((grant) => {
+      if (!grant?.canShare || isGrantExpired(grant.expiresAt)) {
+        return false;
+      }
+      return grant.userId === ctx.principalId || (grant.tenantId && grant.tenantId === ctx.tenantId);
+    });
+  }
+
+  async function incrementDownloads(tokenHash: string, currentDownloads: number): Promise<void> {
+    await db.update({
+      model: 'fileShares',
+      where: [{ field: 'tokenHash', operator: 'eq', value: tokenHash }],
+      data: { downloads: currentDownloads + 1 },
+      namespace,
+    });
+  }
+
+  async function resolveDownload(
+    token: string,
+    ctx: FileProviderContext & { isAuthenticated?: boolean },
+  ): Promise<{ tokenHash: string; share: FileShareRecord; file: FileRecord; version: FileVersionRecord }> {
+    const tokenHash = hashToken(token);
+
+    const share = await db.findOne<FileShareRecord>({
+      model: 'fileShares',
+      where: [{ field: 'tokenHash', operator: 'eq', value: tokenHash }],
+      namespace,
+    });
+
+    if (!share) {
+      throw errors.shareNotFound();
+    }
+
+    if (share.revokedAt) {
+      throw errors.shareRevoked();
+    }
+
+    const now = new Date().toISOString();
+    if (share.expiresAt && share.expiresAt < now) {
+      throw errors.shareExpired();
+    }
+
+    if (share.maxDownloads !== null && share.downloads >= share.maxDownloads) {
+      throw errors.shareDownloadsExceeded();
+    }
+
+    if (share.requiresAuth && !ctx.isAuthenticated) {
+      throw errors.authRequired();
+    }
+
+    const file = await getFile(share.fileId);
+    if (!file) {
+      throw errors.shareNotFound();
+    }
+
+    const versionId = share.versionId || file.currentVersionId;
+    const version = await db.findOne<FileVersionRecord>({
+      model: 'fileVersions',
+      where: [{ field: 'versionId', operator: 'eq', value: versionId }],
+      namespace,
+    });
+
+    if (!version || version.fileId !== file.fileId) {
+      throw errors.notFound('Version');
+    }
+
+    return { tokenHash, share, file, version };
+  }
+
+  return {
+    async createShareLink(
+      input: CreateShareLinkInput,
+      ctx: FileProviderContext
+    ): Promise<{ token: string; expiresAt: string | null }> {
+      const file = await getFile(input.fileId);
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const canShare = await canShareFile(file, ctx);
+      if (!canShare) {
+        throw errors.forbidden();
+      }
+
+      const token = generateToken();
+      const tokenHash = hashToken(token);
+
+      const share: FileShareRecord = {
+        tokenHash,
+        fileId: input.fileId,
+        versionId: input.versionId || null,
+        expiresAt: input.expiresAt || null,
+        requiresAuth: input.requiresAuth ?? false,
+        maxDownloads: input.maxDownloads ?? null,
+        downloads: 0,
+        createdAt: new Date().toISOString(),
+        revokedAt: null,
+      };
+
+      await db.create({
+        model: 'fileShares',
+        data: share,
+        namespace,
+      });
+
+      return { token, expiresAt: share.expiresAt };
+    },
+
+    async downloadViaShareLink(
+      token: string,
+      ctx: FileProviderContext & { isAuthenticated?: boolean }
+    ): Promise<{ url: string; headers?: Record<string, string>; fileName: string; mimeType: string }> {
+      const { tokenHash, share, file, version } = await resolveDownload(token, ctx);
+      const storageTarget = resolveStorageTarget(policies?.get(file.policy) ?? {});
+
+      if (getStorageCapabilities(storage, storageTarget).signedDownloadUrls && storage.signDownloadUrl) {
+        const result = await storage.signDownloadUrl({
+          key: version.storageKey,
+          target: storageTarget,
+          expiresInSeconds: signedUrlTtlSeconds,
+        });
+        await incrementDownloads(tokenHash, share.downloads);
+        return { url: result.url, headers: result.headers, fileName: file.name, mimeType: file.mimeType };
+      }
+
+      return {
+        url: `/proxy/share-links/${encodeURIComponent(token)}/download`,
+        fileName: file.name,
+        mimeType: file.mimeType,
+      };
+    },
+
+    async getDownloadStreamViaShareLink(
+      token: string,
+      ctx: FileProviderContext & { isAuthenticated?: boolean },
+    ): Promise<{ stream: ReadableStream; contentType: string; size: number; fileName: string; mimeType: string }> {
+      const { tokenHash, share, file, version } = await resolveDownload(token, ctx);
+      const storageTarget = resolveStorageTarget(policies?.get(file.policy) ?? {});
+
+      if (!storage.openDownloadStream) {
+        throw new Error('Storage adapter does not support streaming');
+      }
+
+      const stream = await storage.openDownloadStream({ key: version.storageKey, target: storageTarget });
+      await incrementDownloads(tokenHash, share.downloads);
+
+      return {
+        stream: stream as unknown as ReadableStream,
+        contentType: version.mimeType,
+        size: version.size,
+        fileName: file.name,
+        mimeType: file.mimeType,
+      };
+    },
+
+    async revokeShareLink(fileId: string, token: string, ctx: FileProviderContext): Promise<void> {
+      const file = await getFile(fileId);
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const canShare = await canShareFile(file, ctx);
+      if (!canShare) {
+        throw errors.forbidden();
+      }
+
+      const tokenHash = hashToken(token);
+
+      const share = await db.findOne<FileShareRecord>({
+        model: 'fileShares',
+        where: [
+          { field: 'tokenHash', operator: 'eq', value: tokenHash },
+          { field: 'fileId', operator: 'eq', value: fileId },
+        ],
+        namespace,
+      });
+
+      if (!share) {
+        throw errors.shareNotFound();
+      }
+
+      await db.update({
+        model: 'fileShares',
+        where: [{ field: 'tokenHash', operator: 'eq', value: tokenHash }],
+        data: { revokedAt: new Date().toISOString() },
+        namespace,
+      });
+    },
+
+    async listShareLinks(fileId: string, ctx: FileProviderContext): Promise<Array<Omit<FileShareRecord, 'tokenHash'> & { tokenHashPrefix: string }>> {
+      const file = await getFile(fileId);
+      if (!file) {
+        throw errors.notFound('File');
+      }
+
+      const canShare = await canShareFile(file, ctx);
+      if (!canShare) {
+        throw errors.forbidden();
+      }
+
+      const shares = await db.findMany<FileShareRecord>({
+        model: 'fileShares',
+        where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+        namespace,
+      });
+
+      return shares.map(share => ({
+        tokenHashPrefix: share.tokenHash.substring(0, 8),
+        fileId: share.fileId,
+        versionId: share.versionId,
+        expiresAt: share.expiresAt,
+        requiresAuth: share.requiresAuth,
+        maxDownloads: share.maxDownloads,
+        downloads: share.downloads,
+        createdAt: share.createdAt,
+        revokedAt: share.revokedAt,
+      }));
+    },
+  };
+}
+
+export type SharesService = ReturnType<typeof createSharesService>;

--- a/filefn/server/src/upload-sessions/routes.ts
+++ b/filefn/server/src/upload-sessions/routes.ts
@@ -1,0 +1,248 @@
+import type { UploadSessionService } from './service.js';
+import type { FileFnPrincipal, AuthConfig } from '../auth.js';
+import type { RateLimiter } from '@superfunctions/middleware';
+import { resolvePrincipal } from '../auth.js';
+import { FileFnError, authRequired, rateLimited } from '../errors.js';
+
+export interface RouteContext {
+  service: UploadSessionService;
+  auth: AuthConfig;
+  rateLimiter?: RateLimiter;
+  rateLimits?: {
+    uploadInit?: {
+      windowSeconds: number;
+      maxRequests: number;
+    };
+    uploadSign?: {
+      windowSeconds: number;
+      maxRequests: number;
+    };
+    uploadComplete?: {
+      windowSeconds: number;
+      maxRequests: number;
+    };
+  };
+  legacyGlobalRateLimit?: boolean;
+}
+
+function getRequestId(request: Request): string | undefined {
+  return request.headers.get('x-request-id') || undefined;
+}
+
+function getIdempotencyKey(request: Request): string | undefined {
+  return request.headers.get('x-idempotency-key') || undefined;
+}
+
+function getUploadSessionToken(request: Request): string | undefined {
+  return request.headers.get('x-upload-session-token') || undefined;
+}
+
+function successResponse(data: unknown, requestId?: string, warnings: string[] = []): Response {
+  return Response.json(
+    { ok: true, data, warnings, requestId },
+    { status: 200 }
+  );
+}
+
+function errorResponse(error: FileFnError, requestId?: string): Response {
+  return Response.json(
+    { ok: false, error: error.toJSON(), requestId },
+    { status: error.statusCode }
+  );
+}
+
+async function parseJsonBody<T>(request: Request): Promise<T> {
+  return await request.json() as T;
+}
+
+export function createUploadSessionRoutes(ctx: RouteContext) {
+  const { service, auth, rateLimiter, rateLimits, legacyGlobalRateLimit = false } = ctx;
+
+  async function resolveCaller(request: Request): Promise<FileFnPrincipal | null> {
+    const principal = await resolvePrincipal(request, auth);
+    if (!principal && auth.required !== false) {
+      throw authRequired();
+    }
+    return principal;
+  }
+
+  async function checkRateLimit(
+    categoryKey: string,
+    principal: FileFnPrincipal | null,
+    categoryLimit?: { windowSeconds: number; maxRequests: number }
+  ): Promise<void> {
+    if (!rateLimiter) {
+      return;
+    }
+    if (!categoryLimit && !legacyGlobalRateLimit) {
+      return;
+    }
+
+    const result = await rateLimiter.check({
+      key: `${categoryKey}:${principal?.tenantId || 'global'}:${principal?.principalId || 'anonymous'}`,
+      windowSeconds: categoryLimit?.windowSeconds,
+      limit: categoryLimit?.maxRequests,
+    });
+    if (!result.allowed) {
+      throw rateLimited(result.resetAt);
+    }
+  }
+
+  return {
+    async initSession(request: Request): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await resolveCaller(request);
+        await checkRateLimit('upload-init', principal, rateLimits?.uploadInit);
+
+        const body = await parseJsonBody<{
+          policy: string;
+          fileName: string;
+          size: number;
+          mimeType: string;
+          fileId?: string;
+          metadata?: Record<string, unknown>;
+        }>(request);
+
+        const result = await service.createSession(
+          { ...body, idempotencyKey: getIdempotencyKey(request) },
+          { principalId: principal?.principalId, tenantId: principal?.tenantId, requestId }
+        );
+
+        return successResponse(result, requestId, result.warnings);
+      } catch (err) {
+        if (err instanceof FileFnError) {
+          return errorResponse(err, requestId);
+        }
+        throw err;
+      }
+    },
+
+    async getStatus(request: Request, uploadSessionId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await resolveCaller(request);
+        const result = await service.getSessionStatus(uploadSessionId, {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        }, getUploadSessionToken(request));
+        return successResponse(result, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) {
+          return errorResponse(err, requestId);
+        }
+        throw err;
+      }
+    },
+
+    async signPart(request: Request, uploadSessionId: string, partNumber: number): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await resolveCaller(request);
+        await checkRateLimit('upload-sign', principal, rateLimits?.uploadSign);
+
+        const body = await parseJsonBody<{ contentLength: number; checksumSha256Base64?: string }>(request);
+        const result = await service.signPart(uploadSessionId, partNumber, body.contentLength, {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        }, getUploadSessionToken(request));
+        return successResponse(result, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) {
+          return errorResponse(err, requestId);
+        }
+        throw err;
+      }
+    },
+
+    async uploadPartBytes(request: Request, uploadSessionId: string, partNumber: number): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await resolveCaller(request);
+        await checkRateLimit('upload-complete', principal, rateLimits?.uploadComplete);
+        // Rate limit check for data plane might differ, but using sign limit for now or skipping
+        // await checkRateLimit(`upload-part:${principal.principalId}`, requestId);
+
+        const contentLength = parseInt(request.headers.get('content-length') || '0', 10);
+        if (!request.body) {
+          throw new FileFnError('FILEFN_INVALID_REQUEST', 'Missing request body', 400);
+        }
+
+        const result = await service.uploadPartBytes(uploadSessionId, partNumber, request.body, contentLength, {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        }, getUploadSessionToken(request));
+        
+        return successResponse({ ...result, recorded: true }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) {
+          return errorResponse(err, requestId);
+        }
+        throw err;
+      }
+    },
+
+    async completePart(request: Request, uploadSessionId: string, partNumber: number): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await resolveCaller(request);
+        const body = await parseJsonBody<{ etag: string; size: number; checksumSha256Base64?: string }>(request);
+        await checkRateLimit('upload-complete', principal, rateLimits?.uploadComplete);
+
+        await service.completePart(uploadSessionId, partNumber, body.etag, body.size, {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        }, getUploadSessionToken(request));
+        return successResponse({ recorded: true }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) {
+          return errorResponse(err, requestId);
+        }
+        throw err;
+      }
+    },
+
+    async completeSession(request: Request, uploadSessionId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await resolveCaller(request);
+        await checkRateLimit('upload-complete', principal, rateLimits?.uploadComplete);
+        const result = await service.completeSession(uploadSessionId, {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        }, getUploadSessionToken(request));
+        return successResponse(result, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) {
+          return errorResponse(err, requestId);
+        }
+        throw err;
+      }
+    },
+
+    async abortSession(request: Request, uploadSessionId: string): Promise<Response> {
+      const requestId = getRequestId(request);
+      try {
+        const principal = await resolveCaller(request);
+        await service.abortSession(uploadSessionId, {
+          principalId: principal?.principalId,
+          tenantId: principal?.tenantId,
+          requestId,
+        }, getUploadSessionToken(request));
+        return successResponse({ aborted: true }, requestId);
+      } catch (err) {
+        if (err instanceof FileFnError) {
+          return errorResponse(err, requestId);
+        }
+        throw err;
+      }
+    },
+  };
+}
+
+export type UploadSessionRoutes = ReturnType<typeof createUploadSessionRoutes>;

--- a/filefn/server/src/upload-sessions/service.ts
+++ b/filefn/server/src/upload-sessions/service.ts
@@ -1,0 +1,1055 @@
+import type { Adapter } from '@superfunctions/db';
+import { getStorageCapabilities, type StorageAdapter } from '@superfunctions/storage';
+import type { FileProviderContext } from '@superfunctions/files';
+import {
+  matchesContentType,
+  resolveStorageTarget,
+  type Policy,
+  type PolicyRegistry,
+} from '../policies.js';
+import type { FileFnEventEmitter } from '../events.js';
+import type { Logger } from '../observability/logger.js';
+import type { DeduplicationService } from '../dedup/service.js';
+import type { ProcessingService } from '../processing/service.js';
+import * as errors from '../errors.js';
+import { createHash, randomBytes } from 'crypto';
+import {
+  createUploadStartedEvent,
+  createPartRecordedEvent,
+  createFileUploadedEvent,
+} from '../events.js';
+
+export interface QuotaProvider {
+  checkQuota(input: { principalId?: string; tenantId?: string; requestedBytes: number }): Promise<{
+    allowed: boolean;
+    current: number;
+    limit: number;
+    warning?: string;
+  }>;
+  recordUsage(input: { principalId?: string; tenantId?: string; bytes: number }): Promise<void>;
+  getUsage?(principalId?: string, tenantId?: string): Promise<{ current: number; limit: number }>;
+}
+
+export interface FileWriteAuthChecker {
+  canWriteFile(fileId: string, ctx: FileProviderContext): Promise<boolean>;
+}
+
+export interface UploadSessionServiceConfig {
+  db: Adapter;
+  storage: StorageAdapter;
+  policies: PolicyRegistry;
+  events: FileFnEventEmitter;
+  logger?: Logger;
+  quota?: QuotaProvider;
+  dedup?: DeduplicationService;
+  fileWriteChecker?: FileWriteAuthChecker;
+  processingService?: ProcessingService;
+  namespace?: string;
+  defaultChunkSizeBytes?: number;
+  uploadSessionTtlSeconds?: number;
+  signedUrlTtlSeconds?: number;
+  generateId?: () => string;
+}
+
+export interface CreateSessionInput {
+  policy: string;
+  fileName: string;
+  size: number;
+  mimeType: string;
+  fileId?: string;
+  metadata?: Record<string, unknown>;
+  idempotencyKey?: string;
+}
+
+export interface UploadSession {
+  uploadSessionId: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'aborted' | 'expired';
+  policy: string;
+  fileId: string | null;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  uploadMode: string;
+  chunkSizeBytes: number;
+  totalParts: number;
+  storageKey: string;
+  storageUploadId: string | null;
+  ownerId: string;
+  tenantId: string | null;
+  metadata?: Record<string, unknown> | null;
+  expiresAt: string;
+  createdAt: string;
+  idempotencyKey?: string | null;
+  idempotencyPayloadHash?: string | null;
+  completionVersionId?: string | null;
+  uploadSessionToken?: string | null;
+  uploadSessionTokenHash?: string | null;
+}
+
+function generateDefaultId(): string {
+  return `upl_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function hashPayload(input: CreateSessionInput, ctx: { principalId?: string; tenantId?: string }): string {
+  const payload = {
+    p: input.policy,
+    fn: input.fileName,
+    s: input.size,
+    mt: input.mimeType,
+    fid: input.fileId,
+    md: input.metadata,
+    pr: ctx.principalId,
+    tn: ctx.tenantId
+  };
+  const str = JSON.stringify(payload);
+  return createHash('sha256').update(str).digest('hex');
+}
+
+function isAnonymousContext(ctx: FileProviderContext): boolean {
+  return !ctx.principalId || ctx.principalId === 'anonymous';
+}
+
+function isAnonymousSession(session: UploadSession): boolean {
+  return session.ownerId === 'anonymous';
+}
+
+function generateUploadSessionToken(): string {
+  return `upls_live_${randomBytes(18).toString('base64url')}`;
+}
+
+function hashUploadSessionToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+function isExpiredAt(expiresAt: string): boolean {
+  const expiresAtMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiresAtMs)) {
+    return true;
+  }
+  return expiresAtMs <= Date.now();
+}
+
+async function forEachBodyChunk(
+  body: ReadableStream | Blob | Buffer,
+  onChunk: (chunk: Uint8Array) => Promise<void> | void
+): Promise<void> {
+  if (body instanceof ReadableStream) {
+    const reader = body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+      await onChunk(chunk);
+    }
+    return;
+  }
+
+  if (body instanceof Blob) {
+    await onChunk(new Uint8Array(await body.arrayBuffer()));
+    return;
+  }
+
+  if (Buffer.isBuffer(body)) {
+    await onChunk(body);
+    return;
+  }
+
+  throw new Error('Unsupported body type for proxy upload');
+}
+
+function computeStorageKey(
+  policy: Policy,
+  ctx: { fileName: string; principalId?: string; tenantId?: string; fileId: string; versionId: string }
+): string {
+  if (policy.storagePath) {
+    return policy.storagePath(ctx);
+  }
+  const parts: string[] = [];
+  if (ctx.tenantId) parts.push(ctx.tenantId);
+  if (ctx.principalId) parts.push(ctx.principalId);
+  parts.push(ctx.fileId);
+  parts.push(`${ctx.versionId}-${ctx.fileName}`);
+  return parts.join('/');
+}
+
+export function createUploadSessionService(config: UploadSessionServiceConfig) {
+  const {
+    db,
+    storage,
+    policies,
+    events,
+    logger,
+    quota,
+    dedup,
+    fileWriteChecker,
+    processingService,
+    namespace = 'filefn',
+    defaultChunkSizeBytes = 8 * 1024 * 1024, // 8 MiB
+    uploadSessionTtlSeconds = 86400, // 24h
+    signedUrlTtlSeconds = 900, // 15m
+    generateId = generateDefaultId,
+  } = config;
+
+  function selectUploadMode(storageTarget: string): string {
+    const capabilities = getStorageCapabilities(storage, storageTarget);
+    if (capabilities.signedUploadUrls && capabilities.multipart) {
+      return 'multipart-signed-url';
+    }
+    if (capabilities.proxyStreamingUpload) {
+      return 'proxy';
+    }
+    throw errors.noSupportedUploadMode();
+  }
+
+  function computeTotalParts(size: number, chunkSize: number): number {
+    return Math.ceil(size / chunkSize);
+  }
+
+  function proxyPartKey(storageKey: string, partNumber: number): string {
+    return `${storageKey}.part${partNumber}`;
+  }
+
+  async function deleteProxyTempPartObjects(session: UploadSession): Promise<void> {
+    if (session.uploadMode !== 'proxy' || !storage.deleteObject) {
+      return;
+    }
+    const policy = policies.get(session.policy);
+    const storageTarget = policy ? resolveStorageTarget(policy) : undefined;
+
+    const parts = await db.findMany<{ partNumber: number }>({
+      model: 'uploadParts',
+      where: [{ field: 'uploadSessionId', operator: 'eq', value: session.uploadSessionId }],
+      select: ['partNumber'],
+      namespace,
+    });
+
+    for (const part of parts) {
+      try {
+        await storage.deleteObject({ key: proxyPartKey(session.storageKey, part.partNumber), target: storageTarget });
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  }
+
+  return {
+    assertSessionAccess(session: UploadSession, ctx: FileProviderContext, uploadSessionToken?: string): void {
+      // Legacy safety: pre-binding records may not carry ownerId.
+      // Current sessions always persist ownerId, so this only preserves older fixtures.
+      if (!session.ownerId) {
+        return;
+      }
+
+      if (!isAnonymousSession(session)) {
+        if (!ctx.principalId || ctx.principalId !== session.ownerId) {
+          throw errors.forbidden();
+        }
+
+        const sessionTenant = session.tenantId ?? null;
+        const callerTenant = ctx.tenantId ?? null;
+        if (sessionTenant !== callerTenant) {
+          throw errors.forbidden();
+        }
+
+        return;
+      }
+
+      if (!uploadSessionToken) {
+        throw errors.sessionTokenRequired();
+      }
+
+      if (!session.uploadSessionTokenHash) {
+        throw errors.sessionTokenRequired();
+      }
+
+      if (hashUploadSessionToken(uploadSessionToken) !== session.uploadSessionTokenHash) {
+        throw errors.sessionTokenInvalid();
+      }
+    },
+
+    async createSession(input: CreateSessionInput, ctx: FileProviderContext): Promise<{
+      uploadSessionId: string;
+      uploadMode: string;
+      chunkSizeBytes: number;
+      totalParts: number;
+      expiresAt: string;
+      warnings: string[];
+      uploadSessionToken?: string;
+    }> {
+      const warnings: string[] = [];
+
+      // Check idempotency
+      if (input.idempotencyKey) {
+        const existing = await db.findOne<UploadSession>({
+          model: 'uploadSessions',
+          where: [{ field: 'idempotencyKey', operator: 'eq', value: input.idempotencyKey }],
+          namespace,
+        });
+
+        if (existing) {
+          const expectedHash = hashPayload(input, { principalId: ctx.principalId, tenantId: ctx.tenantId });
+          if (existing.idempotencyPayloadHash !== expectedHash) {
+            throw errors.idempotencyConflict();
+          }
+
+          let uploadSessionToken: string | undefined;
+          if (isAnonymousSession(existing)) {
+            if (existing.uploadSessionToken) {
+              uploadSessionToken = existing.uploadSessionToken;
+            } else {
+              // Older sessions may only have the hash persisted. Preserve access by
+              // minting and persisting a replacement token once, then replay it
+              // deterministically for future idempotent responses.
+              uploadSessionToken = generateUploadSessionToken();
+              await db.update({
+                model: 'uploadSessions',
+                where: [{ field: 'uploadSessionId', operator: 'eq', value: existing.uploadSessionId }],
+                data: {
+                  uploadSessionToken,
+                  uploadSessionTokenHash: hashUploadSessionToken(uploadSessionToken),
+                },
+                namespace,
+              });
+            }
+          }
+
+          return {
+            uploadSessionId: existing.uploadSessionId,
+            uploadMode: existing.uploadMode,
+            chunkSizeBytes: existing.chunkSizeBytes,
+            totalParts: existing.totalParts,
+            expiresAt: existing.expiresAt,
+            warnings: [],
+            uploadSessionToken,
+          };
+        }
+      }
+
+      // Validate policy
+      const policy = policies.get(input.policy);
+      if (!policy) {
+        throw errors.policyNotFound(input.policy);
+      }
+
+      // Validate constraints
+      if (policy.contentTypes && policy.contentTypes.length > 0) {
+        if (!policy.contentTypes.some((pattern) => matchesContentType(pattern, input.mimeType))) {
+          throw errors.policyContentTypeNotAllowed(input.policy, input.mimeType);
+        }
+      }
+
+      if (policy.maxSizeBytes !== undefined && input.size > policy.maxSizeBytes) {
+        throw errors.policyMaxSizeExceeded(input.policy, policy.maxSizeBytes, input.size);
+      }
+
+      // Check authorization for replace-by-fileId
+      if (input.fileId && fileWriteChecker) {
+        const canWrite = await fileWriteChecker.canWriteFile(input.fileId, ctx);
+        if (!canWrite) {
+          throw errors.forbidden({ fileId: input.fileId, operation: 'replace' });
+        }
+      }
+
+      // Check quota
+      if (quota) {
+        const quotaResult = await quota.checkQuota({
+          principalId: ctx.principalId,
+          tenantId: ctx.tenantId,
+          requestedBytes: input.size,
+        });
+
+        if (!quotaResult.allowed) {
+          throw errors.quotaExceeded(quotaResult.current, quotaResult.limit, input.size);
+        }
+
+        if (quotaResult.warning) {
+          warnings.push(quotaResult.warning);
+        }
+      }
+
+      const storageTarget = resolveStorageTarget(policy);
+      const uploadMode = selectUploadMode(storageTarget);
+      const chunkSizeBytes = defaultChunkSizeBytes;
+      const totalParts = computeTotalParts(input.size, chunkSizeBytes);
+      const uploadSessionId = generateId();
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + uploadSessionTtlSeconds * 1000).toISOString();
+      const fileId = input.fileId || `file_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+      const versionId = `ver_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+
+      const storageKey = computeStorageKey(policy, {
+        fileName: input.fileName,
+        principalId: ctx.principalId,
+        tenantId: ctx.tenantId,
+        fileId,
+        versionId,
+      });
+
+      let storageUploadId: string | null = null;
+      let uploadSessionToken: string | undefined;
+      let uploadSessionTokenHash: string | null = null;
+
+      if (isAnonymousContext(ctx)) {
+        uploadSessionToken = generateUploadSessionToken();
+        uploadSessionTokenHash = hashUploadSessionToken(uploadSessionToken);
+      }
+
+      // Create multipart upload only for multipart mode.
+      if (uploadMode === 'multipart-signed-url' && storage.createMultipartUpload) {
+        const result = await storage.createMultipartUpload({
+          key: storageKey,
+          target: storageTarget,
+          contentType: input.mimeType,
+        });
+        storageUploadId = result.uploadId;
+      }
+
+      // Save session
+      await db.create({
+        model: 'uploadSessions',
+        data: {
+          uploadSessionId,
+          status: 'pending',
+          policy: input.policy,
+          fileId,
+          fileName: input.fileName,
+          mimeType: input.mimeType,
+          size: input.size,
+          uploadMode,
+          chunkSizeBytes,
+          totalParts,
+          storageKey,
+          storageUploadId,
+          ownerId: ctx.principalId || 'anonymous',
+          tenantId: ctx.tenantId || null,
+          metadata: input.metadata ?? {},
+          idempotencyKey: input.idempotencyKey || null,
+          idempotencyPayloadHash: input.idempotencyKey ? hashPayload(input, { principalId: ctx.principalId, tenantId: ctx.tenantId }) : null,
+          uploadSessionToken: uploadSessionToken || null,
+          uploadSessionTokenHash,
+          expiresAt,
+          createdAt: now.toISOString(),
+        },
+        namespace,
+      });
+
+      events.emit('upload.started', createUploadStartedEvent({
+        uploadSessionId,
+        fileName: input.fileName,
+        size: input.size,
+        mimeType: input.mimeType,
+        policy: input.policy,
+        principalId: ctx.principalId,
+        tenantId: ctx.tenantId,
+      }, ctx.requestId));
+
+      logger?.info('Upload session created', {
+        uploadSessionId,
+        requestId: ctx.requestId,
+        fileName: input.fileName,
+        size: input.size,
+        uploadMode,
+        fileId,
+      });
+
+      return { uploadSessionId, uploadMode, chunkSizeBytes, totalParts, expiresAt, warnings, uploadSessionToken };
+    },
+
+    async getSessionStatus(uploadSessionId: string, ctx: FileProviderContext, uploadSessionToken?: string): Promise<{
+      uploadSessionId: string;
+      fileId?: string;
+      status: string;
+      totalParts: number;
+      recordedParts: number[];
+      uploadedParts: number[];
+      chunkSizeBytes: number;
+      fileSize: number;
+      expiresAt: string;
+    }> {
+      const session = await db.findOne<UploadSession>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      if (!session) {
+        throw errors.sessionNotFound();
+      }
+
+      this.assertSessionAccess(session, ctx, uploadSessionToken);
+
+      const parts = await db.findMany<{ partNumber: number }>({
+        model: 'uploadParts',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        select: ['partNumber'],
+        namespace,
+      });
+
+      const recordedParts = parts.map(p => p.partNumber).sort((a, b) => a - b);
+
+      return {
+        uploadSessionId,
+        fileId: session.fileId ?? undefined,
+        status: session.status,
+        totalParts: session.totalParts,
+        recordedParts,
+        uploadedParts: recordedParts,
+        chunkSizeBytes: session.chunkSizeBytes,
+        fileSize: session.size,
+        expiresAt: session.expiresAt,
+      };
+    },
+
+    async signPart(uploadSessionId: string, partNumber: number, contentLength: number, ctx: FileProviderContext, uploadSessionToken?: string): Promise<{
+      url: string;
+      headers?: Record<string, string>;
+      expiresAt: string;
+    }> {
+      const session = await db.findOne<UploadSession>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      if (!session) throw errors.sessionNotFound();
+      this.assertSessionAccess(session, ctx, uploadSessionToken);
+      if (session.status === 'aborted') throw errors.uploadAborted();
+      if (session.status === 'completed') throw errors.uploadAlreadyCompleted();
+      if (isExpiredAt(session.expiresAt)) throw errors.uploadExpired();
+      if (partNumber < 1 || partNumber > session.totalParts) throw errors.invalidPartNumber();
+
+      if (session.uploadMode === 'proxy') {
+        // Return URL to the proxy PUT endpoint
+        // The client will PUT to this URL
+        // We assume the router is mounted at root or handled correctly by client
+        // Returning a relative path that the client SDK resolves against baseUrl
+        return {
+          url: `/upload/${uploadSessionId}/parts/${partNumber}`,
+          headers: {
+            'content-type': session.mimeType === 'application/octet-stream' ? 'application/octet-stream' : session.mimeType
+          },
+          expiresAt: session.expiresAt
+        };
+      }
+
+      if (!storage.signMultipartUploadPartUrl) {
+        throw errors.noSupportedUploadMode();
+      }
+
+      const result = await storage.signMultipartUploadPartUrl({
+        key: session.storageKey,
+        target: policies.get(session.policy) ? resolveStorageTarget(policies.get(session.policy)!) : undefined,
+        uploadId: session.storageUploadId!,
+        partNumber,
+        expiresInSeconds: signedUrlTtlSeconds,
+        constraints: { contentLength },
+      });
+
+      const expiresAt = new Date(Date.now() + signedUrlTtlSeconds * 1000).toISOString();
+
+      logger?.info('Upload part signed', {
+        uploadSessionId,
+        partNumber,
+        requestId: ctx.requestId,
+      });
+
+      return { url: result.url, headers: result.headers, expiresAt };
+    },
+
+    async uploadPartBytes(uploadSessionId: string, partNumber: number, body: ReadableStream | Blob | Buffer, contentLength: number, ctx: FileProviderContext, uploadSessionToken?: string): Promise<{ etag: string; size: number }> {
+      void contentLength;
+      const session = await db.findOne<UploadSession>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      if (!session) throw errors.sessionNotFound();
+      this.assertSessionAccess(session, ctx, uploadSessionToken);
+      if (session.status === 'aborted') throw errors.uploadAborted();
+      if (session.status === 'completed') throw errors.uploadAlreadyCompleted();
+      if (isExpiredAt(session.expiresAt)) throw errors.uploadExpired();
+      if (partNumber < 1 || partNumber > session.totalParts) throw errors.invalidPartNumber();
+      if (session.uploadMode !== 'proxy') throw errors.noSupportedUploadMode();
+
+      const existingPart = await db.findOne<{ etag: string; size: number }>({
+        model: 'uploadParts',
+        where: [
+          { field: 'uploadSessionId', operator: 'eq', value: uploadSessionId },
+          { field: 'partNumber', operator: 'eq', value: partNumber },
+        ],
+        namespace,
+      });
+
+      if (existingPart) {
+        const hasher = createHash('sha256');
+        let incomingSize = 0;
+        await forEachBodyChunk(body, (chunk) => {
+          hasher.update(chunk);
+          incomingSize += chunk.byteLength;
+        });
+
+        const incomingEtag = `proxy-sha256-${hasher.digest('hex')}`;
+        if (existingPart.etag === incomingEtag && existingPart.size === incomingSize) {
+          return { etag: incomingEtag, size: incomingSize };
+        }
+
+        throw errors.partConflict(uploadSessionId, partNumber);
+      }
+
+      const partKey = proxyPartKey(session.storageKey, partNumber);
+      const storageTarget = policies.get(session.policy) ? resolveStorageTarget(policies.get(session.policy)!) : undefined;
+
+      if (!storage.openUploadStream) {
+        throw new Error('Storage adapter does not support streaming upload required for proxy mode');
+      }
+
+      const writeStream = await storage.openUploadStream({
+        key: partKey,
+        target: storageTarget,
+        contentType: session.mimeType
+      });
+
+      const hasher = createHash('sha256');
+      let size = 0;
+      const writer = writeStream.getWriter();
+      try {
+        await forEachBodyChunk(body, async (chunk) => {
+          hasher.update(chunk);
+          size += chunk.byteLength;
+          await writer.write(chunk);
+        });
+      } finally {
+        await writer.close();
+      }
+
+      const etag = `proxy-sha256-${hasher.digest('hex')}`;
+
+      await db.create({
+        model: 'uploadParts',
+        data: { uploadSessionId, partNumber, etag, size, checksumSha256Base64: null },
+        namespace,
+      });
+
+      if (session.status === 'pending') {
+        await db.update({
+          model: 'uploadSessions',
+          where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+          data: { status: 'in_progress' },
+          namespace,
+        });
+      }
+
+      events.emit('part.recorded', createPartRecordedEvent({ uploadSessionId, partNumber, size }, ctx.requestId));
+      return { etag, size };
+    },
+
+    async completePart(uploadSessionId: string, partNumber: number, etag: string, size: number, ctx: FileProviderContext, uploadSessionToken?: string): Promise<void> {
+      const session = await db.findOne<UploadSession>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      if (!session) throw errors.sessionNotFound();
+      this.assertSessionAccess(session, ctx, uploadSessionToken);
+      if (session.status === 'aborted') throw errors.uploadAborted();
+      if (session.status === 'completed') throw errors.uploadAlreadyCompleted();
+      if (isExpiredAt(session.expiresAt)) throw errors.uploadExpired();
+      if (partNumber < 1 || partNumber > session.totalParts) throw errors.invalidPartNumber();
+      if (!etag || etag.trim() === '') throw errors.invalidEtag();
+
+      const existingPart = await db.findOne<{ partNumber: number; etag: string; size: number }>({
+        model: 'uploadParts',
+        where: [
+          { field: 'uploadSessionId', operator: 'eq', value: uploadSessionId },
+          { field: 'partNumber', operator: 'eq', value: partNumber },
+        ],
+        namespace,
+      });
+
+      if (existingPart) {
+        if (existingPart.etag === etag && existingPart.size === size) return; // Idempotent success
+        throw errors.partConflict(uploadSessionId, partNumber);
+      }
+
+      await db.create({
+        model: 'uploadParts',
+        data: { uploadSessionId, partNumber, etag, size, checksumSha256Base64: null },
+        namespace,
+      });
+
+      // Update status to in_progress if still pending
+      if (session.status === 'pending') {
+        await db.update({
+          model: 'uploadSessions',
+          where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+          data: { status: 'in_progress' },
+          namespace,
+        });
+      }
+
+      events.emit('part.recorded', createPartRecordedEvent({ uploadSessionId, partNumber, size }, ctx.requestId));
+    },
+
+    async completeSession(uploadSessionId: string, ctx: FileProviderContext, uploadSessionToken?: string): Promise<{ fileId: string; versionId: string }> {
+      const session = await db.findOne<UploadSession>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      if (!session) throw errors.sessionNotFound();
+      this.assertSessionAccess(session, ctx, uploadSessionToken);
+      if (session.status === 'aborted') throw errors.uploadAborted();
+      if (session.status === 'completed') {
+        // Idempotent: return existing result
+        if (session.fileId && session.completionVersionId) {
+          return { fileId: session.fileId, versionId: session.completionVersionId };
+        }
+        // Fallback for legacy sessions or partial failures (should not happen with transaction, but we assume eventual consistency here)
+        const file = await db.findOne<{ fileId: string; currentVersionId: string }>({
+          model: 'files',
+          where: [{ field: 'fileId', operator: 'eq', value: session.fileId! }],
+          namespace,
+        });
+        if (file) return { fileId: file.fileId, versionId: file.currentVersionId };
+        throw errors.uploadAlreadyCompleted();
+      }
+      if (isExpiredAt(session.expiresAt)) throw errors.uploadExpired();
+
+      const parts = await db.findMany<{ partNumber: number; etag: string }>({
+        model: 'uploadParts',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      if (parts.length !== session.totalParts) {
+        throw errors.uploadIncomplete();
+      }
+
+      // Re-check quota
+      if (quota) {
+        const quotaResult = await quota.checkQuota({
+          principalId: ctx.principalId,
+          tenantId: ctx.tenantId,
+          requestedBytes: session.size,
+        });
+        if (!quotaResult.allowed) {
+          throw errors.quotaExceeded(quotaResult.current, quotaResult.limit, session.size);
+        }
+      }
+
+      if (session.fileId && fileWriteChecker) {
+        const canWrite = await fileWriteChecker.canWriteFile(session.fileId, ctx);
+        if (!canWrite) {
+          throw errors.forbidden({ fileId: session.fileId, operation: 'replace' });
+        }
+      }
+      const policy = policies.get(session.policy);
+      const policyStorageTarget = policy ? resolveStorageTarget(policy) : undefined;
+
+      // Complete multipart upload
+      if (
+        session.uploadMode === 'multipart-signed-url' &&
+        getStorageCapabilities(storage, policyStorageTarget).multipart &&
+        storage.completeMultipartUpload &&
+        session.storageUploadId
+      ) {
+        await storage.completeMultipartUpload({
+          key: session.storageKey,
+          target: policyStorageTarget,
+          uploadId: session.storageUploadId,
+          parts: parts.sort((a, b) => a.partNumber - b.partNumber).map(p => ({ partNumber: p.partNumber, etag: p.etag })),
+        });
+      } else if (session.uploadMode === 'proxy') {
+        // Stitch proxy parts
+        if (!storage.openUploadStream || !storage.openDownloadStream) {
+            throw new Error('Storage adapter does not support streaming required for proxy upload completion');
+        }
+
+        const sortedParts = parts.sort((a, b) => a.partNumber - b.partNumber);
+        const writeStream = await storage.openUploadStream({ 
+            key: session.storageKey,
+            target: policyStorageTarget,
+            contentType: session.mimeType
+        });
+
+        const writer = writeStream.getWriter();
+        try {
+            for (const part of sortedParts) {
+                const partKey = proxyPartKey(session.storageKey, part.partNumber);
+                const readStream = await storage.openDownloadStream({ key: partKey, target: policyStorageTarget });
+                const reader = readStream.getReader();
+
+                try {
+                    while (true) {
+                        const { done, value } = await reader.read();
+                        if (done) break;
+                        await writer.write(value);
+                    }
+                } finally {
+                    reader.releaseLock();
+                }
+            }
+        } finally {
+            await writer.close();
+        }
+
+        // Cleanup parts
+        for (const part of sortedParts) {
+             const partKey = proxyPartKey(session.storageKey, part.partNumber);
+             try {
+                 await storage.deleteObject({ key: partKey, target: policyStorageTarget });
+             } catch {
+                 // ignore
+             }
+        }
+      }
+
+      // Validate size if supported
+      if (storage.statObject) {
+        try {
+          const stat = await storage.statObject({ key: session.storageKey, target: policyStorageTarget });
+          if (stat.size !== session.size) {
+            throw errors.uploadSizeMismatch(session.size, stat.size);
+          }
+        } catch (err) {
+            if (err instanceof errors.FileFnError) throw err;
+            // Ignore stat errors if object doesn't exist (should exist though)
+        }
+      }
+
+      const now = new Date().toISOString();
+      const fileId = session.fileId || `file_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+      const versionId = `ver_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+      const metadata = session.metadata ?? {};
+
+      // Check for deduplication
+      let finalStorageKey = session.storageKey;
+      let checksumSha256Base64: string | null = null;
+      let isDeduplicated = false;
+
+      if (dedup && dedup.isEnabled()) {
+        const dedupResult = await dedup.computeAndCheckDuplicate(
+          session.storageKey,
+          session.tenantId,
+          policyStorageTarget ?? null,
+          storage
+        );
+
+        checksumSha256Base64 = dedupResult.checksumSha256Base64;
+
+        if (dedupResult.isDuplicate && dedupResult.existingStorageKey) {
+          // Reuse existing storage key (reference to existing object)
+          finalStorageKey = dedupResult.existingStorageKey;
+          isDeduplicated = true;
+
+          // Delete the newly uploaded file since we're reusing an existing one
+          if (storage.deleteObject && finalStorageKey !== session.storageKey) {
+            try {
+              await storage.deleteObject({ key: session.storageKey, target: policyStorageTarget });
+            } catch {
+              // Ignore deletion errors - storage cleanup is non-critical
+            }
+          }
+        }
+      }
+
+      // Create or update file
+      const existingFile = session.fileId ? await db.findOne({ model: 'files', where: [{ field: 'fileId', operator: 'eq', value: session.fileId }], namespace }) : null;
+
+      if (existingFile) {
+        await db.update({
+          model: 'files',
+          where: [{ field: 'fileId', operator: 'eq', value: fileId }],
+          data: {
+            currentVersionId: versionId,
+            size: session.size,
+            mimeType: session.mimeType,
+            metadata,
+            updatedAt: now,
+          },
+          namespace,
+        });
+      } else {
+        await db.create({
+          model: 'files',
+          data: {
+            fileId,
+            currentVersionId: versionId,
+            ownerId: session.ownerId,
+            tenantId: session.tenantId,
+            visibility: policy?.visibility || 'private',
+            policy: session.policy,
+            mimeType: session.mimeType,
+            size: session.size,
+            name: session.fileName,
+            metadata,
+            createdAt: now,
+            updatedAt: now,
+          },
+          namespace,
+        });
+      }
+
+      // Create version
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId,
+          fileId,
+          storageKey: finalStorageKey,
+          mimeType: session.mimeType,
+          size: session.size,
+          checksumSha256Base64,
+          tenantId: session.tenantId,
+          createdAt: now,
+        },
+        namespace,
+      });
+
+      // Update session
+      await db.update({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        data: { status: 'completed', fileId, completionVersionId: versionId },
+        namespace,
+      });
+
+      await db.deleteMany({
+        model: 'uploadParts',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      // Record quota usage
+      if (quota) {
+        await quota.recordUsage({ principalId: ctx.principalId, tenantId: ctx.tenantId, bytes: session.size });
+      }
+
+      events.emit('file:uploaded', createFileUploadedEvent({
+        fileId,
+        versionId,
+        fileName: session.fileName,
+        size: session.size,
+        mimeType: session.mimeType,
+        ownerId: session.ownerId,
+        tenantId: session.tenantId || undefined,
+      }, ctx.requestId));
+
+      logger?.info('Upload session completed', {
+        uploadSessionId,
+        fileId,
+        versionId,
+        requestId: ctx.requestId,
+      });
+
+      if (processingService) {
+        await processingService.triggerProcessing({
+          fileId,
+          versionId,
+          storageKey: finalStorageKey,
+          mimeType: session.mimeType,
+          size: session.size,
+          fileName: session.fileName,
+          tenantId: session.tenantId || undefined,
+        }, ctx);
+      }
+
+      return { fileId, versionId };
+    },
+
+    async abortSession(uploadSessionId: string, ctx: FileProviderContext, uploadSessionToken?: string): Promise<void> {
+      const session = await db.findOne<UploadSession>({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      if (!session) throw errors.sessionNotFound();
+      this.assertSessionAccess(session, ctx, uploadSessionToken);
+      if (session.status === 'completed') throw errors.uploadAlreadyCompleted();
+
+      // Abort multipart upload
+      const policy = policies.get(session.policy);
+      const storageTarget = policy ? resolveStorageTarget(policy) : undefined;
+      if (
+        getStorageCapabilities(storage, storageTarget).multipart &&
+        storage.abortMultipartUpload &&
+        session.storageUploadId
+      ) {
+        try {
+          await storage.abortMultipartUpload({ key: session.storageKey, target: storageTarget, uploadId: session.storageUploadId });
+        } catch {
+          // Ignore abort errors (may already be aborted)
+        }
+      }
+
+      await deleteProxyTempPartObjects(session);
+      await db.deleteMany({
+        model: 'uploadParts',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        namespace,
+      });
+
+      await db.update({
+        model: 'uploadSessions',
+        where: [{ field: 'uploadSessionId', operator: 'eq', value: uploadSessionId }],
+        data: { status: 'aborted' },
+        namespace,
+      });
+    },
+
+    async cleanupExpiredSessions(): Promise<{ deletedSessions: number; abortedMultipart: number }> {
+        const now = new Date().toISOString();
+        const expiredSessions = await db.findMany<UploadSession>({
+            model: 'uploadSessions',
+            where: [
+                { field: 'expiresAt', operator: 'lt', value: now },
+                { field: 'status', operator: 'ne', value: 'completed' }
+            ],
+            namespace
+        });
+
+        let deletedSessions = 0;
+        let abortedMultipart = 0;
+
+        for (const session of expiredSessions) {
+            const policy = policies.get(session.policy);
+            const storageTarget = policy ? resolveStorageTarget(policy) : undefined;
+            if (session.storageUploadId && storage.abortMultipartUpload) {
+                try {
+                    await storage.abortMultipartUpload({
+                        key: session.storageKey,
+                        target: storageTarget,
+                        uploadId: session.storageUploadId
+                    });
+                    abortedMultipart++;
+                } catch {
+                    // ignore
+                }
+            }
+
+            await deleteProxyTempPartObjects(session);
+            await db.deleteMany({
+                model: 'uploadParts',
+                where: [{ field: 'uploadSessionId', operator: 'eq', value: session.uploadSessionId }],
+                namespace
+            });
+            
+            await db.delete({
+                model: 'uploadSessions',
+                where: [{ field: 'uploadSessionId', operator: 'eq', value: session.uploadSessionId }],
+                namespace
+            });
+            deletedSessions++;
+        }
+
+        return { deletedSessions, abortedMultipart };
+    }
+  };
+}
+
+export type UploadSessionService = ReturnType<typeof createUploadSessionService>;

--- a/filefn/server/tests/dedup.test.ts
+++ b/filefn/server/tests/dedup.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDeduplicationService } from '../src/dedup/service.js';
+import { createFileFn } from '../src/index.js';
+import type { Adapter } from '@superfunctions/db';
+import { Readable } from 'node:stream';
+import { createFakeStorageAdapter } from '@superfunctions/storage';
+
+function createMockDb(): Adapter {
+  const storage = new Map<string, Map<string, unknown>>();
+
+  return {
+    async create({ model, data, namespace }) {
+      const key = `${namespace}:${model}`;
+      if (!storage.has(key)) storage.set(key, new Map());
+      const id = (data as any).versionId || (data as any).fileId || Math.random().toString();
+      storage.get(key)!.set(id, data);
+      return data;
+    },
+    async findOne({ model, where, namespace }) {
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return null;
+      for (const record of records.values()) {
+        const match = where.every((w: any) => (record as any)[w.field] === w.value);
+        if (match) return record as any;
+      }
+      return null;
+    },
+    async findMany({ model, namespace }) {
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return [];
+      return Array.from(records.values()) as any[];
+    },
+    async update() {
+      return {} as any;
+    },
+    async upsert() {
+      return {} as any;
+    },
+    async delete() {},
+    async deleteMany() {},
+    getDialect() {
+      return 'sqlite' as any;
+    },
+    isReady() {
+      return Promise.resolve(true);
+    },
+    close() {
+      return Promise.resolve();
+    },
+  } as Adapter;
+}
+
+function createMockStorage() {
+  const objects = new Map<string, Uint8Array>();
+
+  return {
+    setData(key: string, data: Uint8Array) {
+      objects.set(key, data);
+    },
+    async openDownloadStream({ key }: { key: string }) {
+      const data = objects.get(key);
+      if (!data) throw new Error('Not found');
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      });
+    },
+  };
+}
+
+describe('Deduplication Service', () => {
+  let db: Adapter;
+  let storage: ReturnType<typeof createMockStorage>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    storage = createMockStorage();
+  });
+
+  describe('Hash computation', () => {
+    it('should compute SHA-256 hash from Uint8Array', () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const data = new TextEncoder().encode('Hello, World!');
+      const hash = service.computeHash(data);
+
+      expect(hash).toBe('3/1gIbsr1bCvZ2KQgJ7DpTGR3YHH9wpLKGiKNiGCmG8=');
+    });
+
+    it('should compute same hash for identical data', () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const data1 = new TextEncoder().encode('Test content');
+      const data2 = new TextEncoder().encode('Test content');
+
+      const hash1 = service.computeHash(data1);
+      const hash2 = service.computeHash(data2);
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it('should compute different hashes for different data', () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const data1 = new TextEncoder().encode('Content A');
+      const data2 = new TextEncoder().encode('Content B');
+
+      const hash1 = service.computeHash(data1);
+      const hash2 = service.computeHash(data2);
+
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('should compute hash from readable stream', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const data = new TextEncoder().encode('Stream content');
+
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      });
+
+      const hash = await service.computeHashFromStream(stream);
+
+      expect(hash).toBeDefined();
+      expect(typeof hash).toBe('string');
+      expect(hash.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('TV-DEDUP-001: Deduplicate identical content within tenant', () => {
+    it('should detect duplicate content in same tenant', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const tenantId = 'org_123';
+      const content = new TextEncoder().encode('Duplicate content');
+      const hash = service.computeHash(content);
+
+      // Create first version with this hash
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_001',
+          fileId: 'file_001',
+          storageKey: 'org_123/file_001/ver_001.txt',
+          mimeType: 'text/plain',
+          size: content.length,
+          checksumSha256Base64: hash,
+          tenantId,
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Check for duplicate
+      const result = await service.checkForDuplicate(hash, tenantId);
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.existingVersionId).toBe('ver_001');
+      expect(result.existingStorageKey).toBe('org_123/file_001/ver_001.txt');
+      expect(result.checksumSha256Base64).toBe(hash);
+    });
+
+    it('should not detect duplicate for different content', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const tenantId = 'org_123';
+      const content1 = new TextEncoder().encode('Content A');
+      const content2 = new TextEncoder().encode('Content B');
+      const hash1 = service.computeHash(content1);
+      const hash2 = service.computeHash(content2);
+
+      // Create first version
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_001',
+          fileId: 'file_001',
+          storageKey: 'org_123/file_001/ver_001.txt',
+          mimeType: 'text/plain',
+          size: content1.length,
+          checksumSha256Base64: hash1,
+          tenantId,
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Check for duplicate with different hash
+      const result = await service.checkForDuplicate(hash2, tenantId);
+
+      expect(result.isDuplicate).toBe(false);
+      expect(result.existingVersionId).toBeUndefined();
+      expect(result.checksumSha256Base64).toBe(hash2);
+    });
+
+    it('should compute and check duplicate from storage', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const tenantId = 'org_123';
+      const content = new TextEncoder().encode('Storage content');
+      const hash = service.computeHash(content);
+
+      // Store content
+      storage.setData('org_123/file_001/ver_001.txt', content);
+
+      // Create first version
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_001',
+          fileId: 'file_001',
+          storageKey: 'org_123/file_001/ver_001.txt',
+          mimeType: 'text/plain',
+          size: content.length,
+          checksumSha256Base64: hash,
+          tenantId,
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Store duplicate content with different key
+      storage.setData('org_123/file_002/ver_002.txt', content);
+
+      // Check for duplicate from storage
+      const result = await service.computeAndCheckDuplicate(
+        'org_123/file_002/ver_002.txt',
+        tenantId,
+        storage
+      );
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.existingVersionId).toBe('ver_001');
+      expect(result.existingStorageKey).toBe('org_123/file_001/ver_001.txt');
+    });
+  });
+
+  describe('TV-DEDUP-NEG-001: Cross-tenant dedupe is forbidden', () => {
+    it('should not detect duplicate across different tenants', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const content = new TextEncoder().encode('Same content');
+      const hash = service.computeHash(content);
+
+      // Create version in tenant A
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_001',
+          fileId: 'file_001',
+          storageKey: 'org_A/file_001/ver_001.txt',
+          mimeType: 'text/plain',
+          size: content.length,
+          checksumSha256Base64: hash,
+          tenantId: 'org_A',
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Check for duplicate in tenant B
+      const result = await service.checkForDuplicate(hash, 'org_B');
+
+      expect(result.isDuplicate).toBe(false);
+      expect(result.existingVersionId).toBeUndefined();
+      expect(result.checksumSha256Base64).toBe(hash);
+    });
+
+    it('should not deduplicate when tenantIds differ', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const content = new TextEncoder().encode('Content for both tenants');
+      const hash = service.computeHash(content);
+
+      // Create version in tenant_1
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_001',
+          fileId: 'file_001',
+          storageKey: 'tenant_1/file_001/ver_001.txt',
+          mimeType: 'text/plain',
+          size: content.length,
+          checksumSha256Base64: hash,
+          tenantId: 'tenant_1',
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Create version in tenant_2
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_002',
+          fileId: 'file_002',
+          storageKey: 'tenant_2/file_002/ver_002.txt',
+          mimeType: 'text/plain',
+          size: content.length,
+          checksumSha256Base64: hash,
+          tenantId: 'tenant_2',
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Check for duplicate in tenant_1 - should find ver_001
+      const result1 = await service.checkForDuplicate(hash, 'tenant_1');
+      expect(result1.isDuplicate).toBe(true);
+      expect(result1.existingVersionId).toBe('ver_001');
+
+      // Check for duplicate in tenant_2 - should find ver_002
+      const result2 = await service.checkForDuplicate(hash, 'tenant_2');
+      expect(result2.isDuplicate).toBe(true);
+      expect(result2.existingVersionId).toBe('ver_002');
+
+      // Verify they found different versions (tenant-scoped)
+      expect(result1.existingVersionId).not.toBe(result2.existingVersionId);
+    });
+
+    it('should handle null tenantId separately', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const content = new TextEncoder().encode('Global content');
+      const hash = service.computeHash(content);
+
+      // Create version with null tenantId
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_001',
+          fileId: 'file_001',
+          storageKey: 'global/file_001/ver_001.txt',
+          mimeType: 'text/plain',
+          size: content.length,
+          checksumSha256Base64: hash,
+          tenantId: null,
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Check for duplicate with null tenantId - should find it
+      const resultNull = await service.checkForDuplicate(hash, null);
+      expect(resultNull.isDuplicate).toBe(true);
+      expect(resultNull.existingVersionId).toBe('ver_001');
+
+      // Check for duplicate with specific tenant - should NOT find it
+      const resultTenant = await service.checkForDuplicate(hash, 'org_123');
+      expect(resultTenant.isDuplicate).toBe(false);
+    });
+  });
+
+  describe('Deduplication enabled/disabled', () => {
+    it('should return isDuplicate false when dedup is disabled', async () => {
+      const service = createDeduplicationService({ db, enabled: false });
+      const content = new TextEncoder().encode('Content');
+      const hash = service.computeHash(content);
+
+      // Create version (even though dedup is disabled)
+      await db.create({
+        model: 'fileVersions',
+        data: {
+          versionId: 'ver_001',
+          fileId: 'file_001',
+          storageKey: 'org_123/file_001/ver_001.txt',
+          mimeType: 'text/plain',
+          size: content.length,
+          checksumSha256Base64: hash,
+          tenantId: 'org_123',
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      // Check - should always return isDuplicate false
+      const result = await service.checkForDuplicate(hash, 'org_123');
+
+      expect(result.isDuplicate).toBe(false);
+      expect(result.checksumSha256Base64).toBe(hash);
+    });
+
+    it('should check isEnabled() correctly', () => {
+      const enabledService = createDeduplicationService({ db, enabled: true });
+      const disabledService = createDeduplicationService({ db, enabled: false });
+
+      expect(enabledService.isEnabled()).toBe(true);
+      expect(disabledService.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('Hash verification', () => {
+    it('should verify hash matches content', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const content = new TextEncoder().encode('Verify me');
+      const hash = service.computeHash(content);
+
+      storage.setData('test/verify.txt', content);
+
+      const isValid = await service.verifyHash('test/verify.txt', hash, storage);
+
+      expect(isValid).toBe(true);
+    });
+
+    it('should detect hash mismatch', async () => {
+      const service = createDeduplicationService({ db, enabled: true });
+      const content = new TextEncoder().encode('Original content');
+      const wrongHash = service.computeHash(new TextEncoder().encode('Different content'));
+
+      storage.setData('test/verify.txt', content);
+
+      const isValid = await service.verifyHash('test/verify.txt', wrongHash, storage);
+
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe('Public dedupe config wiring', () => {
+    it('createFileFn uses dedup.enabled to control dedupe behavior', async () => {
+      const storage = createFakeStorageAdapter({
+        capabilities: {
+          signedUploadUrls: true,
+          signedDownloadUrls: true,
+          multipart: true,
+          proxyStreamingUpload: false,
+          proxyStreamingDownload: false,
+        },
+        async statObject(input) {
+          return { key: input.key, size: 3 };
+        },
+      });
+
+      const fileFnWithoutDedup = createFileFn({
+        db: createMockDb(),
+        storage,
+        policies: [{ name: 'user-avatar', contentTypes: ['text/plain'], maxSizeBytes: 1024 }],
+        dedup: { enabled: false },
+        auth: { required: false },
+      });
+
+      const { uploadSessionId: noDedupSessionId } = await fileFnWithoutDedup.createUploadSession(
+        { policy: 'user-avatar', fileName: 'a.txt', size: 3, mimeType: 'text/plain' },
+        { principalId: 'user_123', tenantId: 'org_123' }
+      );
+      await fileFnWithoutDedup.completeUploadPart(
+        { uploadSessionId: noDedupSessionId, partNumber: 1, etag: 'etag-1', size: 3 },
+        { principalId: 'user_123', tenantId: 'org_123' }
+      );
+      await expect(
+        fileFnWithoutDedup.completeUploadSession(
+          { uploadSessionId: noDedupSessionId },
+          { principalId: 'user_123', tenantId: 'org_123' }
+        )
+      ).resolves.toMatchObject({ fileId: expect.any(String), versionId: expect.any(String) });
+
+      const fileFnWithDedup = createFileFn({
+        db: createMockDb(),
+        storage,
+        policies: [{ name: 'user-avatar', contentTypes: ['text/plain'], maxSizeBytes: 1024 }],
+        dedup: { enabled: true },
+        auth: { required: false },
+      });
+
+      const { uploadSessionId: dedupSessionId } = await fileFnWithDedup.createUploadSession(
+        { policy: 'user-avatar', fileName: 'b.txt', size: 3, mimeType: 'text/plain' },
+        { principalId: 'user_123', tenantId: 'org_123' }
+      );
+      await fileFnWithDedup.completeUploadPart(
+        { uploadSessionId: dedupSessionId, partNumber: 1, etag: 'etag-2', size: 3 },
+        { principalId: 'user_123', tenantId: 'org_123' }
+      );
+      await expect(
+        fileFnWithDedup.completeUploadSession(
+          { uploadSessionId: dedupSessionId },
+          { principalId: 'user_123', tenantId: 'org_123' }
+        )
+      ).rejects.toThrow('streaming downloads required for deduplication');
+    });
+  });
+});

--- a/filefn/server/tests/processing.integration.test.ts
+++ b/filefn/server/tests/processing.integration.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createProcessingService, type Processor } from '../src/processing/service.js';
+import type { StorageAdapter } from '@superfunctions/storage';
+import type { Adapter } from '@superfunctions/db';
+import { createEventEmitter } from '../src/events.js';
+
+function createMockDb(): Adapter {
+  const storage = new Map<string, Map<string, unknown>>();
+
+  return {
+    async create({ model, data, namespace }) {
+      const key = `${namespace}:${model}`;
+      if (!storage.has(key)) storage.set(key, new Map());
+      const id = (data as any).artifactId || (data as any).fileId || Math.random().toString();
+      storage.get(key)!.set(id, data);
+      return data;
+    },
+    async findOne({ model, where, namespace }) {
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return null;
+      for (const record of records.values()) {
+        const match = where.every((w: any) => (record as any)[w.field] === w.value);
+        if (match) return record as any;
+      }
+      return null;
+    },
+    async findMany({ model, namespace }) {
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return [];
+      return Array.from(records.values()) as any[];
+    },
+    async update() { return {} as any; },
+    async upsert() { return {} as any; },
+    async delete() {},
+    async deleteMany() {},
+    getDialect() { return 'sqlite' as any; },
+    isReady() { return Promise.resolve(true); },
+    close() { return Promise.resolve(); },
+  } as Adapter;
+}
+
+function createMockStorage(): StorageAdapter {
+  const objects = new Map<string, Uint8Array>();
+
+  return {
+    name: 'mock',
+    capabilities: {
+      signedUploadUrls: true,
+      signedDownloadUrls: true,
+      multipart: true,
+      proxyStreamingUpload: true,
+      proxyStreamingDownload: true,
+    },
+    async statObject({ key }) {
+      const data = objects.get(key);
+      if (!data) throw new Error('Not found');
+      return { key, size: data.length };
+    },
+    async deleteObject({ key }) {
+      objects.delete(key);
+    },
+    async signDownloadUrl({ key }) {
+      return { url: `https://storage.test/download/${key}` };
+    },
+    async openDownloadStream({ key }) {
+      const data = objects.get(key);
+      if (!data) throw new Error('Not found');
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      });
+    },
+    async openUploadStream({ key }) {
+      const chunks: Uint8Array[] = [];
+      return new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+        close() {
+          const total = chunks.reduce((sum, c) => sum + c.length, 0);
+          const merged = new Uint8Array(total);
+          let offset = 0;
+          for (const chunk of chunks) {
+            merged.set(chunk, offset);
+            offset += chunk.length;
+          }
+          objects.set(key, merged);
+        },
+      });
+    },
+    setData(key: string, data: Uint8Array) {
+      objects.set(key, data);
+    },
+  } as StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+}
+
+function createMockProcessor(name: string, mimeTypes: string[]): Processor {
+  return {
+    name,
+    supportedMimeTypes: mimeTypes,
+    async process(input, getData) {
+      const data = await getData();
+      return {
+        success: true,
+        artifacts: [
+          {
+            kind: `${name}-output`,
+            data: new Uint8Array([...data.slice(0, 10), 1, 2, 3]),
+            mimeType: 'application/octet-stream',
+            storageKey: `${input.storageKey}.${name}`,
+          },
+        ],
+      };
+    },
+  };
+}
+
+describe('ProcessingService Integration', () => {
+  let db: Adapter;
+  let storage: StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+  let events: ReturnType<typeof createEventEmitter>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    storage = createMockStorage();
+    events = createEventEmitter();
+  });
+
+  describe('TV-PROCESS-001: Processing triggered after upload', () => {
+    it('should trigger processing and create artifacts', async () => {
+      const processor = createMockProcessor('test', ['image/png']);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      storage.setData('test/image.png', testData);
+
+      const processingStarted = vi.fn();
+      events.on('processing.started', processingStarted);
+
+      const result = await service.triggerProcessing(
+        {
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: testData.length,
+          fileName: 'image.png',
+        },
+        { principalId: 'user_123', requestId: 'req_001' }
+      );
+
+      expect(processingStarted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'processing.started',
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+        })
+      );
+
+      await vi.waitFor(async () => {
+        const artifacts = await service.listArtifacts('file_0001', {});
+        expect(artifacts.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('TV-PROCESS-NEG-001: Processing disabled', () => {
+    it('should not trigger processing when disabled', async () => {
+      const processor = createMockProcessor('test', ['image/png']);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: false,
+      });
+
+      const processingStarted = vi.fn();
+      events.on('processing.started', processingStarted);
+
+      const result = await service.triggerProcessing(
+        {
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: 1000,
+          fileName: 'image.png',
+        },
+        { principalId: 'user_123', requestId: 'req_001' }
+      );
+
+      expect(result.enqueued).toBe(false);
+      expect(processingStarted).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger processing when no processors configured', async () => {
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [],
+        enabled: true,
+      });
+
+      const result = await service.triggerProcessing(
+        {
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: 1000,
+          fileName: 'image.png',
+        },
+        { principalId: 'user_123', requestId: 'req_001' }
+      );
+
+      expect(result.enqueued).toBe(false);
+    });
+  });
+
+  describe('TV-PROCESS-FLOW-001: FlowFn integration', () => {
+    it('should enqueue processing via FlowFn when provided', async () => {
+      const processor = createMockProcessor('test', ['image/png']);
+      const mockQueueAdd = vi.fn().mockResolvedValue({ jobId: 'job_001' });
+      const mockFlowFn = {
+        getQueue: vi.fn().mockReturnValue({
+          name: 'filefn.processing',
+          add: mockQueueAdd,
+        }),
+      };
+
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        flowFn: mockFlowFn,
+        enabled: true,
+      });
+
+      const result = await service.triggerProcessing(
+        {
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          storageKey: 'test/image.png',
+          mimeType: 'image/png',
+          size: 1000,
+          fileName: 'image.png',
+        },
+        { principalId: 'user_123', requestId: 'req_001' }
+      );
+
+      expect(result.enqueued).toBe(true);
+      expect(result.jobId).toBe('job_001');
+      expect(mockFlowFn.getQueue).toHaveBeenCalledWith('filefn.processing');
+      expect(mockQueueAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          idempotencyKey: 'processing:file_0001:ver_0001:test',
+        })
+      );
+    });
+
+    it('should throw FILEFN_PROCESSING_ENQUEUE_FAILED on queue error', async () => {
+      const processor = createMockProcessor('test', ['image/png']);
+      const mockFlowFn = {
+        getQueue: vi.fn().mockReturnValue({
+          name: 'filefn.processing',
+          add: vi.fn().mockRejectedValue(new Error('Queue error')),
+        }),
+      };
+
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        flowFn: mockFlowFn,
+        enabled: true,
+      });
+
+      await expect(
+        service.triggerProcessing(
+          {
+            fileId: 'file_0001',
+            versionId: 'ver_0001',
+            storageKey: 'test/image.png',
+            mimeType: 'image/png',
+            size: 1000,
+            fileName: 'image.png',
+          },
+          { principalId: 'user_123', requestId: 'req_001' }
+        )
+      ).rejects.toMatchObject({ code: 'FILEFN_PROCESSING_ENQUEUE_FAILED' });
+    });
+  });
+
+  describe('Artifact management', () => {
+    it('should list artifacts for a file', async () => {
+      await db.create({
+        model: 'fileArtifacts',
+        data: {
+          artifactId: 'art_001',
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          kind: 'thumbnail-small',
+          storageKey: 'test/thumb.jpg',
+          mimeType: 'image/jpeg',
+          size: 1000,
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [],
+        enabled: false,
+      });
+
+      const artifacts = await service.listArtifacts('file_0001', {});
+
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].artifactId).toBe('art_001');
+      expect(artifacts[0].kind).toBe('thumbnail-small');
+    });
+
+    it('should get artifact download URL', async () => {
+      await db.create({
+        model: 'fileArtifacts',
+        data: {
+          artifactId: 'art_001',
+          fileId: 'file_0001',
+          versionId: 'ver_0001',
+          kind: 'thumbnail-small',
+          storageKey: 'test/thumb.jpg',
+          mimeType: 'image/jpeg',
+          size: 1000,
+          createdAt: new Date().toISOString(),
+        },
+        namespace: 'filefn',
+      });
+
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [],
+        enabled: false,
+      });
+
+      const { url } = await service.getArtifactDownloadUrl('art_001', {});
+
+      expect(url).toBe('https://storage.test/download/test/thumb.jpg');
+    });
+
+    it('should throw not found for missing artifact', async () => {
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [],
+        enabled: false,
+      });
+
+      await expect(
+        service.getArtifactDownloadUrl('nonexistent', {})
+      ).rejects.toThrow('not found');
+    });
+  });
+});

--- a/filefn/server/tests/processing.ocr.integration.test.ts
+++ b/filefn/server/tests/processing.ocr.integration.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createProcessingService } from '../src/processing/service.js';
+import {
+  createOCRProcessor,
+  createImageTransformProcessor,
+  type OCRConfig,
+  type ImageTransformConfig,
+} from '@filefn/processing';
+import type { StorageAdapter } from '@superfunctions/storage';
+import type { Adapter } from '@superfunctions/db';
+import { createEventEmitter } from '../src/events.js';
+import sharp from 'sharp';
+
+function createMockDb(): Adapter {
+  const storage = new Map<string, Map<string, unknown>>();
+
+  return {
+    async create({ model, data, namespace }) {
+      const key = `${namespace}:${model}`;
+      if (!storage.has(key)) storage.set(key, new Map());
+      const id = (data as any).artifactId || (data as any).fileId || Math.random().toString();
+      storage.get(key)!.set(id, data);
+      return data;
+    },
+    async findOne({ model, where, namespace }) {
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return null;
+      for (const record of records.values()) {
+        const match = where.every((w: any) => (record as any)[w.field] === w.value);
+        if (match) return record as any;
+      }
+      return null;
+    },
+    async findMany({ model, where, namespace, orderBy }) {
+      void orderBy;
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return [];
+      if (!where || where.length === 0) {
+        return Array.from(records.values()) as any[];
+      }
+      const filtered = [];
+      for (const record of records.values()) {
+        const match = where.every((w: any) => (record as any)[w.field] === w.value);
+        if (match) filtered.push(record);
+      }
+      return filtered as any[];
+    },
+    async update() {
+      return {} as any;
+    },
+    async upsert() {
+      return {} as any;
+    },
+    async delete() {},
+    async deleteMany() {},
+    getDialect() {
+      return 'sqlite' as any;
+    },
+    isReady() {
+      return Promise.resolve(true);
+    },
+    close() {
+      return Promise.resolve();
+    },
+  } as Adapter;
+}
+
+function createMockStorage(): StorageAdapter & { setData: (key: string, data: Uint8Array) => void } {
+  const objects = new Map<string, Uint8Array>();
+
+  return {
+    name: 'mock',
+    capabilities: {
+      signedUploadUrls: true,
+      signedDownloadUrls: true,
+      multipart: true,
+      proxyStreamingUpload: true,
+      proxyStreamingDownload: true,
+    },
+    async statObject({ key }) {
+      const data = objects.get(key);
+      if (!data) throw new Error('Not found');
+      return { key, size: data.length };
+    },
+    async deleteObject({ key }) {
+      objects.delete(key);
+    },
+    async signDownloadUrl({ key }) {
+      return { url: `https://storage.test/download/${key}` };
+    },
+    async openDownloadStream({ key }) {
+      const data = objects.get(key);
+      if (!data) throw new Error('Not found');
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      });
+    },
+    async openUploadStream({ key }) {
+      const chunks: Uint8Array[] = [];
+      return new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+        close() {
+          const total = chunks.reduce((sum, c) => sum + c.length, 0);
+          const merged = new Uint8Array(total);
+          let offset = 0;
+          for (const chunk of chunks) {
+            merged.set(chunk, offset);
+            offset += chunk.length;
+          }
+          objects.set(key, merged);
+        },
+      });
+    },
+    setData(key: string, data: Uint8Array) {
+      objects.set(key, data);
+    },
+  } as StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+}
+
+async function createTestImage(width: number, height: number): Promise<Uint8Array> {
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 255, g: 255, b: 255 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return new Uint8Array(buffer);
+}
+
+describe('OCR Processing Integration', () => {
+  let db: Adapter;
+  let storage: StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+  let events: ReturnType<typeof createEventEmitter>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    storage = createMockStorage();
+    events = createEventEmitter();
+  });
+
+  describe('OCR processor with server integration', () => {
+    it('should process image and create OCR text artifact', async () => {
+      const ocrConfig: OCRConfig = {
+        language: 'eng',
+        outputFormat: 'text',
+      };
+
+      const processor = createOCRProcessor(ocrConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      storage.setData('tenant/file_001/ver_001.png', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_001/ver_001.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'document.png',
+        },
+        { principalId: 'user_123', requestId: 'req_001' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_001', {});
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].kind).toBe('ocr-text');
+      expect(artifacts[0].mimeType).toBe('text/plain');
+      expect(artifacts[0].storageKey).toBe('tenant/file_001/ver_001-ocr.txt');
+    });
+
+    it('should create multiple OCR output formats when format is "all"', async () => {
+      const ocrConfig: OCRConfig = {
+        language: 'eng',
+        outputFormat: 'all',
+      };
+
+      const processor = createOCRProcessor(ocrConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      storage.setData('tenant/file_002/ver_001.png', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_002',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_002/ver_001.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'invoice.png',
+        },
+        { principalId: 'user_123', requestId: 'req_002' }
+      );
+
+      expect(result.artifactsCreated).toBe(3);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_002', {});
+      expect(artifacts).toHaveLength(3);
+
+      const kinds = artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['ocr-hocr', 'ocr-json', 'ocr-text']);
+
+      const mimeTypes = artifacts.map((a) => a.mimeType).sort();
+      expect(mimeTypes).toEqual(['application/json', 'text/html', 'text/plain']);
+    });
+
+    it('should handle OCR for JPEG images', async () => {
+      const processor = createOCRProcessor({ outputFormat: 'json' });
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(1024, 768);
+      storage.setData('tenant/file_003/ver_001.jpg', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_003',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_003/ver_001.jpg',
+          mimeType: 'image/jpeg',
+          size: testImage.length,
+          fileName: 'scan.jpg',
+        },
+        { principalId: 'user_123', requestId: 'req_003' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+
+      const artifacts = await service.listArtifacts('file_003', {});
+      expect(artifacts[0].kind).toBe('ocr-json');
+      expect(artifacts[0].mimeType).toBe('application/json');
+    });
+  });
+
+  describe('Image Transform processor with server integration', () => {
+    it('should process resize operation and create artifact', async () => {
+      const transformConfig: ImageTransformConfig = {
+        operations: [
+          {
+            operation: 'resize',
+            options: { width: 400, height: 300, fit: 'cover' },
+            suffix: 'medium',
+          },
+        ],
+        outputFormat: 'jpeg',
+        outputQuality: 85,
+      };
+
+      const processor = createImageTransformProcessor(transformConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(1600, 1200);
+      storage.setData('tenant/file_004/ver_001.png', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_004',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_004/ver_001.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'photo.png',
+        },
+        { principalId: 'user_123', requestId: 'req_004' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_004', {});
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].kind).toBe('transform-medium');
+      expect(artifacts[0].mimeType).toBe('image/jpeg');
+      expect(artifacts[0].storageKey).toBe('tenant/file_004/ver_001-medium.jpg');
+    });
+
+    it('should process crop operation and create artifact', async () => {
+      const transformConfig: ImageTransformConfig = {
+        operations: [
+          {
+            operation: 'crop',
+            options: { left: 100, top: 50, width: 400, height: 300 },
+            suffix: 'cropped',
+          },
+        ],
+        outputFormat: 'png',
+      };
+
+      const processor = createImageTransformProcessor(transformConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      storage.setData('tenant/file_005/ver_001.jpg', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_005',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_005/ver_001.jpg',
+          mimeType: 'image/jpeg',
+          size: testImage.length,
+          fileName: 'landscape.jpg',
+        },
+        { principalId: 'user_123', requestId: 'req_005' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+
+      const artifacts = await service.listArtifacts('file_005', {});
+      expect(artifacts[0].kind).toBe('transform-cropped');
+      expect(artifacts[0].mimeType).toBe('image/png');
+    });
+
+    it('should process rotate operation and create artifact', async () => {
+      const transformConfig: ImageTransformConfig = {
+        operations: [
+          {
+            operation: 'rotate',
+            options: { angle: 90, background: { r: 255, g: 255, b: 255 } },
+            suffix: 'rotated',
+          },
+        ],
+        outputFormat: 'jpeg',
+      };
+
+      const processor = createImageTransformProcessor(transformConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      storage.setData('tenant/file_006/ver_001.png', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_006',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_006/ver_001.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'portrait.png',
+        },
+        { principalId: 'user_123', requestId: 'req_006' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+
+      const artifacts = await service.listArtifacts('file_006', {});
+      expect(artifacts[0].kind).toBe('transform-rotated');
+    });
+
+    it('should process multiple transform operations and create multiple artifacts', async () => {
+      const transformConfig: ImageTransformConfig = {
+        operations: [
+          {
+            operation: 'resize',
+            options: { width: 800, height: 600 },
+            suffix: 'large',
+          },
+          {
+            operation: 'resize',
+            options: { width: 400, height: 300 },
+            suffix: 'medium',
+          },
+          {
+            operation: 'resize',
+            options: { width: 200, height: 150 },
+            suffix: 'small',
+          },
+        ],
+        outputFormat: 'webp',
+        outputQuality: 80,
+      };
+
+      const processor = createImageTransformProcessor(transformConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(1600, 1200);
+      storage.setData('tenant/file_007/ver_001.png', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_007',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_007/ver_001.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'gallery.png',
+        },
+        { principalId: 'user_123', requestId: 'req_007' }
+      );
+
+      expect(result.artifactsCreated).toBe(3);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_007', {});
+      expect(artifacts).toHaveLength(3);
+
+      const kinds = artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['transform-large', 'transform-medium', 'transform-small']);
+
+      artifacts.forEach((artifact) => {
+        expect(artifact.mimeType).toBe('image/webp');
+      });
+    });
+  });
+
+  describe('Combined OCR and Transform processing', () => {
+    it('should run both OCR and transform processors on the same image', async () => {
+      const ocrProcessor = createOCRProcessor({ outputFormat: 'text' });
+      const transformProcessor = createImageTransformProcessor({
+        operations: [{ operation: 'resize', options: { width: 400 }, suffix: 'thumb' }],
+      });
+
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [ocrProcessor, transformProcessor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      storage.setData('tenant/file_008/ver_001.png', testImage);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_008',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_008/ver_001.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'receipt.png',
+        },
+        { principalId: 'user_123', requestId: 'req_008' }
+      );
+
+      expect(result.artifactsCreated).toBe(2);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_008', {});
+      expect(artifacts).toHaveLength(2);
+
+      const kinds = artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['ocr-text', 'transform-thumb']);
+    });
+  });
+
+  describe('Artifact retrieval and download', () => {
+    it('should retrieve OCR artifact download URL', async () => {
+      const processor = createOCRProcessor({ outputFormat: 'text' });
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testImage = await createTestImage(800, 600);
+      storage.setData('tenant/file_009/ver_001.png', testImage);
+
+      await service.runProcessing(
+        {
+          fileId: 'file_009',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_009/ver_001.png',
+          mimeType: 'image/png',
+          size: testImage.length,
+          fileName: 'doc.png',
+        },
+        { principalId: 'user_123', requestId: 'req_009' }
+      );
+
+      const artifacts = await service.listArtifacts('file_009', {});
+      const artifactId = artifacts[0].artifactId;
+
+      const { url } = await service.getArtifactDownloadUrl(artifactId, {});
+
+      expect(url).toContain('tenant/file_009/ver_001-ocr.txt');
+      expect(url).toMatch(/^https:\/\/storage\.test\/download\//);
+    });
+  });
+});

--- a/filefn/server/tests/processing.video-audio.integration.test.ts
+++ b/filefn/server/tests/processing.video-audio.integration.test.ts
@@ -1,0 +1,706 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createProcessingService } from '../src/processing/service.js';
+import {
+  createVideoProcessor,
+  createAudioProcessor,
+  type VideoConfig,
+  type AudioConfig,
+} from '@filefn/processing';
+import type { StorageAdapter } from '@superfunctions/storage';
+import type { Adapter } from '@superfunctions/db';
+import { createEventEmitter } from '../src/events.js';
+
+function createMockDb(): Adapter {
+  const storage = new Map<string, Map<string, unknown>>();
+
+  return {
+    async create({ model, data, namespace }) {
+      const key = `${namespace}:${model}`;
+      if (!storage.has(key)) storage.set(key, new Map());
+      const id = (data as any).artifactId || (data as any).fileId || Math.random().toString();
+      storage.get(key)!.set(id, data);
+      return data;
+    },
+    async findOne({ model, where, namespace }) {
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return null;
+      for (const record of records.values()) {
+        const match = where.every((w: any) => (record as any)[w.field] === w.value);
+        if (match) return record as any;
+      }
+      return null;
+    },
+    async findMany({ model, where, namespace, orderBy }) {
+      void orderBy;
+      const key = `${namespace}:${model}`;
+      const records = storage.get(key);
+      if (!records) return [];
+      if (!where || where.length === 0) {
+        return Array.from(records.values()) as any[];
+      }
+      const filtered = [];
+      for (const record of records.values()) {
+        const match = where.every((w: any) => (record as any)[w.field] === w.value);
+        if (match) filtered.push(record);
+      }
+      return filtered as any[];
+    },
+    async update() {
+      return {} as any;
+    },
+    async upsert() {
+      return {} as any;
+    },
+    async delete() {},
+    async deleteMany() {},
+    getDialect() {
+      return 'sqlite' as any;
+    },
+    isReady() {
+      return Promise.resolve(true);
+    },
+    close() {
+      return Promise.resolve();
+    },
+  } as Adapter;
+}
+
+function createMockStorage(): StorageAdapter & { setData: (key: string, data: Uint8Array) => void } {
+  const objects = new Map<string, Uint8Array>();
+
+  return {
+    name: 'mock',
+    capabilities: {
+      signedUploadUrls: true,
+      signedDownloadUrls: true,
+      multipart: true,
+      proxyStreamingUpload: true,
+      proxyStreamingDownload: true,
+    },
+    async statObject({ key }) {
+      const data = objects.get(key);
+      if (!data) throw new Error('Not found');
+      return { key, size: data.length };
+    },
+    async deleteObject({ key }) {
+      objects.delete(key);
+    },
+    async signDownloadUrl({ key }) {
+      return { url: `https://storage.test/download/${key}` };
+    },
+    async openDownloadStream({ key }) {
+      const data = objects.get(key);
+      if (!data) throw new Error('Not found');
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(data);
+          controller.close();
+        },
+      });
+    },
+    async openUploadStream({ key }) {
+      const chunks: Uint8Array[] = [];
+      return new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+        close() {
+          const total = chunks.reduce((sum, c) => sum + c.length, 0);
+          const merged = new Uint8Array(total);
+          let offset = 0;
+          for (const chunk of chunks) {
+            merged.set(chunk, offset);
+            offset += chunk.length;
+          }
+          objects.set(key, merged);
+        },
+      });
+    },
+    setData(key: string, data: Uint8Array) {
+      objects.set(key, data);
+    },
+  } as StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+}
+
+function createMockVideoData(size: number = 5000): Uint8Array {
+  const data = new Uint8Array(size);
+  const header = new TextEncoder().encode('MOCK_VIDEO_DATA');
+  data.set(header, 0);
+  for (let i = header.length; i < size; i++) {
+    data[i] = Math.floor(Math.random() * 256);
+  }
+  return data;
+}
+
+function createMockAudioData(size: number = 3000): Uint8Array {
+  const data = new Uint8Array(size);
+  const header = new TextEncoder().encode('MOCK_AUDIO_DATA');
+  data.set(header, 0);
+  for (let i = header.length; i < size; i++) {
+    data[i] = Math.floor(Math.random() * 256);
+  }
+  return data;
+}
+
+describe('Video Processing Integration', () => {
+  let db: Adapter;
+  let storage: StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+  let events: ReturnType<typeof createEventEmitter>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    storage = createMockStorage();
+    events = createEventEmitter();
+  });
+
+  describe('Video processor with server integration', () => {
+    it('should process video and create poster artifact', async () => {
+      const videoConfig: VideoConfig = {
+        generatePoster: true,
+        posterOptions: {
+          timestamp: 1.5,
+          width: 1280,
+          height: 720,
+          format: 'jpeg',
+        },
+        transcode: false,
+      };
+
+      const processor = createVideoProcessor(videoConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testVideo = createMockVideoData(10000);
+      storage.setData('tenant/file_001/ver_001.mp4', testVideo);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_001',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_001/ver_001.mp4',
+          mimeType: 'video/mp4',
+          size: testVideo.length,
+          fileName: 'video.mp4',
+        },
+        { principalId: 'user_123', requestId: 'req_001' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_001', {});
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].kind).toBe('video-poster');
+      expect(artifacts[0].mimeType).toBe('image/jpeg');
+      expect(artifacts[0].storageKey).toBe('tenant/file_001/ver_001-poster.jpg');
+    });
+
+    it('should transcode video and create transcoded artifact', async () => {
+      const videoConfig: VideoConfig = {
+        generatePoster: false,
+        transcode: true,
+        transcodeOptions: {
+          codec: 'h264',
+          resolution: '720p',
+          bitrate: '2M',
+          fps: 30,
+        },
+      };
+
+      const processor = createVideoProcessor(videoConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testVideo = createMockVideoData(10000);
+      storage.setData('tenant/file_002/ver_001.mp4', testVideo);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_002',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_002/ver_001.mp4',
+          mimeType: 'video/mp4',
+          size: testVideo.length,
+          fileName: 'video.mp4',
+        },
+        { principalId: 'user_123', requestId: 'req_002' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+
+      const artifacts = await service.listArtifacts('file_002', {});
+      expect(artifacts[0].kind).toBe('video-transcoded-720p');
+      expect(artifacts[0].mimeType).toBe('video/mp4');
+      expect(artifacts[0].storageKey).toBe('tenant/file_002/ver_001-720p.mp4');
+    });
+
+    it('should extract video metadata', async () => {
+      const videoConfig: VideoConfig = {
+        generatePoster: false,
+        transcode: false,
+        extractMetadata: true,
+      };
+
+      const processor = createVideoProcessor(videoConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testVideo = createMockVideoData(5000);
+      storage.setData('tenant/file_003/ver_001.webm', testVideo);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_003',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_003/ver_001.webm',
+          mimeType: 'video/webm',
+          size: testVideo.length,
+          fileName: 'video.webm',
+        },
+        { principalId: 'user_123', requestId: 'req_003' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+
+      const artifacts = await service.listArtifacts('file_003', {});
+      expect(artifacts[0].kind).toBe('video-metadata');
+      expect(artifacts[0].mimeType).toBe('application/json');
+    });
+
+    it('should create all video artifacts when all options enabled', async () => {
+      const videoConfig: VideoConfig = {
+        generatePoster: true,
+        transcode: true,
+        extractMetadata: true,
+      };
+
+      const processor = createVideoProcessor(videoConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testVideo = createMockVideoData(10000);
+      storage.setData('tenant/file_004/ver_001.mp4', testVideo);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_004',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_004/ver_001.mp4',
+          mimeType: 'video/mp4',
+          size: testVideo.length,
+          fileName: 'full-video.mp4',
+        },
+        { principalId: 'user_123', requestId: 'req_004' }
+      );
+
+      expect(result.artifactsCreated).toBe(3);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_004', {});
+      expect(artifacts).toHaveLength(3);
+
+      const kinds = artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['video-metadata', 'video-poster', 'video-transcoded-720p']);
+    });
+
+    it('should transcode to multiple resolutions', async () => {
+      const processor720 = createVideoProcessor({
+        generatePoster: false,
+        transcode: true,
+        transcodeOptions: { resolution: '720p' },
+      });
+
+      const processor480 = createVideoProcessor({
+        generatePoster: false,
+        transcode: true,
+        transcodeOptions: { resolution: '480p' },
+      });
+
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor720, processor480],
+        enabled: true,
+      });
+
+      const testVideo = createMockVideoData(15000);
+      storage.setData('tenant/file_005/ver_001.mp4', testVideo);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_005',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_005/ver_001.mp4',
+          mimeType: 'video/mp4',
+          size: testVideo.length,
+          fileName: 'multi-res.mp4',
+        },
+        { principalId: 'user_123', requestId: 'req_005' }
+      );
+
+      expect(result.artifactsCreated).toBe(2);
+
+      const artifacts = await service.listArtifacts('file_005', {});
+      const kinds = artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['video-transcoded-480p', 'video-transcoded-720p']);
+    });
+  });
+});
+
+describe('Audio Processing Integration', () => {
+  let db: Adapter;
+  let storage: StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+  let events: ReturnType<typeof createEventEmitter>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    storage = createMockStorage();
+    events = createEventEmitter();
+  });
+
+  describe('Audio processor with server integration', () => {
+    it('should transcode audio and create artifact', async () => {
+      const audioConfig: AudioConfig = {
+        transcode: true,
+        transcodeOptions: {
+          codec: 'aac',
+          bitrate: '128k',
+          sampleRate: 44100,
+          channels: 2,
+        },
+      };
+
+      const processor = createAudioProcessor(audioConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testAudio = createMockAudioData(5000);
+      storage.setData('tenant/file_006/ver_001.mp3', testAudio);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_006',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_006/ver_001.mp3',
+          mimeType: 'audio/mpeg',
+          size: testAudio.length,
+          fileName: 'audio.mp3',
+        },
+        { principalId: 'user_123', requestId: 'req_006' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_006', {});
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0].kind).toBe('audio-transcoded-aac');
+      expect(artifacts[0].mimeType).toBe('audio/mp4');
+      expect(artifacts[0].storageKey).toBe('tenant/file_006/ver_001-aac.m4a');
+    });
+
+    it('should extract audio metadata', async () => {
+      const audioConfig: AudioConfig = {
+        transcode: false,
+        extractMetadata: true,
+      };
+
+      const processor = createAudioProcessor(audioConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testAudio = createMockAudioData(5000);
+      storage.setData('tenant/file_007/ver_001.flac', testAudio);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_007',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_007/ver_001.flac',
+          mimeType: 'audio/flac',
+          size: testAudio.length,
+          fileName: 'audio.flac',
+        },
+        { principalId: 'user_123', requestId: 'req_007' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+
+      const artifacts = await service.listArtifacts('file_007', {});
+      expect(artifacts[0].kind).toBe('audio-metadata');
+      expect(artifacts[0].mimeType).toBe('application/json');
+    });
+
+    it('should generate audio waveform', async () => {
+      const audioConfig: AudioConfig = {
+        transcode: false,
+        generateWaveform: true,
+      };
+
+      const processor = createAudioProcessor(audioConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testAudio = createMockAudioData(5000);
+      storage.setData('tenant/file_008/ver_001.mp3', testAudio);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_008',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_008/ver_001.mp3',
+          mimeType: 'audio/mpeg',
+          size: testAudio.length,
+          fileName: 'podcast.mp3',
+        },
+        { principalId: 'user_123', requestId: 'req_008' }
+      );
+
+      expect(result.artifactsCreated).toBe(1);
+
+      const artifacts = await service.listArtifacts('file_008', {});
+      expect(artifacts[0].kind).toBe('audio-waveform');
+      expect(artifacts[0].mimeType).toBe('application/json');
+    });
+
+    it('should create all audio artifacts when all options enabled', async () => {
+      const audioConfig: AudioConfig = {
+        transcode: true,
+        extractMetadata: true,
+        generateWaveform: true,
+      };
+
+      const processor = createAudioProcessor(audioConfig);
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processor],
+        enabled: true,
+      });
+
+      const testAudio = createMockAudioData(5000);
+      storage.setData('tenant/file_009/ver_001.wav', testAudio);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_009',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_009/ver_001.wav',
+          mimeType: 'audio/wav',
+          size: testAudio.length,
+          fileName: 'full-audio.wav',
+        },
+        { principalId: 'user_123', requestId: 'req_009' }
+      );
+
+      expect(result.artifactsCreated).toBe(3);
+      expect(result.errors).toHaveLength(0);
+
+      const artifacts = await service.listArtifacts('file_009', {});
+      expect(artifacts).toHaveLength(3);
+
+      const kinds = artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['audio-metadata', 'audio-transcoded-aac', 'audio-waveform']);
+    });
+
+    it('should transcode to multiple formats', async () => {
+      const processorAAC = createAudioProcessor({
+        transcode: true,
+        transcodeOptions: { codec: 'aac', bitrate: '128k' },
+      });
+
+      const processorMP3 = createAudioProcessor({
+        transcode: true,
+        transcodeOptions: { codec: 'mp3', bitrate: '192k' },
+      });
+
+      const service = createProcessingService({
+        db,
+        storage,
+        events,
+        processors: [processorAAC, processorMP3],
+        enabled: true,
+      });
+
+      const testAudio = createMockAudioData(8000);
+      storage.setData('tenant/file_010/ver_001.flac', testAudio);
+
+      const result = await service.runProcessing(
+        {
+          fileId: 'file_010',
+          versionId: 'ver_001',
+          storageKey: 'tenant/file_010/ver_001.flac',
+          mimeType: 'audio/flac',
+          size: testAudio.length,
+          fileName: 'multi-format.flac',
+        },
+        { principalId: 'user_123', requestId: 'req_010' }
+      );
+
+      expect(result.artifactsCreated).toBe(2);
+
+      const artifacts = await service.listArtifacts('file_010', {});
+      const kinds = artifacts.map((a) => a.kind).sort();
+      expect(kinds).toEqual(['audio-transcoded-aac', 'audio-transcoded-mp3']);
+    });
+  });
+});
+
+describe('Combined Video and Audio Processing', () => {
+  let db: Adapter;
+  let storage: StorageAdapter & { setData: (key: string, data: Uint8Array) => void };
+  let events: ReturnType<typeof createEventEmitter>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    storage = createMockStorage();
+    events = createEventEmitter();
+  });
+
+  it('should handle mixed media processing with video and audio processors', async () => {
+    const videoProcessor = createVideoProcessor({ generatePoster: true, transcode: false });
+    const audioProcessor = createAudioProcessor({ transcode: true, extractMetadata: false });
+
+    const service = createProcessingService({
+      db,
+      storage,
+      events,
+      processors: [videoProcessor, audioProcessor],
+      enabled: true,
+    });
+
+    const testVideo = createMockVideoData(8000);
+    storage.setData('tenant/file_011/ver_001.mp4', testVideo);
+
+    const videoResult = await service.runProcessing(
+      {
+        fileId: 'file_011',
+        versionId: 'ver_001',
+        storageKey: 'tenant/file_011/ver_001.mp4',
+        mimeType: 'video/mp4',
+        size: testVideo.length,
+        fileName: 'movie.mp4',
+      },
+      { principalId: 'user_123', requestId: 'req_011' }
+    );
+
+    expect(videoResult.artifactsCreated).toBe(1);
+
+    const testAudio = createMockAudioData(5000);
+    storage.setData('tenant/file_012/ver_001.mp3', testAudio);
+
+    const audioResult = await service.runProcessing(
+      {
+        fileId: 'file_012',
+        versionId: 'ver_001',
+        storageKey: 'tenant/file_012/ver_001.mp3',
+        mimeType: 'audio/mpeg',
+        size: testAudio.length,
+        fileName: 'song.mp3',
+      },
+      { principalId: 'user_123', requestId: 'req_012' }
+    );
+
+    expect(audioResult.artifactsCreated).toBe(1);
+
+    const videoArtifacts = await service.listArtifacts('file_011', {});
+    const audioArtifacts = await service.listArtifacts('file_012', {});
+
+    expect(videoArtifacts[0].kind).toBe('video-poster');
+    expect(audioArtifacts[0].kind).toBe('audio-transcoded-aac');
+  });
+
+  it('should retrieve video and audio artifact download URLs', async () => {
+    const videoProcessor = createVideoProcessor({ generatePoster: true, transcode: false });
+    const audioProcessor = createAudioProcessor({ transcode: true });
+
+    const service = createProcessingService({
+      db,
+      storage,
+      events,
+      processors: [videoProcessor, audioProcessor],
+      enabled: true,
+    });
+
+    const testVideo = createMockVideoData(5000);
+    storage.setData('tenant/file_013/ver_001.mp4', testVideo);
+
+    await service.runProcessing(
+      {
+        fileId: 'file_013',
+        versionId: 'ver_001',
+        storageKey: 'tenant/file_013/ver_001.mp4',
+        mimeType: 'video/mp4',
+        size: testVideo.length,
+        fileName: 'video.mp4',
+      },
+      { principalId: 'user_123', requestId: 'req_013' }
+    );
+
+    const testAudio = createMockAudioData(4000);
+    storage.setData('tenant/file_014/ver_001.mp3', testAudio);
+
+    await service.runProcessing(
+      {
+        fileId: 'file_014',
+        versionId: 'ver_001',
+        storageKey: 'tenant/file_014/ver_001.mp3',
+        mimeType: 'audio/mpeg',
+        size: testAudio.length,
+        fileName: 'song.mp3',
+      },
+      { principalId: 'user_123', requestId: 'req_014' }
+    );
+
+    const videoArtifacts = await service.listArtifacts('file_013', {});
+    const audioArtifacts = await service.listArtifacts('file_014', {});
+    const videoArtifactId = videoArtifacts[0].artifactId;
+    const audioArtifactId = audioArtifacts.find((artifact) => artifact.kind.startsWith('audio-transcoded-'))?.artifactId;
+
+    const { url: videoUrl } = await service.getArtifactDownloadUrl(videoArtifactId, {});
+    const { url: audioUrl } = await service.getArtifactDownloadUrl(audioArtifactId!, {});
+
+    expect(videoUrl).toContain('tenant/file_013/ver_001-poster.jpg');
+    expect(videoUrl).toMatch(/^https:\/\/storage\.test\/download\//);
+    expect(audioUrl).toContain('tenant/file_014/ver_001-aac.m4a');
+    expect(audioUrl).toMatch(/^https:\/\/storage\.test\/download\//);
+  });
+});

--- a/filefn/server/tsconfig.json
+++ b/filefn/server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/filefn/server/vitest.config.ts
+++ b/filefn/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "datafn/extfn",
     "datafn/server",
     "datafn/svelte",
+    "filefn/*",
     "clifn/*",
     "packages/*"
   ],


### PR DESCRIPTION
## Summary
- add the `@filefn/server` package for upload sessions, policies, authz, dedup, and file routing
- include the minimal root workspace wiring for `filefn/*`
- keep `.conduct` excluded for the `origin/dev` target

## Testing
- branch-local install/build verification is currently blocked on `origin/dev` because `@superfunctions/files` is not available from the npm registry and is not present in this extracted baseline

## Notes
- `.conduct` was intentionally excluded from this PR
- `.gitignore` was not changed
- `package-lock.json` is intentionally not updated in this PR because the extracted `origin/dev` baseline cannot resolve the server package's shared-package dependencies yet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@filefn/server`, a server SDK for uploads, downloads, sharing, rendering, and processing to deliver SF‑14. Provides typed services, per‑route rate‑limited HTTP endpoints, structured errors, secure logging/redaction, and a combined router.

- **New Features**
  - Upload sessions: init/sign/complete (multipart), idempotency, size checks on completion, GC, and proxy fallback with per‑route limits.
  - Files: deterministic list/get/delete, version metadata + binding checks, signed download URLs or proxy streams, render endpoints, and cascade deletes.
  - Auth/permissions: pluggable session resolve, composable authorizers, and grants CRUD with HTTP routes.
  - Sharing: share links with auth/expiry/max‑downloads and rate‑limited downloads.
  - Processing: pluggable processors (OCR/image/video/audio), artifact storage, and artifact download routes with rate limits.
  - Policies/quota/dedup: policy registry + list route, quota route, checksum‑based dedup with storage target routing, and sanitized storage paths.
  - Platform: combined router with reserved paths, structured errors (incl. rate‑limit responses), event emitter with secret redaction, and a logger that preserves correlation IDs and redacts secrets.

- **Dependencies**
  - Adds workspace `filefn/*`.
  - `@filefn/server` depends on `@superfunctions/db`, `@superfunctions/files`, `@superfunctions/storage`, `@superfunctions/middleware`, and `@filefn/processing`.
  - Build/install on `origin/dev` remains blocked until these packages are available; `package-lock.json` is not updated.

<sup>Written for commit e3cd775b91e976ece7776308b5ede204adf0cc18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Complete server API: upload sessions (multiple modes), file/version management, proxy downloads, render intents, share links, grants/permissions, processing (OCR/transforms/media), deduplication, quota and policy endpoints, observability/logging, and structured events.

* **Tests**
  * Extensive unit & integration test coverage across uploads, proxy flows, deletes, shares, permissions, processing, dedupe, observability, rate limits, and routing.

* **Chores**
  * Added server package manifest, TypeScript project config, and Vitest config; updated workspace to include the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->