### PR TITLE
SF-21: feat(authfn): add client package

### DIFF
--- a/authfn/client/package.json
+++ b/authfn/client/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@authfn/client",
+  "version": "0.0.1",
+  "description": "Typed browser client for authfn",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@authfn/core": "^0.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/authfn/client/src/__tests__/client-account-settings.test.ts
+++ b/authfn/client/src/__tests__/client-account-settings.test.ts
@@ -1,0 +1,381 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { memoryAdapter } from '../../../../packages/db/src/testing/index.js';
+import {
+  authFnApiKeyPlugin,
+  authFnMultiRegionPlugin,
+  authFnPasswordPlugin,
+  authFnTwoFactorPlugin,
+  createAuthFn,
+  type AuthFnConfig
+} from '@authfn/core';
+import { createAuthFnClient } from '../index.js';
+
+const TEST_NOW = new Date('2026-03-25T00:00:00.000Z');
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const ACCOUNT_EMAIL = 'bea@example.com';
+const ACCOUNT_PASSWORD = 'Sup3rSecurePassphrase!';
+
+function createAccountSettingsConfig(): AuthFnConfig {
+  return {
+    database: memoryAdapter({ debug: false }),
+    namespace: 'authfn',
+    plugins: [
+      authFnPasswordPlugin(),
+      authFnApiKeyPlugin({
+        now: () => TEST_NOW
+      }),
+      authFnTwoFactorPlugin({
+        issuer: 'authfn-client-tests',
+        now: () => TEST_NOW,
+        recoveryCodeCount: 3
+      })
+    ]
+  };
+}
+
+function createMultiRegionConfig(): AuthFnConfig {
+  return {
+    database: memoryAdapter({ debug: false }),
+    namespace: 'authfn',
+    runtime: {
+      resolve(request) {
+        const url = new URL(request.url);
+        return {
+          issuer: url.origin,
+          baseUrl: url.origin,
+          cookie: {
+            prefix: 'authfn-base',
+            sameSite: 'lax'
+          },
+          oauth: {
+            google: {
+              clientId: 'base-google-client',
+              scopes: ['openid', 'email']
+            }
+          }
+        };
+      }
+    },
+    plugins: [
+      authFnPasswordPlugin(),
+      authFnMultiRegionPlugin({
+        regions: [
+          {
+            regionId: 'us-east-1',
+            authority: 'https://us.account.example.com',
+            hosts: ['us.account.example.com'],
+            cookie: {
+              prefix: 'authfn-us'
+            },
+            oauth: {
+              google: {
+                clientId: 'us-google-client',
+                scopes: ['openid', 'email', 'profile']
+              }
+            }
+          },
+          {
+            regionId: 'eu-west-1',
+            authority: 'https://eu.account.example.com',
+            hosts: ['eu.account.example.com'],
+            domain: '.example.com',
+            cookie: {
+              prefix: 'authfn-eu',
+              sameSite: 'none'
+            },
+            oauth: {
+              google: {
+                clientId: 'eu-google-client',
+                scopes: ['openid', 'email', 'profile']
+              }
+            }
+          }
+        ],
+        directory: {
+          lookupByIdentifier({ identifier }) {
+            if (identifier === 'ada@example.com') {
+              return {
+                userId: 'user_ada',
+                regionId: 'eu-west-1',
+                authority: 'https://eu.account.example.com',
+                domain: '.example.com'
+              };
+            }
+            return null;
+          }
+        }
+      })
+    ]
+  };
+}
+
+function createCookieJar() {
+  const values = new Map<string, string>();
+
+  return {
+    header(): string {
+      return Array.from(values.entries())
+        .map(([name, value]) => `${name}=${encodeURIComponent(value)}`)
+        .join('; ');
+    },
+    applySetCookies(cookies: string[]): void {
+      for (const cookie of cookies) {
+        const [pair] = cookie.split(';');
+        const separatorIndex = pair.indexOf('=');
+        const name = pair.slice(0, separatorIndex);
+        const value = decodeURIComponent(pair.slice(separatorIndex + 1));
+        if (value === '') {
+          values.delete(name);
+        } else {
+          values.set(name, value);
+        }
+      }
+    }
+  };
+}
+
+function createClient(config: AuthFnConfig, baseUrl: string) {
+  const auth = createAuthFn(config);
+  const cookieJar = createCookieJar();
+
+  const client = createAuthFnClient({
+    baseUrl,
+    cookieAccessor: () => cookieJar.header(),
+    fetch: async (input, init) => {
+      const headers = new Headers(init?.headers);
+      const cookieHeader = cookieJar.header();
+      if (cookieHeader) {
+        headers.set('cookie', cookieHeader);
+      }
+
+      const response = await auth.router.handle(
+        new Request(typeof input === 'string' ? input : input.toString(), {
+          method: init?.method,
+          headers,
+          body: init?.body
+        })
+      );
+      cookieJar.applySetCookies(response.headers.getSetCookie());
+      return response;
+    }
+  });
+
+  return {
+    auth,
+    client
+  };
+}
+
+function decodeBase32(secret: string): Buffer {
+  let buffer = 0;
+  let bits = 0;
+  const bytes: number[] = [];
+
+  for (const char of secret.replace(/=+$/g, '').toUpperCase()) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index < 0) {
+      continue;
+    }
+
+    buffer = (buffer << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((buffer >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Buffer.from(bytes);
+}
+
+function generateTotp(secret: string, now: Date = TEST_NOW, digits = 6, periodSeconds = 30): string {
+  const counter = Math.floor(now.getTime() / 1000 / periodSeconds);
+  const key = decodeBase32(secret);
+  const buffer = Buffer.alloc(8);
+  buffer.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+  buffer.writeUInt32BE(counter >>> 0, 4);
+  const digest = createHmac('sha1', key).update(buffer).digest();
+  const offset = digest[digest.length - 1] & 0x0f;
+  const binary = ((digest[offset] & 0x7f) << 24)
+    | ((digest[offset + 1] & 0xff) << 16)
+    | ((digest[offset + 2] & 0xff) << 8)
+    | (digest[offset + 3] & 0xff);
+  return String(binary % (10 ** digits)).padStart(digits, '0');
+}
+
+describe('@authfn/client account-settings flows', () => {
+  it('covers 2fa challenge/disable and the api key lifecycle via typed methods', async () => {
+    const { auth, client } = createClient(createAccountSettingsConfig(), 'https://account.example.com/auth');
+
+    const signUp = await client.signUpWithPassword({
+      email: ACCOUNT_EMAIL,
+      password: ACCOUNT_PASSWORD
+    });
+    if (!signUp.ok) {
+      throw new Error('sign-up should have succeeded');
+    }
+
+    const enrollment = await client.enableTwoFactor();
+    if (!enrollment.ok) {
+      throw new Error('2fa enrollment should have succeeded');
+    }
+
+    const confirm = await client.confirmTwoFactor({
+      code: generateTotp(enrollment.data.secret)
+    });
+    expect(confirm.ok).toBe(true);
+
+    const signOut = await client.signOut();
+    expect(signOut.ok).toBe(true);
+
+    const gated = await client.signInWithPassword({
+      email: ACCOUNT_EMAIL,
+      password: ACCOUNT_PASSWORD
+    });
+    expect(gated.ok).toBe(false);
+    if (gated.ok) {
+      throw new Error('2fa-enabled sign-in should be gated');
+    }
+    expect(gated.error.code).toBe('AUTHFN_2FA_REQUIRED');
+
+    const challenge = await client.completeTwoFactorChallenge({
+      challengeId: String(gated.error.details?.challengeId),
+      code: generateTotp(enrollment.data.secret)
+    });
+    expect(challenge.ok).toBe(true);
+    if (challenge.ok) {
+      expect(challenge.data.session.methods).toEqual(['password', 'two-factor']);
+    }
+
+    const createdKey = await client.createApiKey({
+      name: 'playwright',
+      scopes: ['read']
+    });
+    expect(createdKey.ok).toBe(true);
+    if (!createdKey.ok) {
+      throw new Error('api key creation should have succeeded');
+    }
+    expect(createdKey.data.secret).toMatch(/^ak_/);
+
+    const listedKeys = await client.listApiKeys();
+    expect(listedKeys.ok).toBe(true);
+    if (listedKeys.ok) {
+      expect(listedKeys.data.keys).toEqual([
+        expect.objectContaining({
+          id: createdKey.data.keyId,
+          scopes: ['read']
+        })
+      ]);
+    }
+
+    const authenticated = await auth.provider.authenticate(
+      new Request('https://account.example.com/demo/protected', {
+        headers: {
+          authorization: `Bearer ${createdKey.data.secret}`
+        }
+      })
+    );
+    expect(authenticated?.type).toBe('api-key');
+
+    const revokedKey = await client.revokeApiKey({
+      keyId: createdKey.data.keyId
+    });
+    expect(revokedKey.ok).toBe(true);
+
+    const disabled = await client.disableTwoFactor({
+      code: generateTotp(enrollment.data.secret)
+    });
+    expect(disabled.ok).toBe(true);
+    if (disabled.ok) {
+      expect(disabled.data.disabled).toBe(true);
+    }
+  });
+
+  it('returns typed runtime and region lookup envelopes for multi-region routes', async () => {
+    const { client } = createClient(createMultiRegionConfig(), 'https://us.account.example.com/auth');
+
+    const runtime = await client.getRuntime();
+    expect(runtime.ok).toBe(true);
+    if (runtime.ok) {
+      expect(runtime.data.regionId).toBe('us-east-1');
+      expect(runtime.data.cookie.prefix).toBe('authfn-us');
+      expect(runtime.data.oauth.google?.clientId).toBe('us-google-client');
+    }
+
+    const lookup = await client.lookupRegion({
+      identifier: 'ada@example.com'
+    });
+    expect(lookup.ok).toBe(true);
+    if (lookup.ok) {
+      expect(lookup.data.regionId).toBe('eu-west-1');
+      expect(lookup.data.redirectTo).toBe('https://eu.account.example.com');
+      expect(lookup.data.continueLocally).toBe(false);
+    }
+  });
+
+  it('returns canonical failure envelopes for 2fa disable and social disconnect', async () => {
+    const { client } = createClient(createAccountSettingsConfig(), 'https://account.example.com/auth');
+
+    const signUp = await client.signUpWithPassword({
+      email: ACCOUNT_EMAIL,
+      password: ACCOUNT_PASSWORD
+    });
+    if (!signUp.ok) {
+      throw new Error('sign-up should have succeeded');
+    }
+
+    const enrollment = await client.enableTwoFactor();
+    if (!enrollment.ok) {
+      throw new Error('2fa enrollment should have succeeded');
+    }
+
+    const confirm = await client.confirmTwoFactor({
+      code: generateTotp(enrollment.data.secret)
+    });
+    expect(confirm.ok).toBe(true);
+
+    const disable = await client.disableTwoFactor({
+      code: '000000'
+    });
+    expect(disable.ok).toBe(false);
+    if (!disable.ok) {
+      expect(disable.error.code).toBe('AUTHFN_2FA_INVALID_CODE');
+    }
+
+    const disconnectClient = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async (input, init) => {
+        expect(typeof input === 'string' ? input : input.toString()).toBe(
+          'https://account.example.com/auth/social/disconnect/google'
+        );
+        expect(init?.method).toBe('POST');
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: {
+              code: 'AUTHFN_NOT_FOUND',
+              message: 'Linked social account not found',
+              retryable: false
+            },
+            requestId: 'req_disconnect'
+          }),
+          {
+            status: 404,
+            headers: {
+              'content-type': 'application/json'
+            }
+          }
+        );
+      }
+    });
+
+    const disconnect = await disconnectClient.disconnectSocialAccount({
+      provider: 'google'
+    });
+    expect(disconnect.ok).toBe(false);
+    if (!disconnect.ok) {
+      expect(disconnect.error.code).toBe('AUTHFN_NOT_FOUND');
+    }
+  });
+});

