### PR TITLE
SF-14: feat(filefn): add viewer package

### DIFF
--- a/filefn/viewer/package.json
+++ b/filefn/viewer/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@filefn/viewer",
+  "version": "0.1.0",
+  "description": "Framework-agnostic viewer resolution helpers for FileFn",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "filefn",
+    "viewer",
+    "render"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "filefn/viewer"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/filefn/viewer/src/__tests__/resolver.test.ts
+++ b/filefn/viewer/src/__tests__/resolver.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createViewerResolver,
+  resolveViewerSource,
+  type FileFnClientLike,
+  type RenderDescriptor,
+} from '../resolver.js';
+
+describe('@filefn/viewer', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('TV-VIEW-001: createViewerResolver returns the underlying render descriptor', async () => {
+    const descriptor: RenderDescriptor = {
+      fileId: 'file_pdf_1',
+      versionId: 'ver_pdf_1',
+      intent: 'preview',
+      state: 'ready',
+      mimeType: 'image/png',
+      name: 'note.pdf',
+      size: 120,
+      source: {
+        mode: 'artifact',
+        artifactId: 'art_pdf_1',
+        artifactKind: 'pdf-preview-page-1-large',
+        url: '/proxy/files/file_pdf_1/artifacts/art_pdf_1/download',
+      },
+    };
+    const client: FileFnClientLike = {
+      resolveRenderable: vi.fn().mockResolvedValue(descriptor),
+    };
+
+    const resolver = createViewerResolver(client);
+    const resolved = await resolver.resolve({
+      fileId: 'file_pdf_1',
+      intent: 'preview',
+    });
+
+    expect(resolved).toEqual(descriptor);
+    expect(client.resolveRenderable).toHaveBeenCalledWith({
+      fileId: 'file_pdf_1',
+      intent: 'preview',
+    });
+  });
+
+  it('TV-VIEW-002: resolveViewerSource prefers pending-local sources when provided by the client', async () => {
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      revokeObjectURL,
+    });
+
+    const client: FileFnClientLike = {
+      resolveRenderable: vi.fn().mockResolvedValue({
+        fileId: 'file_local_pdf_1',
+        versionId: 'upl_local_1',
+        intent: 'preview',
+        state: 'pending-local',
+        mimeType: 'application/pdf',
+        name: 'draft.pdf',
+        size: 99,
+        source: {
+          mode: 'placeholder',
+          placeholderKind: 'pdf-processing',
+        },
+      } satisfies RenderDescriptor),
+    };
+
+    const source = await resolveViewerSource({
+      client,
+      fileId: 'file_local_pdf_1',
+      intent: 'preview',
+      preferLocal: true,
+    });
+
+    expect(source).toEqual({
+      fileId: 'file_local_pdf_1',
+      versionId: 'upl_local_1',
+      intent: 'preview',
+      state: 'pending-local',
+      mimeType: 'application/pdf',
+      name: 'draft.pdf',
+      size: 99,
+      placeholderKind: 'pdf-processing',
+    });
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('TV-VIEW-003: attaches revoke() for local blob URLs', async () => {
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      revokeObjectURL,
+    });
+
+    const client: FileFnClientLike = {
+      resolveRenderable: vi.fn().mockResolvedValue({
+        fileId: 'file_local_img',
+        versionId: 'upl_local_img',
+        intent: 'preview',
+        state: 'pending-local',
+        mimeType: 'image/jpeg',
+        name: 'photo.jpg',
+        size: 12,
+        source: {
+          mode: 'original',
+          url: 'blob:file_local_img',
+        },
+      } satisfies RenderDescriptor),
+    };
+
+    const source = await resolveViewerSource({
+      client,
+      fileId: 'file_local_img',
+      intent: 'preview',
+      preferLocal: true,
+    });
+
+    expect(source.url).toBe('blob:file_local_img');
+    expect(source.versionId).toBe('upl_local_img');
+    expect(source.name).toBe('photo.jpg');
+    expect(source.size).toBe(12);
+    expect(source.revoke).toBeTypeOf('function');
+    source.revoke?.();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:file_local_img');
+  });
+
+  it('TV-VIEW-004: returns unsupported placeholders deterministically for generic preview flows', async () => {
+    const client: FileFnClientLike = {
+      resolveRenderable: vi.fn().mockResolvedValue({
+        fileId: 'file_generic_1',
+        versionId: 'ver_generic_1',
+        intent: 'preview',
+        state: 'unsupported',
+        mimeType: 'application/zip',
+        name: 'bundle.zip',
+        size: 45,
+        source: {
+          mode: 'placeholder',
+          placeholderKind: 'unsupported-preview',
+        },
+      } satisfies RenderDescriptor),
+    };
+
+    const source = await resolveViewerSource({
+      client,
+      fileId: 'file_generic_1',
+      intent: 'preview',
+    });
+
+    expect(source).toEqual({
+      fileId: 'file_generic_1',
+      versionId: 'ver_generic_1',
+      intent: 'preview',
+      state: 'unsupported',
+      mimeType: 'application/zip',
+      name: 'bundle.zip',
+      size: 45,
+      placeholderKind: 'unsupported-preview',
+    });
+  });
+
+  it('TV-VIEW-005: preserves source headers for protected artifact URLs', async () => {
+    const client: FileFnClientLike = {
+      resolveRenderable: vi.fn().mockResolvedValue({
+        fileId: 'file_artifact_1',
+        versionId: 'ver_artifact_1',
+        intent: 'preview',
+        state: 'ready',
+        mimeType: 'image/png',
+        name: 'preview.png',
+        size: 128,
+        source: {
+          mode: 'artifact',
+          artifactId: 'artifact_1',
+          artifactKind: 'pdf-preview-page-1-large',
+          url: '/proxy/files/file_artifact_1/artifacts/artifact_1/download',
+          headers: {
+            Authorization: 'Bearer token',
+          },
+        },
+      } satisfies RenderDescriptor),
+    };
+
+    const source = await resolveViewerSource({
+      client,
+      fileId: 'file_artifact_1',
+      intent: 'preview',
+    });
+
+    expect(source).toEqual({
+      fileId: 'file_artifact_1',
+      versionId: 'ver_artifact_1',
+      intent: 'preview',
+      state: 'ready',
+      mimeType: 'image/png',
+      name: 'preview.png',
+      size: 128,
+      url: '/proxy/files/file_artifact_1/artifacts/artifact_1/download',
+      headers: {
+        Authorization: 'Bearer token',
+      },
+      revoke: undefined,
+    });
+  });
+});

