### PR TITLE
SF-28 add monorepo-aware CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,191 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - next
+      - main
+  pull_request:
+    branches:
+      - dev
+      - next
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    name: Plan
+    runs-on: ubuntu-latest
+    outputs:
+      base_ref: ${{ steps.plan.outputs.base_ref }}
+      changed_files_count: ${{ steps.plan.outputs.changed_files_count }}
+      run_js: ${{ steps.plan.outputs.run_js }}
+      full_js: ${{ steps.plan.outputs.full_js }}
+      has_js_build: ${{ steps.plan.outputs.has_js_build }}
+      has_js_test: ${{ steps.plan.outputs.has_js_test }}
+      has_js_lint: ${{ steps.plan.outputs.has_js_lint }}
+      has_js_typecheck: ${{ steps.plan.outputs.has_js_typecheck }}
+      js_build_filters: ${{ steps.plan.outputs.js_build_filters }}
+      js_test_filters: ${{ steps.plan.outputs.js_test_filters }}
+      js_lint_filters: ${{ steps.plan.outputs.js_lint_filters }}
+      js_typecheck_filters: ${{ steps.plan.outputs.js_typecheck_filters }}
+      run_python: ${{ steps.plan.outputs.run_python }}
+      full_python: ${{ steps.plan.outputs.full_python }}
+      python_matrix: ${{ steps.plan.outputs.python_matrix }}
+      run_docs: ${{ steps.plan.outputs.run_docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Refresh common target branches
+        run: |
+          git fetch --no-tags --depth=1 origin dev || true
+          git fetch --no-tags --depth=1 origin next || true
+          git fetch --no-tags --depth=1 origin main || true
+
+      - name: Build CI plan
+        id: plan
+        run: node scripts/ci-plan.mjs
+
+  javascript:
+    name: JavaScript
+    needs: plan
+    if: needs.plan.outputs.run_js == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Show plan
+        run: |
+          echo "base: ${{ needs.plan.outputs.base_ref }}"
+          echo "changed files: ${{ needs.plan.outputs.changed_files_count }}"
+          echo "full js: ${{ needs.plan.outputs.full_js }}"
+          echo "build filters: ${{ needs.plan.outputs.js_build_filters }}"
+          echo "test filters: ${{ needs.plan.outputs.js_test_filters }}"
+          echo "lint filters: ${{ needs.plan.outputs.js_lint_filters }}"
+          echo "typecheck filters: ${{ needs.plan.outputs.js_typecheck_filters }}"
+
+      - name: Build
+        if: needs.plan.outputs.has_js_build == 'true'
+        run: |
+          if [ "${{ needs.plan.outputs.full_js }}" = "true" ]; then
+            npx turbo run build
+          else
+            npx turbo run build ${{ needs.plan.outputs.js_build_filters }}
+          fi
+
+      - name: Typecheck
+        if: needs.plan.outputs.has_js_typecheck == 'true'
+        run: |
+          if [ "${{ needs.plan.outputs.full_js }}" = "true" ]; then
+            npx turbo run typecheck
+          else
+            npx turbo run typecheck ${{ needs.plan.outputs.js_typecheck_filters }}
+          fi
+
+      - name: Test
+        if: needs.plan.outputs.has_js_test == 'true'
+        run: |
+          if [ "${{ needs.plan.outputs.full_js }}" = "true" ]; then
+            npx turbo run test
+          else
+            npx turbo run test ${{ needs.plan.outputs.js_test_filters }}
+          fi
+
+      - name: Lint
+        if: needs.plan.outputs.has_js_lint == 'true'
+        run: |
+          if [ "${{ needs.plan.outputs.full_js }}" = "true" ]; then
+            npx turbo run lint
+          else
+            npx turbo run lint ${{ needs.plan.outputs.js_lint_filters }}
+          fi
+
+  python:
+    name: Python
+    needs: plan
+    if: needs.plan.outputs.run_python == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.plan.outputs.python_matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            **/pyproject.toml
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip build
+
+      - name: Check package
+        run: node scripts/ci-run-python-package.mjs "${{ matrix.package.path }}"
+
+  docs:
+    name: Docs Guardrails
+    needs: plan
+    if: needs.plan.outputs.run_docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Docs checks
+        run: |
+          npm -w docs run build
+          npm -w docs run check:coverage
+          npm -w docs run check:content
+          npm -w docs run check:snippets
+          npm -w docs run check:links

--- a/scripts/ci-plan.mjs
+++ b/scripts/ci-plan.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+
+import {
+  discoverJsPackages,
+  discoverPythonPackages,
+  findNearestManifestDir,
+  manifestExists,
+} from "./ci-utils.mjs";
+
+const repoRoot = process.cwd();
+
+const JS_GLOBAL_PATTERNS = [
+  /^package\.json$/,
+  /^package-lock\.json$/,
+  /^turbo\.json$/,
+  /^vitest\.config\.[cm]?[jt]s$/,
+  /^tsconfig(?:\..+)?\.json$/,
+  /^\.github\/workflows\//,
+  /^scripts\//,
+];
+
+const PYTHON_GLOBAL_PATTERNS = [
+  /^\.github\/workflows\//,
+  /^scripts\/ci-.*\.mjs$/,
+  /^scripts\/publish-python\.sh$/,
+];
+
+const DOCS_PATTERNS = [
+  /^docs\//,
+  /^docsfn\//,
+  /^packages\/docs-theme\//,
+  /^scripts\/check-docs-/,
+  /^scripts\/docs-coverage-check\.mjs$/,
+];
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  }).trim();
+}
+
+function gitOk(args) {
+  try {
+    git(args);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureRemoteBranch(branchName) {
+  if (!branchName) {
+    return false;
+  }
+
+  if (gitOk(["rev-parse", "--verify", `refs/remotes/origin/${branchName}`])) {
+    return true;
+  }
+
+  try {
+    git([
+      "fetch",
+      "--no-tags",
+      "--depth=1",
+      "origin",
+      `+refs/heads/${branchName}:refs/remotes/origin/${branchName}`,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function loadGitHubEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !existsSync(eventPath)) {
+    return {};
+  }
+
+  return JSON.parse(readFileSync(eventPath, "utf8"));
+}
+
+function isRealCommit(value) {
+  return Boolean(value) && !/^0+$/.test(value);
+}
+
+function ensureCommit(commitish) {
+  return isRealCommit(commitish) && gitOk(["cat-file", "-e", `${commitish}^{commit}`]);
+}
+
+function resolveDiffBase(event) {
+  const eventName = process.env.GITHUB_EVENT_NAME || "local";
+  const defaultBranch = event.repository?.default_branch || "dev";
+
+  if (eventName === "pull_request" || eventName === "pull_request_target") {
+    const baseSha = event.pull_request?.base?.sha;
+    if (ensureCommit(baseSha)) {
+      return baseSha;
+    }
+
+    const baseRef = event.pull_request?.base?.ref;
+    if (ensureRemoteBranch(baseRef)) {
+      return git(["merge-base", "HEAD", `refs/remotes/origin/${baseRef}`]);
+    }
+  }
+
+  if (eventName === "push") {
+    const before = event.before;
+    if (ensureCommit(before)) {
+      return before;
+    }
+  }
+
+  if (ensureRemoteBranch(defaultBranch)) {
+    return git(["merge-base", "HEAD", `refs/remotes/origin/${defaultBranch}`]);
+  }
+
+  if (gitOk(["rev-parse", "--verify", "HEAD^"])) {
+    return git(["rev-parse", "HEAD^"]);
+  }
+
+  return git(["rev-parse", "HEAD"]);
+}
+
+function parseChangedEntries(baseRef) {
+  const output = execFileSync(
+    "git",
+    ["diff", "--name-status", "--find-renames", "-z", `${baseRef}...HEAD`],
+    { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+  );
+
+  const tokens = output.split("\0").filter(Boolean);
+  const entries = [];
+
+  for (let index = 0; index < tokens.length; ) {
+    const status = tokens[index];
+    index += 1;
+
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const fromPath = tokens[index];
+      const toPath = tokens[index + 1];
+      index += 2;
+      entries.push({ status, paths: [fromPath, toPath] });
+      continue;
+    }
+
+    const filePath = tokens[index];
+    index += 1;
+    entries.push({ status, paths: [filePath] });
+  }
+
+  return entries;
+}
+
+function matchesAny(patterns, value) {
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+function buildTurboFilters(packageDirs) {
+  return [...packageDirs]
+    .sort()
+    .map((packageDir) => `--filter=..../${packageDir}`)
+    .join(" ");
+}
+
+function writeOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+
+  appendFileSync(outputPath, `${name}<<__CI_EOF__\n${value}\n__CI_EOF__\n`);
+}
+
+function collectPythonDependents(seedNames, manifestsByName) {
+  const dependents = new Map();
+
+  for (const manifest of manifestsByName.values()) {
+    for (const dependency of manifest.dependencies) {
+      if (!manifestsByName.has(dependency)) {
+        continue;
+      }
+
+      if (!dependents.has(dependency)) {
+        dependents.set(dependency, new Set());
+      }
+
+      dependents.get(dependency).add(manifest.name);
+    }
+  }
+
+  const selected = new Set(seedNames);
+  const queue = [...seedNames];
+
+  while (queue.length > 0) {
+    const packageName = queue.shift();
+    const directDependents = dependents.get(packageName);
+    if (!directDependents) {
+      continue;
+    }
+
+    for (const dependent of directDependents) {
+      if (selected.has(dependent)) {
+        continue;
+      }
+
+      selected.add(dependent);
+      queue.push(dependent);
+    }
+  }
+
+  return selected;
+}
+
+const event = loadGitHubEvent();
+const baseRef = resolveDiffBase(event);
+const changedEntries = parseChangedEntries(baseRef);
+const changedPaths = [...new Set(changedEntries.flatMap((entry) => entry.paths))].sort();
+
+const jsPackages = discoverJsPackages(repoRoot);
+const pythonPackages = discoverPythonPackages(repoRoot).map((manifest) => ({
+  ...manifest,
+  name: manifest.name.toLowerCase(),
+}));
+
+const jsByDir = new Map(jsPackages.map((manifest) => [manifest.dir, manifest]));
+const pythonByDir = new Map(pythonPackages.map((manifest) => [manifest.dir, manifest]));
+const pythonByName = new Map(pythonPackages.map((manifest) => [manifest.name, manifest]));
+
+const jsDirs = new Set(jsByDir.keys());
+const pythonDirs = new Set(pythonByDir.keys());
+
+let fullJs = false;
+let fullPython = false;
+let runDocs = false;
+
+const changedJsDirs = new Set();
+const changedPythonNames = new Set();
+
+for (const entry of changedEntries) {
+  for (const changedPath of entry.paths) {
+    if (matchesAny(JS_GLOBAL_PATTERNS, changedPath)) {
+      fullJs = true;
+    }
+
+    if (matchesAny(PYTHON_GLOBAL_PATTERNS, changedPath)) {
+      fullPython = true;
+    }
+
+    if (matchesAny(DOCS_PATTERNS, changedPath)) {
+      runDocs = true;
+    }
+
+    const jsDir = findNearestManifestDir(changedPath, jsDirs);
+    if (jsDir && jsByDir.has(jsDir)) {
+      changedJsDirs.add(jsDir);
+    }
+
+    const pythonDir = findNearestManifestDir(changedPath, pythonDirs);
+    if (pythonDir && pythonByDir.has(pythonDir)) {
+      changedPythonNames.add(pythonByDir.get(pythonDir).name);
+    }
+  }
+
+  if (entry.status.startsWith("D")) {
+    const deletedPath = entry.paths[0];
+
+    if (deletedPath.endsWith("/package.json") && !manifestExists(repoRoot, deletedPath)) {
+      fullJs = true;
+    }
+
+    if (deletedPath.endsWith("/pyproject.toml") && !manifestExists(repoRoot, deletedPath)) {
+      fullPython = true;
+    }
+  }
+}
+
+const selectedJsPackages = fullJs
+  ? jsPackages
+  : [...changedJsDirs].map((dir) => jsByDir.get(dir)).filter(Boolean);
+
+const selectedPythonPackages = fullPython
+  ? pythonPackages
+  : [...collectPythonDependents(changedPythonNames, pythonByName)]
+      .map((packageName) => pythonByName.get(packageName))
+      .filter(Boolean);
+
+const jsBuildPackages = new Set(
+  selectedJsPackages.filter((manifest) => manifest.scripts.build).map((manifest) => manifest.dir)
+);
+const jsTestPackages = new Set(
+  selectedJsPackages.filter((manifest) => manifest.scripts.test).map((manifest) => manifest.dir)
+);
+const jsLintPackages = new Set(
+  selectedJsPackages.filter((manifest) => manifest.scripts.lint).map((manifest) => manifest.dir)
+);
+const jsTypecheckPackages = new Set(
+  selectedJsPackages.filter((manifest) => manifest.scripts.typecheck).map((manifest) => manifest.dir)
+);
+
+const pythonMatrix = selectedPythonPackages
+  .map((manifest) => ({ name: manifest.name, path: manifest.dir }))
+  .sort((left, right) => left.path.localeCompare(right.path));
+
+const summary = {
+  baseRef,
+  changedFiles: changedPaths,
+  fullJs,
+  fullPython,
+  runDocs,
+  jsPackages: selectedJsPackages.map((manifest) => manifest.name).sort(),
+  pythonPackages: pythonMatrix,
+};
+
+console.log(JSON.stringify(summary, null, 2));
+
+writeOutput("base_ref", baseRef);
+writeOutput("changed_files_count", String(changedPaths.length));
+writeOutput("run_js", String(fullJs || selectedJsPackages.length > 0));
+writeOutput("full_js", String(fullJs));
+writeOutput("has_js_build", String(fullJs || jsBuildPackages.size > 0));
+writeOutput("has_js_test", String(fullJs || jsTestPackages.size > 0));
+writeOutput("has_js_lint", String(fullJs || jsLintPackages.size > 0));
+writeOutput("has_js_typecheck", String(fullJs || jsTypecheckPackages.size > 0));
+writeOutput("js_build_filters", fullJs ? "" : buildTurboFilters(jsBuildPackages));
+writeOutput("js_test_filters", fullJs ? "" : buildTurboFilters(jsTestPackages));
+writeOutput("js_lint_filters", fullJs ? "" : buildTurboFilters(jsLintPackages));
+writeOutput("js_typecheck_filters", fullJs ? "" : buildTurboFilters(jsTypecheckPackages));
+writeOutput("run_python", String(fullPython || pythonMatrix.length > 0));
+writeOutput("full_python", String(fullPython));
+writeOutput("python_matrix", JSON.stringify(pythonMatrix));
+writeOutput("run_docs", String(runDocs));

--- a/scripts/ci-run-python-package.mjs
+++ b/scripts/ci-run-python-package.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { discoverPythonPackages, topologicalLocalDependencies } from "./ci-utils.mjs";
+
+const repoRoot = process.cwd();
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const packageDir = args.find((value) => value !== "--dry-run");
+
+if (!packageDir) {
+  console.error("usage: node scripts/ci-run-python-package.mjs [--dry-run] <package-dir>");
+  process.exit(1);
+}
+
+const normalizedTargetDir = packageDir.replace(/\/+$/, "");
+const pythonPackages = discoverPythonPackages(repoRoot).map((manifest) => ({
+  ...manifest,
+  name: manifest.name.toLowerCase(),
+}));
+const manifestsByDir = new Map(pythonPackages.map((manifest) => [manifest.dir, manifest]));
+const manifestsByName = new Map(pythonPackages.map((manifest) => [manifest.name, manifest]));
+
+if (!manifestsByDir.has(normalizedTargetDir)) {
+  console.error(`unknown python package: ${normalizedTargetDir}`);
+  process.exit(1);
+}
+
+const targetManifest = manifestsByDir.get(normalizedTargetDir);
+const installOrder = topologicalLocalDependencies(targetManifest.name, manifestsByName);
+const dependencyInstalls = installOrder.filter((manifest) => manifest.dir !== targetManifest.dir);
+
+const targetCwd = path.join(repoRoot, targetManifest.dir);
+const hasTestsDir = existsSync(path.join(targetCwd, "tests"));
+
+function run(command, commandArgs, options = {}) {
+  const rendered = [command, ...commandArgs].join(" ");
+  console.log(`$ ${rendered}`);
+
+  if (dryRun) {
+    return;
+  }
+
+  execFileSync(command, commandArgs, {
+    cwd: options.cwd || repoRoot,
+    stdio: "inherit",
+  });
+}
+
+if (dependencyInstalls.length > 0) {
+  run(
+    "python",
+    ["-m", "pip", "install", ...dependencyInstalls.flatMap((manifest) => ["-e", manifest.dir])]
+  );
+}
+
+const targetSpecifier = targetManifest.hasDevDependencyGroup
+  ? `${targetManifest.dir}[dev]`
+  : targetManifest.dir;
+
+run("python", ["-m", "pip", "install", "-e", targetSpecifier]);
+
+if (!targetManifest.hasDevDependencyGroup) {
+  run("python", [
+    "-m",
+    "pip",
+    "install",
+    "build",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "mypy",
+    "ruff",
+  ]);
+}
+
+run("python", ["-m", "build", "--wheel", "--sdist", "."], { cwd: targetCwd });
+
+if (targetManifest.hasRuff) {
+  run("python", ["-m", "ruff", "check", "."], { cwd: targetCwd });
+}
+
+if (targetManifest.hasMypy) {
+  run("python", ["-m", "mypy", "."], { cwd: targetCwd });
+}
+
+if (targetManifest.hasPytest || hasTestsDir) {
+  run("python", ["-m", "pytest", "."], { cwd: targetCwd });
+}
+
+console.log(
+  JSON.stringify(
+    {
+      package: targetManifest.name,
+      path: targetManifest.dir,
+      dependencies: dependencyInstalls.map((manifest) => manifest.dir),
+      dryRun,
+    },
+    null,
+    2
+  )
+);

--- a/scripts/ci-utils.mjs
+++ b/scripts/ci-utils.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const IGNORED_DIRS = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
+
+export function walkFiles(rootDir, targetFileName, results = [], currentDir = rootDir) {
+  const entries = readdirSync(currentDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) {
+        continue;
+      }
+
+      walkFiles(rootDir, targetFileName, results, path.join(currentDir, entry.name));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name === targetFileName) {
+      results.push(path.relative(rootDir, path.join(currentDir, entry.name)));
+    }
+  }
+
+  return results;
+}
+
+export function discoverJsPackages(rootDir) {
+  return walkFiles(rootDir, "package.json")
+    .filter((relativePath) => relativePath !== "package.json")
+    .map((relativePath) => {
+      const manifest = JSON.parse(readFileSync(path.join(rootDir, relativePath), "utf8"));
+      return {
+        dir: path.dirname(relativePath),
+        file: relativePath,
+        name: manifest.name || path.dirname(relativePath),
+        private: Boolean(manifest.private),
+        scripts: manifest.scripts || {},
+      };
+    });
+}
+
+function extractQuotedStrings(source) {
+  const values = [];
+  const matcher = /"([^"]+)"/g;
+  let match;
+
+  while ((match = matcher.exec(source)) !== null) {
+    values.push(match[1]);
+  }
+
+  return values;
+}
+
+function readTomlArray(lines, startIndex) {
+  let cursor = startIndex;
+  let combined = lines[cursor];
+
+  while (!combined.includes("]") && cursor + 1 < lines.length) {
+    cursor += 1;
+    combined += `\n${lines[cursor]}`;
+  }
+
+  return {
+    items: extractQuotedStrings(combined),
+    nextIndex: cursor + 1,
+  };
+}
+
+function normalizeDependencyName(specifier) {
+  const cleaned = specifier.replace(/\s+#.*$/, "").trim();
+  const boundary = cleaned.search(/[<>=!~;\[]/);
+  const packageName = boundary === -1 ? cleaned : cleaned.slice(0, boundary);
+  return packageName.trim().toLowerCase();
+}
+
+export function parsePyprojectManifest(rootDir, relativePath) {
+  const source = readFileSync(path.join(rootDir, relativePath), "utf8");
+  const lines = source.split(/\r?\n/);
+
+  let cursor = 0;
+  let section = "";
+  let name = null;
+  let dependencies = [];
+  let hasDevDependencyGroup = false;
+  let hasRuff = false;
+  let hasMypy = false;
+  let hasPytest = false;
+
+  while (cursor < lines.length) {
+    const trimmed = lines[cursor].trim();
+
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      section = trimmed.slice(1, -1);
+      hasRuff ||= section === "tool.ruff" || section === "tool.ruff.lint";
+      hasMypy ||= section === "tool.mypy";
+      hasPytest ||= section === "tool.pytest.ini_options";
+      cursor += 1;
+      continue;
+    }
+
+    if (section === "project" && trimmed.startsWith("name =")) {
+      const match = trimmed.match(/name\s*=\s*"([^"]+)"/);
+      if (match) {
+        name = match[1];
+      }
+      cursor += 1;
+      continue;
+    }
+
+    if (section === "project" && trimmed.startsWith("dependencies = [")) {
+      const parsed = readTomlArray(lines, cursor);
+      dependencies = parsed.items.map(normalizeDependencyName).filter(Boolean);
+      cursor = parsed.nextIndex;
+      continue;
+    }
+
+    if (section === "project.optional-dependencies" && trimmed.startsWith("dev = [")) {
+      hasDevDependencyGroup = true;
+      const parsed = readTomlArray(lines, cursor);
+      if (parsed.items.length > 0) {
+        hasPytest ||= parsed.items.some((item) => item.startsWith("pytest"));
+        hasMypy ||= parsed.items.some((item) => item.startsWith("mypy"));
+        hasRuff ||= parsed.items.some((item) => item.startsWith("ruff"));
+      }
+      cursor = parsed.nextIndex;
+      continue;
+    }
+
+    cursor += 1;
+  }
+
+  return {
+    dir: path.dirname(relativePath),
+    file: relativePath,
+    name: name || path.dirname(relativePath),
+    dependencies,
+    hasDevDependencyGroup,
+    hasMypy,
+    hasPytest,
+    hasRuff,
+  };
+}
+
+export function discoverPythonPackages(rootDir) {
+  return walkFiles(rootDir, "pyproject.toml").map((relativePath) =>
+    parsePyprojectManifest(rootDir, relativePath)
+  );
+}
+
+export function findNearestManifestDir(filePath, manifestDirs) {
+  let current = filePath;
+
+  while (current && current !== ".") {
+    if (manifestDirs.has(current)) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+
+    current = parent;
+  }
+
+  return null;
+}
+
+export function topologicalLocalDependencies(packageName, manifestsByName) {
+  const ordered = [];
+  const visited = new Set();
+
+  function visit(name) {
+    if (visited.has(name)) {
+      return;
+    }
+
+    visited.add(name);
+    const manifest = manifestsByName.get(name);
+    if (!manifest) {
+      return;
+    }
+
+    for (const dependency of manifest.dependencies) {
+      if (!manifestsByName.has(dependency)) {
+        continue;
+      }
+
+      visit(dependency);
+    }
+
+    ordered.push(manifest);
+  }
+
+  visit(packageName);
+  return ordered;
+}
+
+export function manifestExists(rootDir, relativePath) {
+  return existsSync(path.join(rootDir, relativePath));
+}