--- a/authfn/client/src/__tests__/client-otp.test.ts
+++ b/authfn/client/src/__tests__/client-otp.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+import { memoryAdapter } from '../../../../packages/db/src/testing/index.js';
+import {
+  authFnEmailOtpPlugin,
+  authFnPasswordPlugin,
+  createAuthFn,
+  type AuthFnConfig,
+  type AuthFnDeliveryRequest
+} from '@authfn/core';
+import { createAuthFnClient } from '../index.js';
+import { createAuthFnHttpClient } from '../http-client.js';
+
+function createCookieJar() {
+  const values = new Map<string, string>();
+
+  return {
+    header(): string {
+      return Array.from(values.entries())
+        .map(([name, value]) => `${name}=${encodeURIComponent(value)}`)
+        .join('; ');
+    },
+    applySetCookies(cookies: string[]): void {
+      for (const cookie of cookies) {
+        const [pair] = cookie.split(';');
+        const separatorIndex = pair.indexOf('=');
+        const name = pair.slice(0, separatorIndex);
+        const value = decodeURIComponent(pair.slice(separatorIndex + 1));
+        if (value === '') {
+          values.delete(name);
+        } else {
+          values.set(name, value);
+        }
+      }
+    }
+  };
+}
+
+describe('@authfn/client otp flows', () => {
+  it('treats empty error responses as failures', async () => {
+    const client = createAuthFnHttpClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async () =>
+        new Response(null, {
+          status: 500,
+          headers: {
+            'x-request-id': 'req_empty'
+          }
+        })
+    });
+
+    const result = await client.requestJson({
+      method: 'GET',
+      path: '/session'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('empty 500 response should be treated as an error');
+    }
+    expect(result.error.code).toBe('AUTHFN_INTERNAL_ERROR');
+    expect(result.error.details?.status).toBe(500);
+  });
+
+  it('normalizes rejected fetch calls into an error envelope', async () => {
+    const client = createAuthFnHttpClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async () => {
+        throw new Error('socket closed');
+      }
+    });
+
+    const result = await client.requestJson({
+      method: 'GET',
+      path: '/session'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('rejected fetch should return an error envelope');
+    }
+    expect(result.error.code).toBe('AUTHFN_NETWORK_ERROR');
+    expect(result.error.message).toBe('socket closed');
+    expect(result.error.details?.name).toBe('Error');
+  });
+
+  it('treats invalid json payloads as envelope failures', async () => {
+    const client = createAuthFnHttpClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async () =>
+        new Response(JSON.stringify({ redirectTo: 'https://app.example.com/post-auth' }), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'x-request-id': 'req_invalid'
+          }
+        })
+    });
+
+    const result = await client.requestJson({
+      method: 'GET',
+      path: '/session'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('invalid JSON payload should be rejected');
+    }
+    expect(result.error.code).toBe('AUTHFN_INTERNAL_ERROR');
+    expect(result.requestId).toBe('req_invalid');
+  });
+
+  it('rejects malformed error envelopes that omit required fields', async () => {
+    const client = createAuthFnHttpClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async () =>
+        new Response(JSON.stringify({
+          ok: false,
+          error: {
+            code: 'AUTHFN_INVALID_CREDENTIALS'
+          },
+          requestId: 'req_malformed'
+        }), {
+          status: 401,
+          headers: {
+            'content-type': 'application/json',
+            'x-request-id': 'req_malformed'
+          }
+        })
+    });
+
+    const result = await client.requestJson({
+      method: 'GET',
+      path: '/session'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('malformed error envelopes should be rejected');
+    }
+    expect(result.error.code).toBe('AUTHFN_INTERNAL_ERROR');
+    expect(result.requestId).toBe('req_malformed');
+  });
+
+  it('does not throw when csrf cookie encoding is malformed', async () => {
+    const client = createAuthFnHttpClient({
+      baseUrl: 'https://account.example.com/auth',
+      cookieAccessor: () => 'authfn.session=session-token; authfn.csrf=bad%zzvalue',
+      fetch: async (_input, init) => {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            receivedCsrf: new Headers(init?.headers).get('x-authfn-csrf')
+          },
+          requestId: 'req_cookie'
+        }), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json'
+          }
+        });
+      }
+    });
+
+    const result = await client.requestJson<{
+      ok: true;
+      data: { receivedCsrf: string | null };
+      requestId: string;
+    }>({
+      method: 'POST',
+      path: '/sign-out',
+      body: {},
+      csrf: true
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error('malformed cookie values should not break requestJson');
+    }
+    expect(result.data.receivedCsrf).toBe('bad%zzvalue');
+  });
+
+  it('supports verify-email, otp sign-in, and reset-password completion', async () => {
+    const codes = new Map<string, string>();
+    const provider = {
+      async send(input: AuthFnDeliveryRequest) {
+        codes.set(`${input.purpose}:${input.email}`, input.code);
+        return { sent: true };
+      }
+    };
+
+    const auth = createAuthFn({
+      database: memoryAdapter({ debug: false }),
+      namespace: 'authfn',
+      plugins: [
+        authFnPasswordPlugin({
+          otp: {
+            delivery: provider,
+            codeGenerator: () => '731942'
+          }
+        }),
+        authFnEmailOtpPlugin({
+          delivery: provider,
+          codeGenerator: () => '731942'
+        })
+      ]
+    } satisfies AuthFnConfig);
+
+    const cookieJar = createCookieJar();
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      cookieAccessor: () => cookieJar.header(),
+      fetch: async (input, init) => {
+        const headers = new Headers(init?.headers);
+        const cookieHeader = cookieJar.header();
+        if (cookieHeader) {
+          headers.set('cookie', cookieHeader);
+        }
+        const response = await auth.router.handle(
+          new Request(typeof input === 'string' ? input : input.toString(), {
+            method: init?.method,
+            headers,
+            body: init?.body
+          })
+        );
+        cookieJar.applySetCookies(response.headers.getSetCookie());
+        return response;
+      }
+    });
+
+    await client.signUpWithPassword({
+      email: 'ada@example.com',
+      password: 'Sup3rSecurePassphrase!'
+    });
+    await client.signOut();
+
+    const sent = await client.sendOtp({
+      purpose: 'verify-email',
+      email: 'ada@example.com'
+    });
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) {
+      throw new Error('sendOtp should succeed');
+    }
+
+    const verified = await client.verifyOtp({
+      purpose: 'verify-email',
+      email: 'ada@example.com',
+      code: codes.get('verify-email:ada@example.com')!
+    });
+    expect(verified.ok).toBe(true);
+
+    await client.sendOtp({
+      purpose: 'sign-in',
+      email: 'ada@example.com'
+    });
+    const signedIn = await client.verifyOtp({
+      purpose: 'sign-in',
+      email: 'ada@example.com',
+      code: codes.get('sign-in:ada@example.com')!
+    });
+    expect(signedIn.ok).toBe(true);
+    if (!signedIn.ok || !('session' in signedIn.data)) {
+      throw new Error('otp sign-in should yield a session envelope');
+    }
+    expect(signedIn.data.session?.methods).toEqual(['email-otp']);
+
+    const currentSession = await client.getSession();
+    expect(currentSession.ok).toBe(true);
+    if (!currentSession.ok) {
+      throw new Error('getSession should succeed');
+    }
+    expect(currentSession.data.session?.primaryEmail).toBe('ada@example.com');
+
+    const resetStart = await client.startPasswordReset({
+      email: 'ada@example.com'
+    });
+    expect(resetStart.ok).toBe(true);
+
+    const resetComplete = await client.completePasswordReset({
+      email: 'ada@example.com',
+      code: codes.get('reset-password:ada@example.com')!,
+      newPassword: 'An0therSecurePassphrase!'
+    });
+    expect(resetComplete.ok).toBe(true);
+    if (!resetComplete.ok) {
+      throw new Error('reset completion should succeed');
+    }
+    expect(resetComplete.data.passwordUpdated).toBe(true);
+
+    await client.signOut();
+    const wrongOldPassword = await client.signInWithPassword({
+      email: 'ada@example.com',
+      password: 'Sup3rSecurePassphrase!'
+    });
+    expect(wrongOldPassword.ok).toBe(false);
+    if (wrongOldPassword.ok) {
+      throw new Error('old password should fail');
+    }
+    expect(wrongOldPassword.error.code).toBe('AUTHFN_INVALID_CREDENTIALS');
+
+    const newPassword = await client.signInWithPassword({
+      email: 'ada@example.com',
+      password: 'An0therSecurePassphrase!'
+    });
+    expect(newPassword.ok).toBe(true);
+  });
+});