--- a/filefn/viewer/src/index.ts
+++ b/filefn/viewer/src/index.ts
@@ -1,0 +1,14 @@
+export type {
+  FileFnClientLike,
+  RenderDescriptor,
+  RenderIntent,
+  RenderPlaceholderKind,
+  RenderState,
+  ViewerResolver,
+  ViewerSource,
+} from './resolver.js';
+
+export {
+  createViewerResolver,
+  resolveViewerSource,
+} from './resolver.js';

--- a/filefn/viewer/src/resolver.ts
+++ b/filefn/viewer/src/resolver.ts
@@ -1,0 +1,127 @@
+export type RenderIntent = 'thumbnail' | 'preview' | 'full' | 'download';
+export type RenderState = 'ready' | 'processing' | 'pending-local' | 'unsupported';
+export type RenderPlaceholderKind = 'generic-file' | 'pdf-processing' | 'unsupported-preview';
+
+export interface RenderDescriptor {
+  fileId: string;
+  versionId: string;
+  intent: RenderIntent;
+  state: RenderState;
+  mimeType: string;
+  name: string;
+  size: number;
+  source:
+    | {
+        mode: 'artifact';
+        artifactId: string;
+        artifactKind: string;
+        url: string;
+        headers?: Record<string, string>;
+      }
+    | {
+        mode: 'original';
+        url: string;
+        headers?: Record<string, string>;
+      }
+    | {
+        mode: 'placeholder';
+        placeholderKind: RenderPlaceholderKind;
+      };
+  warnings?: string[];
+}
+
+export interface FileFnClientLike {
+  resolveRenderable(input: {
+    fileId: string;
+    intent: RenderIntent;
+    versionId?: string;
+    preferLocal?: boolean;
+  }): Promise<RenderDescriptor>;
+}
+
+export interface ViewerResolver {
+  resolve(input: {
+    fileId: string;
+    intent: RenderIntent;
+    versionId?: string;
+    preferLocal?: boolean;
+  }): Promise<RenderDescriptor>;
+}
+
+export interface ViewerSource {
+  fileId: string;
+  versionId: string;
+  intent: RenderIntent;
+  state: RenderState;
+  mimeType: string;
+  name: string;
+  size: number;
+  url?: string;
+  headers?: Record<string, string>;
+  placeholderKind?: RenderPlaceholderKind;
+  warnings?: string[];
+  revoke?: () => void;
+}
+
+function createBlobRevoke(url: string): (() => void) | undefined {
+  if (!url.startsWith('blob:')) {
+    return undefined;
+  }
+  if (typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
+    return undefined;
+  }
+  return () => {
+    URL.revokeObjectURL(url);
+  };
+}
+
+export function createViewerResolver(client: FileFnClientLike): ViewerResolver {
+  return {
+    async resolve(input) {
+      return client.resolveRenderable(input);
+    },
+  };
+}
+
+export async function resolveViewerSource(input: {
+  client: FileFnClientLike;
+  fileId: string;
+  intent: RenderIntent;
+  versionId?: string;
+  preferLocal?: boolean;
+}): Promise<ViewerSource> {
+  const descriptor = await input.client.resolveRenderable({
+    fileId: input.fileId,
+    intent: input.intent,
+    versionId: input.versionId,
+    preferLocal: input.preferLocal,
+  });
+
+  if (descriptor.source.mode === 'placeholder') {
+    return {
+      fileId: descriptor.fileId,
+      versionId: descriptor.versionId,
+      intent: descriptor.intent,
+      state: descriptor.state,
+      mimeType: descriptor.mimeType,
+      name: descriptor.name,
+      size: descriptor.size,
+      placeholderKind: descriptor.source.placeholderKind,
+      warnings: descriptor.warnings,
+    };
+  }
+
+  return {
+    fileId: descriptor.fileId,
+    versionId: descriptor.versionId,
+    intent: descriptor.intent,
+    state: descriptor.state,
+    mimeType: descriptor.mimeType,
+    name: descriptor.name,
+    size: descriptor.size,
+    url: descriptor.source.url,
+    headers: descriptor.source.headers,
+    warnings: descriptor.warnings,
+    revoke: createBlobRevoke(descriptor.source.url),
+  };
+}

