### PR TITLE
SF-21: feat(authfn): add svelte package

### DIFF
--- a/authfn/svelte/package.json
+++ b/authfn/svelte/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@authfn/svelte",
+  "version": "0.0.1",
+  "description": "Svelte wrappers for authfn client",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@authfn/client": "^0.0.1",
+    "svelte": "^5.0.0"
+  },
+  "devDependencies": {
+    "@authfn/client": "^0.0.1",
+    "@types/node": "^22.0.0",
+    "svelte": "^5.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/authfn/svelte/src/__tests__/session-store.test.ts
+++ b/authfn/svelte/src/__tests__/session-store.test.ts
@@ -1,0 +1,192 @@
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+import { createAuthFnSessionStore } from '../session-store.js';
+
+describe('@authfn/svelte session store', () => {
+  it('wraps client.getSession without reimplementing auth logic', async () => {
+    const calls: string[] = [];
+    const store = createAuthFnSessionStore({
+      async getSession() {
+        calls.push('getSession');
+        return {
+          ok: true,
+          data: {
+            session: {
+              id: 'sess_01',
+              type: 'session',
+              subject: {
+                actorId: 'user_01',
+                actorType: 'user',
+                email: 'ada@example.com'
+              },
+              actorType: 'user',
+              actorId: 'user_01',
+              resourceIds: [],
+              methods: ['password'],
+              primaryEmail: 'ada@example.com'
+            }
+          },
+          requestId: 'req_01'
+        };
+      }
+    } as any);
+
+    await store.refresh();
+
+    expect(get(store)).toMatchObject({
+      id: 'sess_01',
+      primaryEmail: 'ada@example.com',
+      methods: ['password']
+    });
+    expect(calls).toEqual(['getSession', 'getSession']);
+  });
+
+  it('clears the store and treats client errors as empty session state', async () => {
+    const responses = [
+      Promise.resolve({
+        ok: false,
+        error: {
+          code: 'AUTHFN_UNAUTHENTICATED',
+          message: 'Authentication required',
+          retryable: false
+        },
+        requestId: 'req_02'
+      }),
+      Promise.resolve({
+        ok: false,
+        error: {
+          code: 'AUTHFN_UNAUTHENTICATED',
+          message: 'Authentication required',
+          retryable: false
+        },
+        requestId: 'req_02'
+      })
+    ];
+
+    const store = createAuthFnSessionStore({
+      async getSession() {
+        return responses.shift()!;
+      }
+    } as any);
+
+    await store.refresh();
+    expect(get(store)).toBeNull();
+
+    store.clear();
+    expect(get(store)).toBeNull();
+  });
+
+  it('does not let an older refresh overwrite a newer session state', async () => {
+    let resolveFirst: ((value: any) => void) | undefined;
+    const store = createAuthFnSessionStore({
+      async getSession() {
+        if (!resolveFirst) {
+          return await new Promise((resolve) => {
+            resolveFirst = resolve;
+          }) as never;
+        }
+
+        return {
+          ok: true,
+          data: {
+            session: {
+              id: 'sess_newer',
+              type: 'session',
+              actorType: 'user',
+              actorId: 'user_1',
+              resourceIds: [],
+              methods: ['password']
+            }
+          },
+          requestId: 'req_newer'
+        };
+      }
+    } as any);
+
+    const firstRefresh = store.refresh();
+    const secondRefresh = store.refresh();
+    await secondRefresh;
+
+    resolveFirst?.({
+      ok: true,
+      data: {
+        session: {
+          id: 'sess_older',
+          type: 'session',
+          actorType: 'user',
+          actorId: 'user_1',
+          resourceIds: [],
+          methods: ['password']
+        }
+      },
+      requestId: 'req_older'
+    });
+    await firstRefresh;
+
+    expect(get(store)?.id).toBe('sess_newer');
+  });
+
+  it('returns the current store state when an older refresh resolves late', async () => {
+    let callCount = 0;
+    let resolveStale: ((value: any) => void) | undefined;
+    const store = createAuthFnSessionStore({
+      async getSession() {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            ok: true,
+            data: {
+              session: null
+            },
+            requestId: 'req_initial'
+          };
+        }
+
+        if (callCount === 2) {
+          return await new Promise((resolve) => {
+            resolveStale = resolve;
+          }) as never;
+        }
+
+        return {
+          ok: true,
+          data: {
+            session: {
+              id: 'sess_current',
+              type: 'session',
+              actorType: 'user',
+              actorId: 'user_1',
+              resourceIds: [],
+              methods: ['password']
+            }
+          },
+          requestId: 'req_current'
+        };
+      }
+    } as any);
+
+    const firstRefresh = store.refresh();
+    const secondResult = await store.refresh();
+
+    resolveStale?.({
+      ok: true,
+      data: {
+        session: {
+          id: 'sess_stale',
+          type: 'session',
+          actorType: 'user',
+          actorId: 'user_1',
+          resourceIds: [],
+          methods: ['password']
+        }
+      },
+      requestId: 'req_stale'
+    });
+
+    const firstResult = await firstRefresh;
+
+    expect(secondResult?.id).toBe('sess_current');
+    expect(firstResult?.id).toBe('sess_current');
+    expect(get(store)?.id).toBe('sess_current');
+  });
+});