--- a/authfn/client/src/__tests__/client-password.test.ts
+++ b/authfn/client/src/__tests__/client-password.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import { memoryAdapter } from '../../../../packages/db/src/testing/index.js';
+import { authFnPasswordPlugin, createAuthFn, type AuthFnConfig } from '@authfn/core';
+import { createAuthFnClient } from '../index.js';
+
+function createConfig(): AuthFnConfig {
+  return {
+    database: memoryAdapter({ debug: false }),
+    namespace: 'authfn',
+    plugins: [authFnPasswordPlugin()]
+  };
+}
+
+function createCookieJar() {
+  const values = new Map<string, string>();
+
+  return {
+    header(): string {
+      return Array.from(values.entries())
+        .map(([name, value]) => `${name}=${encodeURIComponent(value)}`)
+        .join('; ');
+    },
+    applySetCookies(cookies: string[]): void {
+      for (const cookie of cookies) {
+        const [pair] = cookie.split(';');
+        const separatorIndex = pair.indexOf('=');
+        const name = pair.slice(0, separatorIndex);
+        const value = decodeURIComponent(pair.slice(separatorIndex + 1));
+        if (value === '') {
+          values.delete(name);
+        } else {
+          values.set(name, value);
+        }
+      }
+    }
+  };
+}
+
+describe('@authfn/client password flows', () => {
+  it('uses cookie credentials by default and completes sign-up -> session -> sign-out', async () => {
+    const auth = createAuthFn(createConfig());
+    const cookieJar = createCookieJar();
+    const observedCredentials: RequestCredentials[] = [];
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      cookieAccessor: () => cookieJar.header(),
+      fetch: async (input, init) => {
+        observedCredentials.push(init?.credentials ?? 'omit');
+        const headers = new Headers(init?.headers);
+        const cookieHeader = cookieJar.header();
+        if (cookieHeader) {
+          headers.set('cookie', cookieHeader);
+        }
+
+        const response = await auth.router.handle(
+          new Request(typeof input === 'string' ? input : input.toString(), {
+            method: init?.method,
+            headers,
+            body: init?.body
+          })
+        );
+        cookieJar.applySetCookies(response.headers.getSetCookie());
+        return response;
+      }
+    });
+
+    const signUp = await client.signUpWithPassword({
+      email: 'ada@example.com',
+      password: 'Sup3rSecurePassphrase!'
+    });
+    if (!signUp.ok) {
+      throw new Error('sign-up should have succeeded');
+    }
+    expect(signUp.data.session.primaryEmail).toBe('ada@example.com');
+
+    const currentSession = await client.getSession();
+    if (!currentSession.ok) {
+      throw new Error('current session should have succeeded');
+    }
+    expect(currentSession.data.session?.methods).toEqual(['password']);
+
+    const signOut = await client.signOut();
+    if (!signOut.ok) {
+      throw new Error('sign-out should have succeeded');
+    }
+    expect(signOut.data.revoked).toBe(true);
+
+    const postSignOut = await client.getSession();
+    if (!postSignOut.ok) {
+      throw new Error('post sign-out session fetch should have succeeded');
+    }
+    expect(postSignOut.data.session).toBeNull();
+    expect(observedCredentials.every((value) => value === 'include')).toBe(true);
+  });
+
+  it('sends the csrf header from the readable csrf cookie on sign-out', async () => {
+    const auth = createAuthFn(createConfig());
+    const cookieJar = createCookieJar();
+    let observedCsrfHeader: string | null = null;
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      cookieAccessor: () => cookieJar.header(),
+      fetch: async (input, init) => {
+        const headers = new Headers(init?.headers);
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/sign-out')) {
+          observedCsrfHeader = headers.get('x-authfn-csrf');
+        }
+        const cookieHeader = cookieJar.header();
+        if (cookieHeader) {
+          headers.set('cookie', cookieHeader);
+        }
+
+        const response = await auth.router.handle(
+          new Request(url, {
+            method: init?.method,
+            headers,
+            body: init?.body
+          })
+        );
+        cookieJar.applySetCookies(response.headers.getSetCookie());
+        return response;
+      }
+    });
+
+    const signUp = await client.signUpWithPassword({
+      email: 'ada@example.com',
+      password: 'Sup3rSecurePassphrase!'
+    });
+    if (!signUp.ok) {
+      throw new Error('sign-up should have succeeded');
+    }
+
+    await client.signOut();
+    expect(observedCsrfHeader).toMatch(/^csrf_/);
+  });
+
+  it('uses an explicit cookie prefix when the session cookie is httpOnly and hidden from the accessor', async () => {
+    const auth = createAuthFn({
+      ...createConfig(),
+      cookie: {
+        prefix: 'demo-auth'
+      }
+    });
+    const cookieJar = createCookieJar();
+    let observedCsrfHeader: string | null = null;
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      cookieAccessor: () =>
+        cookieJar
+          .header()
+          .split('; ')
+          .filter((part) => !part.startsWith('demo-auth.session=') && !part.startsWith('__Secure-demo-auth.session='))
+          .join('; '),
+      cookiePrefix: 'demo-auth',
+      fetch: async (input, init) => {
+        const headers = new Headers(init?.headers);
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/sign-out')) {
+          observedCsrfHeader = headers.get('x-authfn-csrf');
+        }
+
+        const cookieHeader = cookieJar.header();
+        if (cookieHeader) {
+          headers.set('cookie', cookieHeader);
+        }
+
+        const response = await auth.router.handle(
+          new Request(url, {
+            method: init?.method,
+            headers,
+            body: init?.body
+          })
+        );
+        cookieJar.applySetCookies(response.headers.getSetCookie());
+        return response;
+      }
+    });
+
+    const signUp = await client.signUpWithPassword({
+      email: 'ada@example.com',
+      password: 'Sup3rSecurePassphrase!'
+    });
+    if (!signUp.ok) {
+      throw new Error('sign-up should have succeeded');
+    }
+
+    const signOut = await client.signOut();
+    expect(observedCsrfHeader).toMatch(/^csrf_/);
+    expect(signOut.ok).toBe(true);
+  });
+
+  it('returns canonical auth errors for wrong passwords', async () => {
+    const auth = createAuthFn(createConfig());
+    const cookieJar = createCookieJar();
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      cookieAccessor: () => cookieJar.header(),
+      fetch: async (input, init) => {
+        const headers = new Headers(init?.headers);
+        const cookieHeader = cookieJar.header();
+        if (cookieHeader) {
+          headers.set('cookie', cookieHeader);
+        }
+
+        const response = await auth.router.handle(
+          new Request(typeof input === 'string' ? input : input.toString(), {
+            method: init?.method,
+            headers,
+            body: init?.body
+          })
+        );
+        cookieJar.applySetCookies(response.headers.getSetCookie());
+        return response;
+      }
+    });
+
+    await client.signUpWithPassword({
+      email: 'ada@example.com',
+      password: 'Sup3rSecurePassphrase!'
+    });
+
+    const response = await client.signInWithPassword({
+      email: 'ada@example.com',
+      password: 'wrong-password'
+    });
+
+    expect(response.ok).toBe(false);
+    if (response.ok) {
+      throw new Error('wrong password should not have succeeded');
+    }
+    expect(response.error.code).toBe('AUTHFN_INVALID_CREDENTIALS');
+    expect(response.error.message).toBe('Invalid email or password');
+  });
+
+  it('maps non-json backend failures into a canonical authfn error envelope', async () => {
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async () =>
+        new Response('upstream exploded', {
+          status: 502,
+          headers: {
+            'content-type': 'text/plain',
+            'x-request-id': 'req_non_json'
+          }
+        })
+    });
+
+    const response = await client.getSession();
+    expect(response.ok).toBe(false);
+    if (response.ok) {
+      throw new Error('non-json failure should produce an authfn error envelope');
+    }
+    expect(response.error.code).toBe('AUTHFN_INTERNAL_ERROR');
+    expect(response.requestId).toBe('req_non_json');
+  });
+});