--- a/filefn/viewer/tsconfig.json
+++ b/filefn/viewer/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,13 @@
         "botfn/*",
         "hostfn/*",
         "authfn/*",
-        "extfn/*",
-        "extfn/examples/*",
         "datafn/client",
         "datafn/cli",
         "datafn/core",
         "datafn/docs",
-        "datafn/extfn",
         "datafn/server",
         "datafn/svelte",
+        "filefn/*",
         "clifn/*",
         "packages/*"
       ],
@@ -2346,31 +2344,6 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "datafn/extfn": {
-      "name": "@datafn/extfn",
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@datafn/client": "*",
-        "@datafn/core": "*",
-        "@superfunctions/extfn": "*"
-      },
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "typescript": "^5.6.0",
-        "vitest": "^3.2.4"
-      }
-    },
-    "datafn/extfn/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "datafn/server": {
       "name": "@datafn/server",
       "version": "0.0.2",
@@ -2594,157 +2567,17 @@
         }
       }
     },
-    "extfn/cli": {
-      "name": "@superfunctions/extfn-cli",
+    "filefn/viewer": {
+      "name": "@filefn/viewer",
       "version": "0.1.0",
       "license": "MIT",
-      "dependencies": {
-        "@superfunctions/extfn": "*",
-        "@superfunctions/extfn-vite": "*",
-        "clifn": "*",
-        "commander": "^12.1.0",
-        "fflate": "^0.8.2",
-        "vite": "^5.4.21"
-      },
-      "bin": {
-        "extfn": "dist/cli.js"
-      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
         "vitest": "^3.2.4"
       }
     },
-    "extfn/cli/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "extfn/cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "extfn/core": {
-      "name": "@superfunctions/extfn",
-      "version": "0.1.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "jsdom": "^27.4.0",
-        "typescript": "^5.6.0",
-        "vitest": "^3.2.4"
-      }
-    },
-    "extfn/core/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "extfn/examples/svelte-datafn-demo": {
-      "version": "0.1.0",
-      "dependencies": {
-        "@datafn/core": "*",
-        "@datafn/extfn": "*",
-        "@superfunctions/extfn": "*",
-        "@superfunctions/extfn-svelte": "*",
-        "@superfunctions/extfn-vite": "*",
-        "svelte": "^5.0.0"
-      },
-      "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^4.0.4",
-        "typescript": "^5.6.0",
-        "vite": "^5.4.21"
-      }
-    },
-    "extfn/examples/svelte-multi-content-demo": {
-      "version": "0.1.0",
-      "dependencies": {
-        "@superfunctions/extfn": "*",
-        "@superfunctions/extfn-svelte": "*",
-        "@superfunctions/extfn-vite": "*",
-        "svelte": "^5.0.0"
-      },
-      "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^4.0.4",
-        "typescript": "^5.6.0",
-        "vite": "^5.4.21"
-      }
-    },
-    "extfn/examples/vanilla-messaging-demo": {
-      "version": "0.1.0",
-      "dependencies": {
-        "@superfunctions/extfn": "*",
-        "@superfunctions/extfn-vite": "*"
-      },
-      "devDependencies": {
-        "typescript": "^5.6.0",
-        "vite": "^5.4.21"
-      }
-    },
-    "extfn/svelte": {
-      "name": "@superfunctions/extfn-svelte",
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@superfunctions/extfn": "*"
-      },
-      "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^4.0.4",
-        "@types/node": "^22.0.0",
-        "jsdom": "^27.4.0",
-        "svelte": "^5.0.0",
-        "typescript": "^5.6.0",
-        "vite": "^5.4.21",
-        "vitest": "^3.2.4"
-      },
-      "peerDependencies": {
-        "svelte": "^5.0.0"
-      }
-    },
-    "extfn/svelte/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "extfn/vite": {
-      "name": "@superfunctions/extfn-vite",
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@superfunctions/cli": "*",
-        "@superfunctions/extfn": "*"
-      },
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "typescript": "^5.6.0",
-        "vite": "^5.4.21",
-        "vitest": "^3.2.4"
-      },
-      "peerDependencies": {
-        "vite": "^5.4.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
-    "extfn/vite/node_modules/@types/node": {
+    "filefn/viewer/node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
@@ -3560,13 +3393,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "license": "MIT",
@@ -3615,82 +3441,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -3874,121 +3624,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
     "node_modules/@datafn/cli": {
       "resolved": "datafn/cli",
       "link": true
@@ -4003,10 +3638,6 @@
     },
     "node_modules/@datafn/docs": {
       "resolved": "datafn/docs",
-      "link": true
-    },
-    "node_modules/@datafn/extfn": {
-      "resolved": "datafn/extfn",
       "link": true
     },
     "node_modules/@datafn/server": {
@@ -4334,24 +3965,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "4.0.5",
       "dev": true,
@@ -4492,6 +4105,10 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@filefn/viewer": {
+      "resolved": "filefn/viewer",
+      "link": true
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -5837,6 +5454,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5988,22 +5606,6 @@
       "resolved": "packages/docs-theme",
       "link": true
     },
-    "node_modules/@superfunctions/extfn": {
-      "resolved": "extfn/core",
-      "link": true
-    },
-    "node_modules/@superfunctions/extfn-cli": {
-      "resolved": "extfn/cli",
-      "link": true
-    },
-    "node_modules/@superfunctions/extfn-svelte": {
-      "resolved": "extfn/svelte",
-      "link": true
-    },
-    "node_modules/@superfunctions/extfn-vite": {
-      "resolved": "extfn/vite",
-      "link": true
-    },
     "node_modules/@superfunctions/http": {
       "resolved": "packages/http",
       "link": true
@@ -6030,49 +5632,10 @@
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
-      }
-    },
-    "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.4.tgz",
-      "integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
-        "debug": "^4.3.7",
-        "deepmerge": "^4.3.1",
-        "kleur": "^4.1.5",
-        "magic-string": "^0.30.12",
-        "vitefu": "^1.0.3"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22"
-      },
-      "peerDependencies": {
-        "svelte": "^5.0.0-next.96 || ^5.0.0",
-        "vite": "^5.0.0"
-      }
-    },
-    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-3.0.1.tgz",
-      "integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.7"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22"
-      },
-      "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0||^4.0.0",
-        "svelte": "^5.0.0-next.96 || ^5.0.0",
-        "vite": "^5.0.0"
       }
     },
     "node_modules/@swc/counter": {
@@ -7118,16 +6681,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "dev": true,
@@ -7218,6 +6771,7 @@
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -7338,6 +6892,7 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -7395,16 +6950,6 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bindings": {
@@ -8061,78 +7606,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cssstyle/node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/cssstyle/node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "devOptional": true,
@@ -8575,30 +8048,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/data-urls": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
-      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^15.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "license": "MIT"
@@ -8617,13 +8066,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -8678,6 +8120,7 @@
       "version": "4.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8739,6 +8182,7 @@
     },
     "node_modules/devalue": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -9004,19 +8448,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/error-stack-parser-es": {
       "version": "1.0.5",
       "dev": true,
