### PR TITLE
SF-14: feat(filefn): add python package

### DIFF
--- a/filefn/python/README.md
+++ b/filefn/python/README.md
@@ -1,0 +1,171 @@
+# FileFn Python SDK
+
+The **FileFn Python SDK** is a powerful library for implementing robust file management capabilities in your Python applications. It provides a complete "backend-in-a-box" for handling file uploads, storage abstraction, metadata management, processing pipelines (like image thumbnails), and secure sharing.
+
+Designed to integrate seamlessly with the [Superfunctions](https://github.com/21nCo/super-functions) ecosystem, it delegates persistence and storage to pluggable adapters.
+
+## Features
+
+- **Chunked & Resumable Uploads:** Built-in support for creating upload sessions, handling multi-part uploads, and verifying completion.
+- **Storage Abstraction:** Works with any `StorageAdapter` (S3, GCS, Azure, Local, etc.) provided by Superfunctions.
+- **File Processing:** Extensible processing pipeline. Includes a built-in **Thumbnail Processor** for on-the-fly image resizing.
+- **Deduplication:** Optional content-addressable storage logic to avoid storing duplicate files.
+- **Security & Permissions:**
+  - **Signed URLs:** Secure upload and download links.
+  - **Grants System:** Fine-grained permissions (read/write/delete/share) for users/tenants.
+  - **Policies:** Define storage and access policies.
+- **Sharing:** Generate secure, expiring share links for public or restricted access.
+- **Observability:** Built-in event emitter for tracking file operations.
+
+## Installation
+
+```bash
+pip install filefn
+```
+
+## Quick Start
+
+The core of the library is the `FileFn` class, initialized via `create_file_fn`. You need to provide database and storage adapters.
+
+### 1. Setup & Initialization
+
+```python
+import asyncio
+from filefn.server import create_file_fn, FileFnConfig
+from filefn.processing.processors.thumbnail import create_thumbnail_processor, ThumbnailConfig
+
+# Import adapters from your specific implementation or mocks
+# from superfunctions.db.memory import MemoryAdapter
+# from superfunctions.storage.local import LocalStorageAdapter
+
+async def main():
+    # 1. Initialize Adapters (replace these placeholders with real implementations)
+    db_adapter = ...
+    storage_adapter = ...
+
+    # 2. Configure FileFn
+    config = FileFnConfig(
+        db=db_adapter,
+        storage=storage_adapter,
+        namespace="my-app-files",
+        
+        # Optional: Enable image thumbnail generation
+        processing={
+            "enabled": True,
+            "processors": [
+                create_thumbnail_processor(ThumbnailConfig(
+                    format="jpeg",
+                    quality=80,
+                    sizes=[
+                        {"name": "thumb", "width": 150, "height": 150},
+                        {"name": "preview", "width": 800, "height": 600}
+                    ]
+                ))
+            ]
+        },
+        
+        # Security settings
+        signed_url_ttl_seconds=3600, # 1 hour
+    )
+
+    # 3. Create the Service
+    filefn = create_file_fn(config)
+
+    # Now you can use filefn to manage files
+    print("FileFn Service initialized!")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### 2. Handling Uploads
+
+FileFn uses a session-based approach for uploads (similar to S3 Multipart Uploads) to handle large files reliably.
+
+```python
+# 1. Create an Upload Session
+session_input = {
+    "fileName": "vacation_photo.jpg",
+    "mimeType": "image/jpeg",
+    "size": 1024 * 1024 * 5, # 5MB
+    "ownerId": "user_123",
+    "policy": "default"
+}
+# ctx is a context object, usually containing request/auth info
+ctx = {} 
+session = await filefn.create_upload_session(session_input, ctx)
+print(f"Session created: {session['uploadSessionId']}")
+
+# 2. Client uploads parts using signed URLs provided in the session...
+# (The client would PUT data to session['parts'][0]['url'], etc.)
+
+# 3. Complete the Session (after client finishes uploading)
+await filefn.complete_upload_session({
+    "uploadSessionId": session['uploadSessionId']
+}, ctx)
+
+print("Upload complete & file created!")
+```
+
+### 3. Listing & Downloading
+
+```python
+# List files for a specific owner
+files = await filefn.list_files({
+    "limit": 20
+}, ctx)
+
+for f in files["files"]:
+    print(f"File: {f['name']} ({f['size']} bytes)")
+
+# Get a download URL (Signed URL)
+file_data = await filefn.get_file({"fileId": files["files"][0]["fileId"]}, ctx)
+print(f"Download URL: {file_data['downloadUrl']}")
+```
+
+## Configuration Options
+
+The `FileFnConfig` model accepts the following parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `db` | `Adapter` | **Required.** Database adapter instance. |
+| `storage` | `StorageAdapter` | **Required.** Storage adapter instance. |
+| `namespace` | `str` | Table prefix for database (default: `'filefn'`). |
+| `policies` | `List[Policy]` | Custom storage/access policies. |
+| `processing` | `Dict` | Configuration for file processing (thumbnails, etc.). |
+| `authorizer` | `Authorizer` | Optional custom authorization logic. |
+| `quota` | `QuotaProvider` | Optional quota management provider. |
+| `signed_url_ttl_seconds` | `int` | TTL for generated signed URLs (default: `900`). |
+| `upload_session_ttl_seconds` | `int` | TTL for pending upload sessions (default: `86400`). |
+
+## Processors
+
+### Thumbnail Processor
+
+Automatically generates image thumbnails upon upload completion.
+
+```python
+from filefn.processing.processors.thumbnail import create_thumbnail_processor, ThumbnailConfig
+
+processor = create_thumbnail_processor(ThumbnailConfig(
+    sizes=[
+        {"name": "small", "width": 100, "height": 100},
+        {"name": "large", "width": 1024, "height": 1024}
+    ],
+    format="webp", # 'jpeg', 'png', 'webp'
+    quality=90
+))
+```
+
+## Architecture
+
+FileFn is built on a modular architecture:
+
+- **Core Service (`FileFn`):** Orchestrates all operations.
+- **UploadSessionService:** Manages the lifecycle of multipart uploads.
+- **FileService:** Handles file metadata (indexing, searching) and deletion.
+- **ProcessingService:** Runs background jobs (processors) on new files.
+- **Adapters:** Decouples the logic from specific infrastructure (DB/Storage).
+
+This design allows FileFn to run on your local machine, in a serverless function, or a dedicated container with equal ease.

--- a/filefn/python/filefn/__init__.py
+++ b/filefn/python/filefn/__init__.py
@@ -1,0 +1,7 @@
+from .server import FileFn, FileFnConfig, create_file_fn
+
+__all__ = [
+    "create_file_fn",
+    "FileFn",
+    "FileFnConfig",
+]

--- a/filefn/python/filefn/processing/__init__.py
+++ b/filefn/python/filefn/processing/__init__.py
@@ -1,0 +1,131 @@
+from typing import Any, Awaitable, Callable, List, Optional
+
+from .types import (
+    CompressionConfig,
+    CropOptions,
+    ImageTransformConfig,
+    ImageTransformOperation,
+    OCRConfig,
+    PdfPreviewConfig,
+    Processor,
+    ProcessorInput,
+    ProcessorOutputArtifact,
+    ProcessorResult,
+    ResizeOptions,
+    RotateOptions,
+    ThumbnailConfig,
+    ThumbnailSize,
+)
+
+THUMBNAIL_SUPPORTED_MIME_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+    "image/tiff",
+]
+COMPRESSION_SUPPORTED_MIME_TYPES = ["*/*"]
+OCR_SUPPORTED_MIME_TYPES = ["image/png", "image/jpeg", "image/webp", "image/tiff"]
+IMAGE_TRANSFORM_SUPPORTED_MIME_TYPES = THUMBNAIL_SUPPORTED_MIME_TYPES
+VIDEO_SUPPORTED_MIME_TYPES = ["video/*"]
+AUDIO_SUPPORTED_MIME_TYPES = ["audio/*"]
+PDF_PREVIEW_SUPPORTED_MIME_TYPES = ["application/pdf"]
+
+
+class _UnavailableProcessor:
+    def __init__(
+        self,
+        *,
+        name: str,
+        supported_mime_types: List[str],
+        error_code: str,
+    ):
+        self.name = name
+        self.supportedMimeTypes = supported_mime_types
+        self.error_code = error_code
+
+    async def process(self, input: ProcessorInput, get_data: Callable[[], Awaitable[bytes]]) -> ProcessorResult:
+        return ProcessorResult(success=False, artifacts=[], error=self.error_code)
+
+
+def create_thumbnail_processor(config: Optional[ThumbnailConfig] = None) -> Processor:
+    from .processors.thumbnail import create_thumbnail_processor as _create_thumbnail_processor
+
+    return _create_thumbnail_processor(config)
+
+
+def create_pdf_preview_processor(config: Optional[PdfPreviewConfig] = None) -> Processor:
+    from .processors.pdf_preview import create_pdf_preview_processor as _create_pdf_preview_processor
+
+    return _create_pdf_preview_processor(config)
+
+
+def create_compression_processor(config: Optional[CompressionConfig] = None) -> Processor:
+    from .processors.compression import create_compression_processor as _create_compression_processor
+
+    return _create_compression_processor(config)
+
+
+def create_ocr_processor(config: Optional[OCRConfig] = None) -> Processor:
+    _ = config or OCRConfig()
+    return _UnavailableProcessor(
+        name="ocr",
+        supported_mime_types=OCR_SUPPORTED_MIME_TYPES,
+        error_code="FILEFN_PROCESSING_OCR_PROVIDER_REQUIRED",
+    )
+
+
+def create_image_transform_processor(config: ImageTransformConfig) -> Processor:
+    from .processors.image_transform import create_image_transform_processor as _create_image_transform_processor
+
+    return _create_image_transform_processor(config)
+
+
+def create_video_processor(config: Optional[dict[str, Any]] = None) -> Processor:
+    _ = config or {}
+    return _UnavailableProcessor(
+        name="video",
+        supported_mime_types=VIDEO_SUPPORTED_MIME_TYPES,
+        error_code="FILEFN_PROCESSING_VIDEO_PROVIDER_REQUIRED",
+    )
+
+
+def create_audio_processor(config: Optional[dict[str, Any]] = None) -> Processor:
+    _ = config or {}
+    return _UnavailableProcessor(
+        name="audio",
+        supported_mime_types=AUDIO_SUPPORTED_MIME_TYPES,
+        error_code="FILEFN_PROCESSING_AUDIO_PROVIDER_REQUIRED",
+    )
+
+
+__all__ = [
+    "Processor",
+    "ProcessorInput",
+    "ProcessorOutputArtifact",
+    "ProcessorResult",
+    "ThumbnailConfig",
+    "PdfPreviewConfig",
+    "ThumbnailSize",
+    "CompressionConfig",
+    "OCRConfig",
+    "ImageTransformOperation",
+    "ImageTransformConfig",
+    "ResizeOptions",
+    "CropOptions",
+    "RotateOptions",
+    "create_thumbnail_processor",
+    "create_pdf_preview_processor",
+    "create_compression_processor",
+    "create_ocr_processor",
+    "create_image_transform_processor",
+    "create_video_processor",
+    "create_audio_processor",
+    "THUMBNAIL_SUPPORTED_MIME_TYPES",
+    "COMPRESSION_SUPPORTED_MIME_TYPES",
+    "OCR_SUPPORTED_MIME_TYPES",
+    "IMAGE_TRANSFORM_SUPPORTED_MIME_TYPES",
+    "VIDEO_SUPPORTED_MIME_TYPES",
+    "AUDIO_SUPPORTED_MIME_TYPES",
+    "PDF_PREVIEW_SUPPORTED_MIME_TYPES",
+]

--- a/filefn/python/filefn/processing/processors/compression.py
+++ b/filefn/python/filefn/processing/processors/compression.py
@@ -1,0 +1,53 @@
+import gzip
+import io
+from typing import Any, Optional, List
+from ..types import Processor, ProcessorInput, ProcessorResult, ProcessorOutputArtifact, CompressionConfig
+
+SUPPORTED_MIME_TYPES = ['*/*']
+UNSUPPORTED_ALGORITHM_ERROR = 'FILEFN_PROCESSING_UNSUPPORTED_COMPRESSION_ALGORITHM'
+COMPRESSION_FAILED_ERROR = 'FILEFN_PROCESSING_COMPRESSION_FAILED'
+
+class CompressionProcessor:
+    def __init__(self, config: Optional[CompressionConfig] = None):
+        config = config or CompressionConfig()
+        self.algorithm = config.algorithm or 'gzip'
+        self.level = config.level or 6
+        self.name = 'compression'
+        self.supportedMimeTypes = SUPPORTED_MIME_TYPES
+
+    async def process(self, input: ProcessorInput, get_data: Any) -> ProcessorResult:
+        if self.algorithm != 'gzip':
+             return ProcessorResult(success=False, artifacts=[], error=UNSUPPORTED_ALGORITHM_ERROR)
+
+        try:
+            data = await get_data()
+            
+            out_buffer = io.BytesIO()
+            with gzip.GzipFile(fileobj=out_buffer, mode='wb', compresslevel=self.level) as f:
+                f.write(data)
+            
+            compressed_data = out_buffer.getvalue()
+            
+            artifacts = [ProcessorOutputArtifact(
+                kind='compressed',
+                data=compressed_data,
+                mimeType='application/gzip',
+                storageKey=f"{input.storageKey}.gz",
+                metadata={
+                    'algorithm': self.algorithm,
+                    'level': self.level,
+                    'originalSize': len(data),
+                    'compressedSize': len(compressed_data),
+                    'ratio': len(compressed_data) / len(data) if len(data) > 0 else 0
+                }
+            )]
+
+            return ProcessorResult(success=True, artifacts=artifacts)
+
+        except Exception:
+            return ProcessorResult(success=False, artifacts=[], error=COMPRESSION_FAILED_ERROR)
+
+def create_compression_processor(config: Optional[CompressionConfig] = None) -> Processor:
+    return CompressionProcessor(config)
+
+COMPRESSION_SUPPORTED_MIME_TYPES = SUPPORTED_MIME_TYPES

--- a/filefn/python/filefn/processing/processors/image_transform.py
+++ b/filefn/python/filefn/processing/processors/image_transform.py
@@ -1,0 +1,204 @@
+import io
+from pathlib import PurePosixPath
+from typing import Any, Optional
+
+from ..types import (
+    CropOptions,
+    ImageTransformConfig,
+    Processor,
+    ProcessorInput,
+    ProcessorOutputArtifact,
+    ProcessorResult,
+    ResizeOptions,
+    RotateOptions,
+)
+
+SUPPORTED_MIME_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/tiff"]
+UNSUPPORTED_MIME_TYPE_ERROR = "FILEFN_PROCESSING_UNSUPPORTED_MIME_TYPE"
+IMAGE_TRANSFORM_FAILED_ERROR = "FILEFN_PROCESSING_IMAGE_TRANSFORM_FAILED"
+
+
+class ImageTransformProcessor:
+    def __init__(self, config: ImageTransformConfig):
+        self.config = config
+        self.name = "image-transform"
+        self.supportedMimeTypes = SUPPORTED_MIME_TYPES
+
+    async def process(self, input: ProcessorInput, get_data: Any) -> ProcessorResult:
+        if input.mimeType not in self.supportedMimeTypes:
+            return ProcessorResult(success=False, artifacts=[], error=UNSUPPORTED_MIME_TYPE_ERROR)
+
+        try:
+            from PIL import Image
+
+            source_data = await get_data()
+            with Image.open(io.BytesIO(source_data)) as img:
+                if getattr(img, "n_frames", 1) > 1:
+                    return ProcessorResult(success=False, artifacts=[], error=IMAGE_TRANSFORM_FAILED_ERROR)
+                source_format = img.format
+                working = img.copy()
+                applied = []
+
+                for operation in self.config.operations:
+                    suffix = operation.suffix or operation.operation
+                    applied.append(suffix)
+                    if operation.operation == "resize" and isinstance(operation.options, ResizeOptions):
+                        width = operation.options.width or working.width
+                        height = operation.options.height or working.height
+                        target_size = self._resolve_resize_target(
+                            working.width,
+                            working.height,
+                            width,
+                            height,
+                            operation.options.withoutEnlargement or False,
+                        )
+                        fit = (operation.options.fit or "cover").lower()
+                        if fit == "fill":
+                            working = working.resize(target_size, Image.Resampling.LANCZOS)
+                        elif fit in {"contain", "inside"}:
+                            from PIL import ImageOps
+
+                            working.thumbnail(target_size, Image.Resampling.LANCZOS)
+                            if fit == "contain":
+                                working = ImageOps.pad(
+                                    working,
+                                    target_size,
+                                    method=Image.Resampling.LANCZOS,
+                                )
+                        elif fit == "outside":
+                            from PIL import ImageOps
+
+                            working = ImageOps.fit(
+                                working,
+                                target_size,
+                                method=Image.Resampling.LANCZOS,
+                                bleed=0.0,
+                                centering=(0.5, 0.5),
+                            )
+                        else:
+                            from PIL import ImageOps
+
+                            working = ImageOps.fit(
+                                working,
+                                target_size,
+                                method=Image.Resampling.LANCZOS,
+                                bleed=0.0,
+                                centering=(0.5, 0.5),
+                            )
+                    elif operation.operation == "crop" and isinstance(operation.options, CropOptions):
+                        box = (
+                            operation.options.left,
+                            operation.options.top,
+                            operation.options.left + operation.options.width,
+                            operation.options.top + operation.options.height,
+                        )
+                        working = working.crop(box)
+                    elif operation.operation == "rotate" and isinstance(operation.options, RotateOptions):
+                        working, fillcolor = self._resolve_rotate_fillcolor(working, operation.options.background)
+                        working = working.rotate(operation.options.angle, expand=True, fillcolor=fillcolor)
+
+                output_format = (self.config.outputFormat or source_format or "PNG").upper()
+                if output_format == "JPG":
+                    output_format = "JPEG"
+
+                output_mime = {
+                    "JPEG": "image/jpeg",
+                    "PNG": "image/png",
+                    "WEBP": "image/webp",
+                    "GIF": "image/gif",
+                    "TIFF": "image/tiff",
+                }.get(output_format, "image/png")
+                extension = {
+                    "JPEG": "jpg",
+                    "PNG": "png",
+                    "WEBP": "webp",
+                    "GIF": "gif",
+                    "TIFF": "tiff",
+                }.get(output_format, "png")
+
+                if output_format == "JPEG" and working.mode not in ("RGB", "L"):
+                    working = working.convert("RGB")
+
+                out_buffer = io.BytesIO()
+                save_kwargs: dict[str, Any] = {"format": output_format}
+                if output_format in ("JPEG", "WEBP") and self.config.outputQuality is not None:
+                    save_kwargs["quality"] = self.config.outputQuality
+                working.save(out_buffer, **save_kwargs)
+
+                base_key = self._split_storage_key(input.storageKey)
+                suffix = "-".join(applied) if applied else "transformed"
+                return ProcessorResult(
+                    success=True,
+                    artifacts=[
+                        ProcessorOutputArtifact(
+                            kind="image-transform",
+                            data=out_buffer.getvalue(),
+                            mimeType=output_mime,
+                            storageKey=f"{base_key}-{suffix}.{extension}",
+                            metadata={
+                                "operations": [op.operation for op in self.config.operations],
+                                "sourceFileId": input.fileId,
+                                "sourceVersionId": input.versionId,
+                            },
+                        )
+                    ],
+                )
+        except Exception:
+            return ProcessorResult(success=False, artifacts=[], error=IMAGE_TRANSFORM_FAILED_ERROR)
+
+    @staticmethod
+    def _resolve_resize_target(
+        current_width: int,
+        current_height: int,
+        requested_width: int,
+        requested_height: int,
+        without_enlargement: bool,
+    ) -> tuple[int, int]:
+        width = max(1, requested_width)
+        height = max(1, requested_height)
+        if without_enlargement:
+            width = min(width, current_width)
+            height = min(height, current_height)
+        return (width, height)
+
+    @staticmethod
+    def _split_storage_key(storage_key: str) -> str:
+        path = PurePosixPath(storage_key)
+        stem = path.stem
+        if str(path.parent) in ("", "."):
+            return stem
+        return str(path.parent / stem)
+
+    @staticmethod
+    def _resolve_rotate_fillcolor(image: Any, background: Optional[dict[str, Any]]) -> tuple[Any, Any]:
+        if background is None:
+            return image, None
+
+        red = int(background.get("r", 0))
+        green = int(background.get("g", 0))
+        blue = int(background.get("b", 0))
+        alpha = int(background.get("alpha", 255))
+        grayscale = int(round((0.299 * red) + (0.587 * green) + (0.114 * blue)))
+        mode = image.mode
+
+        if mode in ("RGBA", "RGBa"):
+            return image, (red, green, blue, alpha)
+        if mode in ("RGB", "YCbCr"):
+            return image, (red, green, blue)
+        if mode == "LA":
+            return image, (grayscale, alpha)
+        if mode in ("L", "1"):
+            return image, grayscale
+        if mode in ("CMYK",):
+            return image.convert("RGBA"), (red, green, blue, alpha)
+        if mode in ("P", "PA"):
+            return image.convert("RGBA"), (red, green, blue, alpha)
+
+        return image.convert("RGBA"), (red, green, blue, alpha)
+
+
+def create_image_transform_processor(config: ImageTransformConfig) -> Processor:
+    return ImageTransformProcessor(config)
+
+
+IMAGE_TRANSFORM_SUPPORTED_MIME_TYPES = SUPPORTED_MIME_TYPES

--- a/filefn/python/filefn/processing/processors/pdf_preview.py
+++ b/filefn/python/filefn/processing/processors/pdf_preview.py
@@ -1,0 +1,147 @@
+import io
+import struct
+import zlib
+from typing import Optional, Tuple
+
+from ..types import PdfPreviewConfig, Processor, ProcessorInput, ProcessorOutputArtifact, ProcessorResult, ThumbnailSize
+
+DEFAULT_SIZES = [
+    ThumbnailSize(name='small', width=150, height=150),
+    ThumbnailSize(name='medium', width=300, height=300),
+    ThumbnailSize(name='large', width=600, height=600),
+]
+
+SUPPORTED_MIME_TYPES = ['application/pdf']
+UNSUPPORTED_MIME_TYPE_ERROR = 'FILEFN_PROCESSING_UNSUPPORTED_MIME_TYPE'
+PDF_PREVIEW_FAILED_ERROR = 'FILEFN_PROCESSING_PDF_PREVIEW_FAILED'
+
+
+class PdfPreviewProcessor:
+    def __init__(self, config: Optional[PdfPreviewConfig] = None):
+        config = config or PdfPreviewConfig()
+        self.sizes = config.sizes or DEFAULT_SIZES
+        self.density = config.density or 144
+        self.quality = config.quality or 85
+        self.format = config.format or 'png'
+        self.name = 'pdf-preview'
+        self.supportedMimeTypes = SUPPORTED_MIME_TYPES
+
+    async def process(self, input: ProcessorInput, get_data) -> ProcessorResult:
+        if input.mimeType not in self.supportedMimeTypes:
+            return ProcessorResult(success=False, artifacts=[], error=UNSUPPORTED_MIME_TYPE_ERROR)
+
+        try:
+            pdf_data = await get_data()
+            artifacts = []
+            for size in self.sizes:
+                preview_data, render_mode = self._render_preview(pdf_data, size)
+                base_key = input.storageKey.rsplit('.', 1)[0]
+                output_data, output_mime_type, extension = self._format_output(preview_data)
+                artifacts.append(
+                    ProcessorOutputArtifact(
+                        kind=f'pdf-preview-page-1-{size.name}',
+                        data=output_data,
+                        mimeType=output_mime_type,
+                        storageKey=f'{base_key}-pdf-preview-page-1-{size.name}.{extension}',
+                        metadata={
+                            'width': size.width,
+                            'height': size.height,
+                            'density': self.density,
+                            'pageNumber': 1,
+                            'format': extension,
+                            'renderMode': render_mode,
+                            'sourceFileId': input.fileId,
+                            'sourceVersionId': input.versionId,
+                            'originalSize': len(pdf_data),
+                            'previewSize': len(output_data),
+                        },
+                    )
+                )
+
+            return ProcessorResult(success=True, artifacts=artifacts)
+        except Exception:
+            return ProcessorResult(success=False, artifacts=[], error=PDF_PREVIEW_FAILED_ERROR)
+
+    def _render_preview(self, pdf_data: bytes, size: ThumbnailSize) -> Tuple[bytes, str]:
+        try:
+            from PIL import Image
+
+            with io.BytesIO(pdf_data) as f:
+                with Image.open(f) as img:
+                    img = img.copy()
+                    img.thumbnail((size.width, size.height), Image.Resampling.LANCZOS)
+                    out_buffer = io.BytesIO()
+                    img.save(out_buffer, format='PNG')
+                    return out_buffer.getvalue(), 'page-rasterized'
+        except Exception:
+            return self._generate_placeholder_preview(pdf_data, size), 'placeholder'
+
+    def _generate_placeholder_preview(self, pdf_data: bytes, size: ThumbnailSize) -> bytes:
+        width = max(1, size.width)
+        height = max(1, size.height)
+        accent = sum((index + 17) * byte for index, byte in enumerate(pdf_data[:96])) % 256
+        header_height = max(12, height // 6)
+        margin_x = max(8, width // 8)
+        margin_y = max(8, height // 10)
+        line_gap = max(10, height // 8)
+        line_height = max(2, height // 35)
+        pixels = bytearray()
+
+        for y in range(height):
+            pixels.append(0)
+            for x in range(width):
+                if y < header_height:
+                    r, g, b = accent, (accent * 3) % 256, (accent * 5) % 256
+                elif margin_x <= x <= width - margin_x and margin_y <= y <= height - margin_y:
+                    r, g, b = 255, 255, 255
+                    for offset, length_scale in enumerate((0.78, 0.66, 0.72)):
+                        line_y = margin_y + header_height + offset * line_gap
+                        line_end = margin_x + int(width * length_scale)
+                        if line_y <= y < line_y + line_height and margin_x <= x <= min(width - margin_x, line_end):
+                            r, g, b = 214, 220, 228
+                            break
+                else:
+                    r, g, b = 242, 244, 247
+                pixels.extend((r, g, b))
+
+        compressor = zlib.compressobj()
+        compressed = compressor.compress(bytes(pixels)) + compressor.flush()
+        return b''.join([
+            b'\x89PNG\r\n\x1a\n',
+            self._png_chunk(b'IHDR', struct.pack('>IIBBBBB', width, height, 8, 2, 0, 0, 0)),
+            self._png_chunk(b'IDAT', compressed),
+            self._png_chunk(b'IEND', b''),
+        ])
+
+    def _format_output(self, preview_png: bytes) -> Tuple[bytes, str, str]:
+        if self.format == 'png':
+            return preview_png, 'image/png', 'png'
+
+        try:
+            from PIL import Image
+
+            with Image.open(io.BytesIO(preview_png)) as img:
+                out_buffer = io.BytesIO()
+                fmt = self.format.upper()
+                if fmt == 'JPG':
+                    fmt = 'JPEG'
+                if fmt == 'JPEG' and img.mode in ('RGBA', 'P'):
+                    img = img.convert('RGB')
+                img.save(out_buffer, format=fmt, quality=self.quality)
+                mime_type = 'image/webp' if fmt == 'WEBP' else 'image/jpeg'
+                extension = 'webp' if fmt == 'WEBP' else 'jpg'
+                return out_buffer.getvalue(), mime_type, extension
+        except Exception:
+            return preview_png, 'image/png', 'png'
+
+    def _png_chunk(self, chunk_type: bytes, data: bytes) -> bytes:
+        checksum = zlib.crc32(chunk_type)
+        checksum = zlib.crc32(data, checksum) & 0xffffffff
+        return struct.pack('>I', len(data)) + chunk_type + data + struct.pack('>I', checksum)
+
+
+def create_pdf_preview_processor(config: Optional[PdfPreviewConfig] = None) -> Processor:
+    return PdfPreviewProcessor(config)
+
+
+PDF_PREVIEW_SUPPORTED_MIME_TYPES = SUPPORTED_MIME_TYPES

--- a/filefn/python/filefn/processing/processors/thumbnail.py
+++ b/filefn/python/filefn/processing/processors/thumbnail.py
@@ -1,0 +1,153 @@
+import io
+import struct
+import zlib
+from typing import Any, List, Optional, Tuple
+from ..types import Processor, ProcessorInput, ProcessorResult, ProcessorOutputArtifact, ThumbnailConfig, ThumbnailSize
+
+DEFAULT_SIZES = [
+    ThumbnailSize(name='small', width=150, height=150),
+    ThumbnailSize(name='medium', width=300, height=300),
+    ThumbnailSize(name='large', width=600, height=600),
+]
+
+SUPPORTED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/tiff']
+UNSUPPORTED_MIME_TYPE_ERROR = 'FILEFN_PROCESSING_UNSUPPORTED_MIME_TYPE'
+THUMBNAIL_FAILED_ERROR = 'FILEFN_PROCESSING_THUMBNAIL_FAILED'
+
+class ThumbnailProcessor:
+    def __init__(self, config: Optional[ThumbnailConfig] = None):
+        config = config or ThumbnailConfig()
+        self.sizes = config.sizes or DEFAULT_SIZES
+        self.quality = config.quality or 80
+        self.format = config.format or 'jpeg'
+        self.name = 'thumbnail'
+        self.supportedMimeTypes = SUPPORTED_MIME_TYPES
+
+    async def process(self, input: ProcessorInput, get_data: Any) -> ProcessorResult:
+        if input.mimeType not in self.supportedMimeTypes:
+             return ProcessorResult(success=False, artifacts=[], error=UNSUPPORTED_MIME_TYPE_ERROR)
+
+        try:
+            image_data = await get_data()
+            artifacts = []
+
+            for size in self.sizes:
+                thumbnail_data, render_mode = self._generate_thumbnail(image_data, size)
+                if render_mode == 'placeholder':
+                    thumbnail_data, output_mime_type, extension = self._placeholder_format_output(thumbnail_data)
+                else:
+                    output_mime_type = 'image/jpeg'
+                    extension = 'jpg'
+                    if self.format == 'png':
+                        output_mime_type = 'image/png'
+                        extension = 'png'
+                    elif self.format == 'webp':
+                        output_mime_type = 'image/webp'
+                        extension = 'webp'
+                
+                base_key = input.storageKey.rsplit('.', 1)[0]
+                storage_key = f"{base_key}-thumb-{size.name}.{extension}"
+
+                artifacts.append(ProcessorOutputArtifact(
+                    kind=f"thumbnail-{size.name}",
+                    data=thumbnail_data,
+                    mimeType=output_mime_type,
+                    storageKey=storage_key,
+                    metadata={
+                        'width': size.width,
+                        'height': size.height,
+                        'quality': self.quality,
+                        'format': self.format,
+                        'renderMode': render_mode,
+                        'sourceFileId': input.fileId,
+                        'sourceVersionId': input.versionId,
+                        'originalSize': len(image_data),
+                        'thumbnailSize': len(thumbnail_data)
+                    }
+                ))
+
+            return ProcessorResult(success=True, artifacts=artifacts)
+
+        except Exception:
+            return ProcessorResult(success=False, artifacts=[], error=THUMBNAIL_FAILED_ERROR)
+
+    def _generate_thumbnail(self, image_data: bytes, size: ThumbnailSize) -> Tuple[bytes, str]:
+        try:
+            from PIL import Image
+
+            with io.BytesIO(image_data) as f:
+                with Image.open(f) as img:
+                    img = img.copy()
+
+                    if self.format == 'jpeg' and img.mode in ('RGBA', 'P'):
+                        img = img.convert('RGB')
+
+                    img.thumbnail((size.width, size.height), Image.Resampling.LANCZOS)
+
+                    out_buffer = io.BytesIO()
+                    fmt = self.format.upper()
+                    if fmt == 'JPG':
+                        fmt = 'JPEG'
+
+                    save_args = {'format': fmt, 'quality': self.quality}
+                    if fmt == 'PNG':
+                        save_args['optimize'] = True
+                        del save_args['quality']
+
+                    img.save(out_buffer, **save_args)
+                    return out_buffer.getvalue(), 'image-rasterized'
+        except Exception:
+            return self._generate_placeholder_thumbnail(image_data, size), 'placeholder'
+
+    def _generate_placeholder_thumbnail(self, image_data: bytes, size: ThumbnailSize) -> bytes:
+        seed = sum((index + 1) * byte for index, byte in enumerate(image_data[:128])) % 256
+        pixels = bytearray()
+        width = max(1, size.width)
+        height = max(1, size.height)
+        for y in range(height):
+            pixels.append(0)
+            for x in range(width):
+                r = (seed + (x * 97 // width)) % 256
+                g = (seed + (y * 131 // height)) % 256
+                b = (seed + ((x + y) * 53 // max(1, width + height))) % 256
+                pixels.extend((r, g, b))
+
+        compressor = zlib.compressobj()
+        compressed = compressor.compress(bytes(pixels)) + compressor.flush()
+        return b''.join([
+            b'\x89PNG\r\n\x1a\n',
+            self._png_chunk(b'IHDR', struct.pack('>IIBBBBB', width, height, 8, 2, 0, 0, 0)),
+            self._png_chunk(b'IDAT', compressed),
+            self._png_chunk(b'IEND', b''),
+        ])
+
+    def _placeholder_format_output(self, placeholder_png: bytes) -> Tuple[bytes, str, str]:
+        if self.format == 'png':
+            return placeholder_png, 'image/png', 'png'
+
+        try:
+            from PIL import Image
+
+            with Image.open(io.BytesIO(placeholder_png)) as img:
+                out_buffer = io.BytesIO()
+                fmt = self.format.upper()
+                if fmt == 'JPG':
+                    fmt = 'JPEG'
+                if fmt == 'JPEG' and img.mode in ('RGBA', 'P'):
+                    img = img.convert('RGB')
+                img.save(out_buffer, format=fmt, quality=self.quality)
+                mime_type = 'image/webp' if fmt == 'WEBP' else 'image/jpeg'
+                extension = 'webp' if fmt == 'WEBP' else 'jpg'
+                return out_buffer.getvalue(), mime_type, extension
+        except Exception:
+            return placeholder_png, 'image/png', 'png'
+
+    def _png_chunk(self, chunk_type: bytes, data: bytes) -> bytes:
+        checksum = zlib.crc32(chunk_type)
+        checksum = zlib.crc32(data, checksum) & 0xffffffff
+        return struct.pack('>I', len(data)) + chunk_type + data + struct.pack('>I', checksum)
+
+def create_thumbnail_processor(config: Optional[ThumbnailConfig] = None) -> Processor:
+    return ThumbnailProcessor(config)
+
+THUMBNAIL_SUPPORTED_MIME_TYPES = SUPPORTED_MIME_TYPES

--- a/filefn/python/filefn/processing/types.py
+++ b/filefn/python/filefn/processing/types.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Optional, Protocol, Union, Callable
+from pydantic import BaseModel
+
+class ProcessorInput(BaseModel):
+    fileId: str
+    versionId: str
+    storageKey: str
+    mimeType: str
+    size: int
+    fileName: str
+    tenantId: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+class ProcessorOutputArtifact(BaseModel):
+    kind: str
+    data: bytes
+    mimeType: str
+    storageKey: str
+    metadata: Optional[Dict[str, Any]] = None
+
+class ProcessorResult(BaseModel):
+    success: bool
+    artifacts: List[ProcessorOutputArtifact]
+    error: Optional[str] = None
+
+class Processor(Protocol):
+    name: str
+    supportedMimeTypes: List[str]
+    async def process(self, input: ProcessorInput, get_data: Callable[[], Any]) -> ProcessorResult: ...
+
+class ThumbnailSize(BaseModel):
+    name: str
+    width: int
+    height: int
+
+class ThumbnailConfig(BaseModel):
+    sizes: Optional[List[ThumbnailSize]] = None
+    quality: Optional[int] = 80
+    format: Optional[str] = 'jpeg' # 'jpeg' | 'png' | 'webp'
+
+class PdfPreviewConfig(BaseModel):
+    sizes: Optional[List[ThumbnailSize]] = None
+    density: Optional[int] = 144
+    quality: Optional[int] = 85
+    format: Optional[str] = 'png'
+
+class CompressionConfig(BaseModel):
+    algorithm: Optional[str] = 'gzip'
+    level: Optional[int] = 6
+
+class OCRConfig(BaseModel):
+    language: Optional[str] = 'eng'
+    outputFormat: Optional[str] = 'text'
+
+class ResizeOptions(BaseModel):
+    width: Optional[int] = None
+    height: Optional[int] = None
+    fit: Optional[str] = 'cover' # 'cover' | 'contain' | 'fill' | 'inside' | 'outside'
+    withoutEnlargement: Optional[bool] = False
+
+class CropOptions(BaseModel):
+    left: int
+    top: int
+    width: int
+    height: int
+
+class RotateOptions(BaseModel):
+    angle: int
+    background: Optional[Dict[str, int]] = None # { r, g, b, alpha }
+
+class ImageTransformOperation(BaseModel):
+    operation: str # 'resize' | 'crop' | 'rotate'
+    options: Union[ResizeOptions, CropOptions, RotateOptions]
+    suffix: Optional[str] = None
+
+class ImageTransformConfig(BaseModel):
+    operations: List[ImageTransformOperation]
+    outputFormat: Optional[str] = None
+    outputQuality: Optional[int] = None

--- a/filefn/python/filefn/server/__init__.py
+++ b/filefn/python/filefn/server/__init__.py
@@ -1,0 +1,61 @@
+from .core import (
+    AuthConfig,
+    DedupConfig,
+    FileFn,
+    FileFnConfig,
+    ProcessingConfig,
+    RateLimitCategoryConfig,
+    RateLimitConfig,
+    RateLimitLimitsConfig,
+    create_file_fn,
+)
+from .errors import FileFnError
+from .events import FileFnEventEmitter, create_event_emitter, redact_secrets
+from .policies import (
+    DEFAULT_STORAGE_TARGET,
+    NUCLEUS_ALLOWED_CONTENT_TYPES,
+    NUCLEUS_MAX_SIZE_BYTES,
+    Policy,
+    create_nucleus_policies,
+    create_policy_registry,
+    matches_content_type,
+    resolve_artifact_storage_target,
+    resolve_storage_target,
+)
+from .routed_storage import (
+    STORAGE_TARGET_NOT_CONFIGURED,
+    StorageRoutingError,
+    create_routed_storage_adapter,
+    get_storage_capabilities,
+)
+from .schema import get_schema
+
+__all__ = [
+    "create_file_fn",
+    "FileFn",
+    "FileFnConfig",
+    "AuthConfig",
+    "RateLimitConfig",
+    "RateLimitCategoryConfig",
+    "RateLimitLimitsConfig",
+    "DedupConfig",
+    "ProcessingConfig",
+    "get_schema",
+    "create_policy_registry",
+    "create_nucleus_policies",
+    "Policy",
+    "DEFAULT_STORAGE_TARGET",
+    "NUCLEUS_ALLOWED_CONTENT_TYPES",
+    "NUCLEUS_MAX_SIZE_BYTES",
+    "matches_content_type",
+    "resolve_storage_target",
+    "resolve_artifact_storage_target",
+    "create_event_emitter",
+    "FileFnEventEmitter",
+    "redact_secrets",
+    "FileFnError",
+    "create_routed_storage_adapter",
+    "get_storage_capabilities",
+    "StorageRoutingError",
+    "STORAGE_TARGET_NOT_CONFIGURED",
+]

--- a/filefn/python/filefn/server/authz/grants_service.py
+++ b/filefn/python/filefn/server/authz/grants_service.py
@@ -1,0 +1,119 @@
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+import uuid
+from pydantic import BaseModel
+
+from superfunctions.db import Adapter
+from ..models import FileProviderContext, FileRecord, FilePermissionRecord
+from .. import errors
+
+class CreateGrantInput(BaseModel):
+    fileId: str
+    userId: Optional[str] = None
+    role: Optional[str] = None
+    tenantId: Optional[str] = None
+    canRead: Optional[bool] = None
+    canWrite: Optional[bool] = None
+    canDelete: Optional[bool] = None
+    canShare: Optional[bool] = None
+    expiresAt: Optional[str] = None
+
+class GrantsServiceConfig(BaseModel):
+    db: Any # Adapter
+    namespace: str = 'filefn'
+    
+    class Config:
+        arbitrary_types_allowed = True
+
+class GrantsService:
+    def __init__(self, config: GrantsServiceConfig):
+        self.db = config.db
+        self.namespace = config.namespace
+
+    async def _get_file(self, file_id: str) -> Optional[FileRecord]:
+        data = await self.db.find_one(
+            model='files',
+            where=[{'field': 'fileId', 'operator': 'eq', 'value': file_id}],
+            namespace=self.namespace
+        )
+        return FileRecord(**data) if data else None
+
+    async def _can_manage_permissions(self, file: FileRecord, ctx: FileProviderContext) -> bool:
+        return file.ownerId == ctx.principalId
+
+    async def create_grant(self, input: CreateGrantInput, ctx: FileProviderContext) -> FilePermissionRecord:
+        file = await self._get_file(input.fileId)
+        if not file:
+            raise errors.not_found('File')
+
+        if not await self._can_manage_permissions(file, ctx):
+            raise errors.forbidden()
+
+        if not input.userId and not input.role and not input.tenantId:
+            raise errors.FileFnError('FILEFN_INVALID_GRANT', 'Grant must specify userId, role, or tenantId', 400)
+
+        permission = FilePermissionRecord(
+            permissionId=str(uuid.uuid4()),
+            fileId=input.fileId,
+            userId=input.userId,
+            role=input.role,
+            tenantId=input.tenantId,
+            canRead=input.canRead if input.canRead is not None else True,
+            canWrite=input.canWrite if input.canWrite is not None else False,
+            canDelete=input.canDelete if input.canDelete is not None else False,
+            canShare=input.canShare if input.canShare is not None else False,
+            expiresAt=input.expiresAt,
+            createdAt=datetime.now(timezone.utc).isoformat()
+        )
+
+        await self.db.create(
+            model='filePermissions',
+            data=permission.model_dump(),
+            namespace=self.namespace
+        )
+
+        return permission
+
+    async def list_grants(self, file_id: str, ctx: FileProviderContext) -> List[FilePermissionRecord]:
+        file = await self._get_file(file_id)
+        if not file:
+            raise errors.not_found('File')
+
+        if not await self._can_manage_permissions(file, ctx):
+            raise errors.forbidden()
+
+        data = await self.db.find_many(
+            model='filePermissions',
+            where=[{'field': 'fileId', 'operator': 'eq', 'value': file_id}],
+            namespace=self.namespace
+        )
+        return [FilePermissionRecord(**p) for p in data]
+
+    async def revoke_grant(self, file_id: str, permission_id: str, ctx: FileProviderContext) -> None:
+        file = await self._get_file(file_id)
+        if not file:
+            raise errors.not_found('File')
+
+        if not await self._can_manage_permissions(file, ctx):
+            raise errors.forbidden()
+
+        permission = await self.db.find_one(
+            model='filePermissions',
+            where=[
+                {'field': 'permissionId', 'operator': 'eq', 'value': permission_id},
+                {'field': 'fileId', 'operator': 'eq', 'value': file_id}
+            ],
+            namespace=self.namespace
+        )
+
+        if not permission:
+            raise errors.permission_not_found()
+
+        await self.db.delete(
+            model='filePermissions',
+            where=[{'field': 'permissionId', 'operator': 'eq', 'value': permission_id}],
+            namespace=self.namespace
+        )
+
+def create_grants_service(config: GrantsServiceConfig) -> GrantsService:
+    return GrantsService(config)

--- a/filefn/python/filefn/server/core.py
+++ b/filefn/python/filefn/server/core.py
@@ -1,0 +1,295 @@
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .events import create_event_emitter
+from .policies import Policy, create_nucleus_policies, create_policy_registry
+from .routed_storage import create_routed_storage_adapter
+from .schema import get_schema
+
+
+class RateLimitCategoryConfig(BaseModel):
+    window_seconds: int = Field(alias="windowSeconds", gt=0)
+    max_requests: int = Field(alias="maxRequests", gt=0)
+
+    class Config:
+        populate_by_name = True
+
+
+class RateLimitLimitsConfig(BaseModel):
+    upload_init: Optional[RateLimitCategoryConfig] = Field(default=None, alias="uploadInit")
+    upload_sign: Optional[RateLimitCategoryConfig] = Field(default=None, alias="uploadSign")
+    upload_complete: Optional[RateLimitCategoryConfig] = Field(default=None, alias="uploadComplete")
+    download: Optional[RateLimitCategoryConfig] = None
+    share_download: Optional[RateLimitCategoryConfig] = Field(default=None, alias="shareDownload")
+    artifact_download: Optional[RateLimitCategoryConfig] = Field(default=None, alias="artifactDownload")
+
+    class Config:
+        populate_by_name = True
+
+
+class RateLimitConfig(BaseModel):
+    persistence: Optional[Any] = None
+    algorithm: Literal["fixed-window", "sliding-window", "token-bucket"] = "fixed-window"
+    limits: RateLimitLimitsConfig
+
+    class Config:
+        arbitrary_types_allowed = True
+        populate_by_name = True
+
+
+class AuthConfig(BaseModel):
+    required: bool = False
+    allow_anonymous_uploads: bool = True
+    principal_id_field: str = "principalId"
+    tenant_id_field: str = "tenantId"
+
+
+class DedupConfig(BaseModel):
+    enabled: bool = False
+
+
+class ProcessingConfig(BaseModel):
+    enabled: bool = True
+    processors: List[Any] = Field(default_factory=list)
+    flow_fn: Optional[Any] = Field(default=None, alias="flowFn")
+
+    class Config:
+        populate_by_name = True
+
+
+class FileFnConfig(BaseModel):
+    db: Any
+    storage: Any
+    policies: List[Policy] = Field(default_factory=list)
+    auth: Optional[AuthConfig] = None
+    quota: Optional[Any] = None
+    rate_limit: Optional[RateLimitConfig] = None
+    logger: Optional[Any] = None
+    authorizer: Optional[Any] = None
+    namespace: str = "filefn"
+    default_chunk_size_bytes: Optional[int] = None
+    upload_session_ttl_seconds: Optional[int] = None
+    signed_url_ttl_seconds: Optional[int] = None
+    dedup: Optional[DedupConfig] = None
+    processing: Optional[ProcessingConfig] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        populate_by_name = True
+
+
+class FileFn:
+    def __init__(
+        self,
+        upload_service: Any,
+        file_service: Any,
+        processing_service: Any,
+        grants_service: Any,
+        shares_service: Any,
+        policy_registry: Any,
+        events: Any,
+        namespace: str,
+    ):
+        self.upload_service = upload_service
+        self.file_service = file_service
+        self.processing_service = processing_service
+        self.grants_service = grants_service
+        self.shares_service = shares_service
+        self.policy_registry = policy_registry
+        self.events = events
+        self.namespace = namespace
+
+    async def create_upload_session(self, input: Dict[str, Any], ctx: Any) -> Dict[str, Any]:
+        from .upload_sessions.service import CreateSessionInput
+
+        return await self.upload_service.create_session(CreateSessionInput(**input), ctx)
+
+    async def get_upload_session_status(self, input: Dict[str, Any], ctx: Any) -> Dict[str, Any]:
+        return await self.upload_service.get_session_status(input["uploadSessionId"], ctx)
+
+    async def sign_upload_part(self, input: Dict[str, Any], ctx: Any) -> Dict[str, Any]:
+        return await self.upload_service.sign_part(
+            input["uploadSessionId"],
+            input["partNumber"],
+            input["contentLength"],
+            ctx,
+        )
+
+    async def complete_upload_part(self, input: Dict[str, Any], ctx: Any) -> None:
+        await self.upload_service.complete_part(
+            input["uploadSessionId"],
+            input["partNumber"],
+            input["etag"],
+            input["size"],
+            ctx,
+        )
+
+    async def complete_upload_session(self, input: Dict[str, Any], ctx: Any) -> Dict[str, Any]:
+        return await self.upload_service.complete_session(input["uploadSessionId"], ctx)
+
+    async def abort_upload_session(self, input: Dict[str, Any], ctx: Any) -> None:
+        await self.upload_service.abort_session(input["uploadSessionId"], ctx)
+
+    async def get_file(self, input: Dict[str, Any], ctx: Any) -> Any:
+        return await self.file_service.get_file(input["fileId"], ctx, input.get("versionId"))
+
+    async def list_files(self, input: Dict[str, Any], ctx: Any) -> Any:
+        return await self.file_service.list_files(ctx, input)
+
+    async def delete_file(self, input: Dict[str, Any], ctx: Any) -> None:
+        await self.file_service.delete_file(input["fileId"], ctx)
+
+    async def create_grant(self, input: Dict[str, Any], ctx: Any) -> Any:
+        from .authz.grants_service import CreateGrantInput
+
+        return await self.grants_service.create_grant(CreateGrantInput(**input), ctx)
+
+    async def list_grants(self, input: Dict[str, Any], ctx: Any) -> Any:
+        return await self.grants_service.list_grants(input["fileId"], ctx)
+
+    async def revoke_grant(self, input: Dict[str, Any], ctx: Any) -> None:
+        await self.grants_service.revoke_grant(input["fileId"], input["permissionId"], ctx)
+
+    async def create_share_link(self, input: Dict[str, Any], ctx: Any) -> Any:
+        from .shares.service import CreateShareLinkInput
+
+        return await self.shares_service.create_share_link(CreateShareLinkInput(**input), ctx)
+
+    async def download_via_share_link(self, input: Dict[str, Any], ctx: Any) -> Any:
+        return await self.shares_service.download_via_share_link(
+            input["token"],
+            ctx,
+            is_authenticated=input.get("isAuthenticated", False),
+        )
+
+    async def revoke_share_link(self, input: Dict[str, Any], ctx: Any) -> None:
+        await self.shares_service.revoke_share_link(input["fileId"], input["token"], ctx)
+
+    async def list_share_links(self, input: Dict[str, Any], ctx: Any) -> Any:
+        return await self.shares_service.list_share_links(input["fileId"], ctx)
+
+    def define_policy(self, name: str, policy: Dict[str, Any]) -> None:
+        self.policy_registry.define(name, **policy)
+
+    def get_schema(self) -> Any:
+        return get_schema({"namespace": self.namespace})
+
+
+def _has_configured_route_rate_limits(config: RateLimitLimitsConfig) -> bool:
+    return any(
+        (
+            config.upload_init,
+            config.upload_sign,
+            config.upload_complete,
+            config.download,
+            config.share_download,
+            config.artifact_download,
+        )
+    )
+
+
+def create_file_fn(config: FileFnConfig) -> FileFn:
+    from .authz.grants_service import GrantsServiceConfig, create_grants_service
+    from .dedup.service import DeduplicationServiceConfig, create_deduplication_service
+    from .files.service import FileServiceConfig, create_file_service
+    from .processing.service import ProcessingServiceConfig, create_processing_service
+    from .shares.service import SharesServiceConfig, create_shares_service
+    from .upload_sessions.service import UploadSessionServiceConfig, create_upload_session_service
+
+    policy_registry = create_policy_registry(config.policies)
+    events = create_event_emitter()
+
+    namespace = config.namespace
+    signed_url_ttl = config.signed_url_ttl_seconds or 900
+    upload_ttl = config.upload_session_ttl_seconds or 86400
+    chunk_size = config.default_chunk_size_bytes or 8 * 1024 * 1024
+
+    if config.rate_limit and not _has_configured_route_rate_limits(config.rate_limit.limits):
+        raise ValueError("RATE_LIMIT_CONFIG_INVALID: Missing route-category limits")
+
+    processing_config = config.processing or ProcessingConfig()
+    processing_service = create_processing_service(
+        ProcessingServiceConfig(
+            db=config.db,
+            storage=config.storage,
+            policies=policy_registry,
+            events=events,
+            processors=processing_config.processors,
+            flow_fn=processing_config.flow_fn,
+            namespace=namespace,
+            enabled=processing_config.enabled,
+        )
+    )
+
+    file_service = create_file_service(
+        FileServiceConfig(
+            db=config.db,
+            storage=config.storage,
+            policies=policy_registry,
+            events=events,
+            logger=config.logger,
+            quota=config.quota,
+            authorizer=config.authorizer,
+            namespace=namespace,
+            signed_url_ttl_seconds=signed_url_ttl,
+        )
+    )
+
+    dedup_enabled = config.dedup.enabled if config.dedup is not None else False
+    dedup_service = create_deduplication_service(
+        DeduplicationServiceConfig(
+            db=config.db,
+            policies=policy_registry,
+            namespace=namespace,
+            enabled=dedup_enabled,
+        )
+    )
+
+    upload_service = create_upload_session_service(
+        UploadSessionServiceConfig(
+            db=config.db,
+            storage=config.storage,
+            policies=policy_registry,
+            events=events,
+            logger=config.logger,
+            quota=config.quota,
+            dedup=dedup_service,
+            file_write_checker=file_service,
+            processing_service=processing_service,
+            namespace=namespace,
+            allow_anonymous_uploads=(config.auth.allow_anonymous_uploads if config.auth is not None else True),
+            default_chunk_size_bytes=chunk_size,
+            upload_session_ttl_seconds=upload_ttl,
+            signed_url_ttl_seconds=signed_url_ttl,
+        )
+    )
+
+    grants_service = create_grants_service(
+        GrantsServiceConfig(
+            db=config.db,
+            namespace=namespace,
+        )
+    )
+
+    shares_service = create_shares_service(
+        SharesServiceConfig(
+            db=config.db,
+            storage=config.storage,
+            policies=policy_registry,
+            logger=config.logger,
+            namespace=namespace,
+            signed_url_ttl_seconds=signed_url_ttl,
+        )
+    )
+
+    return FileFn(
+        upload_service=upload_service,
+        file_service=file_service,
+        processing_service=processing_service,
+        grants_service=grants_service,
+        shares_service=shares_service,
+        policy_registry=policy_registry,
+        events=events,
+        namespace=namespace,
+    )

--- a/filefn/python/filefn/server/dedup/service.py
+++ b/filefn/python/filefn/server/dedup/service.py
@@ -1,0 +1,130 @@
+import hashlib
+import base64
+from typing import Any, Optional, AsyncGenerator, Dict, Protocol
+from pydantic import BaseModel
+from superfunctions.db import Adapter
+
+from ..policies import resolve_storage_target
+
+class DeduplicationServiceConfig(BaseModel):
+    db: Any # Adapter
+    policies: Optional[Any] = None
+    namespace: str = 'filefn'
+    enabled: bool = True
+    
+    class Config:
+        arbitrary_types_allowed = True
+
+class DeduplicationResult(BaseModel):
+    isDuplicate: bool
+    existingVersionId: Optional[str] = None
+    existingStorageKey: Optional[str] = None
+    checksumSha256Base64: str
+
+class DeduplicationService:
+    def __init__(self, config: DeduplicationServiceConfig):
+        self.db = config.db
+        self.policies = config.policies
+        self.namespace = config.namespace
+        self.enabled = config.enabled
+
+    async def _resolve_version_storage_target(self, file_id: str) -> str:
+        file_row = await self.db.find_one(
+            model='files',
+            where=[{'field': 'fileId', 'operator': 'eq', 'value': file_id}],
+            namespace=self.namespace,
+        )
+        policy_name = file_row.get('policy') if file_row else None
+        policy = self.policies.get(policy_name) if (self.policies and policy_name) else None
+        return resolve_storage_target(policy)
+
+    def is_enabled(self) -> bool:
+        return self.enabled
+
+    def compute_hash(self, data: bytes) -> str:
+        sha256 = hashlib.sha256()
+        sha256.update(data)
+        return base64.b64encode(sha256.digest()).decode('utf-8')
+
+    async def compute_hash_from_stream(self, stream: AsyncGenerator[bytes, None]) -> str:
+        sha256 = hashlib.sha256()
+        async for chunk in stream:
+            sha256.update(chunk)
+        return base64.b64encode(sha256.digest()).decode('utf-8')
+
+    async def check_for_duplicate(
+        self,
+        checksum_sha256_base64: str,
+        tenant_id: Optional[str],
+        storage_target: Optional[str] = None,
+    ) -> DeduplicationResult:
+        if not self.enabled:
+            return DeduplicationResult(
+                isDuplicate=False,
+                checksumSha256Base64=checksum_sha256_base64
+            )
+
+        where_conditions = [
+            {'field': 'checksumSha256Base64', 'operator': 'eq', 'value': checksum_sha256_base64}
+        ]
+
+        if tenant_id:
+            where_conditions.append({'field': 'tenantId', 'operator': 'eq', 'value': tenant_id})
+        else:
+             where_conditions.append({'field': 'tenantId', 'operator': 'eq', 'value': None})
+
+        existing_versions = await self.db.find_many(
+            model='fileVersions',
+            where=where_conditions,
+            namespace=self.namespace
+        )
+
+        for existing_version in existing_versions:
+            if storage_target is not None:
+                existing_target = await self._resolve_version_storage_target(existing_version.get('fileId'))
+                if existing_target != storage_target:
+                    continue
+            return DeduplicationResult(
+                isDuplicate=True,
+                existingVersionId=existing_version.get('versionId'),
+                existingStorageKey=existing_version.get('storageKey'),
+                checksumSha256Base64=checksum_sha256_base64
+            )
+
+        return DeduplicationResult(
+            isDuplicate=False,
+            checksumSha256Base64=checksum_sha256_base64
+        )
+
+    async def compute_and_check_duplicate(
+        self,
+        storage_key: str,
+        tenant_id: Optional[str],
+        storage_target: Optional[str],
+        storage: Any,
+    ) -> DeduplicationResult:
+        if not self.enabled:
+             return DeduplicationResult(
+                isDuplicate=False,
+                checksumSha256Base64=''
+            )
+
+        if not hasattr(storage, 'open_download_stream'):
+            raise Exception('Storage adapter does not support streaming downloads required for deduplication')
+
+        stream = await storage.open_download_stream(key=storage_key, target=storage_target)
+        checksum = await self.compute_hash_from_stream(stream)
+        
+        return await self.check_for_duplicate(checksum, tenant_id, storage_target)
+
+    async def verify_hash(self, storage_key: str, expected_hash: str, storage: Any, storage_target: Optional[str] = None) -> bool:
+        if not hasattr(storage, 'open_download_stream'):
+            return False
+            
+        stream = await storage.open_download_stream(key=storage_key, target=storage_target)
+        actual_hash = await self.compute_hash_from_stream(stream)
+        
+        return actual_hash == expected_hash
+
+def create_deduplication_service(config: DeduplicationServiceConfig) -> DeduplicationService:
+    return DeduplicationService(config)

--- a/filefn/python/filefn/server/errors.py
+++ b/filefn/python/filefn/server/errors.py
@@ -1,0 +1,163 @@
+from typing import Any, Dict, Optional
+
+class FileFnError(Exception):
+    def __init__(self, code: str, message: str, status: int = 400, details: Optional[Dict[str, Any]] = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status = status
+        self.details = details
+
+    @property
+    def status_code(self) -> int:
+        return self.status
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            'code': self.code,
+            'message': self.message,
+            'details': self.details,
+        }
+
+class ErrorCodes:
+    AUTH_REQUIRED = 'FILEFN_AUTH_REQUIRED'
+    FORBIDDEN = 'FILEFN_FORBIDDEN'
+    NOT_FOUND = 'FILEFN_NOT_FOUND'
+    POLICY_CONTENT_TYPE_NOT_ALLOWED = 'FILEFN_POLICY_CONTENT_TYPE_NOT_ALLOWED'
+    POLICY_MAX_SIZE_EXCEEDED = 'FILEFN_POLICY_MAX_SIZE_EXCEEDED'
+    POLICY_NOT_FOUND = 'FILEFN_POLICY_NOT_FOUND'
+    QUOTA_EXCEEDED = 'FILEFN_QUOTA_EXCEEDED'
+    RATE_LIMITED = 'FILEFN_RATE_LIMITED'
+    INVALID_PART_NUMBER = 'FILEFN_INVALID_PART_NUMBER'
+    INVALID_ETAG = 'FILEFN_INVALID_ETAG'
+    UPLOAD_INCOMPLETE = 'FILEFN_UPLOAD_INCOMPLETE'
+    UPLOAD_EXPIRED = 'FILEFN_UPLOAD_EXPIRED'
+    UPLOAD_ABORTED = 'FILEFN_UPLOAD_ABORTED'
+    UPLOAD_ALREADY_COMPLETED = 'FILEFN_UPLOAD_ALREADY_COMPLETED'
+    IDEMPOTENCY_CONFLICT = 'FILEFN_IDEMPOTENCY_CONFLICT'
+    PART_CONFLICT = 'FILEFN_PART_CONFLICT'
+    UPLOAD_SIZE_MISMATCH = 'FILEFN_UPLOAD_SIZE_MISMATCH'
+    NO_SUPPORTED_UPLOAD_MODE = 'FILEFN_NO_SUPPORTED_UPLOAD_MODE'
+    OFFLINE_UNSUPPORTED = 'FILEFN_OFFLINE_UNSUPPORTED'
+    SESSION_NOT_FOUND = 'FILEFN_SESSION_NOT_FOUND'
+    SHARE_EXPIRED = 'FILEFN_SHARE_EXPIRED'
+    SHARE_REVOKED = 'FILEFN_SHARE_REVOKED'
+    SHARE_DOWNLOADS_EXCEEDED = 'FILEFN_SHARE_DOWNLOADS_EXCEEDED'
+    SHARE_NOT_FOUND = 'FILEFN_SHARE_NOT_FOUND'
+    PERMISSION_NOT_FOUND = 'FILEFN_PERMISSION_NOT_FOUND'
+    PROCESSING_ENQUEUE_FAILED = 'FILEFN_PROCESSING_ENQUEUE_FAILED'
+
+def auth_required() -> FileFnError:
+    return FileFnError(ErrorCodes.AUTH_REQUIRED, 'Authentication required', 401)
+
+def forbidden(details: Optional[Dict[str, Any]] = None) -> FileFnError:
+    return FileFnError(ErrorCodes.FORBIDDEN, 'Access denied', 403, details)
+
+def not_found(resource: str) -> FileFnError:
+    return FileFnError(ErrorCodes.NOT_FOUND, f'{resource} not found', 404)
+
+def policy_content_type_not_allowed(policy: str, mime_type: str) -> FileFnError:
+    return FileFnError(
+        ErrorCodes.POLICY_CONTENT_TYPE_NOT_ALLOWED,
+        'Content type not allowed',
+        400,
+        {'policy': policy, 'mimeType': mime_type}
+    )
+
+def policy_max_size_exceeded(policy: str, max_size_bytes: int, size: int) -> FileFnError:
+    return FileFnError(
+        ErrorCodes.POLICY_MAX_SIZE_EXCEEDED,
+        'File size exceeds policy max',
+        400,
+        {'policy': policy, 'maxSizeBytes': max_size_bytes, 'size': size}
+    )
+
+def policy_not_found(policy: str) -> FileFnError:
+    return FileFnError(ErrorCodes.POLICY_NOT_FOUND, f"Policy '{policy}' not found", 400, {'policy': policy})
+
+def quota_exceeded(current: int, limit: int, requested: int) -> FileFnError:
+    return FileFnError(
+        ErrorCodes.QUOTA_EXCEEDED,
+        'Storage quota exceeded',
+        402,
+        {'current': current, 'limit': limit, 'requested': requested}
+    )
+
+def rate_limited(reset_at: str) -> FileFnError:
+    return FileFnError(ErrorCodes.RATE_LIMITED, 'Rate limit exceeded', 429, {'resetAt': reset_at})
+
+def invalid_part_number() -> FileFnError:
+    return FileFnError(ErrorCodes.INVALID_PART_NUMBER, 'Invalid partNumber', 400)
+
+def invalid_etag() -> FileFnError:
+    return FileFnError(ErrorCodes.INVALID_ETAG, 'Invalid etag', 400)
+
+def upload_incomplete() -> FileFnError:
+    return FileFnError(ErrorCodes.UPLOAD_INCOMPLETE, 'Upload incomplete', 409)
+
+def upload_expired() -> FileFnError:
+    return FileFnError(ErrorCodes.UPLOAD_EXPIRED, 'Upload session expired', 410)
+
+def upload_aborted() -> FileFnError:
+    return FileFnError(ErrorCodes.UPLOAD_ABORTED, 'Upload session was aborted', 410)
+
+def upload_already_completed() -> FileFnError:
+    return FileFnError(ErrorCodes.UPLOAD_ALREADY_COMPLETED, 'Upload session already completed', 409)
+
+def idempotency_conflict() -> FileFnError:
+    return FileFnError(ErrorCodes.IDEMPOTENCY_CONFLICT, 'Idempotency key reuse with different payload', 409)
+
+def no_supported_upload_mode() -> FileFnError:
+    return FileFnError(
+        ErrorCodes.NO_SUPPORTED_UPLOAD_MODE,
+        'No supported upload mode for configured adapter',
+        500
+    )
+
+def session_not_found() -> FileFnError:
+    return FileFnError(ErrorCodes.SESSION_NOT_FOUND, 'Upload session not found', 404)
+
+def share_expired() -> FileFnError:
+    return FileFnError(ErrorCodes.SHARE_EXPIRED, 'Share link has expired', 410)
+
+def share_revoked() -> FileFnError:
+    return FileFnError(ErrorCodes.SHARE_REVOKED, 'Share link has been revoked', 410)
+
+def share_downloads_exceeded() -> FileFnError:
+    return FileFnError(ErrorCodes.SHARE_DOWNLOADS_EXCEEDED, 'Share link download limit exceeded', 410)
+
+def share_not_found() -> FileFnError:
+    return FileFnError(ErrorCodes.SHARE_NOT_FOUND, 'Share link not found', 404)
+
+def permission_not_found() -> FileFnError:
+    return FileFnError(ErrorCodes.PERMISSION_NOT_FOUND, 'Permission not found', 404)
+
+def processing_enqueue_failed() -> FileFnError:
+    return FileFnError(
+        ErrorCodes.PROCESSING_ENQUEUE_FAILED,
+        'Failed to enqueue processing',
+        503
+    )
+
+def part_conflict(upload_session_id: str, part_number: int) -> FileFnError:
+    return FileFnError(
+        ErrorCodes.PART_CONFLICT,
+        'Part already completed with a different etag',
+        409,
+        {'uploadSessionId': upload_session_id, 'partNumber': part_number}
+    )
+
+def upload_size_mismatch(expected: int, actual: int) -> FileFnError:
+    return FileFnError(
+        ErrorCodes.UPLOAD_SIZE_MISMATCH,
+        'Uploaded size does not match expected size',
+        409,
+        {'expected': expected, 'actual': actual}
+    )
+
+def offline_unsupported() -> FileFnError:
+    return FileFnError(
+        ErrorCodes.OFFLINE_UNSUPPORTED,
+        'OPFS unavailable',
+        400
+    )

--- a/filefn/python/filefn/server/events.py
+++ b/filefn/python/filefn/server/events.py
@@ -1,0 +1,179 @@
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Generic, Union
+from pydantic import BaseModel
+
+SAFE_IDENTIFIER_KEYS = {
+    "fileid",
+    "versionid",
+    "artifactid",
+    "policyid",
+    "requestid",
+    "uploadsessionid",
+}
+SENSITIVE_KEY_MARKERS = (
+    "token",
+    "secret",
+    "password",
+    "signature",
+    "authorization",
+    "credential",
+    "cookie",
+    "signedurl",
+    "signed_url",
+)
+
+class FileFnEvent(BaseModel):
+    type: str
+    timestamp: str
+    requestId: Optional[str] = None
+
+class UploadStartedEvent(FileFnEvent):
+    type: str = 'upload.started'
+    uploadSessionId: str
+    fileName: str
+    size: int
+    mimeType: str
+    policy: str
+    principalId: Optional[str] = None
+    tenantId: Optional[str] = None
+
+class PartRecordedEvent(FileFnEvent):
+    type: str = 'part.recorded'
+    uploadSessionId: str
+    partNumber: int
+    size: int
+
+class FileUploadedEvent(FileFnEvent):
+    type: str = 'file:uploaded'
+    fileId: str
+    versionId: str
+    fileName: str
+    size: int
+    mimeType: str
+    ownerId: str
+    tenantId: Optional[str] = None
+
+class FileDeletedEvent(FileFnEvent):
+    type: str = 'file:deleted'
+    fileId: str
+    ownerId: str
+    tenantId: Optional[str] = None
+
+class ProcessingStartedEvent(FileFnEvent):
+    type: str = 'processing.started'
+    fileId: str
+    versionId: str
+
+class ProcessingCompletedEvent(FileFnEvent):
+    type: str = 'processing.completed'
+    fileId: str
+    versionId: str
+    artifactsCreated: int
+
+class ProcessingFailedEvent(FileFnEvent):
+    type: str = 'processing.failed'
+    fileId: str
+    versionId: str
+    error: Optional[str] = None
+
+def get_current_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+def create_upload_started_event(data: Dict[str, Any], request_id: Optional[str] = None) -> UploadStartedEvent:
+    return UploadStartedEvent(
+        timestamp=get_current_timestamp(),
+        requestId=request_id,
+        **data
+    )
+
+def create_part_recorded_event(data: Dict[str, Any], request_id: Optional[str] = None) -> PartRecordedEvent:
+    return PartRecordedEvent(
+        timestamp=get_current_timestamp(),
+        requestId=request_id,
+        **data
+    )
+
+def create_file_uploaded_event(data: Dict[str, Any], request_id: Optional[str] = None) -> FileUploadedEvent:
+    return FileUploadedEvent(
+        timestamp=get_current_timestamp(),
+        requestId=request_id,
+        **data
+    )
+
+def create_file_deleted_event(data: Dict[str, Any], request_id: Optional[str] = None) -> FileDeletedEvent:
+    return FileDeletedEvent(
+        timestamp=get_current_timestamp(),
+        requestId=request_id,
+        **data
+    )
+
+class FileFnEventEmitter:
+    def __init__(self):
+        self._listeners: Dict[str, List[Callable[[Any], None]]] = {}
+
+    def on(self, event_type: str, listener: Callable[[Any], None]) -> 'FileFnEventEmitter':
+        if event_type not in self._listeners:
+            self._listeners[event_type] = []
+        self._listeners[event_type].append(listener)
+        return self
+
+    def emit(self, event_type: str, payload: Any) -> bool:
+        if event_type not in self._listeners:
+            return False
+        for listener in self._listeners[event_type]:
+            try:
+                listener(payload)
+            except Exception:
+                # Log error or suppress? Usually suppress in EventEmitter
+                pass
+        return True
+
+def create_event_emitter() -> FileFnEventEmitter:
+    return FileFnEventEmitter()
+
+
+def _should_redact_key(key: str) -> bool:
+    lower_key = key.lower()
+    if lower_key in SAFE_IDENTIFIER_KEYS:
+        return False
+    return any(marker in lower_key for marker in SENSITIVE_KEY_MARKERS)
+
+
+def _should_redact_string(key: str, value: str) -> bool:
+    lower_key = key.lower()
+    lower_value = value.lower()
+    if lower_key in SAFE_IDENTIFIER_KEYS:
+        return False
+    if value.startswith("http://") or value.startswith("https://"):
+        if "?" in value or "signature=" in lower_value or "sig=" in lower_value or "token=" in lower_value:
+            return True
+    if lower_value.startswith("bearer "):
+        return True
+    if "x-amz-signature" in lower_value:
+        return True
+    return False
+
+
+def redact_secrets(value: Any, key: str = "") -> Any:
+    if value is None:
+        return None
+
+    if isinstance(value, dict):
+        result: Dict[str, Any] = {}
+        for child_key, child_value in value.items():
+            if _should_redact_key(child_key):
+                result[child_key] = "[REDACTED]"
+            else:
+                result[child_key] = redact_secrets(child_value, child_key)
+        return result
+
+    if isinstance(value, list):
+        return [redact_secrets(item, key) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(redact_secrets(item, key) for item in value)
+
+    if isinstance(value, str) and _should_redact_string(key, value):
+        return "[REDACTED]"
+
+    return value

--- a/filefn/python/filefn/server/files/service.py
+++ b/filefn/python/filefn/server/files/service.py
@@ -1,0 +1,604 @@
+import base64
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Protocol, Set, Tuple
+
+from pydantic import BaseModel
+
+from .. import errors
+from ..events import FileFnEventEmitter, create_file_deleted_event
+from ..models import FileProviderContext, FileRecord, FileVersionRecord, Visibility
+from ..policies import resolve_artifact_storage_target, resolve_storage_target
+from ..routed_storage import get_storage_capabilities
+
+
+class Authorizer(Protocol):
+    async def can_read(self, file: FileRecord, ctx: FileProviderContext) -> bool: ...
+
+    async def can_write(self, file: FileRecord, ctx: FileProviderContext) -> bool: ...
+
+    async def can_delete(self, file: FileRecord, ctx: FileProviderContext) -> bool: ...
+
+
+class DefaultAuthorizer:
+    async def can_read(self, file: FileRecord, ctx: FileProviderContext) -> bool:
+        if file.visibility == Visibility.PUBLIC:
+            return True
+        if file.ownerId == ctx.principalId:
+            return True
+        if file.visibility == Visibility.SHARED and file.tenantId and file.tenantId == ctx.tenantId:
+            return True
+        return False
+
+    async def can_write(self, file: FileRecord, ctx: FileProviderContext) -> bool:
+        return file.ownerId == ctx.principalId
+
+    async def can_delete(self, file: FileRecord, ctx: FileProviderContext) -> bool:
+        return file.ownerId == ctx.principalId
+
+
+class QuotaProvider(Protocol):
+    async def record_usage(self, input: Dict[str, Any]) -> None: ...
+
+
+class FileServiceConfig(BaseModel):
+    db: Any
+    storage: Any
+    policies: Optional[Any] = None
+    events: FileFnEventEmitter
+    logger: Optional[Any] = None
+    quota: Optional[Any] = None
+    authorizer: Optional[Any] = None
+    namespace: str = "filefn"
+    signed_url_ttl_seconds: int = 900
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class FileService:
+    def __init__(self, config: FileServiceConfig):
+        self.db = config.db
+        self.storage = config.storage
+        self.policies = config.policies
+        self.events = config.events
+        self.logger = config.logger
+        self.quota = config.quota
+        self.authorizer = config.authorizer or DefaultAuthorizer()
+        self.namespace = config.namespace
+        self.signed_url_ttl_seconds = config.signed_url_ttl_seconds
+
+    async def _get_file_record(self, file_id: str) -> FileRecord:
+        file_data = await self.db.find_one(
+            model="files",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        if not file_data:
+            raise errors.not_found("File")
+        return FileRecord(**file_data)
+
+    async def _get_bound_version(self, file_id: str, version_id: str) -> FileVersionRecord:
+        version_data = await self.db.find_one(
+            model="fileVersions",
+            where=[{"field": "versionId", "operator": "eq", "value": version_id}],
+            namespace=self.namespace,
+        )
+        if not version_data:
+            raise errors.not_found("Version")
+
+        version = FileVersionRecord(**version_data)
+        if version.fileId != file_id:
+            raise errors.not_found("Version")
+        return version
+
+    def _file_storage_target(self, policy_name: Optional[str]) -> str:
+        policy = self.policies.get(policy_name) if (self.policies and policy_name) else None
+        return resolve_storage_target(policy)
+
+    def _artifact_storage_target(self, policy_name: Optional[str]) -> str:
+        policy = self.policies.get(policy_name) if (self.policies and policy_name) else None
+        return resolve_artifact_storage_target(policy)
+
+    def _parse_timestamp(self, value: str) -> datetime:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def _file_sort_key(self, file: FileRecord) -> Tuple[float, str]:
+        timestamp = self._parse_timestamp(file.updatedAt)
+        return (-timestamp.timestamp(), file.fileId)
+
+    def _encode_cursor(self, updated_at: str, file_id: str) -> str:
+        payload = json.dumps({"updatedAt": updated_at, "fileId": file_id}).encode("utf-8")
+        return base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
+
+    def _parse_cursor(self, cursor: str) -> Optional[Dict[str, str]]:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        try:
+            decoded = base64.urlsafe_b64decode(padded.encode("utf-8")).decode("utf-8")
+            parsed = json.loads(decoded)
+        except Exception:
+            return None
+        if isinstance(parsed, dict) and isinstance(parsed.get("updatedAt"), str) and isinstance(parsed.get("fileId"), str):
+            return {"updatedAt": parsed["updatedAt"], "fileId": parsed["fileId"]}
+        return None
+
+    def _is_after_cursor(self, file: FileRecord, cursor: Dict[str, str]) -> bool:
+        file_ts = self._parse_timestamp(file.updatedAt)
+        cursor_ts = self._parse_timestamp(cursor["updatedAt"])
+        if file_ts < cursor_ts:
+            return True
+        if file_ts > cursor_ts:
+            return False
+        return file.fileId > cursor["fileId"]
+
+    def _is_grant_expired(self, expires_at: Optional[str]) -> bool:
+        if not expires_at:
+            return False
+        try:
+            return self._parse_timestamp(expires_at) <= datetime.now(timezone.utc)
+        except Exception:
+            return False
+
+    async def _get_readable_grant_file_ids(self, ctx: FileProviderContext) -> Set[str]:
+        if not ctx.principalId:
+            return set()
+
+        grants: List[Dict[str, Any]] = []
+        grants.extend(
+            await self.db.find_many(
+                model="filePermissions",
+                where=[{"field": "userId", "operator": "eq", "value": ctx.principalId}],
+                namespace=self.namespace,
+            )
+        )
+        if ctx.tenantId:
+            grants.extend(
+                await self.db.find_many(
+                    model="filePermissions",
+                    where=[{"field": "tenantId", "operator": "eq", "value": ctx.tenantId}],
+                    namespace=self.namespace,
+                )
+            )
+
+        readable: Set[str] = set()
+        for grant in grants:
+            if not grant.get("canRead"):
+                continue
+            if self._is_grant_expired(grant.get("expiresAt")):
+                continue
+            if grant.get("userId") == ctx.principalId:
+                readable.add(grant.get("fileId"))
+            elif grant.get("tenantId") and grant.get("tenantId") == ctx.tenantId:
+                readable.add(grant.get("fileId"))
+        return readable
+
+    @staticmethod
+    def _list_order_by() -> List[Dict[str, str]]:
+        return [
+            {"field": "updatedAt", "direction": "desc"},
+            {"field": "fileId", "direction": "asc"},
+        ]
+
+    async def _find_files(
+        self,
+        where: List[Dict[str, Any]],
+        *,
+        limit: Optional[int] = None,
+    ) -> List[FileRecord]:
+        rows = await self.db.find_many(
+            model="files",
+            where=where,
+            order_by=self._list_order_by(),
+            limit=limit,
+            namespace=self.namespace,
+        )
+        return [FileRecord(**item) for item in rows]
+
+    async def _list_accessible_files_default(
+        self,
+        ctx: FileProviderContext,
+        *,
+        source_limit: Optional[int] = None,
+    ) -> List[FileRecord]:
+        files_by_id: Dict[str, FileRecord] = {}
+
+        for file in await self._find_files(
+            [{"field": "visibility", "operator": "eq", "value": Visibility.PUBLIC.value}],
+            limit=source_limit,
+        ):
+            files_by_id[file.fileId] = file
+
+        if ctx.tenantId:
+            for file in await self._find_files(
+                [
+                    {"field": "visibility", "operator": "eq", "value": Visibility.SHARED.value},
+                    {"field": "tenantId", "operator": "eq", "value": ctx.tenantId},
+                ],
+                limit=source_limit,
+            ):
+                files_by_id[file.fileId] = file
+
+        if ctx.principalId:
+            for file in await self._find_files(
+                [{"field": "ownerId", "operator": "eq", "value": ctx.principalId}],
+                limit=source_limit,
+            ):
+                files_by_id[file.fileId] = file
+
+            granted_file_ids = await self._get_readable_grant_file_ids(ctx)
+            for file_id in granted_file_ids:
+                file_data = await self.db.find_one(
+                    model="files",
+                    where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+                    namespace=self.namespace,
+                )
+                if file_data:
+                    files_by_id[file_id] = FileRecord(**file_data)
+
+        return list(files_by_id.values())
+
+    async def _can_read_file(
+        self,
+        file: FileRecord,
+        ctx: FileProviderContext,
+        readable_grant_file_ids: Optional[Set[str]] = None,
+    ) -> bool:
+        if await self.authorizer.can_read(file, ctx):
+            return True
+        return file.fileId in (readable_grant_file_ids or set())
+
+    def _proxy_part_key(self, storage_key: str, part_number: int) -> str:
+        return f"{storage_key}.parts/{part_number}"
+
+    async def get_file(
+        self,
+        file_id: str,
+        ctx: FileProviderContext,
+        version_id: Optional[str] = None,
+    ) -> Any:
+        file = await self._get_file_record(file_id)
+
+        readable_grant_file_ids = await self._get_readable_grant_file_ids(ctx)
+        if not await self._can_read_file(file, ctx, readable_grant_file_ids):
+            raise errors.forbidden()
+
+        if version_id:
+            version = await self._get_bound_version(file_id, version_id)
+            payload = file.model_dump()
+            payload.update(
+                {
+                    "currentVersionId": version.versionId,
+                    "mimeType": version.mimeType,
+                    "size": version.size,
+                    "versionId": version.versionId,
+                    "versionCreatedAt": version.createdAt,
+                    "checksumSha256Base64": version.checksumSha256Base64,
+                    "storageKey": version.storageKey,
+                }
+            )
+            return payload
+
+        return file
+
+    async def list_files(
+        self,
+        ctx: FileProviderContext,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        options = options or {}
+        requested = options.get("limit", 20)
+        try:
+            requested = int(requested)
+        except Exception:
+            requested = 20
+        limit = min(100, max(1, requested))
+
+        if isinstance(self.authorizer, DefaultAuthorizer):
+            source_limit = None if options.get("cursor") else (limit + 1)
+            accessible_files = await self._list_accessible_files_default(ctx, source_limit=source_limit)
+        else:
+            all_files_data = await self.db.find_many(
+                model="files",
+                where=[],
+                namespace=self.namespace,
+            )
+            all_files = [FileRecord(**item) for item in all_files_data]
+            granted_file_ids = await self._get_readable_grant_file_ids(ctx)
+            accessible_files = []
+            for file in all_files:
+                if await self._can_read_file(file, ctx, granted_file_ids):
+                    accessible_files.append(file)
+
+        accessible_files.sort(key=self._file_sort_key)
+
+        paged_files = accessible_files
+        cursor = options.get("cursor")
+        if cursor:
+            tuple_cursor = self._parse_cursor(cursor)
+            if tuple_cursor:
+                paged_files = [file for file in accessible_files if self._is_after_cursor(file, tuple_cursor)]
+            else:
+                anchor = next((file for file in accessible_files if file.fileId == cursor), None)
+                if anchor:
+                    legacy_cursor = {"updatedAt": anchor.updatedAt, "fileId": anchor.fileId}
+                    paged_files = [file for file in accessible_files if self._is_after_cursor(file, legacy_cursor)]
+
+        result_files = paged_files[:limit]
+        has_more = len(paged_files) > limit
+        next_cursor = None
+        if has_more and result_files:
+            anchor = result_files[-1]
+            next_cursor = self._encode_cursor(anchor.updatedAt, anchor.fileId)
+
+        return {"files": [f.model_dump() for f in result_files], "nextCursor": next_cursor}
+
+    async def get_download_url(
+        self,
+        file_id: str,
+        version_id: Optional[str],
+        ctx: FileProviderContext,
+    ) -> Dict[str, Any]:
+        file = await self.get_file(file_id, ctx)
+
+        target_version_id = version_id or file.currentVersionId
+        version = await self._get_bound_version(file_id, target_version_id)
+        storage_target = self._file_storage_target(file.policy)
+
+        if hasattr(self.storage, "sign_download_url") and get_storage_capabilities(self.storage, storage_target).get("signedDownloadUrls"):
+            try:
+                result = await self.storage.sign_download_url(
+                    key=version.storageKey,
+                    expires_in_seconds=self.signed_url_ttl_seconds,
+                    target=storage_target,
+                )
+                return {"url": result["url"], "headers": result.get("headers")}
+            except Exception as exc:
+                logger_warning = getattr(self.logger, "warning", None)
+                if callable(logger_warning):
+                    logger_warning(
+                        "signed download url generation failed; falling back to proxy",
+                        {
+                            "fileId": file_id,
+                            "versionId": version.versionId,
+                            "storageKey": version.storageKey,
+                            "error": str(exc),
+                        },
+                    )
+
+        proxy_url = (
+            f"/proxy/files/{file_id}/versions/{version.versionId}/download"
+            if version_id
+            else f"/proxy/files/{file_id}/download"
+        )
+        return {"url": proxy_url}
+
+    async def get_download_stream(
+        self,
+        file_id: str,
+        version_id: Optional[str],
+        ctx: FileProviderContext,
+    ) -> Dict[str, Any]:
+        file = await self.get_file(file_id, ctx)
+        target_version_id = version_id or file.currentVersionId
+        version = await self._get_bound_version(file_id, target_version_id)
+        storage_target = self._file_storage_target(file.policy)
+
+        stream = await self.storage.open_download_stream(key=version.storageKey, target=storage_target)
+        return {"stream": stream, "contentType": version.mimeType, "size": version.size}
+
+    async def delete_file(self, file_id: str, ctx: FileProviderContext) -> None:
+        file = await self._get_file_record(file_id)
+
+        if not await self.authorizer.can_delete(file, ctx):
+            raise errors.forbidden()
+
+        versions_data = await self.db.find_many(
+            model="fileVersions",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        versions = [FileVersionRecord(**item) for item in versions_data]
+
+        artifacts = await self.db.find_many(
+            model="fileArtifacts",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+
+        all_sessions = await self.db.find_many(
+            model="uploadSessions",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        pending_sessions = [session for session in all_sessions if session.get("status") != "completed"]
+
+        for session in pending_sessions:
+            session_storage_target = self._file_storage_target(session.get("policy"))
+            storage_upload_id = session.get("storageUploadId")
+            if storage_upload_id and hasattr(self.storage, "abort_multipart_upload"):
+                try:
+                    await self.storage.abort_multipart_upload(
+                        key=session.get("storageKey"),
+                        upload_id=storage_upload_id,
+                        target=session_storage_target,
+                    )
+                except Exception:
+                    pass
+
+            parts = await self.db.find_many(
+                model="uploadParts",
+                where=[{"field": "uploadSessionId", "operator": "eq", "value": session.get("uploadSessionId")}],
+                namespace=self.namespace,
+            )
+            if session.get("uploadMode") == "proxy":
+                for part in parts:
+                    try:
+                        await self.storage.delete_object(
+                            key=self._proxy_part_key(session.get("storageKey"), part.get("partNumber")),
+                            target=session_storage_target,
+                        )
+                    except Exception:
+                        pass
+
+            await self.db.delete_many(
+                model="uploadParts",
+                where=[{"field": "uploadSessionId", "operator": "eq", "value": session.get("uploadSessionId")}],
+                namespace=self.namespace,
+            )
+
+        def ref_key(target: str, key: str) -> str:
+            return f"{target}\u0000{key}"
+
+        version_bytes_by_storage_key: Dict[str, int] = {}
+        candidate_storage_keys: Set[str] = set()
+        file_storage_target = self._file_storage_target(file.policy)
+        artifact_storage_target = self._artifact_storage_target(file.policy)
+
+        for version in versions:
+            key = ref_key(file_storage_target, version.storageKey)
+            version_bytes_by_storage_key[key] = max(
+                version_bytes_by_storage_key.get(key, 0),
+                version.size,
+            )
+            candidate_storage_keys.add(key)
+
+        for artifact in artifacts:
+            storage_key = artifact.get("storageKey")
+            if storage_key:
+                candidate_storage_keys.add(ref_key(artifact_storage_target, storage_key))
+
+        storage_keys_referenced_elsewhere: Set[str] = set()
+        if candidate_storage_keys:
+            all_versions = await self.db.find_many(
+                model="fileVersions",
+                where=[],
+                namespace=self.namespace,
+            )
+            all_files = await self.db.find_many(
+                model="files",
+                where=[],
+                namespace=self.namespace,
+            )
+            policy_by_file_id = {row.get("fileId"): row.get("policy") for row in all_files}
+            for version in all_versions:
+                version_target = self._file_storage_target(policy_by_file_id.get(version.get("fileId")))
+                candidate = ref_key(version_target, version.get("storageKey"))
+                if version.get("fileId") != file_id and candidate in candidate_storage_keys:
+                    storage_keys_referenced_elsewhere.add(candidate)
+
+            all_artifacts = await self.db.find_many(
+                model="fileArtifacts",
+                where=[],
+                namespace=self.namespace,
+            )
+            for artifact in all_artifacts:
+                artifact_target = self._artifact_storage_target(policy_by_file_id.get(artifact.get("fileId")))
+                candidate = ref_key(artifact_target, artifact.get("storageKey"))
+                if artifact.get("fileId") != file_id and candidate in candidate_storage_keys:
+                    storage_keys_referenced_elsewhere.add(candidate)
+
+        await self.db.delete_many(
+            model="filePermissions",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        await self.db.delete_many(
+            model="fileShares",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        await self.db.delete_many(
+            model="fileArtifacts",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        await self.db.delete_many(
+            model="fileVersions",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        for session in all_sessions:
+            await self.db.delete(
+                model="uploadSessions",
+                where=[{"field": "uploadSessionId", "operator": "eq", "value": session.get("uploadSessionId")}],
+                namespace=self.namespace,
+            )
+        await self.db.delete(
+            model="files",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+
+        total_bytes_freed = 0
+        for storage_ref in candidate_storage_keys:
+            if storage_ref in storage_keys_referenced_elsewhere:
+                continue
+            try:
+                target, storage_key = storage_ref.split("\u0000", 1)
+                await self.storage.delete_object(key=storage_key, target=target)
+                total_bytes_freed += version_bytes_by_storage_key.get(storage_ref, 0)
+            except Exception:
+                pass
+
+        if self.quota and total_bytes_freed > 0:
+            await self.quota.record_usage(
+                {
+                    "principalId": file.ownerId,
+                    "tenantId": file.tenantId,
+                    "bytes": -total_bytes_freed,
+                }
+            )
+
+        self.events.emit(
+            "file:deleted",
+            create_file_deleted_event(
+                {"fileId": file_id, "ownerId": file.ownerId, "tenantId": file.tenantId},
+                ctx.requestId,
+            ),
+        )
+
+        if self.logger:
+            self.logger.info(
+                "File deleted",
+                {
+                    "fileId": file_id,
+                    "ownerId": file.ownerId,
+                    "tenantId": file.tenantId,
+                    "requestId": ctx.requestId,
+                },
+            )
+
+    async def list_versions(self, file_id: str, ctx: FileProviderContext) -> Dict[str, Any]:
+        await self.get_file(file_id, ctx)
+        versions_data = await self.db.find_many(
+            model="fileVersions",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            order_by=[{"field": "createdAt", "direction": "desc"}],
+            namespace=self.namespace,
+        )
+        return {"versions": versions_data}
+
+    async def can_write_file(self, file_id: str, ctx: FileProviderContext) -> bool:
+        file_data = await self.db.find_one(
+            model="files",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+
+        if not file_data:
+            return True
+
+        file = FileRecord(**file_data)
+        return await self.authorizer.can_write(file, ctx)
+
+    async def get_version(self, file_id: str, version_id: str, ctx: FileProviderContext) -> FileVersionRecord:
+        await self.get_file(file_id, ctx)
+        return await self._get_bound_version(file_id, version_id)
+
+
+def create_file_service(config: FileServiceConfig) -> FileService:
+    return FileService(config)

--- a/filefn/python/filefn/server/models.py
+++ b/filefn/python/filefn/server/models.py
@@ -1,0 +1,103 @@
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel
+from enum import Enum
+
+class Visibility(str, Enum):
+    PRIVATE = 'private'
+    SHARED = 'shared'
+    PUBLIC = 'public'
+
+class FileRecord(BaseModel):
+    fileId: str
+    currentVersionId: str
+    ownerId: str
+    tenantId: Optional[str] = None
+    visibility: Visibility
+    policy: str
+    mimeType: str
+    size: int
+    name: str
+    metadata: Optional[Dict[str, Any]] = None
+    createdAt: str
+    updatedAt: str
+
+class FileVersionRecord(BaseModel):
+    versionId: str
+    fileId: str
+    storageKey: str
+    mimeType: str
+    size: int
+    checksumSha256Base64: Optional[str] = None
+    tenantId: Optional[str] = None
+    createdAt: str
+
+class UploadSessionRecord(BaseModel):
+    uploadSessionId: str
+    status: str
+    policy: str
+    fileId: Optional[str] = None
+    fileName: str
+    mimeType: str
+    size: int
+    uploadMode: str
+    chunkSizeBytes: int
+    totalParts: int
+    storageKey: str
+    storageUploadId: Optional[str] = None
+    ownerId: str
+    tenantId: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    idempotencyKey: Optional[str] = None
+    idempotencyPayloadHash: Optional[str] = None
+    completionVersionId: Optional[str] = None
+    uploadSessionToken: Optional[str] = None
+    sessionTokenHash: Optional[str] = None
+    expiresAt: str
+    createdAt: str
+
+class UploadPartRecord(BaseModel):
+    uploadSessionId: str
+    partNumber: int
+    etag: str
+    size: int
+    checksumSha256Base64: Optional[str] = None
+
+class FilePermissionRecord(BaseModel):
+    permissionId: str
+    fileId: str
+    userId: Optional[str] = None
+    role: Optional[str] = None
+    tenantId: Optional[str] = None
+    canRead: bool
+    canWrite: bool
+    canDelete: bool
+    canShare: bool
+    expiresAt: Optional[str] = None
+    createdAt: str
+
+class FileShareRecord(BaseModel):
+    tokenHash: str
+    fileId: str
+    versionId: Optional[str] = None
+    expiresAt: Optional[str] = None
+    requiresAuth: bool
+    maxDownloads: Optional[int] = None
+    downloads: int
+    createdAt: str
+    revokedAt: Optional[str] = None
+
+class FileArtifactRecord(BaseModel):
+    artifactId: str
+    fileId: str
+    versionId: str
+    kind: str
+    storageKey: str
+    mimeType: str
+    size: Optional[int] = None
+    metadata: Optional[Dict[str, Any]] = None
+    createdAt: str
+
+class FileProviderContext(BaseModel):
+    principalId: Optional[str] = None
+    tenantId: Optional[str] = None
+    requestId: Optional[str] = None

--- a/filefn/python/filefn/server/policies.py
+++ b/filefn/python/filefn/server/policies.py
@@ -1,0 +1,134 @@
+from typing import Callable, List, Optional, Protocol, Dict, Union, Any
+from dataclasses import dataclass, field
+from pydantic import BaseModel
+
+DEFAULT_STORAGE_TARGET = "durable"
+NUCLEUS_MAX_SIZE_BYTES = 100 * 1024 * 1024
+NUCLEUS_ALLOWED_CONTENT_TYPES = [
+    "image/*",
+    "audio/*",
+    "video/*",
+    "application/pdf",
+    "text/markdown",
+    "text/plain",
+]
+
+@dataclass
+class PolicyStoragePathContext:
+    fileName: str
+    fileId: str
+    versionId: str
+    principalId: Optional[str] = None
+    tenantId: Optional[str] = None
+
+class Policy:
+    def __init__(self, 
+                 name: str, 
+                 contentTypes: Optional[List[str]] = None,
+                 maxSizeBytes: Optional[int] = None,
+                 visibility: Optional[str] = None, # 'public' | 'private' | 'shared'
+                 storageTarget: Optional[str] = None,
+                 artifactStorageTarget: Optional[str] = None,
+                 lifecycle: Optional[str] = None,
+                 renderProfile: Optional[str] = None,
+                 storagePath: Optional[Callable[[PolicyStoragePathContext], str]] = None):
+        self.name = name
+        self.contentTypes = contentTypes
+        self.maxSizeBytes = maxSizeBytes
+        self.visibility = visibility
+        self.storageTarget = storageTarget
+        self.artifactStorageTarget = artifactStorageTarget
+        self.lifecycle = lifecycle
+        self.renderProfile = renderProfile
+        self.storagePath = storagePath
+
+class PolicyRegistry(Protocol):
+    def get(self, name: str) -> Optional[Policy]: ...
+    def register(self, policy: Policy) -> None: ...
+    def list(self) -> List[Policy]: ...
+    def define(self, name: str, policy: Dict[str, Any]) -> None: ...
+
+class InMemoryPolicyRegistry:
+    def __init__(self, initial_policies: List[Policy] = None):
+        self._policies: Dict[str, Policy] = {}
+        if initial_policies:
+            for p in initial_policies:
+                self._policies[p.name] = p
+
+    def get(self, name: str) -> Optional[Policy]:
+        return self._policies.get(name)
+
+    def register(self, policy: Policy) -> None:
+        self._policies[policy.name] = policy
+
+    def define(self, name: str, policy: Optional[Dict[str, Any]] = None, **kwargs) -> None:
+        payload = dict(policy or {})
+        payload.update(kwargs)
+        policy = Policy(name=name, **payload)
+        self._policies[name] = policy
+
+    def list(self) -> List[Policy]:
+        return list(self._policies.values())
+
+def create_policy_registry(initial_policies: List[Policy] = None) -> InMemoryPolicyRegistry:
+    return InMemoryPolicyRegistry(initial_policies)
+
+def validate_policy_constraints(policy: Policy, mime_type: str, size: int) -> Dict[str, Union[bool, str]]:
+    if policy.contentTypes and len(policy.contentTypes) > 0:
+        if not any(matches_content_type(pattern, mime_type) for pattern in policy.contentTypes):
+            return {'valid': False, 'error': f"Content type '{mime_type}' not allowed by policy '{policy.name}'"}
+    
+    if policy.maxSizeBytes is not None and size > policy.maxSizeBytes:
+        return {'valid': False, 'error': f"Size {size} exceeds max {policy.maxSizeBytes} for policy '{policy.name}'"}
+
+    return {'valid': True}
+
+def compute_storage_path(policy: Policy, ctx: PolicyStoragePathContext) -> str:
+    if policy.storagePath:
+        return policy.storagePath(ctx)
+    
+    parts = []
+    if ctx.tenantId: parts.append(ctx.tenantId)
+    if ctx.principalId: parts.append(ctx.principalId)
+    parts.append(ctx.fileId)
+    parts.append(f"{ctx.versionId}-{ctx.fileName}")
+    return "/".join(parts)
+
+def resolve_storage_target(policy: Any) -> str:
+    target = getattr(policy, "storageTarget", None) if policy is not None else None
+    return target or DEFAULT_STORAGE_TARGET
+
+def resolve_artifact_storage_target(policy: Any) -> str:
+    target = getattr(policy, "artifactStorageTarget", None) if policy is not None else None
+    return target or resolve_storage_target(policy)
+
+def matches_content_type(pattern: str, mime_type: str) -> bool:
+    if pattern == "*/*":
+        return True
+    if pattern.endswith("/*"):
+        return mime_type.startswith(pattern[:-1])
+    return pattern == mime_type
+
+def create_nucleus_policies() -> List[Policy]:
+    return [
+        Policy(
+            name="nucleus-durable-default",
+            contentTypes=list(NUCLEUS_ALLOWED_CONTENT_TYPES),
+            maxSizeBytes=NUCLEUS_MAX_SIZE_BYTES,
+            visibility="private",
+            storageTarget="durable",
+            artifactStorageTarget="durable",
+            lifecycle="durable",
+            renderProfile="nucleus",
+        ),
+        Policy(
+            name="nucleus-temporary-default",
+            contentTypes=list(NUCLEUS_ALLOWED_CONTENT_TYPES),
+            maxSizeBytes=NUCLEUS_MAX_SIZE_BYTES,
+            visibility="private",
+            storageTarget="temporary",
+            artifactStorageTarget="temporary",
+            lifecycle="temporary",
+            renderProfile="nucleus",
+        ),
+    ]

--- a/filefn/python/filefn/server/processing/service.py
+++ b/filefn/python/filefn/server/processing/service.py
@@ -1,0 +1,394 @@
+import asyncio
+from datetime import datetime, timezone
+import secrets
+from typing import Any, Callable, Dict, List, Optional, Protocol, Set
+
+from pydantic import BaseModel
+
+from .. import errors
+from ..events import (
+    FileFnEventEmitter,
+    ProcessingCompletedEvent,
+    ProcessingFailedEvent,
+    ProcessingStartedEvent,
+)
+from ..models import FileProviderContext, FileRecord, Visibility
+from ..policies import resolve_artifact_storage_target, resolve_storage_target
+from ..routed_storage import get_storage_capabilities
+
+
+class ProcessorInput(BaseModel):
+    fileId: str
+    versionId: str
+    storageKey: str
+    mimeType: str
+    size: int
+    fileName: str
+    tenantId: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class ProcessorOutputArtifact(BaseModel):
+    kind: str
+    data: bytes
+    mimeType: str
+    storageKey: str
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class ProcessorResult(BaseModel):
+    success: bool
+    artifacts: List[ProcessorOutputArtifact]
+    error: Optional[str] = None
+
+
+class Processor(Protocol):
+    name: str
+    supportedMimeTypes: List[str]
+
+    async def process(self, input: ProcessorInput, get_data: Callable[[], Any]) -> ProcessorResult: ...
+
+
+class FlowFnQueue(Protocol):
+    async def add(self, job: Any) -> Dict[str, Any]: ...
+
+
+class FlowFnProvider(Protocol):
+    def get_queue(self, name: str) -> Optional[FlowFnQueue]: ...
+
+
+class ProcessingServiceConfig(BaseModel):
+    db: Any
+    storage: Any
+    policies: Optional[Any] = None
+    events: FileFnEventEmitter
+    processors: List[Any] = []
+    flow_fn: Optional[Any] = None
+    namespace: str = "filefn"
+    enabled: bool = True
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class FileArtifactRecord(BaseModel):
+    artifactId: str
+    fileId: str
+    versionId: str
+    kind: str
+    storageKey: str
+    mimeType: str
+    size: int
+    metadata: Optional[Dict[str, Any]] = None
+    createdAt: str
+
+
+def _generate_id() -> str:
+    return f"art_{secrets.token_urlsafe(12)}"
+
+
+def _supports_processor(processor: Processor, mime_type: str) -> bool:
+    if "*/*" in processor.supportedMimeTypes:
+        return True
+    return mime_type in processor.supportedMimeTypes
+
+
+def _build_processing_idempotency_key(file_id: str, version_id: str, processors: List[Processor]) -> str:
+    processor_key = ",".join(sorted(processor.name for processor in processors))
+    return f"processing:{file_id}:{version_id}:{processor_key}"
+
+
+class ProcessingService:
+    def __init__(self, config: ProcessingServiceConfig):
+        self.db = config.db
+        self.storage = config.storage
+        self.policies = config.policies
+        self.events = config.events
+        self.processors = config.processors
+        self.flow_fn = config.flow_fn
+        self.namespace = config.namespace
+        self.enabled = config.enabled
+        self.queue_name = "filefn.processing"
+        self._background_tasks: Set[asyncio.Task[Any]] = set()
+
+    def _file_storage_target(self, policy_name: Optional[str]) -> str:
+        policy = self.policies.get(policy_name) if (self.policies and policy_name) else None
+        return resolve_storage_target(policy)
+
+    def _artifact_storage_target(self, policy_name: Optional[str]) -> str:
+        policy = self.policies.get(policy_name) if (self.policies and policy_name) else None
+        return resolve_artifact_storage_target(policy)
+
+    async def _get_readable_grant_file_ids(self, ctx: FileProviderContext) -> Set[str]:
+        if not ctx.principalId:
+            return set()
+
+        grants: List[Dict[str, Any]] = []
+        grants.extend(
+            await self.db.find_many(
+                model="filePermissions",
+                where=[{"field": "userId", "operator": "eq", "value": ctx.principalId}],
+                namespace=self.namespace,
+            )
+        )
+        if ctx.tenantId:
+            grants.extend(
+                await self.db.find_many(
+                    model="filePermissions",
+                    where=[{"field": "tenantId", "operator": "eq", "value": ctx.tenantId}],
+                    namespace=self.namespace,
+                )
+            )
+
+        readable: Set[str] = set()
+        for grant in grants:
+            if not grant.get("canRead"):
+                continue
+            if (
+                grant.get("principalId") == ctx.principalId
+                or grant.get("userId") == ctx.principalId
+                or (grant.get("tenantId") and grant.get("tenantId") == ctx.tenantId)
+            ):
+                readable.add(grant["fileId"])
+        return readable
+
+    def is_enabled(self) -> bool:
+        return self.enabled and len(self.processors) > 0
+
+    async def trigger_processing(self, input: Dict[str, Any], ctx: FileProviderContext) -> Dict[str, Any]:
+        if not self.enabled or not self.processors:
+            return {"enqueued": False}
+
+        self.events.emit(
+            "processing.started",
+            ProcessingStartedEvent(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                requestId=ctx.requestId,
+                fileId=input["fileId"],
+                versionId=input["versionId"],
+            ),
+        )
+
+        if self.flow_fn:
+            queue = self.flow_fn.get_queue(self.queue_name)
+            if queue:
+                try:
+                    idempotency_key = _build_processing_idempotency_key(
+                        input["fileId"],
+                        input["versionId"],
+                        self.processors,
+                    )
+                    result = await queue.add(
+                        {
+                            "fileId": input["fileId"],
+                            "versionId": input["versionId"],
+                            "storageKey": input["storageKey"],
+                            "mimeType": input["mimeType"],
+                            "size": input["size"],
+                            "fileName": input["fileName"],
+                            "tenantId": input.get("tenantId"),
+                            "idempotencyKey": idempotency_key,
+                        }
+                    )
+                    return {"enqueued": True, "jobId": result.get("jobId")}
+                except Exception as exc:
+                    raise errors.processing_enqueue_failed() from exc
+
+        task = asyncio.create_task(self._safe_run_processing(ProcessorInput(**input), ctx))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return {"enqueued": False}
+
+    async def _safe_run_processing(self, input: ProcessorInput, ctx: FileProviderContext) -> None:
+        try:
+            await self.run_processing(input, ctx)
+        except Exception as exc:
+            self.events.emit(
+                "processing.failed",
+                ProcessingFailedEvent(
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    requestId=ctx.requestId,
+                    fileId=input.fileId,
+                    versionId=input.versionId,
+                    error=str(exc),
+                ),
+            )
+
+    async def run_processing(self, input: ProcessorInput, ctx: FileProviderContext) -> Dict[str, Any]:
+        applicable_processors = [p for p in self.processors if _supports_processor(p, input.mimeType)]
+        if not applicable_processors:
+            return {"artifactsCreated": 0, "errors": []}
+
+        file_data = await self.db.find_one(
+            model="files",
+            where=[{"field": "fileId", "operator": "eq", "value": input.fileId}],
+            namespace=self.namespace,
+        )
+        policy_name = file_data.get("policy") if file_data else None
+        file_storage_target = self._file_storage_target(policy_name)
+        artifact_storage_target = self._artifact_storage_target(policy_name)
+
+        data_cache: Optional[bytes] = None
+
+        async def get_data() -> bytes:
+            nonlocal data_cache
+            if data_cache is not None:
+                return data_cache
+
+            stream = await self.storage.open_download_stream(key=input.storageKey, target=file_storage_target)
+            chunks: List[bytes] = []
+            async for chunk in stream:
+                chunks.append(chunk)
+            data_cache = b"".join(chunks)
+            return data_cache
+
+        processing_errors: List[str] = []
+        artifacts_created = 0
+
+        for processor in applicable_processors:
+            try:
+                result = await processor.process(input, get_data)
+                if not result.success:
+                    if result.error:
+                        processing_errors.append(f"{processor.name}: {result.error}")
+                    continue
+
+                for artifact in result.artifacts:
+                    await self.storage.put_object(
+                        key=artifact.storageKey,
+                        data=artifact.data,
+                        metadata={"contentType": artifact.mimeType},
+                        target=artifact_storage_target,
+                    )
+
+                    existing_artifact_data = await self.db.find_one(
+                        model="fileArtifacts",
+                        where=[
+                            {"field": "fileId", "operator": "eq", "value": input.fileId},
+                            {"field": "versionId", "operator": "eq", "value": input.versionId},
+                            {"field": "kind", "operator": "eq", "value": artifact.kind},
+                        ],
+                        namespace=self.namespace,
+                    )
+
+                    if existing_artifact_data:
+                        await self.db.update(
+                            model="fileArtifacts",
+                            where=[
+                                {
+                                    "field": "artifactId",
+                                    "operator": "eq",
+                                    "value": existing_artifact_data["artifactId"],
+                                }
+                            ],
+                            data={
+                                "storageKey": artifact.storageKey,
+                                "mimeType": artifact.mimeType,
+                                "size": len(artifact.data),
+                                "metadata": artifact.metadata or {},
+                            },
+                            namespace=self.namespace,
+                        )
+                    else:
+                        await self.db.create(
+                            model="fileArtifacts",
+                            data={
+                                "artifactId": _generate_id(),
+                                "fileId": input.fileId,
+                                "versionId": input.versionId,
+                                "kind": artifact.kind,
+                                "storageKey": artifact.storageKey,
+                                "mimeType": artifact.mimeType,
+                                "size": len(artifact.data),
+                                "metadata": artifact.metadata or {},
+                                "createdAt": datetime.now(timezone.utc).isoformat(),
+                            },
+                            namespace=self.namespace,
+                        )
+                    artifacts_created += 1
+            except Exception as exc:
+                processing_errors.append(f"{processor.name}: {str(exc)}")
+
+        self.events.emit(
+            "processing.completed",
+            ProcessingCompletedEvent(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                requestId=ctx.requestId,
+                fileId=input.fileId,
+                versionId=input.versionId,
+                artifactsCreated=artifacts_created,
+            ),
+        )
+
+        return {"artifactsCreated": artifacts_created, "errors": processing_errors}
+
+    async def _get_readable_file(self, file_id: str, ctx: FileProviderContext) -> FileRecord:
+        file_data = await self.db.find_one(
+            model="files",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        if not file_data:
+            raise errors.not_found("File")
+
+        file = FileRecord(**file_data)
+        if file.visibility == Visibility.PUBLIC:
+            return file
+        if file.ownerId == ctx.principalId:
+            return file
+        if file.visibility == Visibility.SHARED and file.tenantId and file.tenantId == ctx.tenantId:
+            return file
+
+        grant_file_ids = await self._get_readable_grant_file_ids(ctx)
+        if file.fileId in grant_file_ids:
+            return file
+
+        raise errors.forbidden()
+
+    async def list_artifacts(self, file_id: str, ctx: FileProviderContext) -> List[Dict[str, Any]]:
+        await self._get_readable_file(file_id, ctx)
+        artifacts = await self.db.find_many(
+            model="fileArtifacts",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            order_by=[{"field": "createdAt", "direction": "desc"}],
+            namespace=self.namespace,
+        )
+        return artifacts
+
+    async def get_artifact_download_url(
+        self,
+        artifact_id: str,
+        ctx: FileProviderContext,
+        file_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        artifact_data = await self.db.find_one(
+            model="fileArtifacts",
+            where=[{"field": "artifactId", "operator": "eq", "value": artifact_id}],
+            namespace=self.namespace,
+        )
+        if not artifact_data:
+            raise errors.not_found("Artifact")
+
+        artifact = FileArtifactRecord(**artifact_data)
+        if file_id and artifact.fileId != file_id:
+            raise errors.not_found("Artifact")
+
+        file = await self._get_readable_file(artifact.fileId, ctx)
+        artifact_storage_target = self._artifact_storage_target(file.policy)
+
+        if hasattr(self.storage, "sign_download_url") and get_storage_capabilities(self.storage, artifact_storage_target).get("signedDownloadUrls"):
+            try:
+                result = await self.storage.sign_download_url(
+                    key=artifact.storageKey,
+                    expires_in_seconds=900,
+                    target=artifact_storage_target,
+                )
+                return {"url": result["url"], "headers": result.get("headers")}
+            except Exception:
+                pass
+
+        return {"url": f"/proxy/files/{artifact.fileId}/artifacts/{artifact.artifactId}/download"}
+
+
+def create_processing_service(config: ProcessingServiceConfig) -> ProcessingService:
+    return ProcessingService(config)

--- a/filefn/python/filefn/server/protocols.py
+++ b/filefn/python/filefn/server/protocols.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from typing import Any, AsyncGenerator, Dict, Optional, Protocol, Union
+
+from pydantic import BaseModel
+
+
+class StorageObject(BaseModel):
+    key: str
+    size: int
+    etag: str
+    lastModified: Union[str, datetime]
+    metadata: Optional[Dict[str, str]] = None
+
+
+class StorageAdapter(Protocol):
+    capabilities: Optional[Dict[str, bool]]
+    def capabilities_for_target(self, target: str) -> Dict[str, bool]: ...
+
+    async def get_object(self, key: str, target: Optional[str] = None) -> StorageObject: ...
+
+    async def put_object(
+        self,
+        key: str,
+        data: Union[bytes, Any],
+        metadata: Optional[Dict[str, str]] = None,
+        target: Optional[str] = None,
+    ) -> StorageObject: ...
+
+    async def delete_object(self, key: str, target: Optional[str] = None) -> None: ...
+
+    async def open_download_stream(self, key: str, target: Optional[str] = None) -> AsyncGenerator[bytes, None]: ...
+
+    async def sign_download_url(self, key: str, expires_in_seconds: int, target: Optional[str] = None) -> Dict[str, Any]: ...
+
+    async def create_multipart_upload(
+        self,
+        key: str,
+        metadata: Optional[Dict[str, str]] = None,
+        content_type: Optional[str] = None,
+        target: Optional[str] = None,
+    ) -> str: ...
+
+    async def sign_multipart_upload_part_url(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        expires_in_seconds: int,
+        constraints: Optional[Dict[str, Any]] = None,
+        target: Optional[str] = None,
+    ) -> Dict[str, Any]: ...
+
+    async def upload_part(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        data: bytes,
+        target: Optional[str] = None,
+    ) -> str: ...
+
+    async def complete_multipart_upload(
+        self,
+        key: str,
+        upload_id: str,
+        parts: list[Dict[str, Any]],
+        target: Optional[str] = None,
+    ) -> StorageObject: ...
+
+    async def abort_multipart_upload(self, key: str, upload_id: str, target: Optional[str] = None) -> None: ...

--- a/filefn/python/filefn/server/routed_storage.py
+++ b/filefn/python/filefn/server/routed_storage.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+STORAGE_TARGET_NOT_CONFIGURED = "FILEFN_STORAGE_TARGET_NOT_CONFIGURED"
+
+
+class StorageRoutingError(Exception):
+    def __init__(self, target: str):
+        super().__init__(f"Storage target '{target}' is not configured")
+        self.code = STORAGE_TARGET_NOT_CONFIGURED
+        self.target = target
+
+
+def _merge_capabilities(adapters: Dict[str, Any]) -> Dict[str, bool]:
+    keys = (
+        "signedUploadUrls",
+        "signedDownloadUrls",
+        "multipart",
+        "proxyStreamingUpload",
+        "proxyStreamingDownload",
+    )
+    return {
+        key: all(bool((getattr(adapter, "capabilities", {}) or {}).get(key)) for adapter in adapters.values())
+        for key in keys
+    }
+
+
+def get_storage_capabilities(adapter: Any, target: Optional[str] = None) -> Dict[str, bool]:
+    if target and hasattr(adapter, "capabilities_for_target"):
+        return adapter.capabilities_for_target(target)
+    return getattr(adapter, "capabilities", {}) or {}
+
+
+class RoutedStorageAdapter:
+    def __init__(self, adapters: Dict[str, Any], default_target: Optional[str] = None, name: str = "routed"):
+        if not adapters:
+            raise ValueError("create_routed_storage_adapter requires at least one target adapter")
+
+        self._adapters = dict(adapters)
+        self.default_target = default_target or next(iter(self._adapters.keys()))
+        if self.default_target not in self._adapters:
+            raise StorageRoutingError(self.default_target)
+
+        self.name = name
+        self.targets = list(self._adapters.keys())
+        self.capabilities = _merge_capabilities(self._adapters)
+
+    def _pick(self, target: Optional[str]) -> tuple[Any, str]:
+        resolved = target or self.default_target
+        adapter = self._adapters.get(resolved)
+        if adapter is None:
+            raise StorageRoutingError(resolved)
+        return adapter, resolved
+
+    def capabilities_for_target(self, target: str) -> Dict[str, bool]:
+        adapter, _ = self._pick(target)
+        return dict(getattr(adapter, "capabilities", {}) or {})
+
+    async def get_object(self, key: str, target: Optional[str] = None) -> Any:
+        adapter, _ = self._pick(target)
+        return await adapter.get_object(key=key)
+
+    async def put_object(
+        self,
+        key: str,
+        data: Any,
+        metadata: Optional[Dict[str, str]] = None,
+        target: Optional[str] = None,
+    ) -> Any:
+        adapter, _ = self._pick(target)
+        return await adapter.put_object(key=key, data=data, metadata=metadata)
+
+    async def delete_object(self, key: str, target: Optional[str] = None) -> None:
+        adapter, _ = self._pick(target)
+        await adapter.delete_object(key=key)
+
+    async def open_download_stream(self, key: str, target: Optional[str] = None):
+        adapter, _ = self._pick(target)
+        return await adapter.open_download_stream(key=key)
+
+    async def sign_download_url(self, key: str, expires_in_seconds: int, target: Optional[str] = None) -> Dict[str, Any]:
+        adapter, resolved = self._pick(target)
+        if not hasattr(adapter, "sign_download_url"):
+            raise RuntimeError(f"Storage target '{resolved}' does not support signed download URLs")
+        return await adapter.sign_download_url(key=key, expires_in_seconds=expires_in_seconds)
+
+    async def create_multipart_upload(
+        self,
+        key: str,
+        metadata: Optional[Dict[str, str]] = None,
+        content_type: Optional[str] = None,
+        target: Optional[str] = None,
+    ) -> Any:
+        adapter, resolved = self._pick(target)
+        if not hasattr(adapter, "create_multipart_upload"):
+            raise RuntimeError(f"Storage target '{resolved}' does not support multipart uploads")
+        try:
+            return await adapter.create_multipart_upload(key=key, metadata=metadata, content_type=content_type)
+        except TypeError:
+            return await adapter.create_multipart_upload(key=key, metadata=metadata)
+
+    async def sign_multipart_upload_part_url(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        expires_in_seconds: int,
+        constraints: Optional[Dict[str, Any]] = None,
+        target: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        adapter, resolved = self._pick(target)
+        if not hasattr(adapter, "sign_multipart_upload_part_url"):
+            raise RuntimeError(f"Storage target '{resolved}' does not support multipart uploads")
+        return await adapter.sign_multipart_upload_part_url(
+            key=key,
+            upload_id=upload_id,
+            part_number=part_number,
+            expires_in_seconds=expires_in_seconds,
+            constraints=constraints,
+        )
+
+    async def upload_part(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        data: bytes,
+        target: Optional[str] = None,
+    ) -> str:
+        adapter, resolved = self._pick(target)
+        if not hasattr(adapter, "upload_part"):
+            raise RuntimeError(f"Storage target '{resolved}' does not support multipart uploads")
+        return await adapter.upload_part(key=key, upload_id=upload_id, part_number=part_number, data=data)
+
+    async def complete_multipart_upload(
+        self,
+        key: str,
+        upload_id: str,
+        parts: list[Dict[str, Any]],
+        target: Optional[str] = None,
+    ) -> Any:
+        adapter, resolved = self._pick(target)
+        if not hasattr(adapter, "complete_multipart_upload"):
+            raise RuntimeError(f"Storage target '{resolved}' does not support multipart uploads")
+        return await adapter.complete_multipart_upload(key=key, upload_id=upload_id, parts=parts)
+
+    async def abort_multipart_upload(self, key: str, upload_id: str, target: Optional[str] = None) -> None:
+        adapter, resolved = self._pick(target)
+        if not hasattr(adapter, "abort_multipart_upload"):
+            raise RuntimeError(f"Storage target '{resolved}' does not support multipart uploads")
+        await adapter.abort_multipart_upload(key=key, upload_id=upload_id)
+
+
+def create_routed_storage_adapter(
+    adapters: Dict[str, Any],
+    default_target: Optional[str] = None,
+    name: str = "routed",
+) -> RoutedStorageAdapter:
+    return RoutedStorageAdapter(adapters=adapters, default_target=default_target, name=name)

--- a/filefn/python/filefn/server/schema.py
+++ b/filefn/python/filefn/server/schema.py
@@ -1,0 +1,190 @@
+from typing import Any, Dict, List, Optional, Union
+from pydantic import BaseModel, Field
+
+class FieldSchema(BaseModel):
+    type: str
+    required: bool = False
+    unique: bool = False
+
+class IndexSchema(BaseModel):
+    name: str
+    fields: List[str]
+    unique: bool = False
+
+class ConstraintSchema(BaseModel):
+    name: str
+    type: str
+    fields: List[str]
+
+class TableSchema(BaseModel):
+    modelName: str
+    fields: Dict[str, FieldSchema]
+    indexes: List[IndexSchema] = []
+    constraints: List[ConstraintSchema] = []
+
+class SchemaResult(BaseModel):
+    version: int
+    schemas: List[TableSchema]
+
+class FileFnSchemaOptions(BaseModel):
+    namespace: str = "filefn"
+
+def get_schema(options: Optional[FileFnSchemaOptions] = None) -> SchemaResult:
+    options = options or FileFnSchemaOptions()
+    ns = options.namespace
+
+    files = TableSchema(
+        modelName='files',
+        fields={
+            'fileId': FieldSchema(type='string', required=True, unique=True),
+            'currentVersionId': FieldSchema(type='string', required=True),
+            'ownerId': FieldSchema(type='string', required=True),
+            'tenantId': FieldSchema(type='string', required=False),
+            'visibility': FieldSchema(type='string', required=True),
+            'policy': FieldSchema(type='string', required=True),
+            'mimeType': FieldSchema(type='string', required=True),
+            'size': FieldSchema(type='number', required=True),
+            'name': FieldSchema(type='string', required=True),
+            'metadata': FieldSchema(type='json', required=False),
+            'createdAt': FieldSchema(type='string', required=True),
+            'updatedAt': FieldSchema(type='string', required=True),
+        },
+        indexes=[
+            IndexSchema(name=f'{ns}_files_owner_idx', fields=['ownerId']),
+            IndexSchema(name=f'{ns}_files_tenant_idx', fields=['tenantId']),
+        ]
+    )
+
+    file_versions = TableSchema(
+        modelName='fileVersions',
+        fields={
+            'versionId': FieldSchema(type='string', required=True, unique=True),
+            'fileId': FieldSchema(type='string', required=True),
+            'storageKey': FieldSchema(type='string', required=True),
+            'mimeType': FieldSchema(type='string', required=True),
+            'size': FieldSchema(type='number', required=True),
+            'checksumSha256Base64': FieldSchema(type='string', required=False),
+            'tenantId': FieldSchema(type='string', required=False),
+            'createdAt': FieldSchema(type='string', required=True),
+        },
+        indexes=[
+            IndexSchema(name=f'{ns}_versions_file_idx', fields=['fileId']),
+            IndexSchema(name=f'{ns}_versions_checksum_idx', fields=['checksumSha256Base64', 'tenantId']),
+        ]
+    )
+
+    upload_sessions = TableSchema(
+        modelName='uploadSessions',
+        fields={
+            'uploadSessionId': FieldSchema(type='string', required=True, unique=True),
+            'status': FieldSchema(type='string', required=True),
+            'policy': FieldSchema(type='string', required=True),
+            'fileId': FieldSchema(type='string', required=False),
+            'fileName': FieldSchema(type='string', required=True),
+            'mimeType': FieldSchema(type='string', required=True),
+            'size': FieldSchema(type='number', required=True),
+            'uploadMode': FieldSchema(type='string', required=True),
+            'chunkSizeBytes': FieldSchema(type='number', required=True),
+            'totalParts': FieldSchema(type='number', required=True),
+            'storageKey': FieldSchema(type='string', required=True),
+            'storageUploadId': FieldSchema(type='string', required=False),
+            'ownerId': FieldSchema(type='string', required=True),
+            'tenantId': FieldSchema(type='string', required=False),
+            'metadata': FieldSchema(type='json', required=False),
+            'idempotencyKey': FieldSchema(type='string', required=False),
+            'idempotencyPayloadHash': FieldSchema(type='string', required=False),
+            'completionVersionId': FieldSchema(type='string', required=False),
+            'uploadSessionToken': FieldSchema(type='string', required=False),
+            'sessionTokenHash': FieldSchema(type='string', required=False),
+            'expiresAt': FieldSchema(type='string', required=True),
+            'createdAt': FieldSchema(type='string', required=True),
+        },
+        indexes=[
+            IndexSchema(name=f'{ns}_sessions_idem_idx', fields=['idempotencyKey'], unique=True),
+            IndexSchema(name=f'{ns}_sessions_expires_idx', fields=['expiresAt']),
+        ]
+    )
+
+    upload_parts = TableSchema(
+        modelName='uploadParts',
+        fields={
+            'uploadSessionId': FieldSchema(type='string', required=True),
+            'partNumber': FieldSchema(type='number', required=True),
+            'etag': FieldSchema(type='string', required=True),
+            'size': FieldSchema(type='number', required=True),
+            'checksumSha256Base64': FieldSchema(type='string', required=False),
+        },
+        indexes=[
+            IndexSchema(name=f'{ns}_parts_session_idx', fields=['uploadSessionId']),
+        ],
+        constraints=[
+            ConstraintSchema(name=f'{ns}_parts_unique', type='unique', fields=['uploadSessionId', 'partNumber']),
+        ]
+    )
+
+    file_permissions = TableSchema(
+        modelName='filePermissions',
+        fields={
+            'permissionId': FieldSchema(type='string', required=True, unique=True),
+            'fileId': FieldSchema(type='string', required=True),
+            'userId': FieldSchema(type='string', required=False),
+            'role': FieldSchema(type='string', required=False),
+            'tenantId': FieldSchema(type='string', required=False),
+            'canRead': FieldSchema(type='boolean', required=True),
+            'canWrite': FieldSchema(type='boolean', required=True),
+            'canDelete': FieldSchema(type='boolean', required=True),
+            'canShare': FieldSchema(type='boolean', required=True),
+            'expiresAt': FieldSchema(type='string', required=False),
+            'createdAt': FieldSchema(type='string', required=True),
+        },
+        indexes=[
+            IndexSchema(name=f'{ns}_perms_file_idx', fields=['fileId']),
+            IndexSchema(name=f'{ns}_perms_user_idx', fields=['userId']),
+        ]
+    )
+
+    file_shares = TableSchema(
+        modelName='fileShares',
+        fields={
+            'tokenHash': FieldSchema(type='string', required=True, unique=True),
+            'fileId': FieldSchema(type='string', required=True),
+            'versionId': FieldSchema(type='string', required=False),
+            'expiresAt': FieldSchema(type='string', required=False),
+            'requiresAuth': FieldSchema(type='boolean', required=True),
+            'maxDownloads': FieldSchema(type='number', required=False),
+            'downloads': FieldSchema(type='number', required=True),
+            'createdAt': FieldSchema(type='string', required=True),
+            'revokedAt': FieldSchema(type='string', required=False),
+        },
+        indexes=[
+            IndexSchema(name=f'{ns}_shares_file_idx', fields=['fileId']),
+        ]
+    )
+
+    file_artifacts = TableSchema(
+        modelName='fileArtifacts',
+        fields={
+            'artifactId': FieldSchema(type='string', required=True, unique=True),
+            'fileId': FieldSchema(type='string', required=True),
+            'versionId': FieldSchema(type='string', required=True),
+            'kind': FieldSchema(type='string', required=True),
+            'storageKey': FieldSchema(type='string', required=True),
+            'mimeType': FieldSchema(type='string', required=True),
+            'size': FieldSchema(type='number', required=False),
+            'metadata': FieldSchema(type='json', required=False),
+            'createdAt': FieldSchema(type='string', required=True),
+        },
+        indexes=[
+            IndexSchema(name=f'{ns}_artifacts_file_idx', fields=['fileId']),
+            IndexSchema(name=f'{ns}_artifacts_version_idx', fields=['versionId']),
+        ]
+    )
+
+    return SchemaResult(
+        version=1,
+        schemas=[files, file_versions, upload_sessions, upload_parts, file_permissions, file_shares, file_artifacts]
+    )
+
+def get_schema_map(options: Optional[FileFnSchemaOptions] = None) -> Dict[str, TableSchema]:
+    result = get_schema(options)
+    return {s.modelName: s for s in result.schemas}

--- a/filefn/python/filefn/server/shares/service.py
+++ b/filefn/python/filefn/server/shares/service.py
@@ -1,0 +1,332 @@
+from datetime import datetime, timezone
+import hashlib
+import secrets
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from .. import errors
+from ..models import FileProviderContext, FileRecord, FileShareRecord, FileVersionRecord
+from ..policies import resolve_storage_target
+from ..routed_storage import get_storage_capabilities
+
+
+class CreateShareLinkInput(BaseModel):
+    fileId: str
+    versionId: Optional[str] = None
+    expiresAt: Optional[str] = None
+    requiresAuth: Optional[bool] = None
+    maxDownloads: Optional[int] = None
+
+
+class SharesServiceConfig(BaseModel):
+    db: Any
+    storage: Any
+    policies: Optional[Any] = None
+    logger: Optional[Any] = None
+    namespace: str = "filefn"
+    signed_url_ttl_seconds: int = 900
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class SharesService:
+    def __init__(self, config: SharesServiceConfig):
+        self.db = config.db
+        self.storage = config.storage
+        self.policies = config.policies
+        self.logger = config.logger
+        self.namespace = config.namespace
+        self.signed_url_ttl_seconds = config.signed_url_ttl_seconds
+
+    def _storage_target_for_file(self, file: FileRecord) -> str:
+        policy = self.policies.get(file.policy) if self.policies else None
+        return resolve_storage_target(policy)
+
+    def _hash_token(self, token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def _generate_token(self) -> str:
+        return secrets.token_urlsafe(32)
+
+    def _as_utc(self, value: str) -> datetime:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    async def _get_file(self, file_id: str) -> Optional[FileRecord]:
+        data = await self.db.find_one(
+            model="files",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+        return FileRecord(**data) if data else None
+
+    async def _get_version(self, version_id: str) -> Optional[FileVersionRecord]:
+        data = await self.db.find_one(
+            model="fileVersions",
+            where=[{"field": "versionId", "operator": "eq", "value": version_id}],
+            namespace=self.namespace,
+        )
+        return FileVersionRecord(**data) if data else None
+
+    async def _can_share_file(self, file: FileRecord, ctx: FileProviderContext) -> bool:
+        return file.ownerId == ctx.principalId
+
+    async def _reserve_download(self, token_hash: str) -> FileShareRecord:
+        for _ in range(5):
+            current_data = await self.db.find_one(
+                model="fileShares",
+                where=[{"field": "tokenHash", "operator": "eq", "value": token_hash}],
+                namespace=self.namespace,
+            )
+            if not current_data:
+                raise errors.share_not_found()
+
+            current = FileShareRecord(**current_data)
+            if current.revokedAt:
+                raise errors.share_revoked()
+            if current.expiresAt and self._as_utc(current.expiresAt) <= datetime.now(timezone.utc):
+                raise errors.share_expired()
+            if current.maxDownloads is not None and current.downloads >= current.maxDownloads:
+                raise errors.share_downloads_exceeded()
+
+            updated = await self.db.update(
+                model="fileShares",
+                where=[
+                    {"field": "tokenHash", "operator": "eq", "value": token_hash},
+                    {"field": "downloads", "operator": "eq", "value": current.downloads},
+                ],
+                data={"downloads": current.downloads + 1},
+                namespace=self.namespace,
+            )
+            if updated:
+                return FileShareRecord(**updated)
+
+        raise errors.FileFnError(
+            code="FILEFN_SHARE_DOWNLOAD_CONFLICT",
+            message="Could not reserve share download",
+            status=409,
+            details={"tokenHash": token_hash},
+        )
+
+    async def create_share_link(self, input: CreateShareLinkInput, ctx: FileProviderContext) -> Dict[str, Any]:
+        file = await self._get_file(input.fileId)
+        if not file:
+            raise errors.not_found("File")
+
+        if not await self._can_share_file(file, ctx):
+            raise errors.forbidden()
+
+        if input.versionId:
+            version = await self._get_version(input.versionId)
+            if not version or version.fileId != file.fileId:
+                raise errors.not_found("Version")
+
+        token = self._generate_token()
+        token_hash = self._hash_token(token)
+
+        share = FileShareRecord(
+            tokenHash=token_hash,
+            fileId=input.fileId,
+            versionId=input.versionId,
+            expiresAt=input.expiresAt,
+            requiresAuth=input.requiresAuth if input.requiresAuth is not None else False,
+            maxDownloads=input.maxDownloads,
+            downloads=0,
+            createdAt=datetime.now(timezone.utc).isoformat(),
+            revokedAt=None,
+        )
+
+        await self.db.create(
+            model="fileShares",
+            data=share.model_dump(),
+            namespace=self.namespace,
+        )
+
+        return {"token": token, "expiresAt": share.expiresAt}
+
+    async def download_via_share_link(
+        self,
+        token: str,
+        ctx: FileProviderContext,
+        is_authenticated: bool = False,
+    ) -> Dict[str, Any]:
+        token_hash = self._hash_token(token)
+        data = await self.db.find_one(
+            model="fileShares",
+            where=[{"field": "tokenHash", "operator": "eq", "value": token_hash}],
+            namespace=self.namespace,
+        )
+
+        if not data:
+            raise errors.share_not_found()
+
+        share = FileShareRecord(**data)
+        if share.revokedAt:
+            raise errors.share_revoked()
+
+        if share.expiresAt and self._as_utc(share.expiresAt) <= datetime.now(timezone.utc):
+            raise errors.share_expired()
+
+        if share.maxDownloads is not None and share.downloads >= share.maxDownloads:
+            raise errors.share_downloads_exceeded()
+
+        if share.requiresAuth and not is_authenticated:
+            raise errors.auth_required()
+
+        file = await self._get_file(share.fileId)
+        if not file:
+            raise errors.share_not_found()
+
+        version_id = share.versionId or file.currentVersionId
+        version = await self._get_version(version_id)
+        if not version:
+            raise errors.not_found("Version")
+        if version.fileId != file.fileId:
+            raise errors.not_found("Version")
+        storage_target = self._storage_target_for_file(file)
+
+        descriptor: Dict[str, Any]
+        if hasattr(self.storage, "sign_download_url") and get_storage_capabilities(self.storage, storage_target).get("signedDownloadUrls"):
+            try:
+                result = await self.storage.sign_download_url(
+                    key=version.storageKey,
+                    expires_in_seconds=self.signed_url_ttl_seconds,
+                    target=storage_target,
+                )
+                await self._reserve_download(token_hash)
+                descriptor = {
+                    "url": result["url"],
+                    "headers": result.get("headers"),
+                    "fileName": file.name,
+                    "mimeType": file.mimeType,
+                }
+            except Exception as exc:
+                logger_warning = getattr(self.logger, "warning", None)
+                if callable(logger_warning):
+                    logger_warning(
+                        "share signed download url generation failed; falling back to proxy",
+                        {
+                            "fileId": file.fileId,
+                            "versionId": version.versionId,
+                            "storageKey": version.storageKey,
+                            "error": str(exc),
+                        },
+                    )
+                descriptor = {
+                    "url": f"/proxy/share-links/{token}/download",
+                    "fileName": file.name,
+                    "mimeType": file.mimeType,
+                }
+        else:
+            descriptor = {
+                "url": f"/proxy/share-links/{token}/download",
+                "fileName": file.name,
+                "mimeType": file.mimeType,
+            }
+
+        return descriptor
+
+    async def get_download_stream_via_share_link(
+        self,
+        token: str,
+        ctx: FileProviderContext,
+        is_authenticated: bool = False,
+    ) -> Dict[str, Any]:
+        token_hash = self._hash_token(token)
+        data = await self.db.find_one(
+            model="fileShares",
+            where=[{"field": "tokenHash", "operator": "eq", "value": token_hash}],
+            namespace=self.namespace,
+        )
+        if not data:
+            raise errors.share_not_found()
+
+        share = FileShareRecord(**data)
+        if share.revokedAt:
+            raise errors.share_revoked()
+        if share.expiresAt and self._as_utc(share.expiresAt) <= datetime.now(timezone.utc):
+            raise errors.share_expired()
+        if share.maxDownloads is not None and share.downloads >= share.maxDownloads:
+            raise errors.share_downloads_exceeded()
+        if share.requiresAuth and not is_authenticated:
+            raise errors.auth_required()
+
+        file = await self._get_file(share.fileId)
+        if not file:
+            raise errors.share_not_found()
+
+        version_id = share.versionId or file.currentVersionId
+        version = await self._get_version(version_id)
+        if not version or version.fileId != file.fileId:
+            raise errors.not_found("Version")
+
+        storage_target = self._storage_target_for_file(file)
+        stream = await self.storage.open_download_stream(key=version.storageKey, target=storage_target)
+        await self._reserve_download(token_hash)
+        return {
+            "stream": stream,
+            "contentType": version.mimeType,
+            "size": version.size,
+            "fileName": file.name,
+            "mimeType": file.mimeType,
+        }
+
+    async def revoke_share_link(self, file_id: str, token: str, ctx: FileProviderContext) -> None:
+        file = await self._get_file(file_id)
+        if not file:
+            raise errors.not_found("File")
+
+        if not await self._can_share_file(file, ctx):
+            raise errors.forbidden()
+
+        token_hash = self._hash_token(token)
+        share = await self.db.find_one(
+            model="fileShares",
+            where=[
+                {"field": "tokenHash", "operator": "eq", "value": token_hash},
+                {"field": "fileId", "operator": "eq", "value": file_id},
+            ],
+            namespace=self.namespace,
+        )
+        if not share:
+            raise errors.share_not_found()
+
+        await self.db.update(
+            model="fileShares",
+            where=[{"field": "tokenHash", "operator": "eq", "value": token_hash}],
+            data={"revokedAt": datetime.now(timezone.utc).isoformat()},
+            namespace=self.namespace,
+        )
+
+    async def list_share_links(self, file_id: str, ctx: FileProviderContext) -> List[Dict[str, Any]]:
+        file = await self._get_file(file_id)
+        if not file:
+            raise errors.not_found("File")
+
+        if not await self._can_share_file(file, ctx):
+            raise errors.forbidden()
+
+        shares_data = await self.db.find_many(
+            model="fileShares",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+
+        result: List[Dict[str, Any]] = []
+        for raw in shares_data:
+            share = FileShareRecord(**raw)
+            row = share.model_dump()
+            row.pop("tokenHash")
+            row["tokenHashPrefix"] = share.tokenHash[:8]
+            result.append(row)
+
+        return result
+
+
+def create_shares_service(config: SharesServiceConfig) -> SharesService:
+    return SharesService(config)

--- a/filefn/python/filefn/server/upload_sessions/service.py
+++ b/filefn/python/filefn/server/upload_sessions/service.py
@@ -1,0 +1,875 @@
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+import secrets
+from tempfile import SpooledTemporaryFile
+from typing import Any, Dict, List, Optional, Protocol
+
+from pydantic import BaseModel
+
+from .. import errors
+from ..events import (
+    FileFnEventEmitter,
+    create_file_uploaded_event,
+    create_part_recorded_event,
+    create_upload_started_event,
+)
+from ..models import FileProviderContext, UploadSessionRecord
+from ..policies import compute_storage_path, matches_content_type, resolve_storage_target
+from ..routed_storage import get_storage_capabilities
+
+
+class QuotaProvider(Protocol):
+    async def check_quota(self, input: Dict[str, Any]) -> Dict[str, Any]: ...
+
+    async def record_usage(self, input: Dict[str, Any]) -> None: ...
+
+
+class FileWriteAuthChecker(Protocol):
+    async def can_write_file(self, file_id: str, ctx: FileProviderContext) -> bool: ...
+
+
+class ProcessingService(Protocol):
+    async def trigger_processing(self, input: Dict[str, Any], ctx: FileProviderContext) -> Dict[str, Any]: ...
+
+
+class UploadSessionServiceConfig(BaseModel):
+    db: Any
+    storage: Any
+    policies: Any
+    events: FileFnEventEmitter
+    logger: Optional[Any] = None
+    quota: Optional[Any] = None
+    dedup: Optional[Any] = None
+    file_write_checker: Optional[Any] = None
+    processing_service: Optional[Any] = None
+    namespace: str = "filefn"
+    allow_anonymous_uploads: bool = True
+    default_chunk_size_bytes: int = 8 * 1024 * 1024
+    upload_session_ttl_seconds: int = 86400
+    signed_url_ttl_seconds: int = 900
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class CreateSessionInput(BaseModel):
+    policy: str
+    fileName: str
+    size: int
+    mimeType: str
+    fileId: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    idempotencyKey: Optional[str] = None
+
+
+class UploadSessionService:
+    def __init__(self, config: UploadSessionServiceConfig):
+        self.db = config.db
+        self.storage = config.storage
+        self.policies = config.policies
+        self.events = config.events
+        self.logger = config.logger
+        self.quota = config.quota
+        self.dedup = config.dedup
+        self.file_write_checker = config.file_write_checker
+        self.processing_service = config.processing_service
+        self.namespace = config.namespace
+        self.allow_anonymous_uploads = config.allow_anonymous_uploads
+        self.default_chunk_size_bytes = config.default_chunk_size_bytes
+        self.upload_session_ttl_seconds = config.upload_session_ttl_seconds
+        self.signed_url_ttl_seconds = config.signed_url_ttl_seconds
+
+    def _generate_id(self) -> str:
+        return f"upl_{secrets.token_urlsafe(16)}"
+
+    def _hash_payload(self, input: CreateSessionInput, ctx: FileProviderContext) -> str:
+        payload = {
+            "p": input.policy,
+            "fn": input.fileName,
+            "s": input.size,
+            "mt": input.mimeType,
+            "fid": input.fileId,
+            "md": input.metadata,
+            "pr": ctx.principalId,
+            "tn": ctx.tenantId,
+        }
+        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+    def _hash_session_token(self, token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    async def _issue_anonymous_session_token(self, upload_session_id: str) -> str:
+        upload_session_token = secrets.token_urlsafe(32)
+        await self.db.update(
+            model="uploadSessions",
+            where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+            data={
+                "uploadSessionToken": None,
+                "sessionTokenHash": self._hash_session_token(upload_session_token),
+            },
+            namespace=self.namespace,
+        )
+        return upload_session_token
+
+    def _extract_upload_session_token(self, ctx: Any) -> Optional[str]:
+        for attr in ("uploadSessionToken", "upload_session_token", "sessionToken", "session_token"):
+            value = getattr(ctx, attr, None)
+            if value:
+                return value
+
+        headers = getattr(ctx, "headers", None)
+        if isinstance(headers, dict):
+            for key in ("x-upload-session-token", "X-Upload-Session-Token", "x_upload_session_token"):
+                value = headers.get(key)
+                if value:
+                    return value
+
+        return None
+
+    def _as_utc(self, value: str) -> datetime:
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    def _is_expired(self, expires_at: str) -> bool:
+        return self._as_utc(expires_at) <= datetime.now(timezone.utc)
+
+    def _assert_session_binding(self, session_data: Dict[str, Any], ctx: Any) -> None:
+        owner_id = session_data.get("ownerId")
+        tenant_id = session_data.get("tenantId")
+
+        if owner_id and owner_id != "anonymous":
+            if getattr(ctx, "principalId", None) != owner_id:
+                raise errors.forbidden({"uploadSessionId": session_data.get("uploadSessionId")})
+            if tenant_id != getattr(ctx, "tenantId", None):
+                raise errors.forbidden({"uploadSessionId": session_data.get("uploadSessionId")})
+            return
+
+        provided_token = self._extract_upload_session_token(ctx)
+        if not provided_token:
+            raise errors.FileFnError(
+                code="FILEFN_SESSION_TOKEN_REQUIRED",
+                message="Upload session token required",
+                status=401,
+                details={"uploadSessionId": session_data.get("uploadSessionId")},
+            )
+
+        expected_hash = session_data.get("sessionTokenHash")
+        if not expected_hash or self._hash_session_token(provided_token) != expected_hash:
+            raise errors.FileFnError(
+                code="FILEFN_SESSION_TOKEN_INVALID",
+                message="Invalid upload session token",
+                status=403,
+                details={"uploadSessionId": session_data.get("uploadSessionId")},
+            )
+
+    def _proxy_part_key(self, session: UploadSessionRecord, part_number: int) -> str:
+        return f"{session.storageKey}.parts/{part_number}"
+
+    def _select_upload_mode(self, storage_target: Optional[str] = None) -> str:
+        capabilities = get_storage_capabilities(self.storage, storage_target)
+
+        supports_multipart = bool(capabilities.get("signedUploadUrls") and capabilities.get("multipart"))
+        supports_proxy = bool(capabilities.get("proxyStreamingUpload"))
+
+        if not capabilities:
+            supports_multipart = all(
+                hasattr(self.storage, name)
+                for name in (
+                    "create_multipart_upload",
+                    "sign_multipart_upload_part_url",
+                    "complete_multipart_upload",
+                )
+            )
+            supports_proxy = hasattr(self.storage, "put_object") and hasattr(
+                self.storage, "open_download_stream"
+            )
+
+        if supports_multipart:
+            return "multipart-signed-url"
+        if supports_proxy:
+            return "proxy"
+
+        raise errors.no_supported_upload_mode()
+
+    async def _get_session_data(self, upload_session_id: str) -> Dict[str, Any]:
+        session_data = await self.db.find_one(
+            model="uploadSessions",
+            where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+            namespace=self.namespace,
+        )
+        if not session_data:
+            raise errors.session_not_found()
+        return session_data
+
+    async def create_session(self, input: CreateSessionInput, ctx: FileProviderContext) -> Dict[str, Any]:
+        warnings: List[str] = []
+
+        if not ctx.principalId and not self.allow_anonymous_uploads:
+            raise errors.auth_required()
+
+        if input.idempotencyKey:
+            existing_data = await self.db.find_one(
+                model="uploadSessions",
+                where=[{"field": "idempotencyKey", "operator": "eq", "value": input.idempotencyKey}],
+                namespace=self.namespace,
+            )
+            if existing_data:
+                existing = UploadSessionRecord(**existing_data)
+                expected_hash = self._hash_payload(input, ctx)
+                if existing.idempotencyPayloadHash != expected_hash:
+                    raise errors.idempotency_conflict()
+
+                result = {
+                    "uploadSessionId": existing.uploadSessionId,
+                    "fileId": existing.fileId,
+                    "uploadMode": existing.uploadMode,
+                    "chunkSizeBytes": existing.chunkSizeBytes,
+                    "totalParts": existing.totalParts,
+                    "expiresAt": existing.expiresAt,
+                    "warnings": [],
+                }
+                if existing.ownerId == "anonymous":
+                    upload_session_token = await self._issue_anonymous_session_token(
+                        existing.uploadSessionId,
+                    )
+                    result["uploadSessionToken"] = upload_session_token
+                return result
+
+        policy = self.policies.get(input.policy)
+        if not policy:
+            raise errors.policy_not_found(input.policy)
+
+        if policy.contentTypes and not any(matches_content_type(pattern, input.mimeType) for pattern in policy.contentTypes):
+            raise errors.policy_content_type_not_allowed(input.policy, input.mimeType)
+        if policy.maxSizeBytes is not None and input.size > policy.maxSizeBytes:
+            raise errors.policy_max_size_exceeded(input.policy, policy.maxSizeBytes, input.size)
+
+        if input.fileId and self.file_write_checker:
+            if not await self.file_write_checker.can_write_file(input.fileId, ctx):
+                raise errors.forbidden({"fileId": input.fileId, "operation": "replace"})
+
+        if self.quota:
+            quota_result = await self.quota.check_quota(
+                {
+                    "principalId": ctx.principalId,
+                    "tenantId": ctx.tenantId,
+                    "requestedBytes": input.size,
+                }
+            )
+            if not quota_result.get("allowed"):
+                raise errors.quota_exceeded(
+                    quota_result.get("current", 0),
+                    quota_result.get("limit", 0),
+                    input.size,
+                )
+            warning = quota_result.get("warning")
+            if warning:
+                warnings.append(warning)
+
+        storage_target = resolve_storage_target(policy)
+        upload_mode = self._select_upload_mode(storage_target)
+        chunk_size_bytes = self.default_chunk_size_bytes
+        total_parts = max(1, (input.size + chunk_size_bytes - 1) // chunk_size_bytes)
+
+        upload_session_id = self._generate_id()
+        now = datetime.now(timezone.utc)
+        expires_at = (now + timedelta(seconds=self.upload_session_ttl_seconds)).isoformat()
+
+        file_id = input.fileId or f"file_{secrets.token_urlsafe(12)}"
+        version_id = f"ver_{secrets.token_urlsafe(12)}"
+
+        class StoragePathContext:
+            def __init__(self, **kwargs: Any):
+                self.__dict__.update(kwargs)
+
+        storage_ctx = StoragePathContext(
+            fileName=input.fileName,
+            principalId=ctx.principalId,
+            tenantId=ctx.tenantId,
+            fileId=file_id,
+            versionId=version_id,
+        )
+        storage_key = compute_storage_path(policy, storage_ctx)
+
+        storage_upload_id = None
+        if upload_mode == "multipart-signed-url":
+            storage_upload_id = await self.storage.create_multipart_upload(
+                key=storage_key,
+                metadata={"contentType": input.mimeType},
+                content_type=input.mimeType,
+                target=storage_target,
+            )
+
+        upload_session_token: Optional[str] = None
+        session_token_hash: Optional[str] = None
+        owner_id = ctx.principalId or "anonymous"
+        if owner_id == "anonymous":
+            upload_session_token = secrets.token_urlsafe(32)
+            session_token_hash = self._hash_session_token(upload_session_token)
+
+        await self.db.create(
+            model="uploadSessions",
+            data={
+                "uploadSessionId": upload_session_id,
+                "status": "pending",
+                "policy": input.policy,
+                "fileId": file_id,
+                "fileName": input.fileName,
+                "mimeType": input.mimeType,
+                "size": input.size,
+                "uploadMode": upload_mode,
+                "chunkSizeBytes": chunk_size_bytes,
+                "totalParts": total_parts,
+                "storageKey": storage_key,
+                "storageUploadId": storage_upload_id,
+                "ownerId": owner_id,
+                "tenantId": ctx.tenantId,
+                "metadata": input.metadata or {},
+                "idempotencyKey": input.idempotencyKey,
+                "idempotencyPayloadHash": self._hash_payload(input, ctx) if input.idempotencyKey else None,
+                "uploadSessionToken": None,
+                "sessionTokenHash": session_token_hash,
+                "expiresAt": expires_at,
+                "createdAt": now.isoformat(),
+            },
+            namespace=self.namespace,
+        )
+
+        self.events.emit(
+            "upload.started",
+            create_upload_started_event(
+                {
+                    "uploadSessionId": upload_session_id,
+                    "fileName": input.fileName,
+                    "size": input.size,
+                    "mimeType": input.mimeType,
+                    "policy": input.policy,
+                    "principalId": ctx.principalId,
+                    "tenantId": ctx.tenantId,
+                },
+                ctx.requestId,
+            ),
+        )
+
+        result: Dict[str, Any] = {
+            "uploadSessionId": upload_session_id,
+            "fileId": file_id,
+            "uploadMode": upload_mode,
+            "chunkSizeBytes": chunk_size_bytes,
+            "totalParts": total_parts,
+            "expiresAt": expires_at,
+            "warnings": warnings,
+        }
+        if upload_session_token:
+            result["uploadSessionToken"] = upload_session_token
+        return result
+
+    async def get_session_status(self, upload_session_id: str, ctx: Any) -> Dict[str, Any]:
+        session_data = await self._get_session_data(upload_session_id)
+        self._assert_session_binding(session_data, ctx)
+
+        session = UploadSessionRecord(**session_data)
+        if self._is_expired(session.expiresAt):
+            raise errors.upload_expired()
+
+        parts_data = await self.db.find_many(
+            model="uploadParts",
+            where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+            namespace=self.namespace,
+        )
+        recorded_parts = sorted(part["partNumber"] for part in parts_data)
+
+        return {
+            "uploadSessionId": upload_session_id,
+            "fileId": session.fileId,
+            "status": session.status,
+            "totalParts": session.totalParts,
+            "recordedParts": recorded_parts,
+            "chunkSizeBytes": session.chunkSizeBytes,
+            "fileSize": session.size,
+            "expiresAt": session.expiresAt,
+        }
+
+    async def sign_part(
+        self,
+        upload_session_id: str,
+        part_number: int,
+        content_length: int,
+        ctx: Any,
+    ) -> Dict[str, Any]:
+        session_data = await self._get_session_data(upload_session_id)
+        self._assert_session_binding(session_data, ctx)
+
+        session = UploadSessionRecord(**session_data)
+        if session.status == "aborted":
+            raise errors.upload_aborted()
+        if session.status == "completed":
+            raise errors.upload_already_completed()
+        if self._is_expired(session.expiresAt):
+            raise errors.upload_expired()
+
+        if part_number < 1 or part_number > session.totalParts:
+            raise errors.invalid_part_number()
+
+        if session.uploadMode == "proxy":
+            return {
+                "url": f"/upload/{upload_session_id}/parts/{part_number}",
+                "headers": {"content-type": session.mimeType},
+                "expiresAt": session.expiresAt,
+            }
+
+        policy = self.policies.get(session.policy)
+        storage_target = resolve_storage_target(policy)
+        result = await self.storage.sign_multipart_upload_part_url(
+            key=session.storageKey,
+            upload_id=session.storageUploadId,
+            part_number=part_number,
+            expires_in_seconds=self.signed_url_ttl_seconds,
+            constraints={"contentLength": content_length},
+            target=storage_target,
+        )
+
+        expires_at = (datetime.now(timezone.utc) + timedelta(seconds=self.signed_url_ttl_seconds)).isoformat()
+        return {
+            "url": result["url"],
+            "headers": result.get("headers"),
+            "expiresAt": expires_at,
+        }
+
+    async def complete_part(
+        self,
+        upload_session_id: str,
+        part_number: int,
+        etag: str,
+        size: int,
+        ctx: Any,
+    ) -> Dict[str, Any]:
+        session_data = await self._get_session_data(upload_session_id)
+        self._assert_session_binding(session_data, ctx)
+
+        session = UploadSessionRecord(**session_data)
+        if session.status == "aborted":
+            raise errors.upload_aborted()
+        if session.status == "completed":
+            raise errors.upload_already_completed()
+        if self._is_expired(session.expiresAt):
+            raise errors.upload_expired()
+        if part_number < 1 or part_number > session.totalParts:
+            raise errors.invalid_part_number()
+
+        existing = await self.db.find_one(
+            model="uploadParts",
+            where=[
+                {"field": "uploadSessionId", "operator": "eq", "value": upload_session_id},
+                {"field": "partNumber", "operator": "eq", "value": part_number},
+            ],
+            namespace=self.namespace,
+        )
+
+        if existing:
+            if existing.get("etag") == etag and existing.get("size") == size:
+                return {"recorded": True}
+            raise errors.part_conflict(upload_session_id, part_number)
+
+        await self.db.create(
+            model="uploadParts",
+            data={
+                "uploadSessionId": upload_session_id,
+                "partNumber": part_number,
+                "etag": etag,
+                "size": size,
+            },
+            namespace=self.namespace,
+        )
+
+        if session.status == "pending":
+            await self.db.update(
+                model="uploadSessions",
+                where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+                data={"status": "in_progress"},
+                namespace=self.namespace,
+            )
+
+        self.events.emit(
+            "part.recorded",
+            create_part_recorded_event(
+                {"uploadSessionId": upload_session_id, "partNumber": part_number, "size": size},
+                getattr(ctx, "requestId", None),
+            ),
+        )
+        return {"recorded": True}
+
+    async def record_proxy_part(
+        self,
+        upload_session_id: str,
+        part_number: int,
+        data: bytes,
+        ctx: Any,
+    ) -> Dict[str, Any]:
+        session_data = await self._get_session_data(upload_session_id)
+        self._assert_session_binding(session_data, ctx)
+        session = UploadSessionRecord(**session_data)
+
+        if session.uploadMode != "proxy":
+            raise errors.no_supported_upload_mode()
+
+        etag = hashlib.md5(data).hexdigest()
+        if session.status == "aborted":
+            raise errors.upload_aborted()
+        if session.status == "completed":
+            raise errors.upload_already_completed()
+        if self._is_expired(session.expiresAt):
+            raise errors.upload_expired()
+        if part_number < 1 or part_number > session.totalParts:
+            raise errors.invalid_part_number()
+
+        existing = await self.db.find_one(
+            model="uploadParts",
+            where=[
+                {"field": "uploadSessionId", "operator": "eq", "value": upload_session_id},
+                {"field": "partNumber", "operator": "eq", "value": part_number},
+            ],
+            namespace=self.namespace,
+        )
+        if existing:
+            if existing.get("etag") == etag and existing.get("size") == len(data):
+                return {"etag": etag, "size": len(data), "recorded": True}
+            raise errors.part_conflict(upload_session_id, part_number)
+
+        part_key = self._proxy_part_key(session, part_number)
+        policy = self.policies.get(session.policy)
+        storage_target = resolve_storage_target(policy)
+        await self.storage.put_object(
+            key=part_key,
+            data=data,
+            metadata={"contentType": session.mimeType},
+            target=storage_target,
+        )
+        await self.complete_part(upload_session_id, part_number, etag, len(data), ctx)
+
+        return {"etag": etag, "size": len(data), "recorded": True}
+
+    async def _finalize_proxy_upload(self, session: UploadSessionRecord, parts: List[Dict[str, Any]]) -> None:
+        policy = self.policies.get(session.policy)
+        storage_target = resolve_storage_target(policy)
+        sorted_parts = sorted(parts, key=lambda p: p["partNumber"])
+        with SpooledTemporaryFile(max_size=8 * 1024 * 1024) as payload:
+            for part in sorted_parts:
+                part_key = self._proxy_part_key(session, part["partNumber"])
+                stream = await self.storage.open_download_stream(key=part_key, target=storage_target)
+                async for chunk in stream:
+                    payload.write(chunk)
+
+            payload.seek(0)
+            await self.storage.put_object(
+                key=session.storageKey,
+                data=payload,
+                metadata={"contentType": session.mimeType},
+                target=storage_target,
+            )
+
+        for part in sorted_parts:
+            part_key = self._proxy_part_key(session, part["partNumber"])
+            try:
+                await self.storage.delete_object(key=part_key, target=storage_target)
+            except Exception:
+                pass
+
+    async def complete_session(self, upload_session_id: str, ctx: Any) -> Dict[str, str]:
+        session_data = await self._get_session_data(upload_session_id)
+        self._assert_session_binding(session_data, ctx)
+        session = UploadSessionRecord(**session_data)
+
+        if session.status == "completed":
+            return {
+                "fileId": session.fileId,
+                "versionId": session_data.get("completionVersionId") or session_data.get("versionId"),
+            }
+
+        if self._is_expired(session.expiresAt):
+            raise errors.upload_expired()
+
+        if session.fileId and self.file_write_checker:
+            if not await self.file_write_checker.can_write_file(session.fileId, ctx):
+                raise errors.forbidden({"fileId": session.fileId, "operation": "replace"})
+
+        parts_data = await self.db.find_many(
+            model="uploadParts",
+            where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+            namespace=self.namespace,
+        )
+        if len(parts_data) != session.totalParts:
+            raise errors.upload_incomplete()
+        uploaded_size = sum(int(part.get("size") or 0) for part in parts_data)
+        if uploaded_size != session.size:
+            raise errors.upload_size_mismatch(session.size, uploaded_size)
+
+        policy = self.policies.get(session.policy)
+        storage_target = resolve_storage_target(policy)
+
+        if session.uploadMode == "multipart-signed-url":
+            parts = sorted(parts_data, key=lambda p: p["partNumber"])
+            await self.storage.complete_multipart_upload(
+                key=session.storageKey,
+                upload_id=session.storageUploadId,
+                parts=[{"partNumber": p["partNumber"], "etag": p["etag"]} for p in parts],
+                target=storage_target,
+            )
+        elif session.uploadMode == "proxy":
+            await self._finalize_proxy_upload(session, parts_data)
+
+        now_str = datetime.now(timezone.utc).isoformat()
+        file_id = session.fileId
+        version_id = f"ver_{secrets.token_urlsafe(12)}"
+        metadata = session_data.get("metadata") or {}
+
+        final_storage_key = session.storageKey
+        checksum_sha256_base64: Optional[str] = None
+        if self.dedup and self.dedup.is_enabled():
+            dedup_res = await self.dedup.compute_and_check_duplicate(
+                session.storageKey,
+                session.tenantId,
+                storage_target,
+                self.storage,
+            )
+            checksum_sha256_base64 = dedup_res.checksumSha256Base64
+            if dedup_res.isDuplicate and dedup_res.existingStorageKey:
+                final_storage_key = dedup_res.existingStorageKey
+                if final_storage_key != session.storageKey:
+                    try:
+                        await self.storage.delete_object(key=session.storageKey, target=storage_target)
+                    except Exception:
+                        pass
+
+        existing_file = await self.db.find_one(
+            model="files",
+            where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+            namespace=self.namespace,
+        )
+
+        if existing_file:
+            await self.db.update(
+                model="files",
+                where=[{"field": "fileId", "operator": "eq", "value": file_id}],
+                data={
+                    "currentVersionId": version_id,
+                    "size": session.size,
+                    "mimeType": session.mimeType,
+                    "metadata": metadata,
+                    "updatedAt": now_str,
+                },
+                namespace=self.namespace,
+            )
+        else:
+            await self.db.create(
+                model="files",
+                data={
+                    "fileId": file_id,
+                    "currentVersionId": version_id,
+                    "ownerId": session.ownerId,
+                    "tenantId": session.tenantId,
+                    "visibility": getattr(policy, "visibility", "private"),
+                    "policy": session.policy,
+                    "mimeType": session.mimeType,
+                    "size": session.size,
+                    "name": session.fileName,
+                    "metadata": metadata,
+                    "createdAt": now_str,
+                    "updatedAt": now_str,
+                },
+                namespace=self.namespace,
+            )
+
+        await self.db.create(
+            model="fileVersions",
+            data={
+                "versionId": version_id,
+                "fileId": file_id,
+                "storageKey": final_storage_key,
+                "mimeType": session.mimeType,
+                "size": session.size,
+                "checksumSha256Base64": checksum_sha256_base64,
+                "tenantId": session.tenantId,
+                "createdAt": now_str,
+            },
+            namespace=self.namespace,
+        )
+
+        await self.db.update(
+            model="uploadSessions",
+            where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+            data={
+                "status": "completed",
+                "fileId": file_id,
+                "completionVersionId": version_id,
+            },
+            namespace=self.namespace,
+        )
+
+        if self.quota:
+            await self.quota.record_usage(
+                {
+                    "principalId": getattr(ctx, "principalId", None),
+                    "tenantId": getattr(ctx, "tenantId", None),
+                    "bytes": session.size,
+                }
+            )
+
+        self.events.emit(
+            "file:uploaded",
+            create_file_uploaded_event(
+                {
+                    "fileId": file_id,
+                    "versionId": version_id,
+                    "fileName": session.fileName,
+                    "size": session.size,
+                    "mimeType": session.mimeType,
+                    "ownerId": session.ownerId,
+                    "tenantId": session.tenantId,
+                },
+                getattr(ctx, "requestId", None),
+            ),
+        )
+
+        if self.processing_service:
+            await self.processing_service.trigger_processing(
+                {
+                    "fileId": file_id,
+                    "versionId": version_id,
+                    "storageKey": final_storage_key,
+                    "mimeType": session.mimeType,
+                    "size": session.size,
+                    "fileName": session.fileName,
+                    "tenantId": session.tenantId,
+                },
+                ctx,
+            )
+
+        return {"fileId": file_id, "versionId": version_id}
+
+    async def abort_session(self, upload_session_id: str, ctx: Any) -> None:
+        session_data = await self._get_session_data(upload_session_id)
+        self._assert_session_binding(session_data, ctx)
+        session = UploadSessionRecord(**session_data)
+
+        if session.status == "completed":
+            raise errors.upload_already_completed()
+
+        policy = self.policies.get(session.policy)
+        storage_target = resolve_storage_target(policy)
+
+        if session.storageUploadId:
+            try:
+                await self.storage.abort_multipart_upload(
+                    key=session.storageKey,
+                    upload_id=session.storageUploadId,
+                    target=storage_target,
+                )
+            except Exception:
+                pass
+
+        parts_data = await self.db.find_many(
+            model="uploadParts",
+            where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+            namespace=self.namespace,
+        )
+        for part in parts_data:
+            part_key = self._proxy_part_key(session, part["partNumber"])
+            try:
+                await self.storage.delete_object(key=part_key, target=storage_target)
+            except Exception:
+                pass
+
+        await self.db.update(
+            model="uploadSessions",
+            where=[{"field": "uploadSessionId", "operator": "eq", "value": upload_session_id}],
+            data={"status": "aborted"},
+            namespace=self.namespace,
+        )
+
+    async def garbage_collect_expired_sessions(self) -> Dict[str, int]:
+        now = datetime.now(timezone.utc)
+        sessions: List[Dict[str, Any]] = []
+        seen_session_ids: set[str] = set()
+        for status in ("pending", "in_progress", "aborted", "expired"):
+            status_rows = await self.db.find_many(
+                model="uploadSessions",
+                where=[{"field": "status", "operator": "eq", "value": status}],
+                namespace=self.namespace,
+            )
+            for row in status_rows:
+                upload_session_id = row.get("uploadSessionId")
+                if not upload_session_id or upload_session_id in seen_session_ids:
+                    continue
+                seen_session_ids.add(upload_session_id)
+                sessions.append(row)
+
+        completed_sessions = await self.db.find_many(
+            model="uploadSessions",
+            where=[{"field": "status", "operator": "eq", "value": "completed"}],
+            namespace=self.namespace,
+        )
+
+        deleted_sessions = 0
+        preserved_completed_sessions = len(completed_sessions)
+
+        for session_data in sessions:
+            status = session_data.get("status")
+            expires_at_raw = session_data.get("expiresAt")
+            if not expires_at_raw:
+                continue
+
+            expires_at = self._as_utc(expires_at_raw)
+            if expires_at > now:
+                continue
+
+            session = UploadSessionRecord(**session_data)
+            policy = self.policies.get(session.policy)
+            storage_target = resolve_storage_target(policy)
+
+            if session.storageUploadId:
+                try:
+                    await self.storage.abort_multipart_upload(
+                        key=session.storageKey,
+                        upload_id=session.storageUploadId,
+                        target=storage_target,
+                    )
+                except Exception:
+                    pass
+
+            parts = await self.db.find_many(
+                model="uploadParts",
+                where=[{"field": "uploadSessionId", "operator": "eq", "value": session.uploadSessionId}],
+                namespace=self.namespace,
+            )
+            for part in parts:
+                part_key = self._proxy_part_key(session, part["partNumber"])
+                try:
+                    await self.storage.delete_object(key=part_key, target=storage_target)
+                except Exception:
+                    pass
+
+            await self.db.delete_many(
+                model="uploadParts",
+                where=[{"field": "uploadSessionId", "operator": "eq", "value": session.uploadSessionId}],
+                namespace=self.namespace,
+            )
+            await self.db.delete(
+                model="uploadSessions",
+                where=[{"field": "uploadSessionId", "operator": "eq", "value": session.uploadSessionId}],
+                namespace=self.namespace,
+            )
+            deleted_sessions += 1
+
+        return {
+            "deletedSessions": deleted_sessions,
+            "preservedCompletedSessions": preserved_completed_sessions,
+        }
+
+
+def create_upload_session_service(config: UploadSessionServiceConfig) -> UploadSessionService:
+    return UploadSessionService(config)

--- a/filefn/python/pyproject.toml
+++ b/filefn/python/pyproject.toml
@@ -1,0 +1,85 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "filefn"
+version = "0.1.0"
+description = "FileFn SDK for Python - File upload, storage, and processing"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = ["file", "upload", "storage", "processing", "superfunctions"]
+authors = [
+  { name = "21n" }
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+  "pydantic>=2.5.0",
+  "superfunctions>=0.1.0",
+  "Pillow>=10.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4.0",
+  "pytest-asyncio>=0.21.0",
+  "pytest-cov>=4.1.0",
+  "mypy>=1.7.0",
+  "ruff>=0.1.6",
+  "black>=23.11.0",
+]
+
+[project.urls]
+Documentation = "https://docs.superfunctions.dev/filefn"
+Repository = "https://github.com/21nCo/super-functions"
+Issues = "https://github.com/21nCo/super-functions/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["filefn"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+  "E",  # pycodestyle errors
+  "W",  # pycodestyle warnings
+  "F",  # pyflakes
+  "I",  # isort
+  "B",  # flake8-bugbear
+  "C4", # flake8-comprehensions
+]
+ignore = [
+  "E501", # line too long, handled by black
+]
+
+[tool.black]
+line-length = 100
+target-version = ["py310", "py311", "py312"]

--- a/filefn/python/tests/conftest.py
+++ b/filefn/python/tests/conftest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+
+PYTHON_PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+if str(PYTHON_PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PYTHON_PACKAGE_ROOT))

--- a/filefn/python/tests/test_core.py
+++ b/filefn/python/tests/test_core.py
@@ -1,0 +1,77 @@
+def test_import_sanity_package_exists() -> None:
+    import filefn
+    from filefn import FileFn, FileFnConfig, create_file_fn
+
+    assert filefn is not None
+    assert callable(create_file_fn)
+    assert FileFn is not None
+    assert FileFnConfig is not None
+
+
+def test_top_level_exports_documented_server_entrypoints() -> None:
+    import filefn
+    from filefn.server import FileFn, FileFnConfig, create_file_fn
+
+    assert filefn.create_file_fn is create_file_fn
+    assert filefn.FileFnConfig is FileFnConfig
+    assert filefn.FileFn is FileFn
+
+
+def test_processing_package_exports_documented_processor_factories() -> None:
+    from filefn import processing
+
+    assert callable(processing.create_thumbnail_processor)
+    assert callable(processing.create_compression_processor)
+    assert callable(processing.create_ocr_processor)
+    assert callable(processing.create_image_transform_processor)
+    assert callable(processing.create_video_processor)
+    assert callable(processing.create_audio_processor)
+
+
+def test_filefn_config_exposes_auth_rate_limit_and_dedup_surfaces() -> None:
+    from filefn.server import (
+        AuthConfig,
+        DedupConfig,
+        FileFnConfig,
+        RateLimitCategoryConfig,
+        RateLimitConfig,
+        RateLimitLimitsConfig,
+    )
+
+    rate_limit = RateLimitConfig(
+        persistence=object(),
+        limits=RateLimitLimitsConfig(
+            upload_init=RateLimitCategoryConfig(window_seconds=60, max_requests=5),
+            download=RateLimitCategoryConfig(windowSeconds=30, maxRequests=10),
+        ),
+    )
+    config = FileFnConfig(
+        db=object(),
+        storage=object(),
+        auth=AuthConfig(required=True, allow_anonymous_uploads=False),
+        rate_limit=rate_limit,
+        dedup=DedupConfig(enabled=True),
+    )
+
+    assert config.auth is not None
+    assert config.auth.required is True
+    assert config.auth.allow_anonymous_uploads is False
+    assert config.rate_limit is not None
+    assert config.rate_limit.limits.upload_init is not None
+    assert config.rate_limit.limits.upload_init.window_seconds == 60
+    assert config.rate_limit.limits.download is not None
+    assert config.rate_limit.limits.download.max_requests == 10
+    assert config.dedup is not None
+    assert config.dedup.enabled is True
+
+
+def test_policy_registry_define_accepts_policy_dicts() -> None:
+    from filefn.server.policies import create_policy_registry
+
+    registry = create_policy_registry()
+    registry.define("avatars", {"storageTarget": "durable", "visibility": "private"})
+
+    policy = registry.get("avatars")
+    assert policy is not None
+    assert policy.storageTarget == "durable"
+    assert policy.visibility == "private"

--- a/filefn/python/tests/test_downloads.py
+++ b/filefn/python/tests/test_downloads.py
@@ -1,0 +1,818 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from filefn.server import create_event_emitter
+from filefn.server import create_routed_storage_adapter
+from filefn.server.files.service import FileServiceConfig, create_file_service
+from filefn.server.policies import Policy, create_policy_registry
+from filefn.server.shares.service import CreateShareLinkInput, SharesServiceConfig, create_shares_service
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.tables: Dict[str, List[Dict[str, Any]]] = {}
+        self.find_many_calls: List[Dict[str, Any]] = []
+
+    def _table(self, model: str) -> List[Dict[str, Any]]:
+        return self.tables.setdefault(model, [])
+
+    @staticmethod
+    def _matches(row: Dict[str, Any], where: Optional[List[Dict[str, Any]]]) -> bool:
+        if not where:
+            return True
+        for clause in where:
+            if clause.get("operator") != "eq":
+                raise ValueError("FakeDB supports only eq operator")
+            if row.get(clause["field"]) != clause.get("value"):
+                return False
+        return True
+
+    async def create(self, model: str, data: Dict[str, Any], namespace: Optional[str] = None) -> Dict[str, Any]:
+        row = dict(data)
+        self._table(model).append(row)
+        return dict(row)
+
+    async def find_one(
+        self,
+        model: str,
+        where: Optional[List[Dict[str, Any]]] = None,
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for row in self._table(model):
+            if self._matches(row, where):
+                return dict(row)
+        return None
+
+    async def find_many(
+        self,
+        model: str,
+        where: Optional[List[Dict[str, Any]]] = None,
+        order_by: Optional[List[Dict[str, Any]]] = None,
+        limit: Optional[int] = None,
+        namespace: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        self.find_many_calls.append({"model": model, "where": where, "order_by": order_by, "limit": limit})
+        rows = [dict(row) for row in self._table(model) if self._matches(row, where)]
+
+        if order_by:
+            for order in reversed(order_by):
+                reverse = order.get("direction", "asc") == "desc"
+                rows.sort(key=lambda item: item.get(order["field"]), reverse=reverse)
+
+        if limit is not None:
+            rows = rows[:limit]
+        return rows
+
+    async def update(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        data: Dict[str, Any],
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for row in self._table(model):
+            if self._matches(row, where):
+                row.update(data)
+                return dict(row)
+        return None
+
+    async def delete(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        rows = self._table(model)
+        for index, row in enumerate(rows):
+            if self._matches(row, where):
+                return rows.pop(index)
+        return None
+
+    async def delete_many(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        namespace: Optional[str] = None,
+    ) -> int:
+        rows = self._table(model)
+        retained = [row for row in rows if not self._matches(row, where)]
+        deleted = len(rows) - len(retained)
+        self.tables[model] = retained
+        return deleted
+
+
+class FlakyShareDB(FakeDB):
+    def __init__(self) -> None:
+        super().__init__()
+        self.share_update_conflicts = 1
+
+    async def update(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        data: Dict[str, Any],
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        if (
+            model == "fileShares"
+            and self.share_update_conflicts > 0
+            and any(clause.get("field") == "downloads" for clause in where)
+        ):
+            self.share_update_conflicts -= 1
+            return None
+        return await super().update(model=model, where=where, data=data, namespace=namespace)
+
+
+class FakeStorage:
+    def __init__(self, with_signing: bool = False) -> None:
+        self.with_signing = with_signing
+        self.delete_calls: List[str] = []
+        self.name = "fake"
+
+    async def sign_download_url(self, key: str, expires_in_seconds: int, target: Optional[str] = None) -> Dict[str, Any]:
+        if not self.with_signing:
+            raise RuntimeError("signing not supported")
+        return {"url": f"https://download.local/{key}", "headers": {}}
+
+    async def open_download_stream(self, key: str, target: Optional[str] = None):
+        async def _gen():
+            yield b"bytes"
+
+        return _gen()
+
+    async def delete_object(self, key: str, target: Optional[str] = None) -> None:
+        self.delete_calls.append(f"{target or 'default'}:{key}")
+        return None
+
+
+def _ctx(principal_id: Optional[str], tenant_id: Optional[str] = "org_123"):
+    return SimpleNamespace(principalId=principal_id, tenantId=tenant_id, requestId="req_001")
+
+
+async def _seed_file_rows(db: FakeDB) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_0001",
+            "currentVersionId": "ver_0001",
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "user-avatar",
+            "mimeType": "image/png",
+            "size": 3,
+            "name": "a.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+    await db.create(
+        model="fileVersions",
+        data={
+            "versionId": "ver_0001",
+            "fileId": "file_0001",
+            "storageKey": "org_123/user_123/file_0001/ver_0001-a.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "checksumSha256Base64": None,
+            "tenantId": "org_123",
+            "createdAt": now,
+        },
+    )
+    await db.create(
+        model="fileVersions",
+        data={
+            "versionId": "ver_old",
+            "fileId": "file_0001",
+            "storageKey": "org_123/user_123/file_0001/ver_old-a.png",
+            "mimeType": "image/jpeg",
+            "size": 9,
+            "checksumSha256Base64": "sha-old",
+            "tenantId": "org_123",
+            "createdAt": "2026-03-20T00:00:00+00:00",
+        },
+    )
+    await db.create(
+        model="fileVersions",
+        data={
+            "versionId": "ver_other_file",
+            "fileId": "file_9999",
+            "storageKey": "org_123/user_123/file_9999/ver_other_file-a.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "checksumSha256Base64": None,
+            "tenantId": "org_123",
+            "createdAt": now,
+        },
+    )
+
+
+class RecordingQuota:
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def record_usage(self, input: Dict[str, Any]) -> None:
+        self.calls.append(dict(input))
+
+
+@pytest.mark.asyncio
+async def test_file_download_urls_are_real_and_enforce_version_binding() -> None:
+    db = FakeDB()
+    await _seed_file_rows(db)
+
+    file_service = create_file_service(
+        FileServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=False),
+            events=create_event_emitter(),
+            namespace="filefn",
+        )
+    )
+
+    good = await file_service.get_download_url("file_0001", "ver_0001", _ctx("user_123"))
+    assert good["url"] == "/proxy/files/file_0001/versions/ver_0001/download"
+    assert not good["url"].startswith("proxy://")
+
+    with pytest.raises(Exception) as exc_info:
+        await file_service.get_download_url("file_0001", "ver_other_file", _ctx("user_123"))
+    assert getattr(exc_info.value, "code", "") == "FILEFN_NOT_FOUND"
+
+    with pytest.raises(Exception) as exc_file:
+        await file_service.get_file("file_0001", _ctx("user_123"), version_id="ver_other_file")
+    assert getattr(exc_file.value, "code", "") == "FILEFN_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_version_aware_get_file_and_list_files_are_deterministic() -> None:
+    db = FakeDB()
+    await _seed_file_rows(db)
+    now = "2026-03-22T00:00:00+00:00"
+
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_0002",
+            "currentVersionId": "ver_0002",
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "user-avatar",
+            "mimeType": "image/png",
+            "size": 4,
+            "name": "b.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_hidden",
+            "currentVersionId": "ver_hidden",
+            "ownerId": "other_user",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "user-avatar",
+            "mimeType": "image/png",
+            "size": 4,
+            "name": "hidden.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+
+    await db.update(
+        model="files",
+        where=[{"field": "fileId", "operator": "eq", "value": "file_0001"}],
+        data={"updatedAt": now},
+    )
+
+    file_service = create_file_service(
+        FileServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=False),
+            events=create_event_emitter(),
+            namespace="filefn",
+        )
+    )
+
+    versioned = await file_service.get_file("file_0001", _ctx("user_123"), version_id="ver_old")
+    assert versioned["versionId"] == "ver_old"
+    assert versioned["currentVersionId"] == "ver_old"
+    assert versioned["mimeType"] == "image/jpeg"
+    assert versioned["size"] == 9
+    assert versioned["checksumSha256Base64"] == "sha-old"
+
+    first_page = await file_service.list_files(_ctx("user_123"), {"limit": 1})
+    assert [file["fileId"] for file in first_page["files"]] == ["file_0001"]
+    assert first_page["nextCursor"]
+
+    second_page = await file_service.list_files(
+        _ctx("user_123"),
+        {"limit": 2, "cursor": first_page["nextCursor"]},
+    )
+    assert [file["fileId"] for file in second_page["files"]] == ["file_0002"]
+    assert not any(
+        call["model"] == "files" and call["where"] == []
+        for call in db.find_many_calls
+    )
+    assert any(
+        call["model"] == "files"
+        and call["limit"] == 2
+        and call["order_by"] == [
+            {"field": "updatedAt", "direction": "desc"},
+            {"field": "fileId", "direction": "asc"},
+        ]
+        for call in db.find_many_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_share_proxy_descriptor_defers_download_counter_until_stream_access() -> None:
+    db = FakeDB()
+    await _seed_file_rows(db)
+
+    shares_service = create_shares_service(
+        SharesServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=False),
+            namespace="filefn",
+        )
+    )
+
+    create_res = await shares_service.create_share_link(
+        CreateShareLinkInput(fileId="file_0001", versionId="ver_0001"),
+        _ctx("user_123"),
+    )
+
+    token = create_res["token"]
+    descriptor = await shares_service.download_via_share_link(token, _ctx(None), is_authenticated=False)
+
+    assert descriptor["url"] == f"/proxy/share-links/{token}/download"
+    assert descriptor["url"].startswith("/")
+
+    share_rows = await db.find_many("fileShares", where=[])
+    assert share_rows[0]["downloads"] == 0
+
+    stream_result = await shares_service.get_download_stream_via_share_link(
+        token,
+        _ctx(None),
+        is_authenticated=False,
+    )
+    payload = []
+    async for chunk in stream_result["stream"]:
+        payload.append(chunk)
+
+    assert b"".join(payload) == b"bytes"
+    share_rows = await db.find_many("fileShares", where=[])
+    assert share_rows[0]["downloads"] == 1
+
+
+@pytest.mark.asyncio
+async def test_signed_share_descriptor_increments_downloads_once() -> None:
+    db = FakeDB()
+    await _seed_file_rows(db)
+
+    shares_service = create_shares_service(
+        SharesServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=True),
+            namespace="filefn",
+        )
+    )
+    shares_service.storage.capabilities = {"signedDownloadUrls": True}
+
+    create_res = await shares_service.create_share_link(
+        CreateShareLinkInput(fileId="file_0001", versionId="ver_0001"),
+        _ctx("user_123"),
+    )
+
+    token = create_res["token"]
+    descriptor = await shares_service.download_via_share_link(token, _ctx(None), is_authenticated=False)
+
+    assert descriptor["url"].startswith("https://download.local/")
+    share_rows = await db.find_many("fileShares", where=[])
+    assert share_rows[0]["downloads"] == 1
+
+
+@pytest.mark.asyncio
+async def test_signed_share_descriptor_retries_download_reservation_conflicts() -> None:
+    db = FlakyShareDB()
+    await _seed_file_rows(db)
+
+    shares_service = create_shares_service(
+        SharesServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=True),
+            namespace="filefn",
+        )
+    )
+    shares_service.storage.capabilities = {"signedDownloadUrls": True}
+
+    create_res = await shares_service.create_share_link(
+        CreateShareLinkInput(fileId="file_0001", versionId="ver_0001", maxDownloads=1),
+        _ctx("user_123"),
+    )
+
+    token = create_res["token"]
+    descriptor = await shares_service.download_via_share_link(token, _ctx(None), is_authenticated=False)
+
+    assert descriptor["url"].startswith("https://download.local/")
+
+    share_rows = await db.find_many("fileShares", where=[])
+    assert share_rows[0]["downloads"] == 1
+
+    with pytest.raises(Exception) as exc_info:
+        await shares_service.download_via_share_link(token, _ctx(None), is_authenticated=False)
+    assert getattr(exc_info.value, "code", "") == "FILEFN_SHARE_DOWNLOADS_EXCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_share_download_binding_mismatch_is_not_found_and_downloads_not_incremented() -> None:
+    db = FakeDB()
+    await _seed_file_rows(db)
+
+    shares_service = create_shares_service(
+        SharesServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=False),
+            namespace="filefn",
+        )
+    )
+
+    token = "shr_live_bad"
+    await db.create(
+        model="fileShares",
+        data={
+            "tokenHash": shares_service._hash_token(token),  # parity check for token hashing path
+            "fileId": "file_0001",
+            "versionId": "ver_other_file",
+            "expiresAt": None,
+            "requiresAuth": False,
+            "maxDownloads": None,
+            "downloads": 0,
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "revokedAt": None,
+        },
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await shares_service.download_via_share_link(token, _ctx(None), is_authenticated=False)
+    assert getattr(exc_info.value, "code", "") == "FILEFN_NOT_FOUND"
+
+    share_rows = await db.find_many("fileShares", where=[])
+    assert share_rows[0]["downloads"] == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_cascade_is_metadata_complete_and_reference_safe() -> None:
+    db = FakeDB()
+    storage = FakeStorage(with_signing=False)
+    quota = RecordingQuota()
+    now = datetime.now(timezone.utc).isoformat()
+
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_1",
+            "currentVersionId": "ver_1",
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "user-avatar",
+            "mimeType": "image/png",
+            "size": 10,
+            "name": "one.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_2",
+            "currentVersionId": "ver_2",
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "user-avatar",
+            "mimeType": "image/png",
+            "size": 10,
+            "name": "two.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+    await db.create(
+        model="fileVersions",
+        data={
+            "versionId": "ver_1",
+            "fileId": "file_1",
+            "storageKey": "durable/shared/key",
+            "mimeType": "image/png",
+            "size": 10,
+            "checksumSha256Base64": None,
+            "tenantId": "org_123",
+            "createdAt": now,
+        },
+    )
+    await db.create(
+        model="fileVersions",
+        data={
+            "versionId": "ver_2",
+            "fileId": "file_2",
+            "storageKey": "durable/shared/key",
+            "mimeType": "image/png",
+            "size": 10,
+            "checksumSha256Base64": None,
+            "tenantId": "org_123",
+            "createdAt": now,
+        },
+    )
+    await db.create(
+        model="fileArtifacts",
+        data={
+            "artifactId": "art_1",
+            "fileId": "file_1",
+            "versionId": "ver_1",
+            "kind": "thumbnail",
+            "storageKey": "durable/artifacts/file_1-thumb",
+            "mimeType": "image/png",
+            "size": 4,
+            "metadata": {},
+            "createdAt": now,
+        },
+    )
+    await db.create(
+        model="filePermissions",
+        data={
+            "permissionId": "perm_1",
+            "fileId": "file_1",
+            "userId": "user_456",
+            "role": None,
+            "tenantId": None,
+            "canRead": True,
+            "canWrite": False,
+            "canDelete": False,
+            "canShare": False,
+            "expiresAt": None,
+            "createdAt": now,
+        },
+    )
+    await db.create(
+        model="fileShares",
+        data={
+            "tokenHash": "hash_1",
+            "fileId": "file_1",
+            "versionId": "ver_1",
+            "expiresAt": None,
+            "requiresAuth": False,
+            "maxDownloads": None,
+            "downloads": 0,
+            "createdAt": now,
+            "revokedAt": None,
+        },
+    )
+    await db.create(
+        model="uploadSessions",
+        data={
+            "uploadSessionId": "upl_pending",
+            "status": "in_progress",
+            "policy": "user-avatar",
+            "fileId": "file_1",
+            "fileName": "one.png",
+            "mimeType": "image/png",
+            "size": 10,
+            "uploadMode": "proxy",
+            "chunkSizeBytes": 10,
+            "totalParts": 1,
+            "storageKey": "tmp/upload/file_1",
+            "storageUploadId": None,
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "expiresAt": now,
+            "createdAt": now,
+        },
+    )
+    await db.create(
+        model="uploadParts",
+        data={
+            "uploadSessionId": "upl_pending",
+            "partNumber": 1,
+            "etag": "etag_1",
+            "size": 10,
+        },
+    )
+
+    file_service = create_file_service(
+        FileServiceConfig(
+            db=db,
+            storage=storage,
+            events=create_event_emitter(),
+            quota=quota,
+            namespace="filefn",
+        )
+    )
+
+    await file_service.delete_file("file_1", _ctx("user_123"))
+
+    assert await db.find_one("files", where=[{"field": "fileId", "operator": "eq", "value": "file_1"}]) is None
+    assert await db.find_many("filePermissions", where=[{"field": "fileId", "operator": "eq", "value": "file_1"}]) == []
+    assert await db.find_many("fileShares", where=[{"field": "fileId", "operator": "eq", "value": "file_1"}]) == []
+    assert await db.find_many("fileArtifacts", where=[{"field": "fileId", "operator": "eq", "value": "file_1"}]) == []
+    assert await db.find_many("uploadSessions", where=[{"field": "fileId", "operator": "eq", "value": "file_1"}]) == []
+    assert "durable:durable/shared/key" not in storage.delete_calls
+    assert "durable:durable/artifacts/file_1-thumb" in storage.delete_calls
+    assert "durable:tmp/upload/file_1.parts/1" in storage.delete_calls
+    assert quota.calls == []
+
+    await file_service.delete_file("file_2", _ctx("user_123"))
+
+    assert "durable:durable/shared/key" in storage.delete_calls
+    assert quota.calls[-1]["bytes"] == -10
+
+
+@pytest.mark.asyncio
+async def test_delete_treats_same_storage_key_in_different_targets_as_distinct() -> None:
+    db = FakeDB()
+    now = datetime.now(timezone.utc).isoformat()
+
+    for file_id, policy in (("file_durable", "durable-policy"), ("file_temporary", "temporary-policy")):
+        await db.create(
+            model="files",
+            data={
+                "fileId": file_id,
+                "currentVersionId": f"ver_{file_id}",
+                "ownerId": "user_123",
+                "tenantId": "org_123",
+                "visibility": "private",
+                "policy": policy,
+                "mimeType": "image/png",
+                "size": 10,
+                "name": f"{file_id}.png",
+                "metadata": {},
+                "createdAt": now,
+                "updatedAt": now,
+            },
+        )
+        await db.create(
+            model="fileVersions",
+            data={
+                "versionId": f"ver_{file_id}",
+                "fileId": file_id,
+                "storageKey": "shared/object.png",
+                "mimeType": "image/png",
+                "size": 10,
+                "checksumSha256Base64": None,
+                "tenantId": "org_123",
+                "createdAt": now,
+            },
+        )
+
+    durable = FakeStorage()
+    temporary = FakeStorage()
+    storage = create_routed_storage_adapter(
+        {"durable": durable, "temporary": temporary},
+        default_target="durable",
+    )
+    service = create_file_service(
+        FileServiceConfig(
+            db=db,
+            storage=storage,
+            policies=create_policy_registry(
+                [
+                    Policy(name="durable-policy", storageTarget="durable"),
+                    Policy(name="temporary-policy", storageTarget="temporary"),
+                ]
+            ),
+            events=create_event_emitter(),
+            namespace="filefn",
+        )
+    )
+
+    await service.delete_file("file_durable", _ctx("user_123"))
+    assert "default:shared/object.png" in durable.delete_calls
+    assert "default:shared/object.png" not in temporary.delete_calls
+
+    await service.delete_file("file_temporary", _ctx("user_123"))
+    assert "default:shared/object.png" in temporary.delete_calls
+
+
+@pytest.mark.asyncio
+async def test_read_grants_ignore_expired_permissions() -> None:
+    db = FakeDB()
+    await _seed_file_rows(db)
+    await db.update(
+        model="files",
+        where=[{"field": "fileId", "operator": "eq", "value": "file_0001"}],
+        data={"ownerId": "owner_user"},
+    )
+    await db.create(
+        model="filePermissions",
+        data={
+            "permissionId": "perm_valid",
+            "fileId": "file_0001",
+            "userId": "user_123",
+            "tenantId": None,
+            "canRead": True,
+            "canWrite": False,
+            "canDelete": False,
+            "canShare": False,
+            "expiresAt": (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
+    service = create_file_service(
+        FileServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=False),
+            events=create_event_emitter(),
+            namespace="filefn",
+        )
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await service.get_file("file_0001", _ctx("user_123"))
+    assert getattr(exc_info.value, "code", "") == "FILEFN_FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_delete_file_removes_completed_upload_sessions() -> None:
+    db = FakeDB()
+    now = datetime.now(timezone.utc).isoformat()
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_cleanup",
+            "currentVersionId": "ver_cleanup",
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "user-avatar",
+            "mimeType": "image/png",
+            "size": 3,
+            "name": "cleanup.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+    await db.create(
+        model="fileVersions",
+        data={
+            "versionId": "ver_cleanup",
+            "fileId": "file_cleanup",
+            "storageKey": "uploads/file_cleanup/ver_cleanup.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "checksumSha256Base64": None,
+            "tenantId": "org_123",
+            "createdAt": now,
+        },
+    )
+    await db.create(
+        model="uploadSessions",
+        data={
+            "uploadSessionId": "upl_completed",
+            "status": "completed",
+            "policy": "user-avatar",
+            "fileId": "file_cleanup",
+            "fileName": "cleanup.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "uploadMode": "proxy",
+            "chunkSizeBytes": 3,
+            "totalParts": 1,
+            "storageKey": "uploads/file_cleanup/ver_cleanup.png",
+            "storageUploadId": None,
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "metadata": {},
+            "expiresAt": now,
+            "createdAt": now,
+        },
+    )
+
+    service = create_file_service(
+        FileServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=False),
+            events=create_event_emitter(),
+            namespace="filefn",
+        )
+    )
+
+    await service.delete_file("file_cleanup", _ctx("user_123"))
+    assert await db.find_many("uploadSessions", where=[{"field": "fileId", "operator": "eq", "value": "file_cleanup"}]) == []

--- a/filefn/python/tests/test_observability.py
+++ b/filefn/python/tests/test_observability.py
@@ -1,0 +1,29 @@
+from filefn.server import redact_secrets
+
+
+def test_redact_secrets_preserves_safe_identifiers_and_counts() -> None:
+    redacted = redact_secrets(
+        {
+            "fileId": "file_123",
+            "versionId": "ver_123",
+            "artifactId": "art_123",
+            "policyId": "policy_123",
+            "requestId": "req_123",
+            "uploadSessionToken": "secret_upload_token",
+            "shareToken": "secret_share_token",
+            "signedUrl": "https://example.com/file?sig=secret",
+            "authorization": "Bearer secret.jwt.token",
+            "counts": {"imported": 3, "failed": 1},
+        }
+    )
+
+    assert redacted["fileId"] == "file_123"
+    assert redacted["versionId"] == "ver_123"
+    assert redacted["artifactId"] == "art_123"
+    assert redacted["policyId"] == "policy_123"
+    assert redacted["requestId"] == "req_123"
+    assert redacted["uploadSessionToken"] == "[REDACTED]"
+    assert redacted["shareToken"] == "[REDACTED]"
+    assert redacted["signedUrl"] == "[REDACTED]"
+    assert redacted["authorization"] == "[REDACTED]"
+    assert redacted["counts"] == {"imported": 3, "failed": 1}

--- a/filefn/python/tests/test_processing.py
+++ b/filefn/python/tests/test_processing.py
@@ -1,0 +1,949 @@
+from __future__ import annotations
+
+import asyncio
+import io
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from filefn.processing import (
+    PDF_PREVIEW_SUPPORTED_MIME_TYPES,
+    create_audio_processor,
+    create_image_transform_processor,
+    create_ocr_processor,
+    create_pdf_preview_processor,
+    create_thumbnail_processor,
+    create_video_processor,
+)
+from filefn.processing.types import (
+    ImageTransformConfig,
+    ImageTransformOperation,
+    PdfPreviewConfig,
+    ResizeOptions,
+    RotateOptions,
+    ThumbnailConfig,
+)
+from filefn.server import create_event_emitter, create_routed_storage_adapter
+from filefn.server.policies import Policy, create_policy_registry
+from filefn.server.processing.service import (
+    ProcessingServiceConfig,
+    ProcessorInput,
+    ProcessorOutputArtifact,
+    ProcessorResult,
+    create_processing_service,
+)
+
+
+def _assert_image_artifact_format_consistency(artifact: ProcessorOutputArtifact) -> None:
+    if artifact.data.startswith(b"\x89PNG\r\n\x1a\n"):
+        assert artifact.mimeType == "image/png"
+        assert artifact.storageKey.endswith(".png")
+        return
+
+    riff_magic = artifact.data[:4]
+    webp_signature = artifact.data[8:12]
+    if riff_magic == b"RIFF" and webp_signature == b"WEBP":
+        assert artifact.mimeType == "image/webp"
+        assert artifact.storageKey.endswith(".webp")
+        return
+
+    # Placeholder conversion can emit JPEG when Pillow is available.
+    assert artifact.mimeType == "image/jpeg"
+    assert artifact.storageKey.endswith(".jpg")
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.tables: Dict[str, List[Dict[str, Any]]] = {}
+
+    def _table(self, model: str) -> List[Dict[str, Any]]:
+        return self.tables.setdefault(model, [])
+
+    @staticmethod
+    def _matches(row: Dict[str, Any], where: Optional[List[Dict[str, Any]]]) -> bool:
+        if not where:
+            return True
+        for clause in where:
+            if clause.get("operator") != "eq":
+                raise ValueError("FakeDB supports only eq operator")
+            if row.get(clause["field"]) != clause.get("value"):
+                return False
+        return True
+
+    async def create(self, model: str, data: Dict[str, Any], namespace: Optional[str] = None) -> Dict[str, Any]:
+        row = dict(data)
+        self._table(model).append(row)
+        return dict(row)
+
+    async def find_one(
+        self,
+        model: str,
+        where: Optional[List[Dict[str, Any]]] = None,
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for row in self._table(model):
+            if self._matches(row, where):
+                return dict(row)
+        return None
+
+    async def find_many(
+        self,
+        model: str,
+        where: Optional[List[Dict[str, Any]]] = None,
+        order_by: Optional[List[Dict[str, Any]]] = None,
+        limit: Optional[int] = None,
+        namespace: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        rows = [dict(row) for row in self._table(model) if self._matches(row, where)]
+
+        if order_by:
+            for order in reversed(order_by):
+                reverse = order.get("direction", "asc") == "desc"
+                rows.sort(key=lambda item: item.get(order["field"]), reverse=reverse)
+
+        if limit is not None:
+            rows = rows[:limit]
+        return rows
+
+    async def update(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        data: Dict[str, Any],
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for row in self._table(model):
+            if self._matches(row, where):
+                row.update(data)
+                return dict(row)
+        return None
+
+
+class FakeStorage:
+    def __init__(self, with_signing: bool = False) -> None:
+        self.with_signing = with_signing
+        self.objects: Dict[str, bytes] = {}
+        self.put_calls: List[Dict[str, Any]] = []
+        self.name = "fake"
+
+    @staticmethod
+    def _coerce_bytes(data: Any) -> bytes:
+        if isinstance(data, bytes):
+            return data
+        if hasattr(data, "read"):
+            payload = data.read()
+            if isinstance(payload, bytes):
+                return payload
+        return bytes(data)
+
+    async def put_object(
+        self,
+        key: str,
+        data: Any,
+        metadata: Optional[Dict[str, str]] = None,
+        target: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = self._coerce_bytes(data)
+        self.objects[key] = payload
+        self.put_calls.append({"key": key, "metadata": metadata or {}, "target": target})
+        return {
+            "key": key,
+            "size": len(payload),
+            "etag": "etag",
+            "lastModified": datetime.now(timezone.utc).isoformat(),
+            "metadata": metadata or {},
+        }
+
+    async def open_download_stream(self, key: str, target: Optional[str] = None):
+        payload = self.objects.get(key, b"")
+
+        async def _gen():
+            yield payload
+
+        return _gen()
+
+    async def sign_download_url(self, key: str, expires_in_seconds: int, target: Optional[str] = None) -> Dict[str, Any]:
+        if not self.with_signing:
+            raise RuntimeError("signing unavailable")
+        return {"url": f"https://download.local/{key}", "headers": {}}
+
+
+class ThumbnailLikeProcessor:
+    name = "thumbnail"
+    supportedMimeTypes = ["image/png"]
+
+    async def process(self, input: ProcessorInput, get_data):
+        raw = await get_data()
+        return ProcessorResult(
+            success=True,
+            artifacts=[
+                ProcessorOutputArtifact(
+                    kind="thumbnail-small",
+                    data=raw,
+                    mimeType="image/png",
+                    storageKey=f"{input.storageKey}.thumb.png",
+                    metadata={"source": input.fileId},
+                )
+            ],
+        )
+
+
+class RecordingQueue:
+    def __init__(self, fail: bool = False) -> None:
+        self.fail = fail
+        self.jobs: List[Dict[str, Any]] = []
+
+    async def add(self, job: Any) -> Dict[str, Any]:
+        if self.fail:
+            raise RuntimeError("queue down")
+        payload = dict(job)
+        self.jobs.append(payload)
+        return {"jobId": "job_001"}
+
+
+class FlowProvider:
+    def __init__(self, queue: RecordingQueue) -> None:
+        self.queue = queue
+
+    def get_queue(self, name: str):
+        return self.queue
+
+
+def _ctx(principal_id: Optional[str], tenant_id: Optional[str] = "org_123"):
+    return SimpleNamespace(principalId=principal_id, tenantId=tenant_id, requestId="req_001")
+
+
+async def _seed_file_and_artifact(db: FakeDB) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_001",
+            "currentVersionId": "ver_001",
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "user-avatar",
+            "mimeType": "image/png",
+            "size": 3,
+            "name": "a.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+    await db.create(
+        model="fileArtifacts",
+        data={
+            "artifactId": "art_001",
+            "fileId": "file_001",
+            "versionId": "ver_001",
+            "kind": "thumbnail-small",
+            "storageKey": "org_123/user_123/file_001/ver_001-a.png.thumb.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "metadata": {},
+            "createdAt": now,
+        },
+    )
+
+
+def test_processing_public_imports_include_pdf_preview() -> None:
+    assert callable(create_pdf_preview_processor)
+    assert callable(create_thumbnail_processor)
+    assert PDF_PREVIEW_SUPPORTED_MIME_TYPES == ["application/pdf"]
+
+
+def _make_png(width: int = 8, height: int = 8) -> bytes:
+    from PIL import Image
+
+    image = Image.new("RGBA", (width, height), (40, 120, 200, 255))
+    out = io.BytesIO()
+    image.save(out, format="PNG")
+    return out.getvalue()
+
+
+def _make_jpeg(width: int = 8, height: int = 8) -> bytes:
+    from PIL import Image
+
+    image = Image.new("RGB", (width, height), (180, 140, 80))
+    out = io.BytesIO()
+    image.save(out, format="JPEG")
+    return out.getvalue()
+
+
+def _make_animated_gif() -> bytes:
+    from PIL import Image
+
+    first = Image.new("RGBA", (4, 4), (255, 0, 0, 255))
+    second = Image.new("RGBA", (4, 4), (0, 0, 255, 255))
+    out = io.BytesIO()
+    first.save(out, format="GIF", save_all=True, append_images=[second], loop=0, duration=50)
+    return out.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_processing_uses_put_object_and_creates_artifacts() -> None:
+    db = FakeDB()
+    storage = FakeStorage()
+    storage.objects["org_123/user_123/file_001/ver_001-a.png"] = b"abc"
+
+    service = create_processing_service(
+        ProcessingServiceConfig(
+            db=db,
+            storage=storage,
+            events=create_event_emitter(),
+            processors=[ThumbnailLikeProcessor()],
+            namespace="filefn",
+            enabled=True,
+        )
+    )
+
+    result = await service.run_processing(
+        ProcessorInput(
+            fileId="file_001",
+            versionId="ver_001",
+            storageKey="org_123/user_123/file_001/ver_001-a.png",
+            mimeType="image/png",
+            size=3,
+            fileName="a.png",
+            tenantId="org_123",
+        ),
+        _ctx("user_123"),
+    )
+
+    assert result["artifactsCreated"] == 1
+    assert len(storage.put_calls) == 1
+    assert storage.put_calls[0]["key"].endswith(".thumb.png")
+
+
+@pytest.mark.asyncio
+async def test_processing_queue_enqueue_uses_deterministic_idempotency_key_and_surfaces_failures() -> None:
+    ok_queue = RecordingQueue(fail=False)
+    service_ok = create_processing_service(
+        ProcessingServiceConfig(
+            db=FakeDB(),
+            storage=FakeStorage(),
+            events=create_event_emitter(),
+            processors=[ThumbnailLikeProcessor()],
+            flow_fn=FlowProvider(ok_queue),
+            namespace="filefn",
+            enabled=True,
+        )
+    )
+
+    queued = await service_ok.trigger_processing(
+        {
+            "fileId": "file_001",
+            "versionId": "ver_001",
+            "storageKey": "k",
+            "mimeType": "image/png",
+            "size": 3,
+            "fileName": "a.png",
+            "tenantId": "org_123",
+        },
+        _ctx("user_123"),
+    )
+
+    assert queued["enqueued"] is True
+    assert ok_queue.jobs[0]["idempotencyKey"] == "processing:file_001:ver_001:thumbnail"
+
+    bad_queue = RecordingQueue(fail=True)
+    service_bad = create_processing_service(
+        ProcessingServiceConfig(
+            db=FakeDB(),
+            storage=FakeStorage(),
+            events=create_event_emitter(),
+            processors=[ThumbnailLikeProcessor()],
+            flow_fn=FlowProvider(bad_queue),
+            namespace="filefn",
+            enabled=True,
+        )
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await service_bad.trigger_processing(
+            {
+                "fileId": "file_001",
+                "versionId": "ver_001",
+                "storageKey": "k",
+                "mimeType": "image/png",
+                "size": 3,
+                "fileName": "a.png",
+                "tenantId": "org_123",
+            },
+            _ctx("user_123"),
+        )
+    assert getattr(exc_info.value, "code", "") == "FILEFN_PROCESSING_ENQUEUE_FAILED"
+
+
+@pytest.mark.asyncio
+async def test_artifact_access_authorization_and_proxy_descriptor_shape() -> None:
+    db = FakeDB()
+    await _seed_file_and_artifact(db)
+
+    service = create_processing_service(
+        ProcessingServiceConfig(
+            db=db,
+            storage=FakeStorage(with_signing=False),
+            events=create_event_emitter(),
+            processors=[],
+            namespace="filefn",
+            enabled=True,
+        )
+    )
+
+    visible = await service.list_artifacts("file_001", _ctx("user_123"))
+    assert len(visible) == 1
+
+    await db.create(
+        model="filePermissions",
+        data={
+            "permissionId": "perm_001",
+            "fileId": "file_001",
+            "userId": "user_456",
+            "tenantId": None,
+            "canRead": True,
+        },
+    )
+    visible_via_grant = await service.list_artifacts("file_001", _ctx("user_456"))
+    assert len(visible_via_grant) == 1
+
+    with pytest.raises(Exception) as exc_forbidden:
+        await service.list_artifacts("file_001", _ctx("user_999"))
+    assert getattr(exc_forbidden.value, "code", "") == "FILEFN_FORBIDDEN"
+
+    descriptor = await service.get_artifact_download_url("art_001", _ctx("user_123"), file_id="file_001")
+    assert descriptor["url"] == "/proxy/files/file_001/artifacts/art_001/download"
+    assert not descriptor["url"].startswith("proxy://")
+
+    with pytest.raises(Exception) as exc_binding:
+        await service.get_artifact_download_url("art_001", _ctx("user_123"), file_id="file_999")
+    assert getattr(exc_binding.value, "code", "") == "FILEFN_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_processing_events_preserve_request_id() -> None:
+    db = FakeDB()
+    storage = FakeStorage()
+    storage.objects["org_123/user_123/file_001/ver_001-a.png"] = b"abc"
+    events = create_event_emitter()
+    seen: List[Any] = []
+    events.on("processing.started", seen.append)
+    events.on("processing.completed", seen.append)
+
+    service = create_processing_service(
+        ProcessingServiceConfig(
+            db=db,
+            storage=storage,
+            events=events,
+            processors=[ThumbnailLikeProcessor()],
+            namespace="filefn",
+            enabled=True,
+        )
+    )
+
+    await service.run_processing(
+        ProcessorInput(
+            fileId="file_001",
+            versionId="ver_001",
+            storageKey="org_123/user_123/file_001/ver_001-a.png",
+            mimeType="image/png",
+            size=3,
+            fileName="a.png",
+            tenantId="org_123",
+        ),
+        _ctx("user_123"),
+    )
+
+    assert len(seen) == 1
+    assert seen[0].requestId == "req_001"
+
+
+@pytest.mark.asyncio
+async def test_processing_routes_artifacts_to_artifact_storage_target() -> None:
+    db = FakeDB()
+    now = datetime.now(timezone.utc).isoformat()
+    await db.create(
+        model="files",
+        data={
+            "fileId": "file_002",
+            "currentVersionId": "ver_002",
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "visibility": "private",
+            "policy": "artifact-offload",
+            "mimeType": "image/png",
+            "size": 3,
+            "name": "b.png",
+            "metadata": {},
+            "createdAt": now,
+            "updatedAt": now,
+        },
+    )
+
+    durable = FakeStorage()
+    durable.name = "durable"
+    durable.objects["uploads/file_002/ver_002-b.png"] = b"abc"
+    temporary = FakeStorage()
+    temporary.name = "temporary"
+    storage = create_routed_storage_adapter(
+        {"durable": durable, "temporary": temporary},
+        default_target="durable",
+    )
+
+    service = create_processing_service(
+        ProcessingServiceConfig(
+            db=db,
+            storage=storage,
+            policies=create_policy_registry(
+                [
+                    Policy(
+                        name="artifact-offload",
+                        contentTypes=["image/png"],
+                        storageTarget="durable",
+                        artifactStorageTarget="temporary",
+                    )
+                ]
+            ),
+            events=create_event_emitter(),
+            processors=[ThumbnailLikeProcessor()],
+            namespace="filefn",
+            enabled=True,
+        )
+    )
+
+    result = await service.run_processing(
+        ProcessorInput(
+            fileId="file_002",
+            versionId="ver_002",
+            storageKey="uploads/file_002/ver_002-b.png",
+            mimeType="image/png",
+            size=3,
+            fileName="b.png",
+            tenantId="org_123",
+        ),
+        _ctx("user_123"),
+    )
+
+    assert result["artifactsCreated"] == 1
+    assert len(durable.put_calls) == 0
+    assert len(temporary.put_calls) == 1
+    assert temporary.put_calls[0]["key"].endswith(".thumb.png")
+
+
+@pytest.mark.asyncio
+async def test_pdf_preview_processor_emits_canonical_artifact_kinds() -> None:
+    processor = create_pdf_preview_processor()
+    fake_pdf = b"%PDF-bad-but-usable-for-placeholder"
+
+    async def get_pdf() -> bytes:
+        return fake_pdf
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_pdf_001",
+            versionId="ver_pdf_001",
+            storageKey="uploads/file_pdf_001/ver_pdf_001-report.pdf",
+            mimeType="application/pdf",
+            size=len(fake_pdf),
+            fileName="report.pdf",
+            tenantId="org_123",
+        ),
+        get_pdf,
+    )
+
+    assert result.success is True
+    assert [artifact.kind for artifact in result.artifacts] == [
+        "pdf-preview-page-1-small",
+        "pdf-preview-page-1-medium",
+        "pdf-preview-page-1-large",
+    ]
+    assert all(artifact.mimeType == "image/png" for artifact in result.artifacts)
+    assert all(artifact.metadata and artifact.metadata.get("pageNumber") == 1 for artifact in result.artifacts)
+    assert all(artifact.metadata and artifact.metadata.get("renderMode") for artifact in result.artifacts)
+
+
+@pytest.mark.asyncio
+async def test_pdf_preview_processor_respects_configured_output_format_for_placeholder_previews() -> None:
+    processor = create_pdf_preview_processor(PdfPreviewConfig(format="jpeg", quality=70))
+
+    async def get_pdf() -> bytes:
+        return b"%PDF-placeholder"
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_pdf_fmt",
+            versionId="ver_pdf_fmt",
+            storageKey="uploads/file_pdf_fmt/ver_pdf_fmt-report.pdf",
+            mimeType="application/pdf",
+            size=16,
+            fileName="report.pdf",
+            tenantId="org_123",
+        ),
+        get_pdf,
+    )
+
+    assert result.success is True
+    for artifact in result.artifacts:
+        _assert_image_artifact_format_consistency(artifact)
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_processor_keeps_canonical_reserved_kinds() -> None:
+    processor = create_thumbnail_processor()
+    not_a_real_image = b"\x89PNG\r\nplaceholder"
+
+    async def get_image() -> bytes:
+        return not_a_real_image
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_img_001",
+            versionId="ver_img_001",
+            storageKey="uploads/file_img_001/ver_img_001-image.png",
+            mimeType="image/png",
+            size=len(not_a_real_image),
+            fileName="image.png",
+            tenantId="org_123",
+        ),
+        get_image,
+    )
+
+    assert result.success is True
+    assert [artifact.kind for artifact in result.artifacts] == [
+        "thumbnail-small",
+        "thumbnail-medium",
+        "thumbnail-large",
+    ]
+    assert all(artifact.metadata and artifact.metadata.get("renderMode") for artifact in result.artifacts)
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_placeholder_respects_configured_output_format() -> None:
+    processor = create_thumbnail_processor(ThumbnailConfig(format="webp", quality=75))
+
+    async def get_image() -> bytes:
+        return b"\x89PNG\r\nplaceholder"
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_thumb_fmt",
+            versionId="ver_thumb_fmt",
+            storageKey="uploads/file_thumb_fmt/ver_thumb_fmt-image.png",
+            mimeType="image/png",
+            size=16,
+            fileName="image.png",
+            tenantId="org_123",
+        ),
+        get_image,
+    )
+
+    assert result.success is True
+    for artifact in result.artifacts:
+        _assert_image_artifact_format_consistency(artifact)
+
+
+@pytest.mark.asyncio
+async def test_image_transform_processor_applies_real_resize_operations() -> None:
+    processor = create_image_transform_processor(
+        ImageTransformConfig(
+            operations=[
+                ImageTransformOperation(
+                    operation="resize",
+                    options=ResizeOptions(width=4, height=4),
+                    suffix="small",
+                )
+            ],
+            outputFormat="png",
+        )
+    )
+
+    async def get_image() -> bytes:
+        return _make_png()
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_img_transform",
+            versionId="ver_img_transform",
+            storageKey="uploads/file_img_transform/ver_img_transform-image.png",
+            mimeType="image/png",
+            size=16,
+            fileName="image.png",
+            tenantId="org_123",
+        ),
+        get_image,
+    )
+
+    try:
+        import PIL  # noqa: F401
+    except Exception:
+        assert result.success is False
+        assert result.error == "FILEFN_PROCESSING_IMAGE_TRANSFORM_FAILED"
+    else:
+        assert result.success is True
+        assert len(result.artifacts) == 1
+        artifact = result.artifacts[0]
+        assert artifact.kind == "image-transform"
+        assert artifact.mimeType == "image/png"
+        assert artifact.storageKey.endswith("-small.png")
+
+
+@pytest.mark.asyncio
+async def test_image_transform_respects_without_enlargement_and_preserves_dotted_parent_paths() -> None:
+    processor = create_image_transform_processor(
+        ImageTransformConfig(
+            operations=[
+                ImageTransformOperation(
+                    operation="resize",
+                    options=ResizeOptions(width=32, height=32, fit="fill", withoutEnlargement=True),
+                    suffix="bounded",
+                )
+            ],
+            outputFormat="png",
+        )
+    )
+
+    async def get_image() -> bytes:
+        return _make_png()
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_img_transform_2",
+            versionId="ver_img_transform_2",
+            storageKey="uploads/v1.assets/file_img_transform_2/original.image.png",
+            mimeType="image/png",
+            size=16,
+            fileName="image.png",
+            tenantId="org_123",
+        ),
+        get_image,
+    )
+
+    try:
+        from PIL import Image
+    except Exception:
+        assert result.success is False
+        assert result.error == "FILEFN_PROCESSING_IMAGE_TRANSFORM_FAILED"
+    else:
+        assert result.success is True
+        artifact = result.artifacts[0]
+        assert artifact.storageKey == "uploads/v1.assets/file_img_transform_2/original.image-bounded.png"
+        with Image.open(io.BytesIO(artifact.data)) as transformed:
+            assert transformed.size == (8, 8)
+
+
+@pytest.mark.asyncio
+async def test_image_transform_defaults_to_source_format_when_output_format_is_omitted() -> None:
+    processor = create_image_transform_processor(
+        ImageTransformConfig(
+            operations=[
+                ImageTransformOperation(
+                    operation="resize",
+                    options=ResizeOptions(width=4, height=4),
+                    suffix="small",
+                )
+            ],
+        )
+    )
+
+    async def get_image() -> bytes:
+        return _make_jpeg()
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_img_transform_3",
+            versionId="ver_img_transform_3",
+            storageKey="uploads/file_img_transform_3/original.photo.jpg",
+            mimeType="image/jpeg",
+            size=16,
+            fileName="image.jpg",
+            tenantId="org_123",
+        ),
+        get_image,
+    )
+
+    try:
+        from PIL import Image
+    except Exception:
+        assert result.success is False
+        assert result.error == "FILEFN_PROCESSING_IMAGE_TRANSFORM_FAILED"
+    else:
+        assert result.success is True
+        artifact = result.artifacts[0]
+        assert artifact.mimeType == "image/jpeg"
+        assert artifact.storageKey.endswith("-small.jpg")
+        with Image.open(io.BytesIO(artifact.data)) as transformed:
+            assert transformed.format == "JPEG"
+
+
+@pytest.mark.asyncio
+async def test_image_transform_rotate_supports_grayscale_background_fill() -> None:
+    processor = create_image_transform_processor(
+        ImageTransformConfig(
+            operations=[
+                ImageTransformOperation(
+                    operation="rotate",
+                    options=RotateOptions(
+                        angle=90,
+                        background={"r": 255, "g": 0, "b": 0, "alpha": 255},
+                    ),
+                    suffix="rotated",
+                )
+            ],
+            outputFormat="png",
+        )
+    )
+
+    async def get_image() -> bytes:
+        from PIL import Image
+
+        image = Image.new("L", (4, 2), 32)
+        out = io.BytesIO()
+        image.save(out, format="PNG")
+        return out.getvalue()
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_img_transform_4",
+            versionId="ver_img_transform_4",
+            storageKey="uploads/file_img_transform_4/original.png",
+            mimeType="image/png",
+            size=8,
+            fileName="image.png",
+            tenantId="org_123",
+        ),
+        get_image,
+    )
+
+    try:
+        from PIL import Image
+    except Exception:
+        assert result.success is False
+        assert result.error == "FILEFN_PROCESSING_IMAGE_TRANSFORM_FAILED"
+    else:
+        assert result.success is True
+        artifact = result.artifacts[0]
+        with Image.open(io.BytesIO(artifact.data)) as transformed:
+            assert transformed.mode == "L"
+            assert transformed.size == (2, 4)
+
+
+@pytest.mark.asyncio
+async def test_image_transform_rejects_multi_frame_inputs() -> None:
+    processor = create_image_transform_processor(
+        ImageTransformConfig(
+            operations=[
+                ImageTransformOperation(
+                    operation="resize",
+                    options=ResizeOptions(width=2, height=2),
+                    suffix="small",
+                )
+            ],
+            outputFormat="gif",
+        )
+    )
+
+    async def get_image() -> bytes:
+        return _make_animated_gif()
+
+    result = await processor.process(
+        ProcessorInput(
+            fileId="file_img_transform_multi",
+            versionId="ver_img_transform_multi",
+            storageKey="uploads/file_img_transform_multi/original.gif",
+            mimeType="image/gif",
+            size=16,
+            fileName="image.gif",
+            tenantId="org_123",
+        ),
+        get_image,
+    )
+
+    try:
+        import PIL  # noqa: F401
+    except Exception:
+        assert result.success is False
+        assert result.error == "FILEFN_PROCESSING_IMAGE_TRANSFORM_FAILED"
+    else:
+        assert result.success is False
+        assert result.error == "FILEFN_PROCESSING_IMAGE_TRANSFORM_FAILED"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_processing_factories_fail_closed_instead_of_returning_fake_artifacts() -> None:
+    input = ProcessorInput(
+        fileId="file_proc_stub",
+        versionId="ver_proc_stub",
+        storageKey="uploads/file_proc_stub/ver_proc_stub.bin",
+        mimeType="image/png",
+        size=8,
+        fileName="placeholder.png",
+        tenantId="org_123",
+    )
+
+    async def get_data() -> bytes:
+        return b"placeholder"
+
+    ocr = await create_ocr_processor().process(input, get_data)
+    video = await create_video_processor().process(
+        input.model_copy(update={"mimeType": "video/mp4", "fileName": "placeholder.mp4"}),
+        get_data,
+    )
+    audio = await create_audio_processor().process(
+        input.model_copy(update={"mimeType": "audio/mpeg", "fileName": "placeholder.mp3"}),
+        get_data,
+    )
+
+    assert ocr.success is False
+    assert ocr.error == "FILEFN_PROCESSING_OCR_PROVIDER_REQUIRED"
+    assert video.success is False
+    assert video.error == "FILEFN_PROCESSING_VIDEO_PROVIDER_REQUIRED"
+    assert audio.success is False
+    assert audio.error == "FILEFN_PROCESSING_AUDIO_PROVIDER_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_trigger_processing_retains_background_task_until_completion() -> None:
+    gate = asyncio.Event()
+
+    class SlowProcessor:
+        name = "slow"
+        supportedMimeTypes = ["image/png"]
+
+        async def process(self, input: ProcessorInput, get_data):
+            await gate.wait()
+            return ProcessorResult(success=True, artifacts=[])
+
+    service = create_processing_service(
+        ProcessingServiceConfig(
+            db=FakeDB(),
+            storage=FakeStorage(),
+            events=create_event_emitter(),
+            processors=[SlowProcessor()],
+            namespace="filefn",
+            enabled=True,
+        )
+    )
+
+    result = await service.trigger_processing(
+        {
+            "fileId": "file_slow",
+            "versionId": "ver_slow",
+            "storageKey": "uploads/file_slow/ver_slow.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "fileName": "slow.png",
+            "tenantId": "org_123",
+        },
+        _ctx("user_123"),
+    )
+
+    assert result["enqueued"] is False
+    assert len(service._background_tasks) == 1
+
+    gate.set()
+    await asyncio.gather(*list(service._background_tasks))
+    assert len(service._background_tasks) == 0

--- a/filefn/python/tests/test_routed_storage.py
+++ b/filefn/python/tests/test_routed_storage.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import pytest
+
+from filefn.server import (
+    STORAGE_TARGET_NOT_CONFIGURED,
+    StorageRoutingError,
+    create_routed_storage_adapter,
+    get_storage_capabilities,
+)
+
+
+class FakeTargetStorage:
+    def __init__(self, name: str, capabilities: Optional[Dict[str, bool]] = None) -> None:
+        self.name = name
+        self.capabilities = capabilities or {
+            "signedUploadUrls": True,
+            "signedDownloadUrls": True,
+            "multipart": True,
+            "proxyStreamingUpload": True,
+            "proxyStreamingDownload": True,
+        }
+        self.calls: list[str] = []
+
+    async def get_object(self, key: str) -> Dict[str, Any]:
+        self.calls.append(f"{self.name}:get:{key}")
+        return {
+            "key": key,
+            "size": 1,
+            "etag": "etag",
+            "lastModified": datetime.now(timezone.utc).isoformat(),
+            "metadata": {},
+        }
+
+    async def put_object(self, key: str, data: bytes, metadata: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        self.calls.append(f"{self.name}:put:{key}")
+        return {
+            "key": key,
+            "size": len(data),
+            "etag": "etag",
+            "lastModified": datetime.now(timezone.utc).isoformat(),
+            "metadata": metadata or {},
+        }
+
+    async def delete_object(self, key: str) -> None:
+        self.calls.append(f"{self.name}:delete:{key}")
+
+    async def open_download_stream(self, key: str):
+        self.calls.append(f"{self.name}:download:{key}")
+
+        async def _gen():
+            yield b"data"
+
+        return _gen()
+
+    async def sign_download_url(self, key: str, expires_in_seconds: int) -> Dict[str, Any]:
+        self.calls.append(f"{self.name}:sign:{key}")
+        return {"url": f"https://{self.name}.local/{key}", "headers": {}}
+
+    async def create_multipart_upload(
+        self,
+        key: str,
+        metadata: Optional[Dict[str, str]] = None,
+        content_type: Optional[str] = None,
+    ) -> str:
+        self.calls.append(f"{self.name}:multipart:{key}")
+        return f"{self.name}-upload"
+
+    async def sign_multipart_upload_part_url(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        expires_in_seconds: int,
+        constraints: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        self.calls.append(f"{self.name}:part:{key}:{part_number}")
+        return {"url": f"https://{self.name}.local/{upload_id}/{part_number}", "headers": {}}
+
+    async def upload_part(self, key: str, upload_id: str, part_number: int, data: bytes) -> str:
+        self.calls.append(f"{self.name}:upload-part:{key}:{part_number}")
+        return "etag"
+
+    async def complete_multipart_upload(self, key: str, upload_id: str, parts: list[Dict[str, Any]]) -> Dict[str, Any]:
+        self.calls.append(f"{self.name}:complete:{key}")
+        return {
+            "key": key,
+            "size": 1,
+            "etag": "etag",
+            "lastModified": datetime.now(timezone.utc).isoformat(),
+            "metadata": {},
+        }
+
+    async def abort_multipart_upload(self, key: str, upload_id: str) -> None:
+        self.calls.append(f"{self.name}:abort:{key}")
+
+
+@pytest.mark.asyncio
+async def test_routed_storage_imports_and_routes_calls() -> None:
+    durable = FakeTargetStorage("durable")
+    temporary = FakeTargetStorage("temporary")
+    storage = create_routed_storage_adapter({"durable": durable, "temporary": temporary}, default_target="durable")
+
+    await storage.create_multipart_upload(key="files/a.png", target="durable")
+    await storage.sign_download_url(key="files/b.png", expires_in_seconds=60, target="temporary")
+
+    assert "durable:multipart:files/a.png" in durable.calls
+    assert "temporary:sign:files/b.png" in temporary.calls
+    assert get_storage_capabilities(storage, "durable")["multipart"] is True
+
+
+@pytest.mark.asyncio
+async def test_routed_storage_unknown_target_raises_stable_error() -> None:
+    storage = create_routed_storage_adapter({"durable": FakeTargetStorage("durable")}, default_target="durable")
+
+    with pytest.raises(StorageRoutingError) as exc_info:
+        await storage.sign_download_url(key="files/missing.png", expires_in_seconds=60, target="temporary")
+
+    assert exc_info.value.code == STORAGE_TARGET_NOT_CONFIGURED
+    assert exc_info.value.target == "temporary"

--- a/filefn/python/tests/test_upload_flow.py
+++ b/filefn/python/tests/test_upload_flow.py
@@ -1,0 +1,771 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import base64
+import hashlib
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from filefn.server import create_event_emitter
+from filefn.server import create_routed_storage_adapter
+from filefn.server.policies import Policy, create_nucleus_policies, create_policy_registry
+from filefn.server.upload_sessions.service import (
+    CreateSessionInput,
+    UploadSessionService,
+    UploadSessionServiceConfig,
+    create_upload_session_service,
+)
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.tables: Dict[str, List[Dict[str, Any]]] = {}
+
+    def _table(self, model: str) -> List[Dict[str, Any]]:
+        return self.tables.setdefault(model, [])
+
+    @staticmethod
+    def _matches(row: Dict[str, Any], where: Optional[List[Dict[str, Any]]]) -> bool:
+        if not where:
+            return True
+        for clause in where:
+            if clause.get("operator") != "eq":
+                raise ValueError("FakeDB supports only eq operator")
+            if row.get(clause["field"]) != clause.get("value"):
+                return False
+        return True
+
+    async def create(self, model: str, data: Dict[str, Any], namespace: Optional[str] = None) -> Dict[str, Any]:
+        row = dict(data)
+        self._table(model).append(row)
+        return dict(row)
+
+    async def find_one(
+        self,
+        model: str,
+        where: Optional[List[Dict[str, Any]]] = None,
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for row in self._table(model):
+            if self._matches(row, where):
+                return dict(row)
+        return None
+
+    async def find_many(
+        self,
+        model: str,
+        where: Optional[List[Dict[str, Any]]] = None,
+        order_by: Optional[List[Dict[str, Any]]] = None,
+        limit: Optional[int] = None,
+        namespace: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        rows = [dict(row) for row in self._table(model) if self._matches(row, where)]
+
+        if order_by:
+            for order in reversed(order_by):
+                reverse = order.get("direction", "asc") == "desc"
+                rows.sort(key=lambda item: item.get(order["field"]), reverse=reverse)
+
+        if limit is not None:
+            rows = rows[:limit]
+        return rows
+
+    async def update(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        data: Dict[str, Any],
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for row in self._table(model):
+            if self._matches(row, where):
+                row.update(data)
+                return dict(row)
+        return None
+
+    async def delete(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        namespace: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        rows = self._table(model)
+        for idx, row in enumerate(rows):
+            if self._matches(row, where):
+                removed = rows.pop(idx)
+                return dict(removed)
+        return None
+
+    async def delete_many(
+        self,
+        model: str,
+        where: List[Dict[str, Any]],
+        namespace: Optional[str] = None,
+    ) -> int:
+        rows = self._table(model)
+        before = len(rows)
+        self.tables[model] = [row for row in rows if not self._matches(row, where)]
+        return before - len(self.tables[model])
+
+
+class FakeStorage:
+    def __init__(self, capabilities: Optional[Dict[str, bool]] = None) -> None:
+        self.capabilities = capabilities or {}
+        self.objects: Dict[str, bytes] = {}
+        self.multipart: Dict[str, Dict[str, Any]] = {}
+        self.aborted_uploads: List[str] = []
+        self.calls: List[str] = []
+        self.name = "fake"
+
+    @staticmethod
+    def _coerce_bytes(data: Any) -> bytes:
+        if isinstance(data, bytes):
+            return data
+        if hasattr(data, "read"):
+            payload = data.read()
+            if isinstance(payload, bytes):
+                return payload
+        return bytes(data)
+
+    async def get_object(self, key: str, target: Optional[str] = None) -> Dict[str, Any]:
+        data = self.objects[key]
+        return {
+            "key": key,
+            "size": len(data),
+            "etag": "etag",
+            "lastModified": datetime.now(timezone.utc).isoformat(),
+            "metadata": {},
+        }
+
+    async def put_object(
+        self,
+        key: str,
+        data: Any,
+        metadata: Optional[Dict[str, str]] = None,
+        target: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = self._coerce_bytes(data)
+        self.objects[key] = payload
+        if target:
+            self.calls.append(f"{self.name}:put:{target}:{key}")
+        return {
+            "key": key,
+            "size": len(payload),
+            "etag": f"etag-{len(payload)}",
+            "lastModified": datetime.now(timezone.utc).isoformat(),
+            "metadata": metadata or {},
+        }
+
+    async def delete_object(self, key: str, target: Optional[str] = None) -> None:
+        self.objects.pop(key, None)
+        if target:
+            self.calls.append(f"{self.name}:delete:{target}:{key}")
+
+    async def open_download_stream(self, key: str, target: Optional[str] = None):
+        payload = self.objects.get(key, b"")
+        if target:
+            self.calls.append(f"{self.name}:download:{target}:{key}")
+
+        async def _gen():
+            yield payload
+
+        return _gen()
+
+    async def sign_download_url(self, key: str, expires_in_seconds: int, target: Optional[str] = None) -> Dict[str, Any]:
+        return {"url": f"https://download.local/{key}", "headers": {}}
+
+    async def create_multipart_upload(
+        self,
+        key: str,
+        metadata: Optional[Dict[str, str]] = None,
+        content_type: Optional[str] = None,
+        target: Optional[str] = None,
+    ) -> str:
+        upload_id = f"mp-{len(self.multipart) + 1}"
+        self.multipart[upload_id] = {"key": key, "parts": {}}
+        self.calls.append(f"{self.name}:multipart:{target or 'default'}:{key}")
+        return upload_id
+
+    async def sign_multipart_upload_part_url(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        expires_in_seconds: int,
+        constraints: Optional[Dict[str, Any]] = None,
+        target: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return {"url": f"https://upload.local/{upload_id}/{part_number}", "headers": {}}
+
+    async def upload_part(
+        self,
+        key: str,
+        upload_id: str,
+        part_number: int,
+        data: bytes,
+        target: Optional[str] = None,
+    ) -> str:
+        self.multipart.setdefault(upload_id, {"key": key, "parts": {}})["parts"][part_number] = bytes(data)
+        return f"etag-{part_number}"
+
+    async def complete_multipart_upload(
+        self,
+        key: str,
+        upload_id: str,
+        parts: list[Dict[str, Any]],
+        target: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        self.objects[key] = self.objects.get(key, b"")
+        if target:
+            self.calls.append(f"{self.name}:complete:{target}:{key}")
+        return {
+            "key": key,
+            "size": len(self.objects[key]),
+            "etag": "etag-final",
+            "lastModified": datetime.now(timezone.utc).isoformat(),
+            "metadata": {},
+        }
+
+    async def abort_multipart_upload(self, key: str, upload_id: str, target: Optional[str] = None) -> None:
+        self.aborted_uploads.append(upload_id)
+
+
+class FakeDedup:
+    def __init__(self, db: FakeDB, enabled: bool) -> None:
+        self.db = db
+        self.enabled = enabled
+
+    def is_enabled(self) -> bool:
+        return self.enabled
+
+    async def compute_and_check_duplicate(
+        self,
+        storage_key: str,
+        tenant_id: Optional[str],
+        storage_target: Optional[str],
+        storage: FakeStorage,
+    ):
+        if not self.enabled:
+            return SimpleNamespace(
+                isDuplicate=False,
+                existingStorageKey=None,
+                checksumSha256Base64="",
+            )
+
+        stream = await storage.open_download_stream(storage_key, target=storage_target)
+        chunks: List[bytes] = []
+        async for chunk in stream:
+            chunks.append(chunk)
+        payload = b"".join(chunks)
+        checksum = base64.b64encode(hashlib.sha256(payload).digest()).decode("ascii")
+
+        versions = await self.db.find_many("fileVersions", where=[])
+        for version in versions:
+            if version.get("checksumSha256Base64") != checksum:
+                continue
+            if version.get("tenantId") != tenant_id:
+                continue
+            return SimpleNamespace(
+                isDuplicate=True,
+                existingStorageKey=version.get("storageKey"),
+                checksumSha256Base64=checksum,
+            )
+
+        return SimpleNamespace(
+            isDuplicate=False,
+            existingStorageKey=None,
+            checksumSha256Base64=checksum,
+        )
+
+
+def _ctx(
+    principal_id: Optional[str] = "user_123",
+    tenant_id: Optional[str] = "org_123",
+    upload_session_token: Optional[str] = None,
+):
+    ctx = SimpleNamespace(principalId=principal_id, tenantId=tenant_id, requestId="req_001")
+    if upload_session_token:
+        ctx.uploadSessionToken = upload_session_token
+    return ctx
+
+
+def _make_service(
+    db: Optional[FakeDB] = None,
+    storage: Optional[FakeStorage] = None,
+    dedup_enabled: bool = False,
+    chunk_size: int = 3,
+    allow_anonymous_uploads: bool = True,
+) -> UploadSessionService:
+    db = db or FakeDB()
+    storage = storage or FakeStorage({"proxyStreamingUpload": True})
+    dedup = FakeDedup(db=db, enabled=dedup_enabled)
+
+    return create_upload_session_service(
+        UploadSessionServiceConfig(
+            db=db,
+            storage=storage,
+            policies=create_policy_registry(
+                [
+                    Policy(
+                        name="user-avatar",
+                        contentTypes=["image/png", "image/jpeg"],
+                        maxSizeBytes=20_000_000,
+                        visibility="private",
+                    )
+                ]
+            ),
+            events=create_event_emitter(),
+            dedup=dedup,
+            namespace="filefn",
+            allow_anonymous_uploads=allow_anonymous_uploads,
+            default_chunk_size_bytes=chunk_size,
+            upload_session_ttl_seconds=3600,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_mode_selection_is_capability_gated() -> None:
+    service_a = _make_service(storage=FakeStorage({"signedUploadUrls": True, "multipart": True}))
+    result_a = await service_a.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="a.png", size=3, mimeType="image/png"),
+        _ctx(),
+    )
+    assert result_a["uploadMode"] == "multipart-signed-url"
+
+    service_b = _make_service(storage=FakeStorage({"proxyStreamingUpload": True}))
+    result_b = await service_b.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="b.png", size=3, mimeType="image/png"),
+        _ctx(),
+    )
+    assert result_b["uploadMode"] == "proxy"
+
+    service_c = _make_service(storage=FakeStorage({"signedUploadUrls": True, "multipart": False, "proxyStreamingUpload": False}))
+    with pytest.raises(Exception) as exc_info:
+        await service_c.create_session(
+            CreateSessionInput(policy="user-avatar", fileName="c.png", size=3, mimeType="image/png"),
+            _ctx(),
+        )
+    assert getattr(exc_info.value, "code", "") == "FILEFN_NO_SUPPORTED_UPLOAD_MODE"
+
+
+@pytest.mark.asyncio
+async def test_status_shape_uses_recorded_parts_canonical_fields() -> None:
+    db = FakeDB()
+    storage = FakeStorage({"proxyStreamingUpload": True})
+    service = _make_service(db=db, storage=storage)
+
+    session = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="resume.png", size=3, mimeType="image/png"),
+        _ctx(),
+    )
+
+    await service.complete_part(session["uploadSessionId"], 1, "etag-1", 3, _ctx())
+    status = await service.get_session_status(session["uploadSessionId"], _ctx())
+
+    assert status["fileId"] == session["fileId"]
+    assert status["recordedParts"] == [1]
+    assert status["chunkSizeBytes"] == 3
+    assert status["fileSize"] == 3
+    assert status["totalParts"] == 1
+    assert status["status"] in {"pending", "in_progress"}
+    assert "expiresAt" in status
+    assert "uploadedParts" not in status
+
+
+@pytest.mark.asyncio
+async def test_upload_session_binding_for_authenticated_and_anonymous_flows() -> None:
+    service = _make_service()
+
+    auth_session = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="auth.png", size=3, mimeType="image/png"),
+        _ctx(principal_id="user_123", tenant_id="org_123"),
+    )
+
+    await service.get_session_status(auth_session["uploadSessionId"], _ctx("user_123", "org_123"))
+
+    for method in (
+        lambda: service.get_session_status(auth_session["uploadSessionId"], _ctx("user_999", "org_123")),
+        lambda: service.sign_part(auth_session["uploadSessionId"], 1, 3, _ctx("user_999", "org_123")),
+        lambda: service.complete_part(auth_session["uploadSessionId"], 1, "etag", 3, _ctx("user_999", "org_123")),
+        lambda: service.complete_session(auth_session["uploadSessionId"], _ctx("user_999", "org_123")),
+        lambda: service.abort_session(auth_session["uploadSessionId"], _ctx("user_999", "org_123")),
+    ):
+        with pytest.raises(Exception) as exc_info:
+            await method()
+        assert getattr(exc_info.value, "code", "") == "FILEFN_FORBIDDEN"
+
+    anon_session = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="anon.png", size=3, mimeType="image/png"),
+        _ctx(principal_id=None, tenant_id="org_123"),
+    )
+    token = anon_session.get("uploadSessionToken")
+    assert isinstance(token, str) and token
+
+    with pytest.raises(Exception) as exc_missing:
+        await service.get_session_status(anon_session["uploadSessionId"], _ctx(principal_id=None, tenant_id="org_123"))
+    assert getattr(exc_missing.value, "code", "") == "FILEFN_SESSION_TOKEN_REQUIRED"
+
+    with pytest.raises(Exception) as exc_invalid:
+        await service.get_session_status(
+            anon_session["uploadSessionId"],
+            _ctx(principal_id=None, tenant_id="org_123", upload_session_token="wrong-token"),
+        )
+    assert getattr(exc_invalid.value, "code", "") == "FILEFN_SESSION_TOKEN_INVALID"
+
+    status = await service.get_session_status(
+        anon_session["uploadSessionId"],
+        _ctx(principal_id=None, tenant_id="org_123", upload_session_token=token),
+    )
+    assert status["uploadSessionId"] == anon_session["uploadSessionId"]
+
+
+@pytest.mark.asyncio
+async def test_anonymous_init_replay_rotates_token_and_persists_hash_only() -> None:
+    db = FakeDB()
+    service = _make_service(db=db)
+    init = CreateSessionInput(
+        policy="user-avatar",
+        fileName="anon-replay.png",
+        size=3,
+        mimeType="image/png",
+        idempotencyKey="idem_anon_001",
+    )
+
+    first = await service.create_session(init, _ctx(principal_id=None, tenant_id=None))
+    replay = await service.create_session(init, _ctx(principal_id=None, tenant_id=None))
+
+    assert first["uploadSessionId"] == replay["uploadSessionId"]
+    assert first["uploadSessionToken"] != replay["uploadSessionToken"]
+
+    session_row = await db.find_one(
+        model="uploadSessions",
+        where=[{"field": "uploadSessionId", "operator": "eq", "value": first["uploadSessionId"]}],
+        namespace="filefn",
+    )
+    assert session_row is not None
+    assert session_row["uploadSessionToken"] is None
+    assert session_row["sessionTokenHash"] == service._hash_session_token(replay["uploadSessionToken"])
+
+
+@pytest.mark.asyncio
+async def test_create_session_respects_anonymous_upload_policy() -> None:
+    service = _make_service(allow_anonymous_uploads=False)
+
+    with pytest.raises(Exception) as exc_info:
+        await service.create_session(
+            CreateSessionInput(policy="user-avatar", fileName="anon-disabled.png", size=3, mimeType="image/png"),
+            _ctx(principal_id=None, tenant_id="org_123"),
+        )
+    assert getattr(exc_info.value, "code", "") == "FILEFN_AUTH_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_completion_persists_upload_metadata() -> None:
+    db = FakeDB()
+    storage = FakeStorage({"proxyStreamingUpload": True})
+    service = _make_service(db=db, storage=storage)
+    metadata = {"source": "nucleus", "isMeta": True}
+
+    session = await service.create_session(
+        CreateSessionInput(
+            policy="user-avatar",
+            fileName="meta.png",
+            size=3,
+            mimeType="image/png",
+            metadata=metadata,
+        ),
+        _ctx(),
+    )
+
+    await service.record_proxy_part(session["uploadSessionId"], 1, b"abc", _ctx())
+    completed = await service.complete_session(session["uploadSessionId"], _ctx())
+    file_row = await db.find_one(
+        model="files",
+        where=[{"field": "fileId", "operator": "eq", "value": completed["fileId"]}],
+        namespace="filefn",
+    )
+
+    assert file_row is not None
+    assert file_row["metadata"] == metadata
+
+
+@pytest.mark.asyncio
+async def test_proxy_part_recording_idempotency_conflict_and_complete_idempotency() -> None:
+    service = _make_service()
+
+    session = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="proxy.png", size=3, mimeType="image/png"),
+        _ctx(),
+    )
+
+    first = await service.record_proxy_part(session["uploadSessionId"], 1, b"abc", _ctx())
+    second = await service.record_proxy_part(session["uploadSessionId"], 1, b"abc", _ctx())
+
+    assert first["recorded"] is True
+    assert second["recorded"] is True
+
+    with pytest.raises(Exception) as exc_conflict:
+        await service.record_proxy_part(session["uploadSessionId"], 1, b"xyz", _ctx())
+    assert getattr(exc_conflict.value, "code", "") == "FILEFN_PART_CONFLICT"
+
+    completed_once = await service.complete_session(session["uploadSessionId"], _ctx())
+    completed_twice = await service.complete_session(session["uploadSessionId"], _ctx())
+
+    assert completed_once["fileId"] == completed_twice["fileId"]
+    assert completed_once["versionId"] == completed_twice["versionId"]
+
+    incomplete_session = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="incomplete.png", size=6, mimeType="image/png"),
+        _ctx(),
+    )
+    await service.record_proxy_part(incomplete_session["uploadSessionId"], 1, b"abc", _ctx())
+    with pytest.raises(Exception) as exc_incomplete:
+        await service.complete_session(incomplete_session["uploadSessionId"], _ctx())
+    assert getattr(exc_incomplete.value, "code", "") == "FILEFN_UPLOAD_INCOMPLETE"
+
+
+@pytest.mark.asyncio
+async def test_complete_session_validates_uploaded_size_matches_declared_size() -> None:
+    service = _make_service()
+    session = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="size-mismatch.png", size=6, mimeType="image/png"),
+        _ctx(),
+    )
+
+    await service.record_proxy_part(session["uploadSessionId"], 1, b"abc", _ctx())
+    await service.record_proxy_part(session["uploadSessionId"], 2, b"xy", _ctx())
+
+    with pytest.raises(Exception) as exc_info:
+        await service.complete_session(session["uploadSessionId"], _ctx())
+    assert getattr(exc_info.value, "code", "") == "FILEFN_UPLOAD_SIZE_MISMATCH"
+
+
+@pytest.mark.asyncio
+async def test_complete_session_uses_high_entropy_version_ids() -> None:
+    service = _make_service()
+
+    first = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="first.png", size=3, mimeType="image/png"),
+        _ctx(),
+    )
+    second = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="second.png", size=3, mimeType="image/png"),
+        _ctx(),
+    )
+
+    await service.record_proxy_part(first["uploadSessionId"], 1, b"abc", _ctx())
+    await service.record_proxy_part(second["uploadSessionId"], 1, b"xyz", _ctx())
+
+    completed_first = await service.complete_session(first["uploadSessionId"], _ctx())
+    completed_second = await service.complete_session(second["uploadSessionId"], _ctx())
+
+    assert completed_first["versionId"].startswith("ver_")
+    assert completed_second["versionId"].startswith("ver_")
+    assert "." not in completed_first["versionId"]
+    assert completed_first["versionId"] != completed_second["versionId"]
+
+
+@pytest.mark.asyncio
+async def test_garbage_collection_removes_expired_sessions_and_preserves_completed() -> None:
+    db = FakeDB()
+    storage = FakeStorage({"proxyStreamingUpload": True})
+    service = _make_service(db=db, storage=storage)
+
+    now = datetime.now(timezone.utc)
+    expired = (now - timedelta(hours=1)).isoformat()
+    future = (now + timedelta(hours=1)).isoformat()
+
+    await db.create(
+        model="uploadSessions",
+        data={
+            "uploadSessionId": "upl_expired",
+            "status": "in_progress",
+            "policy": "user-avatar",
+            "fileId": "file_a",
+            "fileName": "a.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "uploadMode": "proxy",
+            "chunkSizeBytes": 3,
+            "totalParts": 1,
+            "storageKey": "org_123/user_123/file_a/ver_a-a.png",
+            "storageUploadId": None,
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "expiresAt": expired,
+            "createdAt": now.isoformat(),
+        },
+    )
+    await db.create(
+        model="uploadParts",
+        data={"uploadSessionId": "upl_expired", "partNumber": 1, "etag": "etag-1", "size": 3},
+    )
+    storage.objects["org_123/user_123/file_a/ver_a-a.png.parts/1"] = b"abc"
+
+    await db.create(
+        model="uploadSessions",
+        data={
+            "uploadSessionId": "upl_completed",
+            "status": "completed",
+            "policy": "user-avatar",
+            "fileId": "file_b",
+            "fileName": "b.png",
+            "mimeType": "image/png",
+            "size": 3,
+            "uploadMode": "proxy",
+            "chunkSizeBytes": 3,
+            "totalParts": 1,
+            "storageKey": "org_123/user_123/file_b/ver_b-b.png",
+            "storageUploadId": None,
+            "ownerId": "user_123",
+            "tenantId": "org_123",
+            "expiresAt": future,
+            "createdAt": now.isoformat(),
+        },
+    )
+
+    result = await service.garbage_collect_expired_sessions()
+
+    assert result["deletedSessions"] == 1
+    assert result["preservedCompletedSessions"] == 1
+    assert await db.find_one("uploadSessions", [{"field": "uploadSessionId", "operator": "eq", "value": "upl_expired"}]) is None
+    assert await db.find_one("uploadSessions", [{"field": "uploadSessionId", "operator": "eq", "value": "upl_completed"}]) is not None
+    assert "org_123/user_123/file_a/ver_a-a.png.parts/1" not in storage.objects
+
+
+@pytest.mark.asyncio
+async def test_dedupe_reuses_storage_within_tenant_but_not_cross_tenant() -> None:
+    db = FakeDB()
+    storage = FakeStorage({"proxyStreamingUpload": True})
+    service = _make_service(db=db, storage=storage, dedup_enabled=True)
+
+    first = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="a.png", size=3, mimeType="image/png"),
+        _ctx("user_123", "org_123"),
+    )
+    await service.record_proxy_part(first["uploadSessionId"], 1, b"abc", _ctx("user_123", "org_123"))
+    completed_first = await service.complete_session(first["uploadSessionId"], _ctx("user_123", "org_123"))
+
+    second = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="b.png", size=3, mimeType="image/png"),
+        _ctx("user_123", "org_123"),
+    )
+    await service.record_proxy_part(second["uploadSessionId"], 1, b"abc", _ctx("user_123", "org_123"))
+    completed_second = await service.complete_session(second["uploadSessionId"], _ctx("user_123", "org_123"))
+
+    third = await service.create_session(
+        CreateSessionInput(policy="user-avatar", fileName="c.png", size=3, mimeType="image/png"),
+        _ctx("user_999", "org_999"),
+    )
+    await service.record_proxy_part(third["uploadSessionId"], 1, b"abc", _ctx("user_999", "org_999"))
+    completed_third = await service.complete_session(third["uploadSessionId"], _ctx("user_999", "org_999"))
+
+    first_version = await db.find_one(
+        "fileVersions",
+        [{"field": "fileId", "operator": "eq", "value": completed_first["fileId"]}],
+    )
+    second_version = await db.find_one(
+        "fileVersions",
+        [{"field": "fileId", "operator": "eq", "value": completed_second["fileId"]}],
+    )
+    third_version = await db.find_one(
+        "fileVersions",
+        [{"field": "fileId", "operator": "eq", "value": completed_third["fileId"]}],
+    )
+
+    assert first_version is not None and second_version is not None and third_version is not None
+    assert second_version["storageKey"] == first_version["storageKey"]
+    assert third_version["storageKey"] != first_version["storageKey"]
+
+
+@pytest.mark.asyncio
+async def test_routed_storage_routes_durable_and_temporary_uploads() -> None:
+    db = FakeDB()
+    durable = FakeStorage({"signedUploadUrls": True, "multipart": True, "proxyStreamingDownload": True})
+    durable.name = "durable"
+    temporary = FakeStorage({"signedUploadUrls": True, "multipart": True, "proxyStreamingDownload": True})
+    temporary.name = "temporary"
+    storage = create_routed_storage_adapter(
+        {"durable": durable, "temporary": temporary},
+        default_target="durable",
+    )
+    service = create_upload_session_service(
+        UploadSessionServiceConfig(
+            db=db,
+            storage=storage,
+            policies=create_policy_registry(
+                [
+                    Policy(name="durable-policy", contentTypes=["image/png"], storageTarget="durable"),
+                    Policy(name="temporary-policy", contentTypes=["image/png"], storageTarget="temporary"),
+                ]
+            ),
+            events=create_event_emitter(),
+            namespace="filefn",
+        )
+    )
+
+    await service.create_session(
+        CreateSessionInput(policy="durable-policy", fileName="a.png", size=3, mimeType="image/png"),
+        _ctx("user_123", "org_123"),
+    )
+    await service.create_session(
+        CreateSessionInput(policy="temporary-policy", fileName="b.png", size=3, mimeType="image/png"),
+        _ctx("user_123", "org_123"),
+    )
+
+    assert any(call.startswith("durable:multipart:") for call in durable.calls)
+    assert any(call.startswith("temporary:multipart:") for call in temporary.calls)
+
+
+@pytest.mark.asyncio
+async def test_nucleus_policy_bundle_enforces_size_and_wildcard_types() -> None:
+    registry = create_policy_registry(create_nucleus_policies())
+    durable = registry.get("nucleus-durable-default")
+    temporary = registry.get("nucleus-temporary-default")
+
+    assert durable is not None and temporary is not None
+    assert durable.maxSizeBytes == 104857600
+    assert durable.renderProfile == "nucleus"
+    assert durable.storageTarget == "durable"
+    assert temporary.storageTarget == "temporary"
+
+    service = _make_service(db=FakeDB(), storage=FakeStorage({"signedUploadUrls": True, "multipart": True}))
+    service.policies = registry
+
+    ok = await service.create_session(
+        CreateSessionInput(
+            policy="nucleus-durable-default",
+            fileName="document.pdf",
+            size=104857600,
+            mimeType="application/pdf",
+        ),
+        _ctx("user_123", "org_123"),
+    )
+    assert ok["uploadSessionId"].startswith("upl_")
+
+    with pytest.raises(Exception) as exc_size:
+        await service.create_session(
+            CreateSessionInput(
+                policy="nucleus-durable-default",
+                fileName="too-big.pdf",
+                size=104857601,
+                mimeType="application/pdf",
+            ),
+            _ctx("user_123", "org_123"),
+        )
+    assert getattr(exc_size.value, "code", "") == "FILEFN_POLICY_MAX_SIZE_EXCEEDED"
+
+    with pytest.raises(Exception) as exc_mime:
+        await service.create_session(
+            CreateSessionInput(
+                policy="nucleus-temporary-default",
+                fileName="notes.zip",
+                size=10,
+                mimeType="application/zip",
+            ),
+            _ctx("user_123", "org_123"),
+        )
+    assert getattr(exc_mime.value, "code", "") == "FILEFN_POLICY_CONTENT_TYPE_NOT_ALLOWED"


### PR DESCRIPTION
## Summary
- add the `filefn` Python package with server services and processing helpers
- keep `.conduct` excluded for the `origin/dev` target

## Testing
- `cd filefn/python && python3 -m pytest`

## Notes
- `.conduct` was intentionally excluded from this PR
- `.gitignore` was not changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `filefn` Python package for chunked/resumable uploads, policy-routed multi-target storage, pluggable processing, secure sharing, and per-file permissions for `superfunctions` apps. Implements SF-14 with a server SDK, redacted events, schema builder, rate-limit config, and a full test suite.

- **New Features**
  - Server SDK and services: `create_file_fn`, config models, policy registry with Nucleus defaults; upload sessions, files/versions, share links (expiry/max downloads/auth), grants/permissions, dedup, structured errors, rate-limit and schema models, events with `redact_secrets`.
  - Storage routing: multi-target adapter with capability detection; signed URLs and proxy streaming for uploads/downloads; `StorageRoutingError` with `STORAGE_TARGET_NOT_CONFIGURED`.
  - Processing: pluggable pipeline (thumbnail, compression, PDF preview, image-transform); OCR/video/audio factories no-op if deps missing; artifacts routed by policy.

- **Refactors**
  - Consolidated exports and processor helpers; improved capability detection and error codes; tightened secret redaction and schema namespacing; added README and extensive tests for uploads, downloads, processing, routing, sharing, and observability.

<sup>Written for commit b8fa2c70fc7024a9e51d9d1521aec5dfe2f88003. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FileFn Python SDK: resumable/session uploads, routed storage with signed URLs & multipart, processing pipeline (thumbnails, PDF previews, compression, image transforms with fallbacks), deduplication, share links with expiring tokens, grants/permission management, policy & rate-limit controls, structured errors, event observability, and full server orchestration APIs.

* **Documentation**
  * Added comprehensive Python SDK README with install, quick-start, config options, usage examples, and architecture overview.

* **Tests**
  * Added extensive test suite covering uploads, downloads, processing, routing, shares, deduplication, observability, and upload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->