--- a/authfn/client/src/__tests__/client-social.test.ts
+++ b/authfn/client/src/__tests__/client-social.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { memoryAdapter } from '../../../../packages/db/src/testing/index.js';
+import {
+  authFnSocialOAuthPlugin,
+  createAuthFn,
+  type AuthFnConfig
+} from '@authfn/core';
+import { createAuthFnClient } from '../index.js';
+
+function createConfig(): AuthFnConfig {
+  return {
+    database: memoryAdapter({ debug: false }),
+    namespace: 'authfn',
+    plugins: [
+      authFnSocialOAuthPlugin({
+        providers: {
+          google: {
+            clientId: 'google-client-id',
+            clientSecret: 'google-client-secret',
+            allowlistedReturnTo: ['https://app.example.com/post-auth']
+          }
+        },
+        fetcher: async () => {
+          throw new Error('social start should not exchange tokens');
+        }
+      })
+    ]
+  };
+}
+
+describe('@authfn/client social flows', () => {
+  it('starts social sign-in and returns the redirect envelope', async () => {
+    const auth = createAuthFn(createConfig());
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async (input, init) =>
+        auth.router.handle(
+          new Request(typeof input === 'string' ? input : input.toString(), {
+            method: init?.method,
+            headers: init?.headers,
+            body: init?.body
+          })
+        )
+    });
+
+    const started = await client.startSocialSignIn({
+      provider: 'google',
+      returnTo: 'https://app.example.com/post-auth'
+    });
+
+    expect(started.ok).toBe(true);
+    if (!started.ok) {
+      throw new Error('social start should have succeeded');
+    }
+
+    expect(started.data).toEqual({
+      provider: 'google',
+      redirectTo: expect.stringContaining('https://accounts.google.com/o/oauth2/v2/auth'),
+      stateId: expect.any(String),
+      expiresAt: expect.any(String)
+    });
+  });
+
+  it('requests json callback mode by default for browser-safe redirects', async () => {
+    let receivedCallbackMode: unknown;
+    const auth = createAuthFn(createConfig());
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async (input, init) => {
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        receivedCallbackMode = body?.callbackMode;
+        return auth.router.handle(
+          new Request(typeof input === 'string' ? input : input.toString(), {
+            method: init?.method,
+            headers: init?.headers,
+            body: init?.body
+          })
+        );
+      }
+    });
+
+    const started = await client.startSocialSignIn({
+      provider: 'google'
+    });
+
+    expect(started.ok).toBe(true);
+    expect(receivedCallbackMode).toBe('json');
+  });
+
+  it('treats bare redirect responses as navigation-required errors', async () => {
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async () =>
+        new Response(null, {
+          status: 303,
+          headers: {
+            location: 'https://app.example.com/post-auth',
+            'x-request-id': 'req_redirect'
+          }
+        })
+    });
+
+    const started = await client.startSocialSignIn({
+      provider: 'google'
+    });
+
+    expect(started.ok).toBe(false);
+    if (started.ok) {
+      throw new Error('redirect response should require explicit navigation');
+    }
+    expect(started.error.code).toBe('AUTHFN_REDIRECT_REQUIRES_NAVIGATION');
+    expect(started.error.details?.redirectTo).toBe('https://app.example.com/post-auth');
+    expect(started.requestId).toBe('req_redirect');
+  });
+
+  it('keeps callback mode pinned to json', async () => {
+    let receivedCallbackMode: unknown;
+    const auth = createAuthFn(createConfig());
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async (input, init) => {
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        receivedCallbackMode = body?.callbackMode;
+        return auth.router.handle(
+          new Request(typeof input === 'string' ? input : input.toString(), {
+            method: init?.method,
+            headers: init?.headers,
+            body: init?.body
+          })
+        );
+      }
+    });
+
+    const started = await client.startSocialSignIn({
+      provider: 'google',
+      returnTo: 'https://app.example.com/post-auth'
+    });
+
+    expect(started.ok).toBe(true);
+    expect(receivedCallbackMode).toBe('json');
+  });
+
+  it('ignores raw caller attempts to force redirect callback mode', async () => {
+    let receivedCallbackMode: unknown;
+    const auth = createAuthFn(createConfig());
+
+    const client = createAuthFnClient({
+      baseUrl: 'https://account.example.com/auth',
+      fetch: async (input, init) => {
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        receivedCallbackMode = body?.callbackMode;
+        return auth.router.handle(
+          new Request(typeof input === 'string' ? input : input.toString(), {
+            method: init?.method,
+            headers: init?.headers,
+            body: init?.body
+          })
+        );
+      }
+    });
+
+    const started = await client.startSocialSignIn({
+      provider: 'google',
+      returnTo: 'https://app.example.com/post-auth',
+      callbackMode: 'redirect' as never
+    });
+
+    expect(started.ok).toBe(true);
+    expect(receivedCallbackMode).toBe('json');
+  });
+});