@@ -9101,6 +8532,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9140,6 +8572,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9323,6 +8756,7 @@
     },
     "node_modules/esm-env": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -9365,7 +8799,9 @@
     },
     "node_modules/esrap": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
@@ -9782,6 +9218,7 @@
     },
     "node_modules/fflate": {
       "version": "0.8.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -10454,19 +9891,6 @@
       "resolved": "hostfn/cli",
       "link": true
     },
-    "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.6.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "dev": true,
@@ -10497,34 +9921,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -10731,15 +10127,9 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-reference": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -10872,68 +10262,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdom": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
-      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@acemir/cssom": "^0.9.28",
-        "@asamuzakjp/dom-selector": "^6.7.6",
-        "@exodus/bytes": "^1.6.0",
-        "cssstyle": "^5.3.4",
-        "data-urls": "^6.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.0",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^15.1.0",
-        "ws": "^8.18.3",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/json-buffer": {
@@ -11169,6 +10497,7 @@
     },
     "node_modules/locate-character": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -13014,19 +12343,6 @@
       "version": "2.0.11",
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "dev": true,
@@ -13837,6 +13153,7 @@
     },
     "node_modules/rollup": {
       "version": "4.53.3",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -14012,19 +13329,6 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
-    },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -14755,7 +14059,9 @@
     },
     "node_modules/svelte": {
       "version": "5.46.1",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -14776,21 +14082,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/svelte-datafn-demo": {
-      "resolved": "extfn/examples/svelte-datafn-demo",
-      "link": true
-    },
-    "node_modules/svelte-multi-content-demo": {
-      "resolved": "extfn/examples/svelte-multi-content-demo",
-      "link": true
-    },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -15014,19 +14305,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -15632,10 +14910,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/vanilla-messaging-demo": {
-      "resolved": "extfn/examples/vanilla-messaging-demo",
-      "link": true
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -15670,6 +14944,7 @@
     },
     "node_modules/vite": {
       "version": "5.4.21",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -15750,6 +15025,7 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "tests/deps/*",
         "tests/projects/*",
@@ -16015,53 +15291,6 @@
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "license": "MIT"
-    },
-    "node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -16355,23 +15584,6 @@
         }
       }
     },