### PR DESCRIPTION
## Summary
- add a monorepo-aware CI workflow for JS, Python, and docs checks
- compute impacted packages from the current branch without assuming origin/dev and next/next have the same project set
- install local Python package dependencies in topological order before package checks

## Validation
- node scripts/ci-plan.mjs
- node scripts/ci-run-python-package.mjs --dry-run authfn/python
- node scripts/ci-run-python-package.mjs --dry-run searchfn/python

## Summary by Sourcery

Introduce a monorepo-aware CI workflow that plans and runs targeted JavaScript, Python, and docs checks based on changed files.

New Features:
- Add a CI planning script that determines impacted JS, Python, and docs components from Git diffs and emits workflow outputs.
- Add a Python package CI runner that installs local package dependencies in topological order and runs linting, type checking, tests, and builds per package.
- Add a GitHub Actions CI workflow that uses the planning script to conditionally run JS, Python, and docs jobs with appropriate scoping.

Enhancements:
- Introduce shared CI utility functions for discovering JS/Python packages, parsing pyproject.toml metadata, and resolving local dependency order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements SF-28 by adding a monorepo‑aware CI that runs only impacted JavaScript, Python, and docs checks. Speeds up CI and installs Python local deps in topological order for correct builds.

- **New Features**
  - Adds `.github/workflows/ci.yml` with a Plan job that resolves a safe diff base and determines impacted JS, Python, and `docs`.
  - JavaScript: runs `turbo` build/test/lint/typecheck with scoped `--filter` targets; falls back to full runs on global changes.
  - Python: builds a matrix of affected packages; installs local deps in topo order; runs `ruff`, `mypy`, `pytest`, and `build` via `scripts/ci-run-python-package.mjs`.
  - Docs: builds `docs` and runs guardrails (`check:coverage`, `check:content`, `check:snippets`, `check:links`).
  - Adds `scripts/ci-plan.mjs` and `scripts/ci-utils.mjs` to detect changed packages and compute filters without assuming `origin/dev` and `origin/next` have the same projects.

<sup>Written for commit 52f9a0167febc978c4429e98f7ad9d10b7782487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