--- a/authfn/client/src/http-client.ts
+++ b/authfn/client/src/http-client.ts
@@ -1,0 +1,214 @@
+import type { AuthFnClientOptions, AuthFnErrorEnvelope } from './types.js';
+
+interface RequestOptions {
+  method: 'GET' | 'POST' | 'DELETE';
+  path: string;
+  body?: unknown;
+  csrf?: boolean;
+}
+
+export function createAuthFnHttpClient(options: AuthFnClientOptions = {}) {
+  const fetchImpl = options.fetch ?? fetch;
+  const baseUrl = (options.baseUrl ?? '/auth').replace(/\/$/, '');
+  const credentials = options.credentials ?? 'include';
+  const cookieAccessor = options.cookieAccessor ?? defaultCookieAccessor;
+  const cookiePrefix = options.cookiePrefix?.trim();
+  const buildTransportError = (error: unknown): AuthFnErrorEnvelope => ({
+    ok: false,
+    error: {
+      code: 'AUTHFN_NETWORK_ERROR',
+      message:
+        error instanceof Error
+          ? error.message
+          : 'AuthFn request failed before a response was received',
+      retryable: true,
+      details:
+        error instanceof Error
+          ? {
+              name: error.name,
+              stack: error.stack
+            }
+          : {
+              cause: error
+            }
+    },
+    requestId: 'authfn-transport-error'
+  });
+
+  return {
+    requestJson: async <T>(request: RequestOptions): Promise<T | AuthFnErrorEnvelope> => {
+      const headers = new Headers();
+
+      if (request.body !== undefined) {
+        headers.set('content-type', 'application/json');
+      }
+
+      if (request.csrf) {
+        const cookieHeader = cookieAccessor();
+        const csrfToken = readCookieValue(
+          cookieHeader,
+          `${cookiePrefix || readCookiePrefix(cookieHeader)}.csrf`
+        );
+        if (csrfToken) {
+          headers.set('x-authfn-csrf', csrfToken);
+        }
+      }
+
+      let response: Response;
+      try {
+        response = await fetchImpl(`${baseUrl}${request.path}`, {
+          method: request.method,
+          headers,
+          credentials,
+          body: request.body !== undefined ? JSON.stringify(request.body) : undefined
+        });
+      } catch (error) {
+        return buildTransportError(error);
+      }
+
+      if (response.status >= 300 && response.status < 400 && response.headers.get('location')) {
+        return {
+          ok: false,
+          error: {
+            code: 'AUTHFN_REDIRECT_REQUIRES_NAVIGATION',
+            message: 'Browser clients must use JSON callback mode or navigate directly for redirect-based auth flows',
+            retryable: false,
+            details: {
+              status: response.status,
+              redirectTo: response.headers.get('location')
+            }
+          },
+          requestId: response.headers.get('x-request-id') ?? 'authfn-redirect'
+        };
+      }
+
+      const raw = await response.text();
+      if (!raw) {
+        if (!response.ok) {
+          return {
+            ok: false,
+            error: {
+              code: 'AUTHFN_INTERNAL_ERROR',
+              message: `AuthFn returned an empty error response (${response.status})`,
+              retryable: response.status >= 500,
+              details: {
+                status: response.status
+              }
+            },
+            requestId: response.headers.get('x-request-id') ?? 'authfn-empty'
+          };
+        }
+
+        return {
+          ok: true,
+          data: {} as Record<string, never>,
+          requestId: response.headers.get('x-request-id') ?? 'authfn-empty'
+        } as T;
+      }
+
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (!isAuthFnEnvelope(parsed)) {
+          return {
+            ok: false,
+            error: {
+              code: 'AUTHFN_INTERNAL_ERROR',
+              message: `AuthFn returned an invalid JSON envelope (${response.status})`,
+              retryable: response.status >= 500,
+              details: {
+                status: response.status
+              }
+            },
+            requestId: response.headers.get('x-request-id') ?? 'authfn-invalid-envelope'
+          };
+        }
+        return parsed as T | AuthFnErrorEnvelope;
+      } catch {
+        return {
+          ok: false,
+          error: {
+            code: 'AUTHFN_INTERNAL_ERROR',
+            message: response.ok
+              ? 'AuthFn returned a non-JSON response'
+              : `AuthFn returned a non-JSON error response (${response.status})`,
+            retryable: response.status >= 500,
+            details: {
+              status: response.status
+            }
+          },
+          requestId: response.headers.get('x-request-id') ?? 'authfn-non-json'
+        };
+      }
+    }
+  };
+}
+
+function isAuthFnEnvelope(value: unknown): value is { ok: boolean; requestId: string } {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.ok !== 'boolean' || typeof candidate.requestId !== 'string') {
+    return false;
+  }
+
+  if (candidate.ok) {
+    return 'data' in candidate;
+  }
+
+  const error = candidate.error;
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const envelopeError = error as Record<string, unknown>;
+  return (
+    typeof envelopeError.code === 'string'
+    && typeof envelopeError.message === 'string'
+    && typeof envelopeError.retryable === 'boolean'
+  );
+}
+
+function defaultCookieAccessor(): string | undefined {
+  const documentLike = globalThis.document as { cookie?: string } | undefined;
+  return documentLike?.cookie;
+}
+
+function readCookiePrefix(cookieHeader: string | undefined): string {
+  if (!cookieHeader) {
+    return 'authfn';
+  }
+
+  for (const part of cookieHeader.split(';')) {
+    const [rawName] = part.trim().split('=');
+    if (rawName.startsWith('__Secure-') && rawName.endsWith('.session')) {
+      return rawName.slice('__Secure-'.length, -'.session'.length);
+    }
+    if (rawName.endsWith('.session')) {
+      return rawName.slice(0, -'.session'.length);
+    }
+  }
+
+  return 'authfn';
+}
+
+function readCookieValue(cookieHeader: string | undefined, name: string): string | undefined {
+  if (!cookieHeader) {
+    return undefined;
+  }
+
+  for (const part of cookieHeader.split(';')) {
+    const [rawName, ...valueParts] = part.trim().split('=');
+    if (rawName === name) {
+      const rawValue = valueParts.join('=');
+      try {
+        return decodeURIComponent(rawValue);
+      } catch {
+        return rawValue;
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/authfn/client/src/index.ts
+++ b/authfn/client/src/index.ts
@@ -1,0 +1,143 @@
+import { createAuthFnHttpClient } from './http-client.js';
+import type {
+  AuthFnClient,
+  AuthFnClientOptions
+} from './types.js';
+
+export type * from './types.js';
+
+export function createAuthFnClient(options: AuthFnClientOptions = {}): AuthFnClient {
+  const http = createAuthFnHttpClient(options);
+
+  return {
+    getSession: () =>
+      http.requestJson({
+        method: 'GET',
+        path: '/session'
+      }),
+    signUpWithPassword: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/sign-up/password',
+        body: input
+      }),
+    signInWithPassword: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/sign-in/password',
+        body: input
+      }),
+    signOut: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/sign-out',
+        body: input ?? {},
+        csrf: true
+      }),
+    listSessions: () =>
+      http.requestJson({
+        method: 'GET',
+        path: '/sessions'
+      }),
+    revokeSession: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: `/sessions/${encodeURIComponent(input.sessionId)}/revoke`,
+        csrf: true
+      }),
+    sendOtp: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/otp/send',
+        body: input
+      }),
+    startPasswordReset: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/password/reset/start',
+        body: input
+      }),
+    verifyOtp: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/otp/verify',
+        body: input
+      }),
+    completePasswordReset: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/password/reset/complete',
+        body: input
+      }),
+    startSocialSignIn: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/social/start',
+        body: {
+          ...input,
+          callbackMode: 'json'
+        }
+      }),
+    disconnectSocialAccount: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: `/social/disconnect/${encodeURIComponent(input.provider)}`,
+        csrf: true
+      }),
+    createApiKey: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/api-keys',
+        body: input,
+        csrf: true
+      }),
+    listApiKeys: () =>
+      http.requestJson({
+        method: 'GET',
+        path: '/api-keys'
+      }),
+    revokeApiKey: (input) =>
+      http.requestJson({
+        method: 'DELETE',
+        path: `/api-keys/${encodeURIComponent(input.keyId)}`,
+        csrf: true
+      }),
+    enableTwoFactor: () =>
+      http.requestJson({
+        method: 'POST',
+        path: '/2fa/enroll',
+        csrf: true
+      }),
+    confirmTwoFactor: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/2fa/confirm',
+        body: input,
+        csrf: true
+      }),
+    completeTwoFactorChallenge: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/2fa/challenge',
+        body: input
+      }),
+    disableTwoFactor: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/2fa/disable',
+        body: input,
+        csrf: true
+      }),
+    lookupRegion: (input) =>
+      http.requestJson({
+        method: 'POST',
+        path: '/regions/lookup',
+        body: input
+      }),
+    getRuntime: () =>
+      http.requestJson({
+        method: 'GET',
+        path: '/runtime'
+      })
+  };
+}