-    "node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "dev": true,
@@ -16455,7 +15667,9 @@
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zod": {
       "version": "3.25.76",


### PR DESCRIPTION
## Summary
- add the `@filefn/viewer` package for render resolution and viewer source helpers
- include the minimal root workspace wiring for `filefn/*`
- keep `.conduct` excluded for the `origin/dev` target

## Testing
- `cd filefn/viewer && npm run build`
- `cd filefn/viewer && npm run typecheck`
- `cd filefn/viewer && npm test -- --run`

## Notes
- `.conduct` was intentionally excluded from this PR
- `.gitignore` was not changed

## Summary by Sourcery

Add a new framework-agnostic viewer helper package for FileFn and wire it into the monorepo workspace.

New Features:
- Introduce the @filefn/viewer package providing typed viewer resolution and source helper utilities for FileFn clients.

Enhancements:
- Register the filefn workspace scope in the root package configuration to include the new viewer package.

Tests:
- Add unit test scaffolding for the viewer resolver utilities in the new @filefn/viewer package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@filefn/viewer`, a framework-agnostic helper to turn FileFn render descriptors into viewer-ready sources. Delivers SF-14 with support for thumbnails, previews, full views, and downloads, including header pass-through and safe blob URL cleanup.

- **New Features**
  - `createViewerResolver(client)` proxies `client.resolveRenderable(...)`.
  - `resolveViewerSource(...)` returns a URL or placeholder, respects `preferLocal`, preserves `headers`, and adds `revoke()` for `blob:` URLs.
  - Typed intents, states, placeholder kinds, and exported client/resolver/source types with warnings pass-through; unit tests with `vitest`.
  - Root workspace wiring now includes `filefn/*`.

<sup>Written for commit 2385a8433de618c330b20336ec35febc1985abcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new viewer package providing file rendering resolution with support for multiple render states (ready, processing, pending-local, unsupported) and intents (thumbnail, preview, full, download).
  * Added placeholder support for files in processing or unsupported formats.
  * Included resource cleanup functionality for blob-based content.

* **Tests**
  * Added comprehensive test suite validating resolver functionality and source resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->