--- a/authfn/svelte/src/index.ts
+++ b/authfn/svelte/src/index.ts
@@ -1,0 +1,25 @@
+export {
+  createAuthFnSessionStore,
+  type AuthFnSessionStore
+} from './session-store.js';
+
+import type { AuthFnClient } from '@authfn/client';
+import { getContext, setContext } from 'svelte';
+
+const AUTHFN_CLIENT_CONTEXT = Symbol('authfn-client');
+
+export function createAuthFnClientContext(client: AuthFnClient): { client: AuthFnClient } {
+  const value = { client };
+  setContext(AUTHFN_CLIENT_CONTEXT, value);
+  return value;
+}
+
+export function getAuthFnClientContext(): { client: AuthFnClient } {
+  const value = getContext<{ client: AuthFnClient } | undefined>(AUTHFN_CLIENT_CONTEXT);
+  if (!value) {
+    throw new Error(
+      '@authfn/svelte: AuthFn client context is not set. Call createAuthFnClientContext() in a parent component first.'
+    );
+  }
+  return value;
+}

--- a/authfn/svelte/src/session-store.ts
+++ b/authfn/svelte/src/session-store.ts
@@ -1,0 +1,48 @@
+import type { AuthFnClient, AuthFnSession } from '@authfn/client';
+import { writable, type Readable } from 'svelte/store';
+
+export interface AuthFnSessionStore extends Readable<AuthFnSession | null> {
+  refresh(): Promise<AuthFnSession | null>;
+  clear(): void;
+}
+
+export function createAuthFnSessionStore(client: AuthFnClient): AuthFnSessionStore {
+  const store = writable<AuthFnSession | null>(null);
+  let currentSession: AuthFnSession | null = null;
+  let refreshVersion = 0;
+
+  const setSession = (session: AuthFnSession | null): void => {
+    currentSession = session;
+    store.set(session);
+  };
+
+  const refresh = async (): Promise<AuthFnSession | null> => {
+    const currentVersion = ++refreshVersion;
+    try {
+      const result = await client.getSession();
+      const session = result.ok ? result.data.session : null;
+      if (currentVersion === refreshVersion) {
+        setSession(session);
+        return session;
+      }
+      return currentSession;
+    } catch {
+      if (currentVersion === refreshVersion) {
+        setSession(null);
+        return null;
+      }
+      return currentSession;
+    }
+  };
+
+  void refresh();
+
+  return {
+    subscribe: store.subscribe,
+    refresh,
+    clear() {
+      refreshVersion += 1;
+      setSession(null);
+    }
+  };
+}

--- a/authfn/svelte/tsconfig.json
+++ b/authfn/svelte/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/__tests__/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the new `@authfn/svelte` package
- ship Svelte session-store wrappers on top of the authfn client package
- include focused store coverage for the Svelte integration surface

## Tests
- `npm test` in `authfn/svelte`

## Notes
- `.conduct` was excluded for the `origin/dev` target

## Summary by Sourcery

Add a new Svelte integration package for authfn providing session store utilities and basic client wiring for Svelte apps.

New Features:
- Introduce the `@authfn/svelte` package exposing Svelte-friendly wrappers around the authfn client.
- Provide a Svelte store-based session helper that manages fetching, refreshing, and clearing the current auth session.
- Add a helper to create a simple authfn client context object for consumption in Svelte components.

Tests:
- Add focused Vitest coverage for the Svelte session store behavior and integration surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@authfn/svelte`, a lightweight Svelte integration for AuthFn. Implements SF-21 with a reactive session store around `@authfn/client` and simple Svelte context helpers.

- **New Features**
  - `createAuthFnSessionStore(client)`: readable `AuthFnSession | null`; auto-refreshes on init via `client.getSession()`, exposes `refresh()` and `clear()`, treats non-OK/errors as no session, and ignores stale refresh results.
  - `createAuthFnClientContext(client)` / `getAuthFnClientContext()`: set and read the client via Svelte context; throws a clear error if no context is set.

<sup>Written for commit b15e4f4c3113f7cdfebd5e6c6195687376bf743d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched @authfn/svelte: reactive session store with refresh/clear controls and Svelte context utilities for easy client integration.
* **Tests**
  * Added comprehensive tests validating refresh behavior, concurrency semantics, error handling, and clear semantics for the session store.
* **Chores**
  * Package and TypeScript configuration added to publish a minimal Svelte wrapper distribution with build/test scripts and type declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->