--- a/authfn/client/src/types.ts
+++ b/authfn/client/src/types.ts
@@ -1,0 +1,212 @@
+export type AuthFnActorType = 'user' | 'api-key';
+export type AuthFnSocialProviderId = 'google' | 'apple' | 'github';
+export type AuthFnAuthMethod =
+  | 'password'
+  | 'email-otp'
+  | 'oauth-google'
+  | 'oauth-apple'
+  | 'oauth-github'
+  | 'api-key'
+  | 'two-factor';
+
+export interface AuthFnSession {
+  id: string;
+  type: 'session' | 'api-key';
+  subject: {
+    actorId: string;
+    actorType: AuthFnActorType;
+    tenantId?: string;
+    regionId?: string;
+    email?: string;
+    attributes?: Record<string, unknown>;
+  };
+  actorType: AuthFnActorType;
+  actorId: string;
+  tenantId?: string;
+  regionId?: string;
+  resourceIds: string[];
+  methods: AuthFnAuthMethod[];
+  primaryEmail?: string;
+  expiresAt?: Date | string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuthFnSuccessEnvelope<TData = Record<string, unknown>> {
+  ok: true;
+  data: TData;
+  requestId: string;
+}
+
+export interface AuthFnErrorEnvelope {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    retryable: boolean;
+    details?: Record<string, unknown>;
+  };
+  requestId: string;
+}
+
+export interface AuthFnSessionEnvelope extends AuthFnSuccessEnvelope<{
+  session: AuthFnSession | null;
+}> {}
+
+export interface AuthFnListSessionsEnvelope extends AuthFnSuccessEnvelope<{
+  sessions: AuthFnSession[];
+  currentSessionId?: string;
+}> {}
+
+export interface AuthFnOtpEnvelope extends AuthFnSuccessEnvelope<{
+  challengeId?: string;
+  sent: boolean;
+}> {}
+
+export interface AuthFnVerifyOtpEnvelope extends AuthFnSuccessEnvelope<{
+  verified: true;
+}> {}
+
+export interface AuthFnApiKeyRecord {
+  id: string;
+  userId?: string | null;
+  name?: string | null;
+  scopes?: string[] | null;
+  metadata?: Record<string, unknown> | null;
+  expiresAt?: Date | string | null;
+  revokedAt?: Date | string | null;
+  lastUsedAt?: Date | string | null;
+  createdAt?: Date | string;
+  updatedAt?: Date | string;
+}
+
+export interface AuthFnRegionLookupResult {
+  identifier: string;
+  userId?: string;
+  regionId: string;
+  authority: string;
+  domain?: string;
+  continueLocally: boolean;
+  redirectTo?: string;
+}
+
+export interface AuthFnRuntimeResolution {
+  issuer: string;
+  baseUrl: string;
+  regionId: string | null;
+  cookie: {
+    prefix: string;
+    domain: string | null;
+    secure: boolean;
+    sameSite: 'strict' | 'lax' | 'none';
+    path: string;
+    sessionCookieName: string;
+    csrfCookieName: string;
+  };
+  oauth: Record<string, {
+    clientId: string | null;
+    hasClientSecret: boolean;
+    hasClientSecretResolver: boolean;
+    allowlistedRedirectUris: string[];
+    allowlistedReturnTo: string[];
+    scopes: string[];
+  }>;
+}
+
+export interface AuthFnClient {
+  getSession(): Promise<AuthFnSessionEnvelope | AuthFnErrorEnvelope>;
+  signUpWithPassword(input: {
+    email: string;
+    password: string;
+    profile?: Record<string, unknown>;
+  }): Promise<AuthFnSessionEnvelope | AuthFnErrorEnvelope>;
+  signInWithPassword(input: {
+    email: string;
+    password: string;
+  }): Promise<AuthFnSessionEnvelope | AuthFnErrorEnvelope>;
+  signOut(input?: { allSessions?: boolean }): Promise<AuthFnSuccessEnvelope<{ revoked: boolean; allSessions: boolean; }> | AuthFnErrorEnvelope>;
+  listSessions(): Promise<AuthFnListSessionsEnvelope | AuthFnErrorEnvelope>;
+  revokeSession(input: { sessionId: string }): Promise<AuthFnSuccessEnvelope<{ revoked: boolean; sessionId: string; }> | AuthFnErrorEnvelope>;
+  sendOtp(input: {
+    purpose: 'verify-email' | 'sign-in' | 'reset-password';
+    email: string;
+  }): Promise<AuthFnOtpEnvelope | AuthFnErrorEnvelope>;
+  startPasswordReset(input: {
+    email: string;
+  }): Promise<AuthFnOtpEnvelope | AuthFnErrorEnvelope>;
+  verifyOtp(input: {
+    purpose: 'verify-email' | 'sign-in' | 'reset-password';
+    email: string;
+    code: string;
+  }): Promise<AuthFnSessionEnvelope | AuthFnVerifyOtpEnvelope | AuthFnErrorEnvelope>;
+  completePasswordReset(input: {
+    email: string;
+    code: string;
+    newPassword: string;
+  }): Promise<AuthFnSuccessEnvelope<{ passwordUpdated: true; }> | AuthFnErrorEnvelope>;
+  startSocialSignIn(input: {
+    provider: AuthFnSocialProviderId;
+    returnTo?: string;
+    callbackMode?: 'json';
+  }): Promise<AuthFnSuccessEnvelope<{
+    provider: AuthFnSocialProviderId;
+    redirectTo: string;
+    stateId: string;
+    expiresAt: string;
+  }> | AuthFnErrorEnvelope>;
+  disconnectSocialAccount(input: {
+    provider: AuthFnSocialProviderId;
+  }): Promise<AuthFnSuccessEnvelope<{
+    disconnected: boolean;
+    provider: AuthFnSocialProviderId;
+  }> | AuthFnErrorEnvelope>;
+  createApiKey(input: {
+    name?: string;
+    scopes?: string[];
+    metadata?: Record<string, unknown>;
+    expiresAt?: string;
+  }): Promise<AuthFnSuccessEnvelope<{
+    keyId: string;
+    secret: string;
+    secretReturnedOnce: true;
+  }> | AuthFnErrorEnvelope>;
+  listApiKeys(): Promise<AuthFnSuccessEnvelope<{
+    keys: AuthFnApiKeyRecord[];
+  }> | AuthFnErrorEnvelope>;
+  revokeApiKey(input: {
+    keyId: string;
+  }): Promise<AuthFnSuccessEnvelope<{
+    revoked: boolean;
+    keyId: string;
+  }> | AuthFnErrorEnvelope>;
+  enableTwoFactor(): Promise<AuthFnSuccessEnvelope<{
+    enrollmentId: string;
+    secret: string;
+    otpauthUri: string;
+    recoveryCodes: string[];
+  }> | AuthFnErrorEnvelope>;
+  confirmTwoFactor(input: { code: string }): Promise<AuthFnSuccessEnvelope | AuthFnErrorEnvelope>;
+  completeTwoFactorChallenge(input: {
+    challengeId: string;
+    code: string;
+  }): Promise<AuthFnSuccessEnvelope<{
+    twoFactorSatisfied: true;
+    session: AuthFnSession;
+  }> | AuthFnErrorEnvelope>;
+  disableTwoFactor(input: {
+    code: string;
+  }): Promise<AuthFnSuccessEnvelope<{
+    disabled: true;
+  }> | AuthFnErrorEnvelope>;
+  lookupRegion(input: {
+    identifier: string;
+  }): Promise<AuthFnSuccessEnvelope<AuthFnRegionLookupResult> | AuthFnErrorEnvelope>;
+  getRuntime(): Promise<AuthFnSuccessEnvelope<AuthFnRuntimeResolution> | AuthFnErrorEnvelope>;
+}
+
+export interface AuthFnClientOptions {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+  cookieAccessor?: () => string | undefined;
+  cookiePrefix?: string;
+  credentials?: RequestCredentials;
+}

--- a/authfn/client/tsconfig.json
+++ b/authfn/client/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/__tests__/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the new `@authfn/client` browser package
- ship typed client flows for password, OTP, social OAuth, and account settings
- include browser-facing regression coverage for the new client surface

## Tests
- `npm run build` in `authfn/client`
- `npm run typecheck` in `authfn/client`
- `npm test` in `authfn/client`

## Notes
- `.conduct` was excluded for the `origin/dev` target

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@authfn/client`, a typed browser SDK for `authfn` that exposes core auth flows, session management, and multi‑region helpers for web apps. Implements SF-21.

- **New Features**
  - New package `@authfn/client` exporting `createAuthFnClient`
  - Auth: password, email OTP, social OAuth (start), social disconnect, 2FA (enroll/confirm/challenge/disable), API keys
  - Sessions: get/list/revoke, sign‑in/sign‑up/sign‑out (CSRF protected)
  - Multi‑region: `lookupRegion`, `getRuntime`
  - Social: pins `startSocialSignIn` to `callbackMode: 'json'` for safe redirects
  - HTTP: `credentials='include'` by default; validates JSON envelopes; supports explicit `cookiePrefix`

- **Bug Fixes**
  - Treats 3xx with Location as `AUTHFN_REDIRECT_REQUIRES_NAVIGATION` (includes redirect URL)
  - Maps non‑JSON, empty, or malformed envelopes to `AUTHFN_INTERNAL_ERROR` with status details
  - Converts rejected fetches into `AUTHFN_NETWORK_ERROR` with error details
  - Sends CSRF from `${prefix}.csrf` via detected or explicit prefix; tolerates malformed CSRF cookie encoding

<sup>Written for commit e105c938ce62a77e7d1da4b183b9590f7dbe5c6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public client library with a typed API and HTTP client for sign-up/sign-in, password management, OTP, two‑factor, social sign‑in, API keys, account settings, region/runtime lookup, and session operations.

* **Tests**
  * Extensive end-to-end and error‑path tests covering password flows, OTP, two‑factor, social auth, API key lifecycle, account settings, multi‑region behavior, and transport/response normalization.

* **Chores**
  * Packaging manifest, TypeScript build config, and build/test/typecheck scripts added for the new client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->