### PR TITLE
SF-30 add OAuth and OpenAPI shared packages

### DIFF
--- a/packages/http-openapi/package.json
+++ b/packages/http-openapi/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@superfunctions/http-openapi",
+  "version": "0.0.1",
+  "description": "Deterministic OpenAPI generation for @superfunctions/http routers",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && vitest",
+    "test:watch": "vitest --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "http",
+    "openapi",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/http-openapi"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/http": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/http-openapi/src/__tests__/generate.test.ts
+++ b/packages/http-openapi/src/__tests__/generate.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+import { createRouter } from "@superfunctions/http";
+import { OpenApiGenerationError, generateOpenApiDocument } from "../index.js";
+
+describe("http-openapi generator", () => {
+  it("generates a deterministic OpenAPI document from router metadata", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "POST",
+          path: "/auth/session",
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              operationId: "createSession",
+              summary: "Create session",
+              tags: ["session", "auth"],
+              requestBodySchema: {
+                type: "object",
+                required: ["email"],
+                properties: {
+                  password: { type: "string" },
+                  email: { type: "string" }
+                }
+              },
+              responseSchemas: {
+                "201": {
+                  type: "object",
+                  properties: {
+                    sessionId: { type: "string" },
+                    userId: { type: "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          method: "GET",
+          path: "/users/:userId",
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              operationId: "getUser",
+              tags: ["users", "auth"]
+            }
+          }
+        }
+      ]
+    });
+
+    const document = generateOpenApiDocument({
+      title: "Auth API",
+      version: "1.0.0",
+      routers: [router]
+    });
+
+    expect(document).toEqual({
+      openapi: "3.1.0",
+      info: {
+        title: "Auth API",
+        version: "1.0.0"
+      },
+      paths: {
+        "/auth/session": {
+          post: {
+            operationId: "createSession",
+            summary: "Create session",
+            tags: ["auth", "session"],
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: {
+                    properties: {
+                      email: { type: "string" },
+                      password: { type: "string" }
+                    },
+                    required: ["email"],
+                    type: "object"
+                  }
+                }
+              }
+            },
+            responses: {
+              "201": {
+                description: "HTTP 201 response",
+                content: {
+                  "application/json": {
+                    schema: {
+                      properties: {
+                        sessionId: { type: "string" },
+                        userId: { type: "string" }
+                      },
+                      type: "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/users/{userId}": {
+          get: {
+            operationId: "getUser",
+            tags: ["auth", "users"],
+            parameters: [
+              {
+                in: "path",
+                name: "userId",
+                required: true,
+                schema: {
+                  type: "string"
+                }
+              }
+            ],
+            responses: {
+              "200": {
+                description: "Success"
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it("skips routes excluded from OpenAPI generation", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/health",
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              include: false,
+              operationId: "healthCheck"
+            }
+          }
+        }
+      ]
+    });
+
+    const document = generateOpenApiDocument({
+      title: "Health API",
+      version: "1.0.0",
+      routers: [router]
+    });
+
+    expect(document).toEqual({
+      openapi: "3.1.0",
+      info: {
+        title: "Health API",
+        version: "1.0.0"
+      },
+      paths: {}
+    });
+  });
+
+  it("fails clearly when included route metadata lacks operationId", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/auth/session",
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              include: true,
+              summary: "Read session"
+            }
+          }
+        }
+      ]
+    });
+
+    expect(() =>
+      generateOpenApiDocument({
+        title: "Broken API",
+        version: "1.0.0",
+        routers: [router]
+      })
+    ).toThrowError(
+      expect.objectContaining<Partial<OpenApiGenerationError>>({
+        code: "OPENAPI_META_INCOMPLETE",
+        details: {
+          method: "GET",
+          path: "/auth/session"
+        }
+      })
+    );
+  });
+
+  it("emits every path parameter required by templated routes", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/teams/:teamId/users/:userId",
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              operationId: "getTeamUser",
+            }
+          }
+        }
+      ]
+    });
+
+    const document = generateOpenApiDocument({
+      title: "Nested API",
+      version: "1.0.0",
+      routers: [router]
+    });
+
+    expect(document).toMatchObject({
+      paths: {
+        "/teams/{teamId}/users/{userId}": {
+          get: {
+            parameters: [
+              {
+                in: "path",
+                name: "teamId",
+                required: true,
+                schema: { type: "string" }
+              },
+              {
+                in: "path",
+                name: "userId",
+                required: true,
+                schema: { type: "string" }
+              }
+            ]
+          }
+        }
+      }
+    });
+  });
+
+  it("fails clearly when two routes normalize to the same method and path", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/users/:userId",
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              operationId: "getUserById",
+            }
+          }
+        },
+        {
+          method: "GET",
+          path: "/users/{userId}".replace("{userId}", ":userId"),
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              operationId: "getUserDuplicate",
+            }
+          }
+        }
+      ]
+    });
+
+    expect(() =>
+      generateOpenApiDocument({
+        title: "Duplicate API",
+        version: "1.0.0",
+        routers: [router]
+      })
+    ).toThrowError(
+      expect.objectContaining<Partial<OpenApiGenerationError>>({
+        code: "OPENAPI_META_INCOMPLETE",
+        details: {
+          method: "GET",
+          path: "/users/{userId}"
+        }
+      })
+    );
+  });
+
+  it("fails clearly when a response schema entry is not an object", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "POST",
+          path: "/broken",
+          handler: () => Response.json({ ok: true }),
+          meta: {
+            openapi: {
+              operationId: "brokenResponseSchema",
+              responseSchemas: {
+                "200": null as never,
+              }
+            }
+          }
+        }
+      ]
+    });
+
+    expect(() =>
+      generateOpenApiDocument({
+        title: "Broken API",
+        version: "1.0.0",
+        routers: [router]
+      })
+    ).toThrowError(
+      expect.objectContaining<Partial<OpenApiGenerationError>>({
+        code: "OPENAPI_META_INCOMPLETE",
+        details: {
+          method: "POST",
+          path: "/broken"
+        }
+      })
+    );
+  });
+});

--- a/packages/http-openapi/src/generate.ts
+++ b/packages/http-openapi/src/generate.ts
@@ -1,0 +1,215 @@
+import type { OpenApiRouteMeta, Route, Router } from "@superfunctions/http";
+
+const METHOD_ORDER = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
+
+export interface OpenApiRouter {
+  getRoutes(): Route[];
+}
+
+export interface GenerateOpenApiDocumentInput {
+  title: string;
+  version: string;
+  routers: Array<Pick<Router, "getRoutes"> | OpenApiRouter>;
+}
+
+export interface OpenApiGenerationErrorDetails {
+  method?: string;
+  path?: string;
+}
+
+export class OpenApiGenerationError extends Error {
+  readonly code: "OPENAPI_META_INCOMPLETE";
+  readonly details?: OpenApiGenerationErrorDetails;
+
+  constructor(message: string, details?: OpenApiGenerationErrorDetails) {
+    super(message);
+    this.name = "OpenApiGenerationError";
+    this.code = "OPENAPI_META_INCOMPLETE";
+    this.details = details;
+  }
+}
+
+export function generateOpenApiDocument(input: GenerateOpenApiDocumentInput): Record<string, unknown> {
+  const pathEntries = new Map<string, Map<string, Record<string, unknown>>>();
+
+  for (const route of collectRoutes(input.routers)) {
+    const meta = route.meta?.openapi;
+    if (!meta || meta.include === false) {
+      continue;
+    }
+
+    if (!meta.operationId) {
+      throw new OpenApiGenerationError("route OpenAPI metadata requires operationId", {
+        method: route.method,
+        path: route.path
+      });
+    }
+
+    const normalizedPath = normalizeOpenApiPath(route.path);
+    const normalizedMethod = route.method.toLowerCase();
+    const operations = pathEntries.get(normalizedPath) ?? new Map<string, Record<string, unknown>>();
+    if (operations.has(normalizedMethod)) {
+      throw new OpenApiGenerationError("duplicate OpenAPI operation for method and path", {
+        method: route.method,
+        path: normalizedPath
+      });
+    }
+    operations.set(normalizedMethod, buildOperation(meta, normalizedPath, route.method));
+    pathEntries.set(normalizedPath, operations);
+  }
+
+  const paths = Object.fromEntries(
+    [...pathEntries.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([path, operations]) => [
+        path,
+        Object.fromEntries(
+          [...operations.entries()].sort(([left], [right]) => compareMethods(left, right))
+        )
+      ])
+  );
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: input.title,
+      version: input.version
+    },
+    paths
+  };
+}
+
+function collectRoutes(routers: GenerateOpenApiDocumentInput["routers"]): Route[] {
+  return routers.flatMap((router) => router.getRoutes());
+}
+
+function buildOperation(
+  meta: OpenApiRouteMeta,
+  normalizedPath: string,
+  method: string
+): Record<string, unknown> {
+  const operation: Record<string, unknown> = {
+    operationId: meta.operationId
+  };
+
+  if (meta.summary) {
+    operation.summary = meta.summary;
+  }
+
+  if (meta.description) {
+    operation.description = meta.description;
+  }
+
+  if (meta.tags && meta.tags.length > 0) {
+    operation.tags = [...meta.tags].sort((left, right) => left.localeCompare(right));
+  }
+
+  if (meta.requestBodySchema) {
+    operation.requestBody = {
+      required: true,
+      content: {
+        "application/json": {
+          schema: sortObject(meta.requestBodySchema)
+        }
+      }
+    };
+  }
+
+  const pathParameters = createPathParameters(normalizedPath);
+  if (pathParameters.length > 0) {
+    operation.parameters = pathParameters;
+  }
+
+  operation.responses = createResponses(meta.responseSchemas, {
+    method,
+    path: normalizedPath,
+  });
+  return operation;
+}
+
+function createResponses(
+  responseSchemas: OpenApiRouteMeta["responseSchemas"],
+  details: OpenApiGenerationErrorDetails
+): Record<string, Record<string, unknown>> {
+  if (!responseSchemas || Object.keys(responseSchemas).length === 0) {
+    return {
+      "200": {
+        description: "Success"
+      }
+    };
+  }
+
+  return Object.fromEntries(
+    Object.entries(responseSchemas)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([statusCode, schema]) => [
+        statusCode,
+        {
+          description: `HTTP ${statusCode} response`,
+          content: {
+            "application/json": {
+              schema: sortObject(assertSchemaObject(schema, details))
+            }
+          }
+        }
+      ])
+  );
+}
+
+function normalizeOpenApiPath(path: string): string {
+  return path.replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+}
+
+function createPathParameters(path: string): Array<Record<string, unknown>> {
+  const matches = path.matchAll(/\{([A-Za-z0-9_]+)\}/g);
+  return [...matches].map((match) => ({
+    name: match[1],
+    in: "path",
+    required: true,
+    schema: {
+      type: "string"
+    }
+  }));
+}
+
+function compareMethods(left: string, right: string): number {
+  const orderDiff = getMethodOrder(left) - getMethodOrder(right);
+  return orderDiff !== 0 ? orderDiff : left.localeCompare(right);
+}
+
+function getMethodOrder(method: string): number {
+  const normalized = method.toLowerCase();
+  const index = METHOD_ORDER.indexOf(normalized as (typeof METHOD_ORDER)[number]);
+  return index >= 0 ? index : METHOD_ORDER.length;
+}
+
+function sortObject(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entryValue]) => [key, sortValue(entryValue)])
+  );
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortValue(item));
+  }
+
+  if (value && typeof value === "object") {
+    return sortObject(value as Record<string, unknown>);
+  }
+
+  return value;
+}
+
+function assertSchemaObject(
+  schema: unknown,
+  details: OpenApiGenerationErrorDetails
+): Record<string, unknown> {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    throw new OpenApiGenerationError("route OpenAPI response schema must be an object", details);
+  }
+
+  return schema as Record<string, unknown>;
+}

--- a/packages/http-openapi/src/index.ts
+++ b/packages/http-openapi/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./generate.js";

--- a/packages/http-openapi/tsconfig.json
+++ b/packages/http-openapi/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-core/README.md
+++ b/packages/oauth-core/README.md
@@ -1,0 +1,69 @@
+# @superfunctions/oauth-core
+
+Shared OAuth primitives for provider descriptors, PKCE, redirect validation, and callback invariants.
+
+## Install
+
+```bash
+npm install @superfunctions/oauth-core @superfunctions/oauth-storage
+```
+
+## Quick Start
+
+```ts
+import { DefaultOAuthService } from "@superfunctions/oauth-core";
+import { MemoryOAuthStateStore } from "@superfunctions/oauth-storage";
+
+const oauth = new DefaultOAuthService({
+  providers: {
+    github: {
+      id: "github",
+      authorizationUrl: "https://github.com/login/oauth/authorize",
+      tokenUrl: "https://github.com/login/oauth/access_token",
+      defaultScopes: ["read:user"],
+      supportsPkce: true,
+      supportsRefreshToken: false,
+      tokenAuthMethod: "client_secret_post",
+    },
+  },
+  providerRuntimeConfig: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID!,
+      allowlistedRedirectUris: ["https://app.example/oauth/callback"],
+    },
+  },
+  stateStore: new MemoryOAuthStateStore(),
+  async exchangeCodeForToken() {
+    return { accessToken: "access-token" };
+  },
+});
+```
+
+## Package Boundary
+
+`@superfunctions/oauth-core` owns protocol-safe OAuth building blocks:
+
+- provider descriptors
+- authorization request creation
+- redirect allowlist checks
+- PKCE/state generation
+- one-time callback state consumption
+
+It does not own HTTP transport, token persistence, or route exposure. Use:
+
+- `@superfunctions/oauth-http` for token exchange and revoke transport
+- `@superfunctions/oauth-storage` for state/token persistence
+- `@superfunctions/oauth-flow` when you want start/callback/refresh/disconnect orchestration
+- `@superfunctions/oauth-router` when you want reusable HTTP routes on top of `oauth-flow`
+
+## Production Notes
+
+- Keep provider descriptors static and resolve client/runtime secrets outside source control.
+- Treat redirect allowlists as exact-match security controls, not loose prefixes.
+- Use durable storage for issued state records in multi-instance deployments.
+- Prefer `@superfunctions/oauth-flow` unless you intentionally need custom orchestration.
+
+## Docs
+
+- Canonical docs: [docs/content/docs/authentication/oauth-core.mdx](../../docs/content/docs/authentication/oauth-core.mdx)
+- Stack overview: [docs/content/docs/architecture/oauth-flow-architecture.mdx](../../docs/content/docs/architecture/oauth-flow-architecture.mdx)

--- a/packages/oauth-core/package.json
+++ b/packages/oauth-core/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@superfunctions/oauth-core",
+  "version": "0.0.1",
+  "description": "Core OAuth types and service contracts for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --config ./vitest.config.ts --run",
+    "test:watch": "vitest --config ./vitest.config.ts --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "oauth",
+    "auth",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/oauth-core"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/oauth-storage": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/oauth-core/src/__tests__/browser-auth-intents.test.ts
+++ b/packages/oauth-core/src/__tests__/browser-auth-intents.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { cloneOAuthStateRecord, type OAuthStateRecord } from "@superfunctions/oauth-storage";
+import { DefaultOAuthService, type OAuthProviderRuntimeConfigResolverInput } from "../index.js";
+
+class TestStateStore {
+  private readonly records = new Map<string, OAuthStateRecord>();
+
+  async put(record: OAuthStateRecord): Promise<void> {
+    this.records.set(record.stateId, cloneOAuthStateRecord(record));
+  }
+
+  async get(stateId: string): Promise<OAuthStateRecord | null> {
+    const record = this.records.get(stateId);
+    return record ? cloneOAuthStateRecord(record) : null;
+  }
+
+  async consume(stateId: string, consumedAt: string): Promise<OAuthStateRecord | null> {
+    const record = this.records.get(stateId);
+    if (!record || record.consumedAt || Date.parse(record.expiresAt) <= Date.parse(consumedAt)) {
+      return null;
+    }
+
+    const consumed = cloneOAuthStateRecord({ ...record, consumedAt });
+    this.records.set(stateId, consumed);
+    return cloneOAuthStateRecord(consumed);
+  }
+
+  async deleteExpired(before: string): Promise<number> {
+    const limit = Date.parse(before);
+    let deleted = 0;
+    for (const [stateId, record] of this.records.entries()) {
+      if (Date.parse(record.expiresAt) < limit) {
+        this.records.delete(stateId);
+        deleted += 1;
+      }
+    }
+
+    return deleted;
+  }
+}
+
+function createBrowserAuthService(
+  resolveProviderRuntimeConfig?: (input: OAuthProviderRuntimeConfigResolverInput) => Promise<{ clientId: string; allowlistedRedirectUris?: string[] }>
+) {
+  const stateStore = new TestStateStore();
+  const exchangeCodeForToken = vi.fn(async () => ({
+    accessToken: "at_browser",
+    tokenType: "bearer"
+  }));
+
+  const service = new DefaultOAuthService({
+    providers: {
+      google: {
+        id: "google",
+        authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenUrl: "https://oauth2.googleapis.com/token",
+        defaultScopes: ["openid", "email", "profile"],
+        supportsPkce: true,
+        supportsRefreshToken: true,
+        scopeSeparator: " "
+      }
+    },
+    resolveProviderRuntimeConfig,
+    providerRuntimeConfig: {
+      google: {
+        clientId: "fallback-client-id",
+        allowlistedRedirectUris: ["https://app/callback"]
+      }
+    },
+    stateStore,
+    exchangeCodeForToken
+  });
+
+  return { service, stateStore, exchangeCodeForToken };
+}
+
+describe("oauth-core browser-auth intents", () => {
+  it("creates authorization requests without a pre-existing user and persists browser-auth subject details", async () => {
+    const { service, stateStore } = createBrowserAuthService();
+
+    const result = await service.createAuthorizationRequest({
+      providerId: "google",
+      redirectUri: "https://app/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_01",
+        tenantId: "tenant_optional",
+        regionId: "eu-west-1",
+        returnTo: "https://app.example/post-auth",
+        metadata: { source: "signin" }
+      }
+    });
+
+    const stored = await stateStore.get(result.stateId);
+    expect(stored?.subject).toMatchObject({
+      kind: "browser-auth",
+      intentId: "intent_01",
+      tenantId: "tenant_optional",
+      regionId: "eu-west-1",
+      returnTo: "https://app.example/post-auth",
+      metadata: { source: "signin" }
+    });
+    expect(stored?.userId).toBeUndefined();
+    expect(new URL(result.authorizationUrl).searchParams.get("client_id")).toBe("fallback-client-id");
+  });
+
+  it("supports resolver-based runtime config for browser-auth requests", async () => {
+    const resolveProviderRuntimeConfig = vi.fn(async ({ subject }: OAuthProviderRuntimeConfigResolverInput) => ({
+      clientId: subject.kind === "browser-auth" && subject.regionId === "eu-west-1" ? "eu-client-id" : "default-client-id",
+      allowlistedRedirectUris: ["https://app/callback"]
+    }));
+    const { service } = createBrowserAuthService(resolveProviderRuntimeConfig);
+
+    const result = await service.createAuthorizationRequest({
+      providerId: "google",
+      redirectUri: "https://app/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_02",
+        regionId: "eu-west-1"
+      }
+    });
+
+    expect(resolveProviderRuntimeConfig).toHaveBeenCalledTimes(1);
+    expect(new URL(result.authorizationUrl).searchParams.get("client_id")).toBe("eu-client-id");
+  });
+
+  it("reconstructs browser-auth subject details during callback exchange", async () => {
+    const { service, exchangeCodeForToken } = createBrowserAuthService();
+
+    const result = await service.createAuthorizationRequest({
+      providerId: "google",
+      redirectUri: "https://app/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_04",
+        tenantId: "tenant_1",
+        regionId: "eu-west-1",
+        returnTo: "https://app.example/post-auth",
+        metadata: { source: "signup" }
+      }
+    });
+
+    await service.handleCallback({
+      providerId: "google",
+      code: "code_123",
+      state: result.stateId,
+      redirectUri: "https://app/callback"
+    });
+
+    expect(exchangeCodeForToken).toHaveBeenCalledTimes(1);
+    expect(exchangeCodeForToken.mock.calls[0]?.[0]).toMatchObject({
+      code: "code_123",
+      redirectUri: "https://app/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_04",
+        tenantId: "tenant_1",
+        regionId: "eu-west-1",
+        returnTo: "https://app.example/post-auth",
+        metadata: { source: "signup" }
+      }
+    });
+  });
+
+  it("fails with canonical provider errors for unsupported providers", async () => {
+    const { service } = createBrowserAuthService();
+
+    await expect(
+      service.createAuthorizationRequest({
+        providerId: "github",
+        redirectUri: "https://app/callback",
+        subject: {
+          kind: "browser-auth",
+          intentId: "intent_03"
+        }
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_PROVIDER_UNSUPPORTED"
+    });
+  });
+});

--- a/packages/oauth-core/src/__tests__/exports.test.ts
+++ b/packages/oauth-core/src/__tests__/exports.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { OAuthIntentSubject, OAuthProviderDescriptor, OAuthService } from "../index.js";
+
+describe("oauth-core exports", () => {
+  it("exposes compile-time contracts", () => {
+    const descriptor: OAuthProviderDescriptor = {
+      id: "example",
+      authorizationUrl: "https://example.com/auth",
+      tokenUrl: "https://example.com/token",
+      defaultScopes: ["read"],
+      supportsPkce: true,
+      supportsRefreshToken: true
+    };
+
+    expect(descriptor.id).toBe("example");
+    const subject: OAuthIntentSubject = {
+      kind: "browser-auth",
+      intentId: "intent_01"
+    };
+    expect(subject.kind).toBe("browser-auth");
+    expectType<OAuthService>();
+  });
+});
+
+function expectType<T>(): void {
+  void (0 as unknown as T);
+}

--- a/packages/oauth-core/src/index.ts
+++ b/packages/oauth-core/src/index.ts
@@ -1,0 +1,83 @@
+export interface OAuthProviderDescriptor {
+  id: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  revocationUrl?: string;
+  defaultScopes: string[];
+  supportsPkce: boolean;
+  supportsRefreshToken: boolean;
+  scopeSeparator?: " " | ",";
+  extraAuthParams?: Record<string, string>;
+  tokenAuthMethod?: "client_secret_post" | "client_secret_basic";
+}
+
+export type OAuthIntentSubject =
+  | {
+      kind: "connection";
+      tenantId: string;
+      userId: string;
+      connectionId?: string;
+    }
+  | {
+      kind: "browser-auth";
+      intentId: string;
+      tenantId?: string;
+      regionId?: string;
+      returnTo?: string;
+      metadata?: Record<string, unknown>;
+    };
+
+export interface AuthorizationRequestBase {
+  providerId: string;
+  redirectUri: string;
+  scopes?: string[];
+  connectionName?: string;
+  prompt?: string;
+  loginHint?: string;
+}
+
+export type AuthorizationRequest =
+  | (AuthorizationRequestBase & { subject: OAuthIntentSubject })
+  | (AuthorizationRequestBase & { tenantId: string; userId: string; connectionId?: string });
+
+export interface AuthorizationResult {
+  authorizationUrl: string;
+  stateId: string;
+  expiresAt: string;
+}
+
+export interface OAuthCallbackInput {
+  providerId: string;
+  code: string;
+  state: string;
+  redirectUri: string;
+}
+
+export interface OAuthTokenSet {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: string;
+  scope?: string;
+  tokenType?: string;
+  idToken?: string;
+}
+
+export interface OAuthService {
+  createAuthorizationRequest(input: AuthorizationRequest): Promise<AuthorizationResult>;
+  handleCallback(input: OAuthCallbackInput): Promise<OAuthTokenSet>;
+  refresh(input: {
+    providerId: string;
+    refreshToken: string;
+    redirectUri: string;
+    scopes?: string[];
+  }): Promise<OAuthTokenSet>;
+  revoke(input: {
+    providerId: string;
+    token: string;
+    tokenTypeHint?: "access_token" | "refresh_token";
+  }): Promise<void>;
+}
+
+export * from "./pkce.js";
+export * from "./state.js";
+export * from "./service.js";

--- a/packages/oauth-core/src/pkce.ts
+++ b/packages/oauth-core/src/pkce.ts
@@ -1,0 +1,33 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+  codeChallengeMethod: "S256";
+}
+
+export function generateStateId(prefix = "st"): string {
+  return `${prefix}_${base64UrlEncode(randomBytes(32))}`;
+}
+
+export function generateNonce(prefix = "nonce"): string {
+  return `${prefix}_${base64UrlEncode(randomBytes(32))}`;
+}
+
+export function generatePkcePair(verifierEntropyBytes = 64): PkcePair {
+  const codeVerifier = base64UrlEncode(randomBytes(verifierEntropyBytes));
+  const codeChallenge = base64UrlEncode(createHash("sha256").update(codeVerifier).digest());
+  return {
+    codeVerifier,
+    codeChallenge,
+    codeChallengeMethod: "S256"
+  };
+}
+
+function base64UrlEncode(input: Buffer): string {
+  return input
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}

--- a/packages/oauth-core/src/service.ts
+++ b/packages/oauth-core/src/service.ts
@@ -1,0 +1,319 @@
+import type { OAuthStateRecord, OAuthStateStore, OAuthStoredSubject } from "@superfunctions/oauth-storage";
+import type {
+  AuthorizationRequest,
+  AuthorizationResult,
+  OAuthCallbackInput,
+  OAuthIntentSubject,
+  OAuthProviderDescriptor,
+  OAuthService,
+  OAuthTokenSet
+} from "./index.js";
+import { generateNonce, generatePkcePair, generateStateId } from "./pkce.js";
+import { OAuthCoreError, assertCallbackStateMatches, assertRedirectUriAllowed, consumeStateOrThrow } from "./state.js";
+
+export interface OAuthProviderRuntimeConfig {
+  clientId: string;
+  allowlistedRedirectUris?: string[];
+}
+
+export interface OAuthProviderRuntimeConfigResolverInput {
+  providerId: string;
+  subject: OAuthIntentSubject;
+  redirectUri?: string;
+  scopes?: string[];
+  prompt?: string;
+  loginHint?: string;
+}
+
+export type OAuthProviderRuntimeConfigResolver = (
+  input: OAuthProviderRuntimeConfigResolverInput
+) => Promise<OAuthProviderRuntimeConfig> | OAuthProviderRuntimeConfig;
+
+export interface OAuthCodeExchangeInput {
+  provider: OAuthProviderDescriptor;
+  code: string;
+  redirectUri: string;
+  subject: OAuthIntentSubject;
+  codeVerifier?: string;
+  scopes?: string[];
+}
+
+export interface OAuthRefreshInput {
+  provider: OAuthProviderDescriptor;
+  refreshToken: string;
+  redirectUri: string;
+  scopes?: string[];
+}
+
+export interface OAuthRevokeInput {
+  provider: OAuthProviderDescriptor;
+  token: string;
+  tokenTypeHint?: "access_token" | "refresh_token";
+}
+
+export interface OAuthServiceDependencies {
+  providers: Record<string, OAuthProviderDescriptor>;
+  providerRuntimeConfig?: Record<string, OAuthProviderRuntimeConfig>;
+  resolveProviderRuntimeConfig?: OAuthProviderRuntimeConfigResolver;
+  stateStore: OAuthStateStore;
+  exchangeCodeForToken: (input: OAuthCodeExchangeInput) => Promise<OAuthTokenSet>;
+  refreshToken?: (input: OAuthRefreshInput) => Promise<OAuthTokenSet>;
+  revokeToken?: (input: OAuthRevokeInput) => Promise<void>;
+  stateTtlMs?: number;
+  now?: () => Date;
+}
+
+export class DefaultOAuthService implements OAuthService {
+  private readonly providers: Record<string, OAuthProviderDescriptor>;
+  private readonly providerRuntimeConfig?: Record<string, OAuthProviderRuntimeConfig>;
+  private readonly resolveProviderRuntimeConfig?: OAuthProviderRuntimeConfigResolver;
+  private readonly stateStore: OAuthStateStore;
+  private readonly exchangeCodeForToken: (input: OAuthCodeExchangeInput) => Promise<OAuthTokenSet>;
+  private readonly refreshTokenHandler?: (input: OAuthRefreshInput) => Promise<OAuthTokenSet>;
+  private readonly revokeTokenHandler?: (input: OAuthRevokeInput) => Promise<void>;
+  private readonly stateTtlMs: number;
+  private readonly now: () => Date;
+
+  constructor(dependencies: OAuthServiceDependencies) {
+    this.providers = dependencies.providers;
+    this.providerRuntimeConfig = dependencies.providerRuntimeConfig;
+    this.resolveProviderRuntimeConfig = dependencies.resolveProviderRuntimeConfig;
+    this.stateStore = dependencies.stateStore;
+    this.exchangeCodeForToken = dependencies.exchangeCodeForToken;
+    this.refreshTokenHandler = dependencies.refreshToken;
+    this.revokeTokenHandler = dependencies.revokeToken;
+    this.stateTtlMs = dependencies.stateTtlMs ?? 10 * 60 * 1000;
+    this.now = dependencies.now ?? (() => new Date());
+  }
+
+  async createAuthorizationRequest(input: AuthorizationRequest): Promise<AuthorizationResult> {
+    const provider = this.getProvider(input.providerId);
+    const subject = normalizeAuthorizationSubject(input);
+    const scopes =
+      input.scopes && input.scopes.length > 0 ? [...input.scopes] : [...provider.defaultScopes];
+    const runtime = await this.getProviderRuntimeConfig({
+      providerId: input.providerId,
+      subject,
+      redirectUri: input.redirectUri,
+      scopes,
+      prompt: input.prompt,
+      loginHint: input.loginHint
+    });
+
+    assertRedirectUriAllowed(input.redirectUri, runtime.allowlistedRedirectUris ?? []);
+
+    const issuedAt = this.now();
+    const createdAt = issuedAt.toISOString();
+    const expiresAt = new Date(issuedAt.getTime() + this.stateTtlMs).toISOString();
+    const stateId = generateStateId();
+    const nonce = generateNonce();
+    const pkce = provider.supportsPkce ? generatePkcePair() : undefined;
+
+    await this.stateStore.put({
+      stateId,
+      providerId: provider.id,
+      subject: toStoredSubject(subject),
+      redirectUri: input.redirectUri,
+      requestedScopes: scopes,
+      codeVerifier: pkce?.codeVerifier,
+      nonce,
+      createdAt,
+      expiresAt
+    });
+
+    const authorizationUrl = new URL(provider.authorizationUrl);
+    authorizationUrl.searchParams.set("response_type", "code");
+    authorizationUrl.searchParams.set("client_id", runtime.clientId);
+    authorizationUrl.searchParams.set("redirect_uri", input.redirectUri);
+    authorizationUrl.searchParams.set("state", stateId);
+    authorizationUrl.searchParams.set("nonce", nonce);
+
+    if (scopes.length > 0) {
+      authorizationUrl.searchParams.set("scope", scopes.join(provider.scopeSeparator ?? " "));
+    }
+
+    if (pkce) {
+      authorizationUrl.searchParams.set("code_challenge", pkce.codeChallenge);
+      authorizationUrl.searchParams.set("code_challenge_method", pkce.codeChallengeMethod);
+    }
+
+    if (input.prompt) {
+      authorizationUrl.searchParams.set("prompt", input.prompt);
+    }
+
+    if (input.loginHint) {
+      authorizationUrl.searchParams.set("login_hint", input.loginHint);
+    }
+
+    for (const [key, value] of Object.entries(provider.extraAuthParams ?? {})) {
+      if (!authorizationUrl.searchParams.has(key)) {
+        authorizationUrl.searchParams.set(key, value);
+      }
+    }
+
+    return {
+      authorizationUrl: authorizationUrl.toString(),
+      stateId,
+      expiresAt
+    };
+  }
+
+  async handleCallback(input: OAuthCallbackInput): Promise<OAuthTokenSet> {
+    const provider = this.getProvider(input.providerId);
+    const consumedAt = this.now().toISOString();
+    const consumedState = await consumeStateOrThrow(this.stateStore, input.state, consumedAt);
+    assertCallbackStateMatches(
+      {
+        providerId: input.providerId,
+        redirectUri: input.redirectUri
+      },
+      consumedState
+    );
+
+    return this.exchangeCodeForToken({
+      provider,
+      code: input.code,
+      redirectUri: input.redirectUri,
+      subject: resolveStateSubject(consumedState),
+      codeVerifier: consumedState.codeVerifier,
+      scopes: consumedState.requestedScopes
+    });
+  }
+
+  async refresh(input: {
+    providerId: string;
+    refreshToken: string;
+    redirectUri: string;
+    scopes?: string[];
+  }): Promise<OAuthTokenSet> {
+    const provider = this.getProvider(input.providerId);
+    if (!this.refreshTokenHandler) {
+      throw new OAuthCoreError("OAUTH_TOKEN_REFRESH_FAILED", "OAuth refresh handler is not configured", { status: 500 });
+    }
+
+    return this.refreshTokenHandler({
+      provider,
+      refreshToken: input.refreshToken,
+      redirectUri: input.redirectUri,
+      scopes: input.scopes
+    });
+  }
+
+  async revoke(input: {
+    providerId: string;
+    token: string;
+    tokenTypeHint?: "access_token" | "refresh_token";
+  }): Promise<void> {
+    const provider = this.getProvider(input.providerId);
+    if (!provider.revocationUrl || !this.revokeTokenHandler) {
+      return;
+    }
+
+    await this.revokeTokenHandler({
+      provider,
+      token: input.token,
+      tokenTypeHint: input.tokenTypeHint
+    });
+  }
+
+  private getProvider(providerId: string): OAuthProviderDescriptor {
+    const provider = this.providers[providerId];
+    if (!provider) {
+      throw new OAuthCoreError("OAUTH_PROVIDER_UNSUPPORTED", `Unknown OAuth provider: ${providerId}`, { status: 400 });
+    }
+
+    return provider;
+  }
+
+  private async getProviderRuntimeConfig(
+    input: OAuthProviderRuntimeConfigResolverInput
+  ): Promise<OAuthProviderRuntimeConfig> {
+    if (this.resolveProviderRuntimeConfig) {
+      try {
+        const resolved = await this.resolveProviderRuntimeConfig(input);
+        if (!resolved?.clientId) {
+          throw new OAuthCoreError("OAUTH_RUNTIME_CONFIG_INVALID", "Resolved OAuth runtime config missing clientId", {
+            status: 500,
+            details: { providerId: input.providerId }
+          });
+        }
+
+        return resolved;
+      } catch (error) {
+        if (error instanceof OAuthCoreError) {
+          throw error;
+        }
+
+        throw new OAuthCoreError("OAUTH_RUNTIME_CONFIG_INVALID", "Failed to resolve OAuth runtime config", {
+          status: 500,
+          details: { providerId: input.providerId }
+        });
+      }
+    }
+
+    const runtime = this.providerRuntimeConfig?.[input.providerId];
+    if (!runtime?.clientId) {
+      throw new OAuthCoreError("OAUTH_RUNTIME_CONFIG_INVALID", `Missing runtime OAuth config for provider: ${input.providerId}`, {
+        status: 500,
+        details: { providerId: input.providerId }
+      });
+    }
+
+    return runtime;
+  }
+}
+
+function normalizeAuthorizationSubject(input: AuthorizationRequest): OAuthIntentSubject {
+  if ("subject" in input) {
+    return input.subject;
+  }
+
+  return {
+    kind: "connection",
+    tenantId: input.tenantId,
+    userId: input.userId,
+    connectionId: input.connectionId
+  };
+}
+
+function toStoredSubject(subject: OAuthIntentSubject): OAuthStoredSubject {
+  if (subject.kind === "connection") {
+    return { ...subject };
+  }
+
+  return {
+    ...subject,
+    metadata: subject.metadata ? { ...subject.metadata } : undefined
+  };
+}
+
+function resolveStateSubject(state: OAuthStateRecord): OAuthIntentSubject {
+  if (state.subject?.kind === "connection") {
+    return { ...state.subject };
+  }
+
+  if (state.subject?.kind === "browser-auth") {
+    return {
+      ...state.subject,
+      metadata: state.subject.metadata ? { ...state.subject.metadata } : undefined
+    };
+  }
+
+  if (state.intentId) {
+    return {
+      kind: "browser-auth",
+      intentId: state.intentId,
+      tenantId: state.tenantId,
+      regionId: state.regionId,
+      returnTo: state.returnTo,
+      metadata: state.metadata ? { ...state.metadata } : undefined
+    };
+  }
+
+  return {
+    kind: "connection",
+    tenantId: state.tenantId ?? "",
+    userId: state.userId ?? "",
+    connectionId: state.connectionId
+  };
+}

--- a/packages/oauth-core/src/state.ts
+++ b/packages/oauth-core/src/state.ts
@@ -1,0 +1,90 @@
+import type { OAuthStateRecord, OAuthStateStore } from "@superfunctions/oauth-storage";
+
+export type OAuthCoreErrorCode =
+  | "OAUTH_STATE_INVALID"
+  | "OAUTH_STATE_REPLAYED"
+  | "OAUTH_CALLBACK_MISMATCH"
+  | "OAUTH_REDIRECT_DISALLOWED"
+  | "OAUTH_PROVIDER_UNSUPPORTED"
+  | "OAUTH_RUNTIME_CONFIG_INVALID"
+  | "VALIDATION_ERROR"
+  | "OAUTH_TOKEN_REFRESH_FAILED";
+
+export class OAuthCoreError extends Error {
+  readonly code: OAuthCoreErrorCode;
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    code: OAuthCoreErrorCode,
+    message: string,
+    options?: { status?: number; retryable?: boolean; details?: Record<string, unknown> }
+  ) {
+    super(message);
+    this.name = "OAuthCoreError";
+    this.code = code;
+    this.status = options?.status ?? 400;
+    this.retryable = options?.retryable ?? false;
+    this.details = options?.details;
+  }
+}
+
+export interface CallbackStateMatchInput {
+  providerId: string;
+  redirectUri: string;
+}
+
+export function assertRedirectUriAllowed(redirectUri: string, allowlistedRedirectUris: ReadonlyArray<string>): void {
+  if (allowlistedRedirectUris.length === 0) {
+    throw new OAuthCoreError("OAUTH_REDIRECT_DISALLOWED", "redirect URI allowlist must not be empty");
+  }
+
+  if (!allowlistedRedirectUris.includes(redirectUri)) {
+    throw new OAuthCoreError("OAUTH_REDIRECT_DISALLOWED", "redirect URI not allowed");
+  }
+}
+
+export function assertCallbackStateMatches(input: CallbackStateMatchInput, state: OAuthStateRecord): void {
+  if (input.providerId !== state.providerId) {
+    throw new OAuthCoreError("OAUTH_CALLBACK_MISMATCH", "provider mismatch for OAuth callback");
+  }
+
+  if (input.redirectUri !== state.redirectUri) {
+    throw new OAuthCoreError("OAUTH_CALLBACK_MISMATCH", "redirect URI not allowed");
+  }
+}
+
+export async function consumeStateOrThrow(
+  stateStore: OAuthStateStore,
+  stateId: string,
+  consumedAt: string
+): Promise<OAuthStateRecord> {
+  const consumed = await stateStore.consume(stateId, consumedAt);
+  if (consumed) {
+    if (Date.parse(consumed.expiresAt) <= Date.parse(consumedAt)) {
+      throw new OAuthCoreError("OAUTH_STATE_INVALID", "OAuth state is invalid or expired");
+    }
+
+    return consumed;
+  }
+
+  let existing: OAuthStateRecord | null = null;
+  try {
+    existing = await stateStore.get(stateId);
+  } catch (error) {
+    throw new OAuthCoreError("OAUTH_STATE_INVALID", "OAuth state could not be validated", {
+      status: 500,
+      retryable: true,
+      details: {
+        stateId,
+        cause: error instanceof Error ? error.message : String(error)
+      }
+    });
+  }
+  if (existing?.consumedAt) {
+    throw new OAuthCoreError("OAUTH_STATE_REPLAYED", "OAuth state already consumed");
+  }
+
+  throw new OAuthCoreError("OAUTH_STATE_INVALID", "OAuth state is invalid or expired");
+}

--- a/packages/oauth-core/tests/oauth-core.test.ts
+++ b/packages/oauth-core/tests/oauth-core.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from "vitest";
+import { cloneOAuthStateRecord, type OAuthStateRecord } from "@superfunctions/oauth-storage";
+import { DefaultOAuthService } from "../src/index.js";
+
+class TestStateStore {
+  private readonly records = new Map<string, OAuthStateRecord>();
+
+  async put(record: OAuthStateRecord): Promise<void> {
+    this.records.set(record.stateId, cloneOAuthStateRecord(record));
+  }
+
+  async get(stateId: string): Promise<OAuthStateRecord | null> {
+    const record = this.records.get(stateId);
+    return record ? cloneOAuthStateRecord(record) : null;
+  }
+
+  async consume(stateId: string, consumedAt: string): Promise<OAuthStateRecord | null> {
+    const record = this.records.get(stateId);
+    if (!record || record.consumedAt) {
+      return null;
+    }
+
+    if (Date.parse(record.expiresAt) <= Date.parse(consumedAt)) {
+      return null;
+    }
+
+    const consumed = cloneOAuthStateRecord({ ...record, consumedAt });
+    this.records.set(stateId, consumed);
+    return cloneOAuthStateRecord(consumed);
+  }
+
+  async deleteExpired(before: string): Promise<number> {
+    const limit = Date.parse(before);
+    let deleted = 0;
+
+    for (const [key, value] of this.records.entries()) {
+      if (Date.parse(value.expiresAt) < limit) {
+        this.records.delete(key);
+        deleted += 1;
+      }
+    }
+
+    return deleted;
+  }
+}
+
+function createService(overrides?: { now?: () => Date; stateTtlMs?: number }) {
+  const stateStore = new TestStateStore();
+  const exchangeCodeForToken = vi.fn(async () => ({
+    accessToken: "at_valid",
+    refreshToken: "rt_valid",
+    tokenType: "bearer"
+  }));
+
+  const service = new DefaultOAuthService({
+    providers: {
+      google: {
+        id: "google",
+        authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenUrl: "https://oauth2.googleapis.com/token",
+        defaultScopes: ["openid", "email", "profile"],
+        supportsPkce: true,
+        supportsRefreshToken: true,
+        scopeSeparator: " "
+      },
+      microsoft: {
+        id: "microsoft",
+        authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        defaultScopes: ["openid", "email", "profile"],
+        supportsPkce: true,
+        supportsRefreshToken: true,
+        scopeSeparator: " "
+      }
+    },
+    providerRuntimeConfig: {
+      google: {
+        clientId: "google-client-id",
+        allowlistedRedirectUris: ["https://app/callback"]
+      },
+      microsoft: {
+        clientId: "microsoft-client-id",
+        allowlistedRedirectUris: ["https://app/callback"]
+      }
+    },
+    stateStore,
+    exchangeCodeForToken,
+    stateTtlMs: overrides?.stateTtlMs,
+    now: overrides?.now
+  });
+
+  return { service, stateStore, exchangeCodeForToken };
+}
+
+describe("oauth-core service", () => {
+  it("creates authorization URL with state and PKCE parameters for connection subjects", async () => {
+    const { service, stateStore } = createService();
+    const result = await service.createAuthorizationRequest({
+      providerId: "google",
+      tenantId: "t1",
+      userId: "u1",
+      connectionId: "conn_1",
+      redirectUri: "https://app/callback"
+    });
+
+    expect(result.stateId).toMatch(/^st_/);
+
+    const authorizationUrl = new URL(result.authorizationUrl);
+    expect(authorizationUrl.searchParams.get("response_type")).toBe("code");
+    expect(authorizationUrl.searchParams.get("client_id")).toBe("google-client-id");
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe("https://app/callback");
+    expect(authorizationUrl.searchParams.get("scope")).toBe("openid email profile");
+    expect(authorizationUrl.searchParams.get("state")).toBe(result.stateId);
+    expect(authorizationUrl.searchParams.get("code_challenge")).toBeTruthy();
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(authorizationUrl.searchParams.get("nonce")).toMatch(/^nonce_/);
+
+    const stored = await stateStore.get(result.stateId);
+    expect(stored?.subject).toMatchObject({
+      kind: "connection",
+      tenantId: "t1",
+      userId: "u1",
+      connectionId: "conn_1"
+    });
+    expect(stored?.codeVerifier).toBeTruthy();
+  });
+
+  it("generates unique high-entropy state values across requests", async () => {
+    const { service } = createService();
+    const stateIds = new Set<string>();
+
+    for (let index = 0; index < 32; index += 1) {
+      const result = await service.createAuthorizationRequest({
+        providerId: "google",
+        tenantId: "t1",
+        userId: `u${index}`,
+        redirectUri: "https://app/callback"
+      });
+
+      stateIds.add(result.stateId);
+      expect(result.stateId.length).toBeGreaterThanOrEqual(20);
+    }
+
+    expect(stateIds.size).toBe(32);
+  });
+
+  it("rejects non-allowlisted redirect URI during auth URL creation", async () => {
+    const { service } = createService();
+
+    await expect(
+      service.createAuthorizationRequest({
+        providerId: "google",
+        tenantId: "t1",
+        userId: "u1",
+        redirectUri: "https://evil.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_REDIRECT_DISALLOWED",
+      message: "redirect URI not allowed"
+    });
+  });
+
+  it("consumes callback state once and blocks replay", async () => {
+    const { service, exchangeCodeForToken } = createService();
+    const auth = await service.createAuthorizationRequest({
+      providerId: "google",
+      tenantId: "t1",
+      userId: "u1",
+      redirectUri: "https://app/callback"
+    });
+
+    const first = await service.handleCallback({
+      providerId: "google",
+      code: "valid-code",
+      state: auth.stateId,
+      redirectUri: "https://app/callback"
+    });
+
+    expect(first.accessToken).toBe("at_valid");
+    expect(exchangeCodeForToken).toHaveBeenCalledTimes(1);
+
+    await expect(
+      service.handleCallback({
+        providerId: "google",
+        code: "valid-code",
+        state: auth.stateId,
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_STATE_REPLAYED",
+      message: "OAuth state already consumed"
+    });
+  });
+
+  it("rejects callback with provider mismatch", async () => {
+    const { service } = createService();
+    const auth = await service.createAuthorizationRequest({
+      providerId: "google",
+      tenantId: "t1",
+      userId: "u1",
+      redirectUri: "https://app/callback"
+    });
+
+    await expect(
+      service.handleCallback({
+        providerId: "microsoft",
+        code: "valid-code",
+        state: auth.stateId,
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_CALLBACK_MISMATCH",
+      message: "provider mismatch for OAuth callback"
+    });
+  });
+
+  it("rejects callback with redirect URI mismatch", async () => {
+    const { service } = createService();
+    const auth = await service.createAuthorizationRequest({
+      providerId: "google",
+      tenantId: "t1",
+      userId: "u1",
+      redirectUri: "https://app/callback"
+    });
+
+    await expect(
+      service.handleCallback({
+        providerId: "google",
+        code: "valid-code",
+        state: auth.stateId,
+        redirectUri: "https://app/other"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_CALLBACK_MISMATCH",
+      message: "redirect URI not allowed"
+    });
+  });
+
+  it("rejects expired callback states", async () => {
+    let now = new Date("2026-01-01T00:00:00.000Z");
+    const { service } = createService({
+      now: () => new Date(now),
+      stateTtlMs: 60_000
+    });
+
+    const auth = await service.createAuthorizationRequest({
+      providerId: "google",
+      tenantId: "t1",
+      userId: "u1",
+      redirectUri: "https://app/callback"
+    });
+
+    now = new Date("2026-01-01T00:02:00.000Z");
+
+    await expect(
+      service.handleCallback({
+        providerId: "google",
+        code: "valid-code",
+        state: auth.stateId,
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_STATE_INVALID",
+      message: "OAuth state is invalid or expired"
+    });
+  });
+});

--- a/packages/oauth-core/tsconfig.json
+++ b/packages/oauth-core/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-core/vitest.config.ts
+++ b/packages/oauth-core/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createOAuthSharedVitestConfig } from "../../scripts/vitest-oauth-shared.mjs";
+
+export default createOAuthSharedVitestConfig();

--- a/packages/oauth-flow/CHANGELOG.md
+++ b/packages/oauth-flow/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.1
+
+- Introduced shared high-level OAuth orchestration package.
+- Migration: move orchestration logic from function-local flows to `@superfunctions/oauth-flow`.
+- Compatibility timeline: wrappers may remain for one minor release where required.

--- a/packages/oauth-flow/README.md
+++ b/packages/oauth-flow/README.md
@@ -1,0 +1,75 @@
+# @superfunctions/oauth-flow
+
+High-level OAuth lifecycle orchestration for start, callback, refresh, and disconnect workflows.
+
+## Install
+
+```bash
+npm install @superfunctions/oauth-flow @superfunctions/oauth-providers @superfunctions/oauth-storage
+```
+
+## Quick Start
+
+```ts
+import { createOAuthFlowService } from "@superfunctions/oauth-flow";
+import { getOAuthProviderDescriptor } from "@superfunctions/oauth-providers";
+import {
+  AesGcmTokenCipher,
+  EncryptedTokenVault,
+  MemoryOAuthStateStore,
+  MemoryTokenVault,
+} from "@superfunctions/oauth-storage";
+
+const encryptionKeyHex = process.env.OAUTH_TOKEN_ENCRYPTION_KEY_HEX!;
+const tokenVault = new EncryptedTokenVault(
+  new MemoryTokenVault(),
+  new AesGcmTokenCipher(() => Buffer.from(encryptionKeyHex, "hex")),
+);
+
+const flow = createOAuthFlowService({
+  providers: {
+    github: getOAuthProviderDescriptor("github"),
+  },
+  providerRuntimeConfig: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID!,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+      allowlistedRedirectUris: ["https://app.example/oauth/github/callback"],
+    },
+  },
+  stateStore: new MemoryOAuthStateStore(),
+  tokenVault,
+});
+```
+
+## Package Boundary
+
+`@superfunctions/oauth-flow` composes:
+
+- `@superfunctions/oauth-core` for state and callback invariants
+- `@superfunctions/oauth-http` for token transport
+- `@superfunctions/oauth-storage` for state/token persistence
+
+It owns orchestration and lifecycle hooks, not route adapters. Use `@superfunctions/oauth-router` when you want reusable HTTP endpoints.
+
+Keep `OAUTH_TOKEN_ENCRYPTION_KEY_HEX` as a deployment secret with 32 random bytes encoded as hex.
+
+## Production Notes
+
+- `EncryptedTokenVault` defaults to `tokenStorageMode: "encrypted-required"`.
+- Legacy plain `TokenVault` wiring stays writable by default for backward compatibility, but new production deployments should migrate to `EncryptedTokenVault`.
+- Set `tokenStorageMode: "encrypted-required"` explicitly if you want upgrades to fail closed on plaintext persistence.
+- `plaintext-unsafe` is for tests, local prototypes, and temporary migration windows only.
+- `disconnect()` now reports `connectionCleanup`, and `connectionDeleted` remains only as a deprecated compatibility alias of `connectionCleanup.deleted`.
+- Keep `resolveProviderRuntimeConfig` deterministic across app servers and background workers.
+
+## Verification
+
+- Repo-root gate: `npm run gate:packages-oauth-shared`
+- Package-local tests: `npm test --workspace @superfunctions/oauth-flow`
+
+## Docs
+
+- Canonical docs: [docs/content/docs/authentication/oauth-flow.mdx](../../docs/content/docs/authentication/oauth-flow.mdx)
+- Route factories: [docs/content/docs/authentication/oauth-router.mdx](../../docs/content/docs/authentication/oauth-router.mdx)
+- Stack overview: [docs/content/docs/architecture/oauth-flow-architecture.mdx](../../docs/content/docs/architecture/oauth-flow-architecture.mdx)

--- a/packages/oauth-flow/package.json
+++ b/packages/oauth-flow/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@superfunctions/oauth-flow",
+  "version": "0.0.1",
+  "description": "High-level OAuth orchestration contracts for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --config ./vitest.config.ts --run",
+    "test:watch": "vitest --config ./vitest.config.ts --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "oauth",
+    "auth",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/oauth-flow"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/oauth-core": "*",
+    "@superfunctions/oauth-http": "*",
+    "@superfunctions/oauth-storage": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/oauth-flow/scripts/run-vitest.mjs
+++ b/packages/oauth-flow/scripts/run-vitest.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2).filter((arg) => arg !== "--runInBand");
+const vitestArgs = ["vitest", "run", ...args];
+const command = process.platform === "win32" ? "npx.cmd" : "npx";
+
+const result = spawnSync(command, vitestArgs, { stdio: "inherit" });
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? (result.signal ? 1 : 0));

--- a/packages/oauth-flow/src/__tests__/browser-auth-flow.test.ts
+++ b/packages/oauth-flow/src/__tests__/browser-auth-flow.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import { AesGcmTokenCipher, EncryptedTokenVault, MemoryOAuthStateStore, MemoryTokenVault } from "@superfunctions/oauth-storage";
+import { createOAuthFlowService, type OAuthFlowEvent } from "../index.js";
+
+const provider: OAuthProviderDescriptor = {
+  id: "google",
+  authorizationUrl: "https://accounts.google.example/o/oauth2/v2/auth",
+  tokenUrl: "https://oauth2.googleapis.example/token",
+  revocationUrl: "https://oauth2.googleapis.example/revoke",
+  defaultScopes: ["openid", "email"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+function createHarness(options?: {
+  useEncryptedVault?: boolean;
+  tokenStorageMode?: "encrypted-required" | "plaintext-unsafe";
+}) {
+  const events: OAuthFlowEvent[] = [];
+  const stateStore = new MemoryOAuthStateStore();
+  const backingStore = new MemoryTokenVault();
+  const tokenVault = options?.useEncryptedVault
+    ? new EncryptedTokenVault(
+        backingStore,
+        new AesGcmTokenCipher((keyRef) => {
+          if (keyRef !== "oauth-default") {
+            throw new Error(`unexpected keyRef: ${keyRef}`);
+          }
+          return Buffer.from("55".repeat(32), "hex");
+        }),
+        () => "2026-01-01T00:00:00.000Z"
+      )
+    : backingStore;
+  const tokenHttpClient = {
+    exchangeToken: vi.fn(async (input) => {
+      if (input.grantType === "refresh_token") {
+        return {
+          accessToken: "access-refreshed",
+          refreshToken: "refresh-existing",
+          expiresIn: 3600,
+          tokenType: "Bearer"
+        };
+      }
+
+      return {
+        accessToken: "access-browser",
+        refreshToken: "refresh-browser",
+        expiresIn: 3600,
+        tokenType: "Bearer",
+        scope: "openid email",
+        idToken: "id-token-browser"
+      };
+    }),
+    revokeToken: vi.fn(async () => {})
+  };
+
+  const service = createOAuthFlowService({
+    providers: { google: provider },
+    providerRuntimeConfig: {
+      google: {
+        clientId: "client_google",
+        clientSecret: "secret_google",
+        allowlistedRedirectUris: ["https://app.example/callback"]
+      }
+    },
+    stateStore,
+    tokenVault,
+    tokenStorageMode: options?.tokenStorageMode ?? "plaintext-unsafe",
+    tokenHttpClient,
+    emitEvent: (event) => events.push(event),
+    now: () => new Date("2026-01-01T00:00:00.000Z")
+  });
+
+  return { service, stateStore, tokenVault, backingStore, tokenHttpClient, events };
+}
+
+describe("oauth-flow browser-auth lifecycle", () => {
+  it("completes browser-auth callbacks without a pre-known local user", async () => {
+    const { service, tokenVault } = createHarness();
+
+    const started = await service.start({
+      providerId: "google",
+      redirectUri: "https://app.example/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_01",
+        regionId: "eu-west-1",
+        returnTo: "https://app.example/post-auth"
+      },
+      requestId: "req_browser_1"
+    });
+
+    const callback = await service.handleCallback({
+      code: "code_browser_1",
+      state: started.stateId,
+      redirectUri: "https://app.example/callback",
+      requestId: "req_browser_2"
+    });
+
+    expect(callback.providerId).toBe("google");
+    expect(callback.subject).toMatchObject({
+      kind: "browser-auth",
+      intentId: "intent_01",
+      regionId: "eu-west-1",
+      returnTo: "https://app.example/post-auth"
+    });
+    expect(callback.tokenSet.accessToken).toBe("access-browser");
+    expect(callback.connectionId).toBeUndefined();
+    expect(callback.tokenRecordId).toBeUndefined();
+    expect(await tokenVault.getByConnection("conn_intent_01")).toBeNull();
+  });
+
+  it("persists tokens after browser-auth identity resolution hooks run", async () => {
+    const { stateStore, tokenVault, backingStore, tokenHttpClient, events } = createHarness({
+      useEncryptedVault: true,
+      tokenStorageMode: "encrypted-required"
+    });
+    const service = createOAuthFlowService({
+      providers: { google: provider },
+      providerRuntimeConfig: {
+        google: {
+          clientId: "client_google",
+          clientSecret: "secret_google",
+          allowlistedRedirectUris: ["https://app.example/callback"]
+        }
+      },
+      stateStore,
+      tokenVault,
+      tokenStorageMode: "encrypted-required",
+      tokenHttpClient,
+      emitEvent: (event) => events.push(event),
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+      identityHooks: {
+        resolveBrowserAuthIdentity: async ({ subject }) => ({
+          tenantId: "tenant_resolved",
+          userId: "user_resolved",
+          connectionId: `conn_${subject.intentId}`
+        })
+      }
+    });
+
+    const started = await service.start({
+      providerId: "google",
+      redirectUri: "https://app.example/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_02"
+      }
+    });
+
+    const callback = await service.handleCallback({
+      code: "code_browser_2",
+      state: started.stateId,
+      redirectUri: "https://app.example/callback"
+    });
+
+    expect(callback.resolvedIdentity).toEqual({
+      tenantId: "tenant_resolved",
+      userId: "user_resolved",
+      connectionId: "conn_intent_02",
+      metadata: undefined,
+      persistTokens: undefined
+    });
+    expect(callback.connectionId).toBe("conn_intent_02");
+    expect(callback.tokenRecordId).toMatch(/^tok_/);
+
+    const stored = await backingStore.getByConnection("conn_intent_02");
+    expect(stored?.providerId).toBe("google");
+    expect(stored?.encryptedPayload).toBeDefined();
+    expect(stored?.encryptedPayload).not.toContain("access-browser");
+    expect(stored?.encryptedPayload).not.toContain("refresh-browser");
+  });
+
+  it("wraps browser-auth identity hook failures with OAUTH_HOOK_FAILED and emits redaction-safe events", async () => {
+    const { stateStore, tokenVault, tokenHttpClient, events } = createHarness();
+    const service = createOAuthFlowService({
+      providers: { google: provider },
+      providerRuntimeConfig: {
+        google: {
+          clientId: "client_google",
+          clientSecret: "secret_google",
+          allowlistedRedirectUris: ["https://app.example/callback"]
+        }
+      },
+      stateStore,
+      tokenVault,
+      tokenHttpClient,
+      emitEvent: (event) => events.push(event),
+      now: () => new Date("2026-01-01T00:00:00.000Z"),
+      identityHooks: {
+        resolveBrowserAuthIdentity: async () => {
+          throw new Error("client secret leaked? secret_google access-browser refresh-browser");
+        }
+      }
+    });
+
+    const started = await service.start({
+      providerId: "google",
+      redirectUri: "https://app.example/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_03"
+      }
+    });
+
+    await expect(
+      service.handleCallback({
+        code: "code_browser_3",
+        state: started.stateId,
+        redirectUri: "https://app.example/callback",
+        requestId: "req_browser_3"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_HOOK_FAILED",
+      status: 500
+    });
+
+    const serializedEvents = JSON.stringify(events);
+    expect(serializedEvents).toContain("oauth.flow.started");
+    expect(serializedEvents).toContain("oauth.flow.callback.failed");
+    expect(serializedEvents).not.toContain("secret_google");
+    expect(serializedEvents).not.toContain("access-browser");
+    expect(serializedEvents).not.toContain("refresh-browser");
+  });
+});

--- a/packages/oauth-flow/src/__tests__/exports.test.ts
+++ b/packages/oauth-flow/src/__tests__/exports.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import type { OAuthProviderDescriptor, OAuthProviderRuntimeConfigResolverInput } from "@superfunctions/oauth-core";
+import type { OAuthFlowCallbackResult, OAuthFlowConnectionCleanup, OAuthFlowDisconnectResult } from "../index.js";
+import {
+  OAuthFlowError,
+  createOAuthFlowService,
+  invokeIdentityHook
+} from "../index.js";
+
+const provider: OAuthProviderDescriptor = {
+  id: "mock",
+  authorizationUrl: "https://mock.example/auth",
+  tokenUrl: "https://mock.example/token",
+  revocationUrl: "https://mock.example/revoke",
+  defaultScopes: ["read"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+function createTestConfig() {
+  return {
+    providers: { mock: provider },
+    providerRuntimeConfig: {
+      mock: {
+        clientId: "client_1",
+        clientSecret: "secret_1",
+        allowlistedRedirectUris: ["https://app.example/callback"]
+      }
+    },
+    tokenStorageMode: "plaintext-unsafe" as const,
+    stateStore: {
+      async put() {},
+      async get() {
+        return null;
+      },
+      async consume() {
+        return null;
+      },
+      async deleteExpired() {
+        return 0;
+      }
+    },
+    tokenVault: {
+      async put() {},
+      async get() {
+        return null;
+      },
+      async getByConnection() {
+        return null;
+      },
+      async rotateKey() {},
+      async deleteByConnection() {}
+    }
+  };
+}
+
+describe("oauth-flow exports", () => {
+  it("exposes required service API surface", () => {
+    const service = createOAuthFlowService(createTestConfig());
+    const cleanup: OAuthFlowConnectionCleanup = {
+      attempted: false,
+      deleted: false,
+      reason: "not-configured"
+    };
+    const disconnectResult: OAuthFlowDisconnectResult = {
+      disconnected: true,
+      remoteRevokeAttempted: false,
+      localTokenDeleted: true,
+      connectionCleanup: cleanup,
+      connectionDeleted: cleanup.deleted
+    };
+
+    expect(typeof service.start).toBe("function");
+    expect(typeof service.handleCallback).toBe("function");
+    expect(typeof service.refresh).toBe("function");
+    expect(typeof service.disconnect).toBe("function");
+    expect(disconnectResult.connectionCleanup.reason).toBe("not-configured");
+    expect(disconnectResult.connectionDeleted).toBe(false);
+  });
+
+  it("invokes identity hooks and wraps hook failures deterministically", async () => {
+    const callbackPayload = {
+      providerId: "mock",
+      subject: {
+        kind: "connection" as const,
+        tenantId: "tenant_1",
+        userId: "user_1",
+        connectionId: "conn_1"
+      },
+      tokenSet: {
+        accessToken: "access_1",
+        refreshToken: "refresh_1"
+      },
+      tokenRecordId: "tok_1",
+      connectionId: "conn_1"
+    } satisfies OAuthFlowCallbackResult;
+
+    let onConnectedCalled = false;
+    await invokeIdentityHook(
+      {
+        async onConnected(result) {
+          onConnectedCalled = true;
+          expect(result.providerId).toBe("mock");
+          expect(result.connectionId).toBe("conn_1");
+          expect(result.subject.tenantId).toBe("tenant_1");
+          expect(result.subject.userId).toBe("user_1");
+          expect(result.tokenSet.refreshToken).toBe("refresh_1");
+        }
+      },
+      "onConnected",
+      callbackPayload
+    );
+    expect(onConnectedCalled).toBe(true);
+
+    await expect(
+      invokeIdentityHook(
+        {
+          async onConnected() {
+            throw new Error("boom");
+          }
+        },
+        "onConnected",
+        callbackPayload
+      )
+    ).rejects.toBeInstanceOf(OAuthFlowError);
+
+    await expect(
+      invokeIdentityHook(
+        {
+          async onConnected() {
+            throw new Error("boom");
+          }
+        },
+        "onConnected",
+        callbackPayload
+      )
+    ).rejects.toMatchObject({
+      code: "OAUTH_HOOK_FAILED",
+      message: "identity hook failed"
+    });
+  });
+
+  it("passes undefined optional resolver fields for disconnect and concrete fields for refresh", async () => {
+    const runtimeResolverCalls: OAuthProviderRuntimeConfigResolverInput[] = [];
+    const service = createOAuthFlowService({
+      providers: { mock: provider },
+      resolveProviderRuntimeConfig: async (input) => {
+        runtimeResolverCalls.push(input);
+        return {
+          clientId: "resolver_client_1",
+          clientSecret: "resolver_secret_1",
+          allowlistedRedirectUris: ["https://app.example/callback"]
+        };
+      },
+      stateStore: {
+        async put() {},
+        async get() {
+          return null;
+        },
+        async consume() {
+          return null;
+        },
+        async deleteExpired() {
+          return 0;
+        }
+      },
+      tokenVault: {
+        async put() {},
+        async get() {
+          return null;
+        },
+        async getByConnection() {
+          return {
+            tokenId: "tok_1",
+            tenantId: "tenant_1",
+            userId: "user_1",
+            providerId: "mock",
+            connectionId: "conn_1",
+            encryptedPayload: JSON.stringify({
+              accessToken: "access_1",
+              refreshToken: "refresh_1"
+            }),
+            keyRef: "oauth-default",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z"
+          };
+        },
+        async rotateKey() {},
+        async deleteByConnection() {}
+      },
+      tokenStorageMode: "plaintext-unsafe",
+      tokenHttpClient: {
+        async exchangeToken() {
+          return {
+            accessToken: "access_2",
+            refreshToken: "refresh_1",
+            expiresIn: 3600
+          };
+        },
+        async revokeToken() {}
+      }
+    });
+
+    await service.refresh({
+      connectionId: "conn_1",
+      providerId: "mock",
+      redirectUri: "https://app.example/callback",
+      scopes: ["read"]
+    });
+
+    await service.disconnect({
+      connectionId: "conn_1",
+      providerId: "mock",
+      revokeRemote: true
+    });
+
+    expect(runtimeResolverCalls).toHaveLength(2);
+    expect(runtimeResolverCalls[0]).toMatchObject({
+      providerId: "mock",
+      subject: {
+        kind: "connection",
+        tenantId: "tenant_1",
+        userId: "user_1",
+        connectionId: "conn_1"
+      },
+      redirectUri: "https://app.example/callback",
+      scopes: ["read"]
+    });
+    expect(runtimeResolverCalls[1]).toMatchObject({
+      providerId: "mock",
+      subject: {
+        kind: "connection",
+        tenantId: "tenant_1",
+        userId: "user_1",
+        connectionId: "conn_1"
+      }
+    });
+    expect(runtimeResolverCalls[1].redirectUri).toBeUndefined();
+    expect(runtimeResolverCalls[1].scopes).toBeUndefined();
+    expect(runtimeResolverCalls[1].prompt).toBeUndefined();
+    expect(runtimeResolverCalls[1].loginHint).toBeUndefined();
+  });
+});

--- a/packages/oauth-flow/src/__tests__/refresh-disconnect.test.ts
+++ b/packages/oauth-flow/src/__tests__/refresh-disconnect.test.ts
@@ -1,0 +1,540 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import { OAuthHttpError } from "@superfunctions/oauth-http";
+import { AesGcmTokenCipher, EncryptedTokenVault, MemoryOAuthStateStore, MemoryTokenVault } from "@superfunctions/oauth-storage";
+import { createOAuthFlowService, type OAuthFlowConnectionCleanup, type OAuthFlowEvent, type OAuthFlowIdentityHooks } from "../index.js";
+
+const provider: OAuthProviderDescriptor = {
+  id: "google",
+  authorizationUrl: "https://accounts.google.example/o/oauth2/v2/auth",
+  tokenUrl: "https://oauth2.googleapis.example/token",
+  revocationUrl: "https://oauth2.googleapis.example/revoke",
+  defaultScopes: ["openid", "email"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+function createHarness(options?: {
+  startAt?: string;
+  useEncryptedVault?: boolean;
+  tokenStorageMode?: "encrypted-required" | "plaintext-unsafe";
+  identityHooks?: OAuthFlowIdentityHooks;
+}) {
+  const startAt = options?.startAt ?? "2026-01-01T00:00:00.000Z";
+  let nowMs = Date.parse(startAt);
+  const now = () => new Date(nowMs);
+  const advanceMs = (ms: number) => {
+    nowMs += ms;
+  };
+
+  const events: OAuthFlowEvent[] = [];
+  const stateStore = new MemoryOAuthStateStore();
+  const backingStore = new MemoryTokenVault();
+  const tokenVault = options?.useEncryptedVault
+    ? new EncryptedTokenVault(
+        backingStore,
+        new AesGcmTokenCipher((keyRef) => {
+          if (keyRef !== "oauth-default") {
+            throw new Error(`unexpected keyRef: ${keyRef}`);
+          }
+          return Buffer.from("66".repeat(32), "hex");
+        }),
+        () => now().toISOString()
+      )
+    : backingStore;
+
+  const tokenHttpClient = {
+    exchangeToken: vi.fn(async (input) => {
+      if (input.grantType === "authorization_code") {
+        return {
+          accessToken: "access-old",
+          refreshToken: "refresh-old",
+          expiresIn: 3600,
+          tokenType: "Bearer",
+          scope: "openid email"
+        };
+      }
+
+      return {
+        accessToken: "access-new",
+        refreshToken: undefined,
+        expiresIn: 7200,
+        tokenType: "Bearer",
+        scope: "openid email"
+      };
+    }),
+    revokeToken: vi.fn(async () => {})
+  };
+
+  const service = createOAuthFlowService({
+    providers: { google: provider },
+    providerRuntimeConfig: {
+      google: {
+        clientId: "client_google",
+        clientSecret: "secret_google",
+        allowlistedRedirectUris: ["https://app.example/callback"]
+      }
+    },
+    stateStore,
+    tokenVault,
+    tokenStorageMode: options?.tokenStorageMode ?? "plaintext-unsafe",
+    tokenHttpClient,
+    identityHooks: options?.identityHooks,
+    now,
+    emitEvent: (event) => events.push(event)
+  });
+
+  return { service, tokenVault, backingStore, events, tokenHttpClient, advanceMs };
+}
+
+async function seedConnection(service: ReturnType<typeof createHarness>["service"], connectionId: string): Promise<void> {
+  const started = await service.start({
+    providerId: "google",
+    tenantId: "tenant_1",
+    userId: "user_1",
+    connectionId,
+    redirectUri: "https://app.example/callback"
+  });
+
+  await service.handleCallback({
+    code: "auth-code",
+    state: started.stateId,
+    redirectUri: "https://app.example/callback"
+  });
+}
+
+describe("oauth-flow refresh/disconnect lifecycle", () => {
+  it("refresh() preserves existing refresh token when provider omits replacement", async () => {
+    const { service, tokenVault, backingStore, advanceMs, events } = createHarness({
+      useEncryptedVault: true,
+      tokenStorageMode: "encrypted-required"
+    });
+    await seedConnection(service, "conn_1");
+    advanceMs(30_000);
+
+    const refreshed = await service.refresh({
+      connectionId: "conn_1",
+      providerId: "google",
+      redirectUri: "https://app.example/callback"
+    });
+
+    expect(refreshed.accessToken).toBe("access-new");
+    expect(refreshed.refreshToken).toBe("refresh-old");
+    expect(events.some((event) => event.name === "oauth.flow.refresh.success")).toBe(true);
+
+    const stored = await backingStore.getByConnection("conn_1");
+    expect(stored).not.toBeNull();
+    expect(stored!.encryptedPayload).not.toContain("access-new");
+    expect(stored!.encryptedPayload).not.toContain("refresh-old");
+
+    if (!("getTokenSetByConnection" in tokenVault)) {
+      throw new Error("expected encrypted token vault");
+    }
+
+    const decrypted = await tokenVault.getTokenSetByConnection("conn_1");
+    expect(decrypted?.tokenSet.accessToken).toBe("access-new");
+    expect(decrypted?.tokenSet.refreshToken).toBe("refresh-old");
+  });
+
+  it("refresh() failure keeps prior token record intact", async () => {
+    const { service, tokenVault, tokenHttpClient, events } = createHarness();
+    await seedConnection(service, "conn_2");
+
+    const before = await tokenVault.getByConnection("conn_2");
+    expect(before).not.toBeNull();
+
+    tokenHttpClient.exchangeToken = vi.fn(async (input) => {
+      if (input.grantType === "authorization_code") {
+        return {
+          accessToken: "access-old",
+          refreshToken: "refresh-old"
+        };
+      }
+
+      throw new OAuthHttpError("invalid_grant", {
+        code: "OAUTH_TOKEN_REFRESH_FAILED",
+        status: 400,
+        retryable: false
+      });
+    });
+
+    await expect(
+      service.refresh({
+        connectionId: "conn_2",
+        providerId: "google",
+        redirectUri: "https://app.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_REFRESH_FAILED"
+    });
+
+    expect(events.some((event) => event.name === "oauth.flow.refresh.failed")).toBe(true);
+
+    const after = await tokenVault.getByConnection("conn_2");
+    expect(after).toEqual(before);
+  });
+
+  it("refresh() rejects plaintext persistence by default and leaves the existing record untouched", async () => {
+    const { service, tokenVault, events } = createHarness({
+      tokenStorageMode: "encrypted-required"
+    });
+
+    await tokenVault.put({
+      tokenId: "tok_plain_existing",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      providerId: "google",
+      connectionId: "conn_plain_existing",
+      encryptedPayload: JSON.stringify({
+        accessToken: "access-old",
+        refreshToken: "refresh-old",
+        expiresAt: "2026-01-01T01:00:00.000Z",
+        tokenType: "Bearer",
+        scope: "openid email"
+      }),
+      keyRef: "oauth-default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T01:00:00.000Z"
+    });
+
+    const before = await tokenVault.getByConnection("conn_plain_existing");
+
+    await expect(
+      service.refresh({
+        connectionId: "conn_plain_existing",
+        providerId: "google",
+        redirectUri: "https://app.example/callback",
+        requestId: "req_plain_refresh"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_STORAGE_UNSAFE",
+      message: "encrypted token storage is required unless plaintext-unsafe mode is explicitly enabled",
+      status: 500,
+      retryable: false
+    });
+
+    const after = await tokenVault.getByConnection("conn_plain_existing");
+    expect(after).toEqual(before);
+
+    const failureEvent = events.find((event) => event.name === "oauth.flow.refresh.failed");
+    expect(failureEvent).toMatchObject({
+      providerId: "google",
+      requestId: "req_plain_refresh",
+      errorCode: "OAUTH_TOKEN_STORAGE_UNSAFE"
+    });
+    expect(failureEvent?.details).toMatchObject({
+      operation: "refresh",
+      providerId: "google",
+      connectionId: "conn_plain_existing",
+      storageMode: "encrypted-required",
+      vaultKind: "plaintext"
+    });
+
+    const serializedEvents = JSON.stringify(events);
+    expect(serializedEvents).not.toContain("access-old");
+    expect(serializedEvents).not.toContain("refresh-old");
+    expect(serializedEvents).not.toContain("secret_google");
+    expect(serializedEvents).not.toContain("encryptedPayload");
+  });
+
+  it("disconnect() reports not-configured cleanup when no disconnect hook exists", async () => {
+    const { service, tokenVault, events } = createHarness();
+    await seedConnection(service, "conn_3");
+
+    const result = await service.disconnect({
+      connectionId: "conn_3",
+      providerId: "google",
+      revokeRemote: false
+    });
+
+    expect(result).toEqual({
+      disconnected: true,
+      remoteRevokeAttempted: false,
+      localTokenDeleted: true,
+      connectionCleanup: {
+        attempted: false,
+        deleted: false,
+        reason: "not-configured"
+      },
+      connectionDeleted: false
+    });
+    expect(await tokenVault.getByConnection("conn_3")).toBeNull();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "oauth.flow.disconnect.success",
+        details: {
+          remoteRevokeAttempted: false,
+          localDeleted: true,
+          cleanupAttempted: false,
+          cleanupDeleted: false,
+          cleanupReason: "not-configured"
+        }
+      })
+    );
+  });
+
+  it("disconnect() uses hook cleanup results and passes normalized disconnect context", async () => {
+    const onDisconnected = vi.fn(async () => ({
+      attempted: true,
+      deleted: true,
+      reason: "deleted"
+    } satisfies OAuthFlowConnectionCleanup));
+    const { service, tokenVault, events } = createHarness({
+      identityHooks: { onDisconnected }
+    });
+    await seedConnection(service, "conn_4");
+
+    const result = await service.disconnect({
+      connectionId: "conn_4",
+      providerId: "google",
+      revokeRemote: true,
+      requestId: "req_disconnect_1"
+    });
+
+    expect(result).toEqual({
+      disconnected: true,
+      remoteRevokeAttempted: true,
+      localTokenDeleted: true,
+      connectionCleanup: {
+        attempted: true,
+        deleted: true,
+        reason: "deleted"
+      },
+      connectionDeleted: true
+    });
+    expect(await tokenVault.getByConnection("conn_4")).toBeNull();
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+    expect(onDisconnected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "google",
+        connectionId: "conn_4",
+        revokeRemote: true,
+        requestId: "req_disconnect_1",
+        remoteRevokeAttempted: true,
+        localTokenDeleted: true,
+        subject: {
+          kind: "connection",
+          tenantId: "tenant_1",
+          userId: "user_1",
+          connectionId: "conn_4"
+        },
+        tokenMetadata: expect.objectContaining({
+          tenantId: "tenant_1",
+          userId: "user_1",
+          providerId: "google",
+          connectionId: "conn_4",
+          keyRef: "oauth-default"
+        })
+      })
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "oauth.flow.disconnect.success",
+        details: {
+          remoteRevokeAttempted: true,
+          localDeleted: true,
+          cleanupAttempted: true,
+          cleanupDeleted: true,
+          cleanupReason: "deleted"
+        }
+      })
+    );
+  });
+
+  it("disconnect() accepts legacy hooks that only perform side effects and return void", async () => {
+    const { service, tokenVault, events } = createHarness({
+      identityHooks: {
+        onDisconnected: async () => {}
+      }
+    });
+    await seedConnection(service, "conn_void_hook");
+
+    const result = await service.disconnect({
+      connectionId: "conn_void_hook",
+      providerId: "google",
+      revokeRemote: false,
+      requestId: "req_disconnect_void"
+    });
+
+    expect(result.connectionCleanup).toEqual({
+      attempted: true,
+      deleted: false,
+      reason: "retained"
+    });
+    expect(result.connectionDeleted).toBe(false);
+    expect(await tokenVault.getByConnection("conn_void_hook")).toBeNull();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "oauth.flow.disconnect.success",
+        requestId: "req_disconnect_void",
+        details: {
+          remoteRevokeAttempted: false,
+          localDeleted: true,
+          cleanupAttempted: true,
+          cleanupDeleted: false,
+          cleanupReason: "retained"
+        }
+      })
+    );
+  });
+
+  it("disconnect() surfaces OAUTH_HOOK_FAILED only after local cleanup and emits redaction-safe details", async () => {
+    const { service, tokenVault, events } = createHarness({
+      identityHooks: {
+        onDisconnected: async () => {
+          throw new Error("cleanup exploded access-old refresh-old secret_google");
+        }
+      }
+    });
+    await seedConnection(service, "conn_5");
+
+    await expect(
+      service.disconnect({
+        connectionId: "conn_5",
+        providerId: "google",
+        revokeRemote: false,
+        requestId: "req_disconnect_2"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_HOOK_FAILED",
+      message: "identity hook failed",
+      details: {
+        remoteRevokeAttempted: false,
+        localDeleted: true,
+        cleanupAttempted: true,
+        cleanupDeleted: false,
+        cleanupReason: "retained"
+      }
+    });
+
+    expect(await tokenVault.getByConnection("conn_5")).toBeNull();
+    const failureEvent = events.find((event) => event.name === "oauth.flow.disconnect.failed");
+    expect(failureEvent).toMatchObject({
+      requestId: "req_disconnect_2",
+      errorCode: "OAUTH_HOOK_FAILED",
+      details: {
+        remoteRevokeAttempted: false,
+        localDeleted: true,
+        cleanupAttempted: true,
+        cleanupDeleted: false,
+        cleanupReason: "retained"
+      }
+    });
+
+    const serializedEvents = JSON.stringify(events);
+    expect(serializedEvents).not.toContain("access-old");
+    expect(serializedEvents).not.toContain("refresh-old");
+    expect(serializedEvents).not.toContain("secret_google");
+    expect(serializedEvents).not.toContain("encryptedPayload");
+  });
+
+  it("disconnect() rejects invalid hook cleanup results after local cleanup", async () => {
+    const { service, tokenVault, events } = createHarness({
+      identityHooks: {
+        onDisconnected: async () => ({ deleted: true } as unknown as OAuthFlowConnectionCleanup)
+      }
+    });
+    await seedConnection(service, "conn_6");
+
+    await expect(
+      service.disconnect({
+        connectionId: "conn_6",
+        providerId: "google",
+        revokeRemote: false,
+        requestId: "req_disconnect_3"
+      })
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "disconnect hook returned invalid cleanup result",
+      details: {
+        remoteRevokeAttempted: false,
+        localDeleted: true,
+        cleanupAttempted: true,
+        cleanupDeleted: false,
+        cleanupReason: "retained"
+      }
+    });
+
+    expect(await tokenVault.getByConnection("conn_6")).toBeNull();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "oauth.flow.disconnect.failed",
+        requestId: "req_disconnect_3",
+        errorCode: "VALIDATION_ERROR",
+        details: {
+          remoteRevokeAttempted: false,
+          localDeleted: true,
+          cleanupAttempted: true,
+          cleanupDeleted: false,
+          cleanupReason: "retained"
+        }
+      })
+    );
+  });
+
+  it("disconnect() still cleans local records when remote revoke fails", async () => {
+    const { service, tokenVault, tokenHttpClient, events } = createHarness();
+    await seedConnection(service, "conn_7");
+
+    tokenHttpClient.revokeToken = vi.fn(async () => {
+      throw new OAuthHttpError("upstream revoke failed", {
+        code: "INTERNAL_ERROR",
+        status: 500,
+        retryable: false
+      });
+    });
+
+    await expect(
+      service.disconnect({
+        connectionId: "conn_7",
+        providerId: "google",
+        revokeRemote: true
+      })
+    ).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+      details: {
+        remoteRevokeAttempted: true,
+        localDeleted: true,
+        cleanupAttempted: false,
+        cleanupDeleted: false,
+        cleanupReason: "not-configured"
+      }
+    });
+
+    expect(await tokenVault.getByConnection("conn_7")).toBeNull();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "oauth.flow.disconnect.failed",
+        details: {
+          remoteRevokeAttempted: true,
+          localDeleted: true,
+          cleanupAttempted: false,
+          cleanupDeleted: false,
+          cleanupReason: "not-configured"
+        }
+      })
+    );
+  });
+
+  it("disconnect() honors tokenTypeHint when choosing which token to revoke", async () => {
+    const { service, tokenHttpClient } = createHarness();
+    await seedConnection(service, "conn_8");
+
+    await service.disconnect({
+      connectionId: "conn_8",
+      providerId: "google",
+      revokeRemote: true,
+      tokenTypeHint: "access_token",
+    });
+
+    expect(tokenHttpClient.revokeToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "access-old",
+        tokenTypeHint: "access_token",
+      })
+    );
+  });
+});

--- a/packages/oauth-flow/src/__tests__/start-callback.test.ts
+++ b/packages/oauth-flow/src/__tests__/start-callback.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OAuthProviderDescriptor, OAuthProviderRuntimeConfigResolverInput } from "@superfunctions/oauth-core";
+import { MemoryOAuthStateStore, MemoryTokenVault } from "@superfunctions/oauth-storage";
+import { createOAuthFlowService, type OAuthFlowEvent } from "../index.js";
+
+const provider: OAuthProviderDescriptor = {
+  id: "google",
+  authorizationUrl: "https://accounts.google.example/o/oauth2/v2/auth",
+  tokenUrl: "https://oauth2.googleapis.example/token",
+  defaultScopes: ["openid", "email"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+class CountingStateStore extends MemoryOAuthStateStore {
+  putCount = 0;
+
+  override async put(record: Parameters<MemoryOAuthStateStore["put"]>[0]): Promise<void> {
+    this.putCount += 1;
+    await super.put(record);
+  }
+}
+
+function createHarness(options?: {
+  startAt?: string;
+  tokenStorageMode?: "encrypted-required" | "plaintext-unsafe";
+  omitTokenStorageMode?: boolean;
+  providerRuntimeConfig?: {
+    google?: {
+      clientId?: string;
+      clientSecret?: string;
+      allowlistedRedirectUris?: string[];
+    };
+  };
+  resolveProviderRuntimeConfig?: (
+    input: OAuthProviderRuntimeConfigResolverInput
+  ) => Promise<{ clientId: string; clientSecret?: string; allowlistedRedirectUris?: string[] }> | { clientId: string; clientSecret?: string; allowlistedRedirectUris?: string[] };
+}) {
+  const startAt = options?.startAt ?? "2026-01-01T00:00:00.000Z";
+  let nowMs = Date.parse(startAt);
+  const now = () => new Date(nowMs);
+  const advanceMs = (ms: number) => {
+    nowMs += ms;
+  };
+
+  const events: OAuthFlowEvent[] = [];
+  const stateStore = new CountingStateStore();
+  const tokenVault = new MemoryTokenVault();
+
+  const tokenHttpClient = {
+    exchangeToken: vi.fn(async () => ({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+      tokenType: "Bearer",
+      scope: "openid email"
+    })),
+    revokeToken: vi.fn(async () => {})
+  };
+
+  const service = createOAuthFlowService({
+    providers: { google: provider },
+    providerRuntimeConfig: {
+      google: {
+        clientId: "client_google",
+        clientSecret: "secret_google",
+        allowlistedRedirectUris: ["https://app.example/callback"],
+        ...options?.providerRuntimeConfig?.google
+      }
+    },
+    resolveProviderRuntimeConfig: options?.resolveProviderRuntimeConfig,
+    stateStore,
+    tokenVault,
+    ...(options?.omitTokenStorageMode
+      ? {}
+      : {
+          tokenStorageMode: options?.tokenStorageMode ?? "plaintext-unsafe"
+        }),
+    tokenHttpClient,
+    now,
+    emitEvent: (event) => events.push(event)
+  });
+
+  return { service, stateStore, tokenVault, events, tokenHttpClient, advanceMs };
+}
+
+describe("oauth-flow start/callback invariants", () => {
+  it("start() validates input, persists state, includes PKCE, and emits started event", async () => {
+    const { service, stateStore, events } = createHarness();
+
+    const started = await service.start({
+      providerId: "google",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      redirectUri: "https://app.example/callback",
+      metadata: { requestId: "req_start_1" }
+    });
+
+    expect(started.providerId).toBe("google");
+    expect(started.authorizationUrl).toContain("state=");
+    expect(started.authorizationUrl).toContain("code_challenge=");
+    expect(started.authorizationUrl).toContain("code_challenge_method=S256");
+
+    const url = new URL(started.authorizationUrl);
+    expect(url.searchParams.get("state")).toBe(started.stateId);
+    expect(url.searchParams.get("client_id")).toBe("client_google");
+
+    const state = await stateStore.get(started.stateId);
+    expect(state?.tenantId).toBe("tenant_1");
+    expect(state?.userId).toBe("user_1");
+    expect(state?.providerId).toBe("google");
+    expect(state?.expiresAt).toBeDefined();
+    expect(state?.subject).toMatchObject({
+      kind: "connection",
+      tenantId: "tenant_1",
+      userId: "user_1"
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        name: "oauth.flow.started",
+        requestId: "req_start_1",
+        providerId: "google",
+        at: "2026-01-01T00:00:00.000Z",
+        ok: true,
+        subjectKind: "connection"
+      })
+    );
+  });
+
+  it("start() rejects non-allowlisted redirect before state creation", async () => {
+    const { service, stateStore } = createHarness();
+
+    await expect(
+      service.start({
+        providerId: "google",
+        tenantId: "tenant_1",
+        userId: "user_1",
+        redirectUri: "https://evil.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_REDIRECT_DISALLOWED",
+      status: 400,
+      retryable: false
+    });
+
+    expect(stateStore.putCount).toBe(0);
+  });
+
+  it("start() rejects unknown providers with deterministic validation error", async () => {
+    const { service } = createHarness();
+
+    await expect(
+      service.start({
+        providerId: "unknown-provider",
+        tenantId: "tenant_1",
+        userId: "user_1",
+        redirectUri: "https://app.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_PROVIDER_UNSUPPORTED",
+      status: 400,
+      retryable: false
+    });
+  });
+
+  it("start() prefers resolver-based runtime config over static config", async () => {
+    const resolveProviderRuntimeConfig = vi.fn(async ({ redirectUri }: OAuthProviderRuntimeConfigResolverInput) => ({
+      clientId: redirectUri === "https://app.example/callback" ? "resolver_client_google" : "fallback_client",
+      clientSecret: "resolver_secret_google",
+      allowlistedRedirectUris: ["https://app.example/callback"]
+    }));
+    const { service } = createHarness({
+      providerRuntimeConfig: {
+        google: {
+          clientId: "static_client_google",
+          clientSecret: "static_secret_google",
+          allowlistedRedirectUris: ["https://app.example/callback"]
+        }
+      },
+      resolveProviderRuntimeConfig
+    });
+
+    const started = await service.start({
+      providerId: "google",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      redirectUri: "https://app.example/callback"
+    });
+
+    expect(resolveProviderRuntimeConfig).toHaveBeenCalledTimes(1);
+    expect(new URL(started.authorizationUrl).searchParams.get("client_id")).toBe("resolver_client_google");
+  });
+
+  it("start() fails with OAUTH_RUNTIME_CONFIG_INVALID when resolver omits clientId", async () => {
+    const { service } = createHarness({
+      resolveProviderRuntimeConfig: vi.fn(async () => ({
+        clientId: "",
+        allowlistedRedirectUris: ["https://app.example/callback"]
+      }))
+    });
+
+    await expect(
+      service.start({
+        providerId: "google",
+        tenantId: "tenant_1",
+        userId: "user_1",
+        redirectUri: "https://app.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_RUNTIME_CONFIG_INVALID",
+      status: 500,
+      retryable: false
+    });
+  });
+
+  it("handleCallback() succeeds once, persists token, and rejects replay deterministically", async () => {
+    const { service, stateStore, tokenVault, events } = createHarness();
+
+    const started = await service.start({
+      providerId: "google",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      redirectUri: "https://app.example/callback"
+    });
+
+    const first = await service.handleCallback({
+      code: "auth-code-1",
+      state: started.stateId,
+      redirectUri: "https://app.example/callback"
+    });
+
+    expect(first.providerId).toBe("google");
+    expect(first.subject.kind).toBe("connection");
+    expect(first.subject.tenantId).toBe("tenant_1");
+    expect(first.subject.userId).toBe("user_1");
+    expect(first.tokenSet.accessToken).toBe("access-token");
+
+    const persistedToken = await tokenVault.get(first.tokenRecordId);
+    expect(persistedToken?.connectionId).toBe(first.connectionId);
+    expect(persistedToken?.providerId).toBe("google");
+
+    const consumedState = await stateStore.get(started.stateId);
+    expect(consumedState?.consumedAt).toBeDefined();
+
+    expect(events.some((event) => event.name === "oauth.flow.callback.success")).toBe(true);
+
+    await expect(
+      service.handleCallback({
+        code: "auth-code-2",
+        state: started.stateId,
+        redirectUri: "https://app.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_STATE_REPLAYED",
+      status: 400,
+      retryable: false
+    });
+  });
+
+  it("handleCallback() keeps legacy plaintext vaults working when tokenStorageMode is omitted", async () => {
+    const { service, tokenVault } = createHarness({
+      omitTokenStorageMode: true
+    });
+
+    const started = await service.start({
+      providerId: "google",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      connectionId: "conn_legacy_plaintext",
+      redirectUri: "https://app.example/callback"
+    });
+
+    const connected = await service.handleCallback({
+      code: "auth-code",
+      state: started.stateId,
+      redirectUri: "https://app.example/callback"
+    });
+
+    expect(connected.connectionId).toBe("conn_legacy_plaintext");
+    await expect(tokenVault.getByConnection("conn_legacy_plaintext")).resolves.toMatchObject({
+      providerId: "google",
+      connectionId: "conn_legacy_plaintext"
+    });
+  });
+
+  it("handleCallback() rejects plaintext persistence by default and emits redaction-safe failure details", async () => {
+    const { service, tokenVault, events } = createHarness({
+      tokenStorageMode: "encrypted-required"
+    });
+
+    const started = await service.start({
+      providerId: "google",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      connectionId: "conn_unsafe_default",
+      redirectUri: "https://app.example/callback"
+    });
+
+    await expect(
+      service.handleCallback({
+        code: "auth-code-unsafe",
+        state: started.stateId,
+        redirectUri: "https://app.example/callback",
+        requestId: "req_unsafe_callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_STORAGE_UNSAFE",
+      message: "encrypted token storage is required unless plaintext-unsafe mode is explicitly enabled",
+      status: 500,
+      retryable: false
+    });
+
+    expect(await tokenVault.getByConnection("conn_unsafe_default")).toBeNull();
+
+    const failureEvent = events.find((event) => event.name === "oauth.flow.callback.failed");
+    expect(failureEvent).toMatchObject({
+      providerId: "google",
+      requestId: "req_unsafe_callback",
+      errorCode: "OAUTH_TOKEN_STORAGE_UNSAFE"
+    });
+    expect(failureEvent?.details).toMatchObject({
+      operation: "handleCallback",
+      providerId: "google",
+      connectionId: "conn_unsafe_default",
+      storageMode: "encrypted-required",
+      vaultKind: "plaintext"
+    });
+
+    const serializedEvents = JSON.stringify(events);
+    expect(serializedEvents).not.toContain("access-token");
+    expect(serializedEvents).not.toContain("refresh-token");
+    expect(serializedEvents).not.toContain("secret_google");
+    expect(serializedEvents).not.toContain("encryptedPayload");
+  });
+
+  it("handleCallback() rejects callback mismatch with deterministic code", async () => {
+    const { service } = createHarness();
+    const started = await service.start({
+      providerId: "google",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      redirectUri: "https://app.example/callback"
+    });
+
+    await expect(
+      service.handleCallback({
+        code: "auth-code-1",
+        state: started.stateId,
+        redirectUri: "https://evil.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_CALLBACK_MISMATCH",
+      status: 400,
+      retryable: false
+    });
+  });
+
+  it("handleCallback() rejects expired state with deterministic code", async () => {
+    const { service, advanceMs } = createHarness();
+    const started = await service.start({
+      providerId: "google",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      redirectUri: "https://app.example/callback"
+    });
+
+    advanceMs(11 * 60 * 1000);
+
+    await expect(
+      service.handleCallback({
+        code: "auth-code-expired",
+        state: started.stateId,
+        redirectUri: "https://app.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_STATE_INVALID",
+      status: 400,
+      retryable: false
+    });
+  });
+});

--- a/packages/oauth-flow/src/index.ts
+++ b/packages/oauth-flow/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./service.js";

--- a/packages/oauth-flow/src/service.ts
+++ b/packages/oauth-flow/src/service.ts
@@ -1,0 +1,1334 @@
+import { randomUUID } from "node:crypto";
+import {
+  DefaultOAuthService,
+  OAuthCoreError,
+  type AuthorizationResult,
+  type OAuthIntentSubject as CoreOAuthIntentSubject,
+  type OAuthProviderDescriptor,
+  type OAuthProviderRuntimeConfig as CoreOAuthProviderRuntimeConfig,
+  type OAuthProviderRuntimeConfigResolverInput,
+  type OAuthTokenSet
+} from "@superfunctions/oauth-core";
+import {
+  DefaultOAuthTokenHttpClient,
+  OAuthHttpError,
+  type OAuthClientSecretResolver as CoreOAuthClientSecretResolver,
+  type OAuthResolvedClientSecret as CoreOAuthResolvedClientSecret,
+  type OAuthRevocationRequest,
+  type OAuthSecretResolverContext as CoreOAuthSecretResolverContext,
+  type OAuthTokenAuthMethod as CoreOAuthTokenAuthMethod,
+  type OAuthTokenEndpointRequest,
+  type OAuthTokenEndpointResponse,
+  type OAuthTokenGrantType as CoreOAuthTokenGrantType,
+  type OAuthTokenHttpClient
+} from "@superfunctions/oauth-http";
+import type {
+  EncryptedTokenVault,
+  OAuthStateRecord,
+  OAuthStateStore,
+  TokenRecord,
+  TokenVault
+} from "@superfunctions/oauth-storage";
+
+/** @deprecated Import from @superfunctions/oauth-core directly. */
+export type OAuthIntentSubject = CoreOAuthIntentSubject;
+
+type OAuthStoredStateRecord = OAuthStateRecord & {
+  subject?: OAuthIntentSubject;
+  connectionId?: string;
+  intentId?: string;
+  regionId?: string;
+  returnTo?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** @deprecated Import from @superfunctions/oauth-http directly. */
+export type OAuthTokenGrantType = CoreOAuthTokenGrantType;
+/** @deprecated Import from @superfunctions/oauth-http directly. */
+export type OAuthTokenAuthMethod = CoreOAuthTokenAuthMethod;
+/** @deprecated Import from @superfunctions/oauth-http directly. */
+export type OAuthResolvedClientSecret = CoreOAuthResolvedClientSecret;
+/** @deprecated Import from @superfunctions/oauth-http directly. */
+export type OAuthSecretResolverContext = CoreOAuthSecretResolverContext;
+/** @deprecated Import from @superfunctions/oauth-http directly. */
+export type OAuthClientSecretResolver = CoreOAuthClientSecretResolver;
+
+export interface OAuthFlowProviderRuntimeConfig extends CoreOAuthProviderRuntimeConfig {
+  clientSecret?: OAuthResolvedClientSecret["clientSecret"];
+  clientSecretResolver?: OAuthClientSecretResolver;
+}
+
+/**
+ * @deprecated Import the base runtime config from @superfunctions/oauth-core, or use OAuthFlowProviderRuntimeConfig
+ * when client-secret fields are required by oauth-flow consumers.
+ */
+export type OAuthProviderRuntimeConfig = OAuthFlowProviderRuntimeConfig;
+
+export type OAuthFlowProviderRuntimeConfigResolver = (
+  input: OAuthProviderRuntimeConfigResolverInput
+) => Promise<OAuthFlowProviderRuntimeConfig> | OAuthFlowProviderRuntimeConfig;
+
+type CreateAuthorizationRequestInput = {
+  providerId: string;
+  redirectUri: string;
+  scopes?: string[];
+  prompt?: string;
+  loginHint?: string;
+  subject: OAuthIntentSubject;
+};
+
+export interface OAuthFlowSubject {
+  kind: "connection" | "browser-auth";
+  tenantId?: string;
+  userId?: string;
+  connectionId?: string;
+  intentId?: string;
+  regionId?: string;
+  returnTo?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OAuthFlowResolvedIdentity {
+  tenantId: string;
+  userId: string;
+  connectionId?: string;
+  metadata?: Record<string, unknown>;
+  persistTokens?: boolean;
+}
+
+export type OAuthTokenStorageMode = "encrypted-required" | "plaintext-unsafe";
+
+export type OAuthFlowStartInput = {
+  providerId: string;
+  redirectUri: string;
+  scopes?: string[];
+  prompt?: string;
+  loginHint?: string;
+  metadata?: Record<string, unknown>;
+  requestId?: string;
+} & (
+  | {
+      subject: OAuthIntentSubject;
+    }
+  | {
+      tenantId: string;
+      userId: string;
+      connectionId?: string;
+    }
+);
+
+export type OAuthFlowCallbackInput = {
+  providerId?: string;
+  code: string;
+  state: string;
+  redirectUri: string;
+  requestId?: string;
+};
+
+export type OAuthFlowRefreshInput = {
+  connectionId: string;
+  providerId: string;
+  redirectUri: string;
+  scopes?: string[];
+  requestId?: string;
+};
+
+export type OAuthFlowDisconnectInput = {
+  connectionId: string;
+  providerId: string;
+  revokeRemote?: boolean;
+  tokenTypeHint?: "access_token" | "refresh_token";
+  requestId?: string;
+};
+
+export type OAuthFlowConnectionCleanupReason = "deleted" | "not-found" | "retained" | "not-configured";
+
+export type OAuthFlowConnectionCleanup = {
+  attempted: boolean;
+  deleted: boolean;
+  reason: OAuthFlowConnectionCleanupReason;
+};
+
+export type OAuthFlowDisconnectTokenMetadata = {
+  tokenId: string;
+  tenantId: string;
+  userId: string;
+  providerId: string;
+  connectionId: string;
+  keyRef: string;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt?: string;
+};
+
+export type OAuthFlowDisconnectContext = OAuthFlowDisconnectInput & {
+  revokeRemote: boolean;
+  subject?: OAuthFlowSubject;
+  tokenMetadata?: OAuthFlowDisconnectTokenMetadata;
+  remoteRevokeAttempted: boolean;
+  localTokenDeleted: boolean;
+};
+
+export type OAuthFlowStartResult = AuthorizationResult & {
+  providerId: string;
+};
+
+export type OAuthFlowCallbackResult = {
+  providerId: string;
+  subject: OAuthFlowSubject;
+  tokenSet: OAuthTokenSet;
+  tokenRecordId?: string;
+  connectionId?: string;
+  resolvedIdentity?: OAuthFlowResolvedIdentity;
+};
+
+export type OAuthFlowDisconnectResult = {
+  disconnected: boolean;
+  remoteRevokeAttempted: boolean;
+  localTokenDeleted: boolean;
+  connectionCleanup: OAuthFlowConnectionCleanup;
+  /** @deprecated Use connectionCleanup.deleted. */
+  connectionDeleted: boolean;
+};
+
+export interface OAuthFlowResolveBrowserAuthIdentityInput {
+  providerId: string;
+  subject: OAuthFlowSubject;
+  state: OAuthStateRecord;
+  tokenSet: OAuthTokenSet;
+}
+
+export type OAuthFlowIdentityHooks = {
+  resolveBrowserAuthIdentity?: (
+    input: OAuthFlowResolveBrowserAuthIdentityInput
+  ) => Promise<OAuthFlowResolvedIdentity | null> | OAuthFlowResolvedIdentity | null;
+  onConnected?: (result: OAuthFlowCallbackResult) => Promise<void>;
+  onDisconnected?: (
+    input: OAuthFlowDisconnectContext
+  ) => Promise<OAuthFlowConnectionCleanup | void> | OAuthFlowConnectionCleanup | void;
+};
+
+export interface OAuthFlowService {
+  start(input: OAuthFlowStartInput): Promise<OAuthFlowStartResult>;
+  handleCallback(input: OAuthFlowCallbackInput): Promise<OAuthFlowCallbackResult>;
+  refresh(input: OAuthFlowRefreshInput): Promise<OAuthTokenSet>;
+  disconnect(input: OAuthFlowDisconnectInput): Promise<OAuthFlowDisconnectResult>;
+}
+
+export type OAuthFlowEventName =
+  | "oauth.flow.started"
+  | "oauth.flow.start.failed"
+  | "oauth.flow.callback.success"
+  | "oauth.flow.callback.failed"
+  | "oauth.flow.refresh.success"
+  | "oauth.flow.refresh.failed"
+  | "oauth.flow.disconnect.success"
+  | "oauth.flow.disconnect.failed";
+
+export type OAuthFlowEvent = {
+  name: OAuthFlowEventName;
+  requestId: string;
+  providerId: string;
+  at: string;
+  ok: boolean;
+  subjectKind?: OAuthFlowSubject["kind"];
+  connectionId?: string;
+  errorCode?: OAuthFlowErrorCode;
+  details?: Record<string, unknown>;
+};
+
+export type OAuthFlowServiceConfig = {
+  providers: Record<string, OAuthProviderDescriptor>;
+  providerRuntimeConfig?: Record<string, OAuthFlowProviderRuntimeConfig>;
+  resolveProviderRuntimeConfig?: OAuthFlowProviderRuntimeConfigResolver;
+  stateStore: OAuthStateStore;
+  tokenVault: TokenVault | EncryptedTokenVault;
+  tokenStorageMode?: OAuthTokenStorageMode;
+  tokenHttpClient?: OAuthTokenHttpClient;
+  identityHooks?: OAuthFlowIdentityHooks;
+  keyRef?: string;
+  now?: () => Date;
+  emitEvent?: (event: OAuthFlowEvent) => void;
+};
+
+export type OAuthFlowErrorCode =
+  | "OAUTH_HOOK_FAILED"
+  | "NOT_IMPLEMENTED"
+  | "OAUTH_STATE_INVALID"
+  | "OAUTH_STATE_REPLAYED"
+  | "OAUTH_CALLBACK_MISMATCH"
+  | "OAUTH_REDIRECT_DISALLOWED"
+  | "OAUTH_PROVIDER_UNSUPPORTED"
+  | "OAUTH_RUNTIME_CONFIG_INVALID"
+  | "OAUTH_SECRET_RESOLUTION_FAILED"
+  | "OAUTH_TOKEN_STORAGE_UNSAFE"
+  | "OAUTH_TOKEN_REFRESH_FAILED"
+  | "OAUTH_TOKEN_EXCHANGE_FAILED"
+  | "VALIDATION_ERROR"
+  | "INTERNAL_ERROR"
+  | "PROVIDER_RATE_LIMITED";
+
+export class OAuthFlowError extends Error {
+  readonly code: OAuthFlowErrorCode;
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    code: OAuthFlowErrorCode,
+    message: string,
+    options?: { status?: number; retryable?: boolean; details?: Record<string, unknown> }
+  ) {
+    super(message);
+    this.name = "OAuthFlowError";
+    this.code = code;
+    this.status = options?.status ?? 400;
+    this.retryable = options?.retryable ?? false;
+    this.details = options?.details;
+  }
+}
+
+type HookPayloadMap = {
+  resolveBrowserAuthIdentity: OAuthFlowResolveBrowserAuthIdentityInput;
+  onConnected: OAuthFlowCallbackResult;
+};
+
+type HookName = keyof HookPayloadMap;
+
+export async function invokeIdentityHook<T extends HookName>(
+  hooks: OAuthFlowIdentityHooks | undefined,
+  hookName: T,
+  payload: HookPayloadMap[T]
+): Promise<T extends "resolveBrowserAuthIdentity" ? OAuthFlowResolvedIdentity | null : void> {
+  const hook = hooks?.[hookName] as ((value: HookPayloadMap[T]) => Promise<unknown> | unknown) | undefined;
+  if (!hook) {
+    return undefined as T extends "resolveBrowserAuthIdentity" ? OAuthFlowResolvedIdentity | null : void;
+  }
+
+  try {
+    const result = await hook(payload);
+    return result as T extends "resolveBrowserAuthIdentity" ? OAuthFlowResolvedIdentity | null : void;
+  } catch (error) {
+    throw new OAuthFlowError("OAUTH_HOOK_FAILED", "identity hook failed", {
+      status: 500,
+      retryable: false,
+      details: sanitizeDetails({
+        hookName,
+        cause: error instanceof Error ? error.message : String(error)
+      })
+    });
+  }
+}
+
+class DefaultOAuthFlowService implements OAuthFlowService {
+  private readonly config: OAuthFlowServiceConfig;
+  private readonly coreService: DefaultOAuthService;
+  private readonly tokenHttpClient: OAuthTokenHttpClient;
+  private readonly pendingConnectionByState = new Map<string, string>();
+  private readonly now: () => Date;
+
+  constructor(config: OAuthFlowServiceConfig) {
+    this.config = config;
+    this.now = config.now ?? (() => new Date());
+    this.tokenHttpClient = config.tokenHttpClient ?? new DefaultOAuthTokenHttpClient();
+    const exchangeToken = this.tokenHttpClient.exchangeToken.bind(this.tokenHttpClient) as (
+      input: OAuthTokenEndpointRequest
+    ) => Promise<OAuthTokenEndpointResponse>;
+    this.coreService = new DefaultOAuthService({
+      providers: config.providers,
+      resolveProviderRuntimeConfig: async (input) => {
+        const runtime = await this.getRuntimeConfig(input);
+        return {
+          clientId: runtime.clientId,
+          allowlistedRedirectUris: runtime.allowlistedRedirectUris
+        };
+      },
+      stateStore: config.stateStore,
+      exchangeCodeForToken: async (input) => {
+        const runtime = await this.getRuntimeConfig({
+          providerId: input.provider.id,
+          subject: input.subject,
+          redirectUri: input.redirectUri,
+          scopes: input.scopes
+        });
+        const response = await exchangeToken({
+          provider: input.provider,
+          grantType: "authorization_code",
+          clientId: runtime.clientId,
+          clientSecret: runtime.clientSecret,
+          clientSecretResolver: runtime.clientSecretResolver,
+          redirectUri: input.redirectUri,
+          code: input.code,
+          codeVerifier: input.codeVerifier,
+          scopes: input.scopes
+        });
+
+        return {
+          accessToken: response.accessToken,
+          refreshToken: response.refreshToken,
+          expiresAt: response.expiresIn
+            ? new Date(this.now().getTime() + response.expiresIn * 1000).toISOString()
+            : undefined,
+          scope: response.scope,
+          tokenType: response.tokenType,
+          idToken: response.idToken
+        };
+      },
+      now: this.now
+    });
+  }
+
+  async start(input: OAuthFlowStartInput): Promise<OAuthFlowStartResult> {
+    const requestId = this.resolveRequestId(input.requestId, input.metadata);
+    const subject = normalizeStartSubject(input);
+
+    try {
+      const provider = this.getProvider(input.providerId);
+      const createAuthorizationRequest = this.coreService.createAuthorizationRequest.bind(this.coreService) as unknown as (
+        request: CreateAuthorizationRequestInput
+      ) => Promise<AuthorizationResult>;
+      const result = await createAuthorizationRequest({
+        providerId: input.providerId,
+        redirectUri: input.redirectUri,
+        scopes: input.scopes,
+        prompt: input.prompt,
+        loginHint: input.loginHint,
+        subject: toIntentSubject(subject)
+      });
+
+      if (subject.kind === "connection" && subject.connectionId) {
+        this.pendingConnectionByState.set(result.stateId, subject.connectionId);
+      }
+
+      this.emitEvent({
+        name: "oauth.flow.started",
+        requestId,
+        providerId: provider.id,
+        at: this.now().toISOString(),
+        ok: true,
+        subjectKind: subject.kind,
+        connectionId: subject.connectionId
+      });
+
+      return {
+        ...result,
+        providerId: provider.id
+      };
+    } catch (error) {
+      const mapped = mapToOAuthFlowError(error);
+      this.emitEvent({
+        name: "oauth.flow.start.failed",
+        requestId,
+        providerId: input.providerId,
+        at: this.now().toISOString(),
+        ok: false,
+        subjectKind: subject.kind,
+        connectionId: subject.connectionId,
+        errorCode: mapped.code,
+        details: mapped.details
+      });
+      throw mapped;
+    }
+  }
+
+  async handleCallback(input: OAuthFlowCallbackInput): Promise<OAuthFlowCallbackResult> {
+    const requestId = input.requestId ?? randomUUID();
+    let providerId = input.providerId;
+    let subjectPreview: OAuthFlowSubject | undefined;
+
+    try {
+      const statePreview = await this.config.stateStore.get(input.state);
+      providerId = input.providerId ?? statePreview?.providerId;
+      subjectPreview = statePreview ? toFlowSubject(statePreview) : undefined;
+
+      if (!providerId) {
+        throw new OAuthFlowError("OAUTH_STATE_INVALID", "OAuth state is invalid or expired", {
+          status: 400,
+          retryable: false
+        });
+      }
+
+      const tokenSet = await this.coreService.handleCallback({
+        providerId,
+        code: input.code,
+        state: input.state,
+        redirectUri: input.redirectUri
+      });
+
+      const consumedState = await this.requireState(input.state);
+      const subject = toFlowSubject(consumedState);
+
+      let connectionId: string | undefined;
+      let tokenRecordId: string | undefined;
+      let resolvedIdentity: OAuthFlowResolvedIdentity | undefined;
+
+      if (subject.kind === "connection") {
+        connectionId = this.pendingConnectionByState.get(input.state) ?? subject.connectionId ?? `conn_${input.state}`;
+        this.pendingConnectionByState.delete(input.state);
+        tokenRecordId = await this.persistTokenSet({
+          state: consumedState,
+          providerId,
+          connectionId,
+          tokenSet
+        });
+      } else {
+        const hookResult = await invokeIdentityHook(this.config.identityHooks, "resolveBrowserAuthIdentity", {
+          providerId,
+          subject,
+          state: consumedState,
+          tokenSet
+        });
+
+        if (hookResult) {
+          resolvedIdentity = cloneResolvedIdentity(hookResult);
+          if (hookResult.persistTokens !== false) {
+            connectionId = hookResult.connectionId ?? `conn_${input.state}`;
+            tokenRecordId = await this.persistTokenSet({
+              state: applyResolvedIdentity(consumedState, hookResult),
+              providerId,
+              connectionId,
+              tokenSet
+            });
+          }
+        }
+      }
+
+      const result: OAuthFlowCallbackResult = {
+        providerId,
+        subject,
+        tokenSet,
+        tokenRecordId,
+        connectionId,
+        resolvedIdentity
+      };
+
+      await invokeIdentityHook(this.config.identityHooks, "onConnected", result);
+
+      this.emitEvent({
+        name: "oauth.flow.callback.success",
+        requestId,
+        providerId,
+        at: this.now().toISOString(),
+        ok: true,
+        subjectKind: subject.kind,
+        connectionId
+      });
+
+      return result;
+    } catch (error) {
+      const mapped = mapToOAuthFlowError(error);
+      this.emitEvent({
+        name: "oauth.flow.callback.failed",
+        requestId,
+        providerId: providerId ?? input.providerId ?? "unknown",
+        at: this.now().toISOString(),
+        ok: false,
+        subjectKind: subjectPreview?.kind,
+        connectionId: subjectPreview?.connectionId,
+        errorCode: mapped.code,
+        details: mapped.details
+      });
+      throw mapped;
+    }
+  }
+
+  async refresh(input: OAuthFlowRefreshInput): Promise<OAuthTokenSet> {
+    const requestId = input.requestId ?? randomUUID();
+
+    try {
+      const exchangeToken = this.tokenHttpClient.exchangeToken.bind(this.tokenHttpClient) as (
+        request: OAuthTokenEndpointRequest
+      ) => Promise<OAuthTokenEndpointResponse>;
+      const provider = this.getProvider(input.providerId);
+      const existing = await this.getTokenSetByConnection(input.connectionId);
+      if (!existing) {
+        throw new OAuthFlowError("OAUTH_TOKEN_REFRESH_FAILED", "OAuth token record not found for connection", {
+          status: 404,
+          retryable: false
+        });
+      }
+
+      if (existing.record.providerId !== input.providerId) {
+        throw new OAuthFlowError("OAUTH_CALLBACK_MISMATCH", "provider mismatch for refresh", {
+          status: 400,
+          retryable: false,
+          details: {
+            expectedProviderId: existing.record.providerId,
+            receivedProviderId: input.providerId,
+            connectionId: input.connectionId
+          }
+        });
+      }
+
+      if (!existing.tokenSet.refreshToken) {
+        throw new OAuthFlowError("OAUTH_TOKEN_REFRESH_FAILED", "refresh token is missing for connection", {
+          status: 400,
+          retryable: false
+        });
+      }
+
+      const runtime = await this.getRuntimeConfig({
+        providerId: input.providerId,
+        subject: {
+          kind: "connection",
+          tenantId: existing.record.tenantId,
+          userId: existing.record.userId,
+          connectionId: existing.record.connectionId
+        },
+        redirectUri: input.redirectUri,
+        scopes: input.scopes
+      });
+
+      const response = await exchangeToken({
+        provider,
+        grantType: "refresh_token",
+        clientId: runtime.clientId,
+        clientSecret: runtime.clientSecret,
+        clientSecretResolver: runtime.clientSecretResolver,
+        refreshToken: existing.tokenSet.refreshToken,
+        redirectUri: input.redirectUri,
+        scopes: input.scopes
+      });
+
+      const merged = this.mergeRefreshTokenSet(existing.tokenSet, response);
+      await this.persistRefreshedTokenSet(existing.record, merged);
+
+      this.emitEvent({
+        name: "oauth.flow.refresh.success",
+        requestId,
+        providerId: input.providerId,
+        at: this.now().toISOString(),
+        ok: true,
+        connectionId: input.connectionId
+      });
+
+      return merged;
+    } catch (error) {
+      const mapped = mapToOAuthFlowError(error);
+      this.emitEvent({
+        name: "oauth.flow.refresh.failed",
+        requestId,
+        providerId: input.providerId,
+        at: this.now().toISOString(),
+        ok: false,
+        connectionId: input.connectionId,
+        errorCode: mapped.code,
+        details: mapped.details
+      });
+      throw mapped;
+    }
+  }
+
+  async disconnect(input: OAuthFlowDisconnectInput): Promise<OAuthFlowDisconnectResult> {
+    const requestId = input.requestId ?? randomUUID();
+    let remoteRevokeAttempted = false;
+    let localTokenDeleted = false;
+    let connectionCleanup: OAuthFlowConnectionCleanup = {
+      attempted: false,
+      deleted: false,
+      reason: "not-configured"
+    };
+
+    try {
+      const revokeToken = this.tokenHttpClient.revokeToken.bind(this.tokenHttpClient) as (
+        request: OAuthRevocationRequest
+      ) => Promise<void>;
+      const provider = this.getProvider(input.providerId);
+      const tokenRecord = await this.getTokenSetByConnection(input.connectionId);
+      const revokeRemote = input.revokeRemote ?? false;
+
+      if (tokenRecord && tokenRecord.record.providerId !== input.providerId) {
+        throw new OAuthFlowError("OAUTH_CALLBACK_MISMATCH", "provider mismatch for disconnect", {
+          status: 400,
+          retryable: false,
+          details: {
+            expectedProviderId: tokenRecord.record.providerId,
+            receivedProviderId: input.providerId,
+            connectionId: input.connectionId
+          }
+        });
+      }
+
+      let revokeError: OAuthFlowError | null = null;
+      if (revokeRemote && provider.revocationUrl && tokenRecord) {
+        remoteRevokeAttempted = true;
+        const runtime = await this.getRuntimeConfig({
+          providerId: input.providerId,
+          subject: {
+            kind: "connection",
+            tenantId: tokenRecord.record.tenantId,
+            userId: tokenRecord.record.userId,
+            connectionId: tokenRecord.record.connectionId
+          },
+          redirectUri: undefined,
+          scopes: undefined,
+          prompt: undefined,
+          loginHint: undefined
+        });
+        const tokenToRevoke =
+          input.tokenTypeHint === "access_token"
+            ? tokenRecord.tokenSet.accessToken ?? tokenRecord.tokenSet.refreshToken
+            : input.tokenTypeHint === "refresh_token"
+              ? tokenRecord.tokenSet.refreshToken ?? tokenRecord.tokenSet.accessToken
+              : tokenRecord.tokenSet.refreshToken ?? tokenRecord.tokenSet.accessToken;
+        try {
+          await revokeToken({
+            provider,
+            clientId: runtime.clientId,
+            clientSecret: runtime.clientSecret,
+            clientSecretResolver: runtime.clientSecretResolver,
+            token: tokenToRevoke,
+            tokenTypeHint: input.tokenTypeHint
+          });
+        } catch (error) {
+          revokeError = mapToOAuthFlowError(error);
+        }
+      }
+
+      await this.deleteTokenByConnection(input.connectionId);
+      localTokenDeleted = tokenRecord !== null;
+      const disconnectContext = this.createDisconnectContext(input, tokenRecord, remoteRevokeAttempted, localTokenDeleted);
+      connectionCleanup = await this.runDisconnectHook(disconnectContext);
+
+      if (revokeError) {
+        const errorWithFlags = new OAuthFlowError("INTERNAL_ERROR", "provider revoke failed after local cleanup", {
+          status: 502,
+          retryable: false,
+          details: toDisconnectEventDetails(remoteRevokeAttempted, localTokenDeleted, connectionCleanup)
+        });
+        this.emitEvent({
+          name: "oauth.flow.disconnect.failed",
+          requestId,
+          providerId: input.providerId,
+          at: this.now().toISOString(),
+          ok: false,
+          connectionId: input.connectionId,
+          errorCode: errorWithFlags.code,
+          details: errorWithFlags.details
+        });
+        throw errorWithFlags;
+      }
+
+      const result: OAuthFlowDisconnectResult = {
+        disconnected: true,
+        remoteRevokeAttempted,
+        localTokenDeleted,
+        connectionCleanup,
+        connectionDeleted: connectionCleanup.deleted
+      };
+
+      this.emitEvent({
+        name: "oauth.flow.disconnect.success",
+        requestId,
+        providerId: input.providerId,
+        at: this.now().toISOString(),
+        ok: true,
+        connectionId: input.connectionId,
+        details: toDisconnectEventDetails(remoteRevokeAttempted, localTokenDeleted, connectionCleanup)
+      });
+
+      return result;
+    } catch (error) {
+      if (error instanceof OAuthFlowError && error.code === "INTERNAL_ERROR") {
+        throw error;
+      }
+
+      const mapped = mapToOAuthFlowError(error);
+      this.emitEvent({
+        name: "oauth.flow.disconnect.failed",
+        requestId,
+        providerId: input.providerId,
+        at: this.now().toISOString(),
+        ok: false,
+        connectionId: input.connectionId,
+        errorCode: mapped.code,
+        details: mapped.details
+      });
+      throw mapped;
+    }
+  }
+
+  private mergeRefreshTokenSet(existing: OAuthTokenSet, response: OAuthTokenEndpointResponse): OAuthTokenSet {
+    return {
+      accessToken: response.accessToken,
+      refreshToken: response.refreshToken ?? existing.refreshToken,
+      expiresAt: response.expiresIn
+        ? new Date(this.now().getTime() + response.expiresIn * 1000).toISOString()
+        : existing.expiresAt,
+      scope: response.scope ?? existing.scope,
+      tokenType: response.tokenType ?? existing.tokenType,
+      idToken: response.idToken ?? existing.idToken
+    };
+  }
+
+  private async persistTokenSet(input: {
+    state: OAuthStateRecord;
+    providerId: string;
+    connectionId: string;
+    tokenSet: OAuthTokenSet;
+  }): Promise<string> {
+    const tenantId = input.state.tenantId;
+    const userId = input.state.userId;
+    if (!tenantId || !userId) {
+      throw new OAuthFlowError("OAUTH_RUNTIME_CONFIG_INVALID", "Token persistence requires resolved tenantId and userId", {
+        status: 500,
+        retryable: false
+      });
+    }
+
+    const timestamp = this.now().toISOString();
+    const tokenId = `tok_${randomUUID()}`;
+    const keyRef = this.config.keyRef ?? "oauth-default";
+
+    if (isEncryptedTokenVault(this.config.tokenVault)) {
+      await this.config.tokenVault.putTokenSet({
+        tokenId,
+        tenantId,
+        userId,
+        providerId: input.providerId,
+        connectionId: input.connectionId,
+        tokenSet: {
+          accessToken: input.tokenSet.accessToken,
+          refreshToken: input.tokenSet.refreshToken,
+          expiresAt: input.tokenSet.expiresAt,
+          scope: input.tokenSet.scope,
+          tokenType: input.tokenSet.tokenType,
+          idToken: input.tokenSet.idToken
+        },
+        keyRef,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        expiresAt: input.tokenSet.expiresAt
+      });
+      return tokenId;
+    }
+
+    this.assertTokenStorageIsSafe("handleCallback", input.providerId, input.connectionId);
+
+    const record: TokenRecord = {
+      tokenId,
+      tenantId,
+      userId,
+      providerId: input.providerId,
+      connectionId: input.connectionId,
+      encryptedPayload: JSON.stringify(input.tokenSet),
+      keyRef,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      expiresAt: input.tokenSet.expiresAt
+    };
+
+    await this.config.tokenVault.put(record);
+    return tokenId;
+  }
+
+  private async requireState(stateId: string): Promise<OAuthStateRecord> {
+    const state = await this.config.stateStore.get(stateId);
+    if (!state) {
+      throw new OAuthFlowError("OAUTH_STATE_INVALID", "OAuth state is invalid or expired", {
+        status: 400,
+        retryable: false
+      });
+    }
+
+    return state;
+  }
+
+  private getProvider(providerId: string): OAuthProviderDescriptor {
+    const provider = this.config.providers[providerId];
+    if (!provider) {
+      throw new OAuthFlowError("OAUTH_PROVIDER_UNSUPPORTED", `Unknown OAuth provider: ${providerId}`, {
+        status: 400,
+        retryable: false
+      });
+    }
+
+    return provider;
+  }
+
+  private async getRuntimeConfig(
+    input: OAuthProviderRuntimeConfigResolverInput
+  ): Promise<OAuthFlowProviderRuntimeConfig> {
+    if (this.config.resolveProviderRuntimeConfig) {
+      try {
+        const resolved = await this.config.resolveProviderRuntimeConfig(input);
+        if (!resolved?.clientId) {
+          throw new OAuthFlowError("OAUTH_RUNTIME_CONFIG_INVALID", "Resolved OAuth runtime config missing clientId", {
+            status: 500,
+            retryable: false,
+            details: { providerId: input.providerId }
+          });
+        }
+
+        return resolved;
+      } catch (error) {
+        if (error instanceof OAuthFlowError) {
+          throw error;
+        }
+
+        throw new OAuthFlowError("OAUTH_RUNTIME_CONFIG_INVALID", "Failed to resolve OAuth runtime config", {
+          status: 500,
+          retryable: false,
+          details: { providerId: input.providerId }
+        });
+      }
+    }
+
+    const runtime = this.config.providerRuntimeConfig?.[input.providerId];
+    if (!runtime?.clientId) {
+      throw new OAuthFlowError("OAUTH_RUNTIME_CONFIG_INVALID", `Missing runtime OAuth config for provider: ${input.providerId}`, {
+        status: 500,
+        retryable: false,
+        details: { providerId: input.providerId }
+      });
+    }
+
+    return runtime;
+  }
+
+  private resolveRequestId(requestId: string | undefined, metadata: Record<string, unknown> | undefined): string {
+    if (requestId) {
+      return requestId;
+    }
+    const metadataRequestId = metadata?.requestId;
+    return typeof metadataRequestId === "string" && metadataRequestId.length > 0 ? metadataRequestId : randomUUID();
+  }
+
+  private emitEvent(event: OAuthFlowEvent): void {
+    this.config.emitEvent?.({
+      ...event,
+      details: sanitizeDetails(event.details)
+    });
+  }
+
+  private async getTokenSetByConnection(connectionId: string): Promise<{ record: TokenRecord; tokenSet: OAuthTokenSet } | null> {
+    if (isEncryptedTokenVault(this.config.tokenVault)) {
+      const decrypted = await this.config.tokenVault.getTokenSetByConnection(connectionId);
+      if (!decrypted) {
+        return null;
+      }
+
+      return {
+        record: decrypted.record,
+        tokenSet: decrypted.tokenSet
+      };
+    }
+
+    const record = await this.config.tokenVault.getByConnection(connectionId);
+    if (!record) {
+      return null;
+    }
+
+    return {
+      record,
+      tokenSet: parseTokenPayload(record.encryptedPayload)
+    };
+  }
+
+  private async persistRefreshedTokenSet(existing: TokenRecord, tokenSet: OAuthTokenSet): Promise<void> {
+    const updatedAt = this.now().toISOString();
+    if (isEncryptedTokenVault(this.config.tokenVault)) {
+      await this.config.tokenVault.putTokenSet({
+        tokenId: existing.tokenId,
+        tenantId: existing.tenantId,
+        userId: existing.userId,
+        providerId: existing.providerId,
+        connectionId: existing.connectionId,
+        tokenSet: {
+          accessToken: tokenSet.accessToken,
+          refreshToken: tokenSet.refreshToken,
+          expiresAt: tokenSet.expiresAt,
+          scope: tokenSet.scope,
+          tokenType: tokenSet.tokenType,
+          idToken: tokenSet.idToken
+        },
+        keyRef: existing.keyRef,
+        createdAt: existing.createdAt,
+        updatedAt,
+        expiresAt: tokenSet.expiresAt
+      });
+      return;
+    }
+
+    this.assertTokenStorageIsSafe("refresh", existing.providerId, existing.connectionId);
+
+    await this.config.tokenVault.put({
+      ...existing,
+      encryptedPayload: JSON.stringify(tokenSet),
+      updatedAt,
+      expiresAt: tokenSet.expiresAt
+    });
+  }
+
+  private async deleteTokenByConnection(connectionId: string): Promise<void> {
+    await this.config.tokenVault.deleteByConnection(connectionId);
+  }
+
+  private createDisconnectContext(
+    input: OAuthFlowDisconnectInput,
+    tokenRecord: { record: TokenRecord; tokenSet: OAuthTokenSet } | null,
+    remoteRevokeAttempted: boolean,
+    localTokenDeleted: boolean
+  ): OAuthFlowDisconnectContext {
+    return {
+      ...input,
+      revokeRemote: input.revokeRemote ?? false,
+      subject: tokenRecord
+        ? {
+            kind: "connection",
+            tenantId: tokenRecord.record.tenantId,
+            userId: tokenRecord.record.userId,
+            connectionId: tokenRecord.record.connectionId
+          }
+        : undefined,
+      tokenMetadata: tokenRecord ? toDisconnectTokenMetadata(tokenRecord.record) : undefined,
+      remoteRevokeAttempted,
+      localTokenDeleted
+    };
+  }
+
+  private async runDisconnectHook(input: OAuthFlowDisconnectContext): Promise<OAuthFlowConnectionCleanup> {
+    const hook = this.config.identityHooks?.onDisconnected;
+    if (!hook) {
+      return {
+        attempted: false,
+        deleted: false,
+        reason: "not-configured"
+      };
+    }
+
+    let result: unknown;
+    try {
+      result = await hook(input);
+    } catch {
+      throw new OAuthFlowError("OAUTH_HOOK_FAILED", "identity hook failed", {
+        status: 500,
+        retryable: false,
+        details: toDisconnectEventDetails(input.remoteRevokeAttempted, input.localTokenDeleted, {
+          attempted: true,
+          deleted: false,
+          reason: "retained"
+        })
+      });
+    }
+
+    return validateDisconnectCleanupResult(result, input);
+  }
+
+  private assertTokenStorageIsSafe(operation: "handleCallback" | "refresh", providerId: string, connectionId: string): void {
+    if (isEncryptedTokenVault(this.config.tokenVault) || this.getTokenStorageMode() === "plaintext-unsafe") {
+      return;
+    }
+
+    throw new OAuthFlowError(
+      "OAUTH_TOKEN_STORAGE_UNSAFE",
+      "encrypted token storage is required unless plaintext-unsafe mode is explicitly enabled",
+      {
+        status: 500,
+        retryable: false,
+        details: {
+          operation,
+          providerId,
+          connectionId,
+          storageMode: this.getTokenStorageMode(),
+          vaultKind: "plaintext"
+        }
+      }
+    );
+  }
+
+  private getTokenStorageMode(): OAuthTokenStorageMode {
+    if (this.config.tokenStorageMode) {
+      return this.config.tokenStorageMode;
+    }
+
+    return isEncryptedTokenVault(this.config.tokenVault) ? "encrypted-required" : "plaintext-unsafe";
+  }
+}
+
+function normalizeStartSubject(input: OAuthFlowStartInput): OAuthFlowSubject {
+  if ("subject" in input) {
+    return toFlowSubject(input.subject);
+  }
+
+  return {
+    kind: "connection",
+    tenantId: input.tenantId,
+    userId: input.userId,
+    connectionId: input.connectionId
+  };
+}
+
+function toIntentSubject(subject: OAuthFlowSubject): OAuthIntentSubject {
+  if (subject.kind === "connection") {
+    return {
+      kind: "connection",
+      tenantId: subject.tenantId ?? "",
+      userId: subject.userId ?? "",
+      connectionId: subject.connectionId
+    };
+  }
+
+  return {
+    kind: "browser-auth",
+    intentId: subject.intentId ?? "",
+    tenantId: subject.tenantId,
+    regionId: subject.regionId,
+    returnTo: subject.returnTo,
+    metadata: subject.metadata ? { ...subject.metadata } : undefined
+  };
+}
+
+function toFlowSubject(subject: OAuthIntentSubject | OAuthStoredStateRecord): OAuthFlowSubject {
+  if ("providerId" in subject) {
+    const stored = subject.subject;
+    if (stored?.kind === "browser-auth" || subject.intentId) {
+      return {
+        kind: "browser-auth",
+        intentId: stored?.kind === "browser-auth" ? stored.intentId : subject.intentId,
+        tenantId: stored?.kind === "browser-auth" ? stored.tenantId : subject.tenantId,
+        regionId: stored?.kind === "browser-auth" ? stored.regionId : subject.regionId,
+        returnTo: stored?.kind === "browser-auth" ? stored.returnTo : subject.returnTo,
+        metadata: stored?.kind === "browser-auth" ? stored.metadata : subject.metadata
+      };
+    }
+
+    return {
+      kind: "connection",
+      tenantId: stored?.kind === "connection" ? stored.tenantId : subject.tenantId,
+      userId: stored?.kind === "connection" ? stored.userId : subject.userId,
+      connectionId: stored?.kind === "connection" ? stored.connectionId : subject.connectionId
+    };
+  }
+
+  if (subject.kind === "connection") {
+    return {
+      kind: "connection",
+      tenantId: subject.tenantId,
+      userId: subject.userId,
+      connectionId: subject.connectionId
+    };
+  }
+
+  return {
+    kind: "browser-auth",
+    intentId: subject.intentId,
+    tenantId: subject.tenantId,
+    regionId: subject.regionId,
+    returnTo: subject.returnTo,
+    metadata: subject.metadata ? { ...subject.metadata } : undefined
+  };
+}
+
+function applyResolvedIdentity(state: OAuthStateRecord, identity: OAuthFlowResolvedIdentity): OAuthStateRecord {
+  return {
+    ...state,
+    tenantId: identity.tenantId,
+    userId: identity.userId,
+    connectionId: identity.connectionId,
+    subject: {
+      kind: "connection",
+      tenantId: identity.tenantId,
+      userId: identity.userId,
+      connectionId: identity.connectionId
+    }
+  } as OAuthStateRecord;
+}
+
+function cloneResolvedIdentity(identity: OAuthFlowResolvedIdentity): OAuthFlowResolvedIdentity {
+  return {
+    ...identity,
+    metadata: identity.metadata ? { ...identity.metadata } : undefined
+  };
+}
+
+function mapToOAuthFlowError(error: unknown): OAuthFlowError {
+  if (error instanceof OAuthFlowError) {
+    return error;
+  }
+
+  if (error instanceof OAuthCoreError) {
+    return new OAuthFlowError(error.code as OAuthFlowErrorCode, error.message, {
+      status: error.status,
+      retryable: error.retryable,
+      details: sanitizeDetails(error.details)
+    });
+  }
+
+  if (error instanceof OAuthHttpError) {
+    return new OAuthFlowError(error.code as OAuthFlowErrorCode, error.message, {
+      status: error.status,
+      retryable: error.retryable,
+      details: sanitizeDetails(error.details)
+    });
+  }
+
+  return new OAuthFlowError("INTERNAL_ERROR", "Unexpected OAuth flow error", {
+    status: 500,
+    retryable: false
+  });
+}
+
+function sanitizeDetails(details: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!details) {
+    return undefined;
+  }
+
+  const copy: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(details)) {
+    const lower = key.toLowerCase();
+    if (lower.includes("token") || lower.includes("secret") || lower.includes("authorization")) {
+      continue;
+    }
+    const sanitizedValue = sanitizeValue(value);
+    if (sanitizedValue !== undefined) {
+      copy[key] = sanitizedValue;
+    }
+  }
+  return Object.keys(copy).length > 0 ? copy : undefined;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    const lower = value.toLowerCase();
+    if (lower.includes("token") || lower.includes("secret") || lower.includes("authorization") || lower.includes("bearer")) {
+      return undefined;
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const sanitizedItems = value
+      .map((entry) => sanitizeValue(entry))
+      .filter((entry) => entry !== undefined);
+    return sanitizedItems.length > 0 ? sanitizedItems : undefined;
+  }
+
+  if (value && typeof value === "object") {
+    return sanitizeDetails(value as Record<string, unknown>);
+  }
+
+  return value;
+}
+
+function isEncryptedTokenVault(vault: TokenVault | EncryptedTokenVault): vault is EncryptedTokenVault {
+  return typeof (vault as EncryptedTokenVault).putTokenSet === "function";
+}
+
+function parseTokenPayload(payload: string): OAuthTokenSet {
+  try {
+    const parsed = JSON.parse(payload) as Partial<OAuthTokenSet>;
+    if (!parsed.accessToken || typeof parsed.accessToken !== "string") {
+      throw new Error("missing access token");
+    }
+
+    return {
+      accessToken: parsed.accessToken,
+      refreshToken: parsed.refreshToken,
+      expiresAt: parsed.expiresAt,
+      scope: parsed.scope,
+      tokenType: parsed.tokenType,
+      idToken: parsed.idToken
+    };
+  } catch {
+    throw new OAuthFlowError("INTERNAL_ERROR", "stored token payload is invalid", {
+      status: 500,
+      retryable: false
+    });
+  }
+}
+
+function validateDisconnectCleanupResult(
+  value: unknown,
+  input: OAuthFlowDisconnectContext
+): OAuthFlowConnectionCleanup {
+  if (value === undefined) {
+    return {
+      attempted: true,
+      deleted: false,
+      reason: "retained"
+    };
+  }
+
+  if (!value || typeof value !== "object") {
+    throw invalidDisconnectCleanupResult(input);
+  }
+
+  const candidate = value as Partial<OAuthFlowConnectionCleanup>;
+  if (
+    typeof candidate.attempted !== "boolean" ||
+    typeof candidate.deleted !== "boolean" ||
+    (candidate.reason !== "deleted" &&
+      candidate.reason !== "not-found" &&
+      candidate.reason !== "retained" &&
+      candidate.reason !== "not-configured")
+  ) {
+    throw invalidDisconnectCleanupResult(input);
+  }
+
+  if (!isValidDisconnectCleanupSemantics(candidate)) {
+    throw invalidDisconnectCleanupResult(input);
+  }
+
+  return {
+    attempted: candidate.attempted,
+    deleted: candidate.deleted,
+    reason: candidate.reason
+  };
+}
+
+function invalidDisconnectCleanupResult(input: OAuthFlowDisconnectContext): OAuthFlowError {
+  return new OAuthFlowError("VALIDATION_ERROR", "disconnect hook returned invalid cleanup result", {
+    status: 500,
+    retryable: false,
+    details: toDisconnectEventDetails(input.remoteRevokeAttempted, input.localTokenDeleted, {
+      attempted: true,
+      deleted: false,
+      reason: "retained"
+    })
+  });
+}
+
+function isValidDisconnectCleanupSemantics(candidate: Partial<OAuthFlowConnectionCleanup>): candidate is OAuthFlowConnectionCleanup {
+  if (candidate.attempted === false) {
+    return candidate.deleted === false && candidate.reason === "not-configured";
+  }
+
+  if (candidate.deleted === true) {
+    return candidate.reason === "deleted";
+  }
+
+  return candidate.reason === "not-found" || candidate.reason === "retained";
+}
+
+function toDisconnectTokenMetadata(record: TokenRecord): OAuthFlowDisconnectTokenMetadata {
+  return {
+    tokenId: record.tokenId,
+    tenantId: record.tenantId,
+    userId: record.userId,
+    providerId: record.providerId,
+    connectionId: record.connectionId,
+    keyRef: record.keyRef,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    expiresAt: record.expiresAt
+  };
+}
+
+function toDisconnectEventDetails(
+  remoteRevokeAttempted: boolean,
+  localTokenDeleted: boolean,
+  connectionCleanup: OAuthFlowConnectionCleanup
+): Record<string, unknown> {
+  return {
+    remoteRevokeAttempted,
+    localDeleted: localTokenDeleted,
+    cleanupAttempted: connectionCleanup.attempted,
+    cleanupDeleted: connectionCleanup.deleted,
+    cleanupReason: connectionCleanup.reason
+  };
+}
+
+export function createOAuthFlowService(config: OAuthFlowServiceConfig): OAuthFlowService {
+  return new DefaultOAuthFlowService(config);
+}

--- a/packages/oauth-flow/tsconfig.json
+++ b/packages/oauth-flow/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-flow/vitest.config.ts
+++ b/packages/oauth-flow/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createOAuthSharedVitestConfig } from "../../scripts/vitest-oauth-shared.mjs";
+
+export default createOAuthSharedVitestConfig();

--- a/packages/oauth-http/README.md
+++ b/packages/oauth-http/README.md
@@ -1,0 +1,54 @@
+# @superfunctions/oauth-http
+
+Reusable OAuth token transport for code exchange, refresh, revocation, retries, and normalized upstream errors.
+
+## Install
+
+```bash
+npm install @superfunctions/oauth-http @superfunctions/oauth-core @superfunctions/oauth-providers
+```
+
+## Quick Start
+
+```ts
+import { DefaultOAuthTokenHttpClient } from "@superfunctions/oauth-http";
+import { getOAuthProviderDescriptor } from "@superfunctions/oauth-providers";
+
+const client = new DefaultOAuthTokenHttpClient();
+const github = getOAuthProviderDescriptor("github");
+
+const tokenSet = await client.exchangeToken({
+  provider: github,
+  grantType: "authorization_code",
+  clientId: process.env.GITHUB_CLIENT_ID!,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+  code: "oauth-code",
+  redirectUri: "https://app.example/oauth/github/callback",
+});
+```
+
+## Package Boundary
+
+`@superfunctions/oauth-http` owns OAuth HTTP transport only:
+
+- token endpoint exchange
+- refresh exchange
+- revocation requests
+- retry policy and normalized transport errors
+
+It does not own state validation, token persistence, or route generation. Pair it with:
+
+- `@superfunctions/oauth-core` for callback invariants
+- `@superfunctions/oauth-flow` for full lifecycle orchestration
+- `@superfunctions/oauth-router` for route exposure
+
+## Production Notes
+
+- Provide secrets through `clientSecretResolver` when your platform resolves secrets dynamically.
+- Tune retries for provider-specific 429/5xx behavior instead of wrapping token calls with ad hoc fetch logic.
+- Treat provider revocation as best effort unless your product contract requires remote confirmation before local cleanup.
+
+## Docs
+
+- Canonical docs: [docs/content/docs/authentication/oauth-http.mdx](../../docs/content/docs/authentication/oauth-http.mdx)
+- Stack overview: [docs/content/docs/architecture/oauth-flow-architecture.mdx](../../docs/content/docs/architecture/oauth-flow-architecture.mdx)

--- a/packages/oauth-http/package.json
+++ b/packages/oauth-http/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@superfunctions/oauth-http",
+  "version": "0.0.1",
+  "description": "OAuth HTTP transport contracts for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --config ./vitest.config.ts --run",
+    "test:watch": "vitest --config ./vitest.config.ts --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "oauth",
+    "http",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/oauth-http"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/oauth-core": "^0.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/oauth-http/src/__tests__/exports.test.ts
+++ b/packages/oauth-http/src/__tests__/exports.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { OAuthHttpError } from "../index.js";
+
+describe("oauth-http exports", () => {
+  it("exports OAuthHttpError", () => {
+    const error = new OAuthHttpError("failed", { code: "OAUTH_TOKEN_EXCHANGE_FAILED", status: 400 });
+    expect(error.code).toBe("OAUTH_TOKEN_EXCHANGE_FAILED");
+    expect(error.status).toBe(400);
+  });
+});

--- a/packages/oauth-http/src/errors.ts
+++ b/packages/oauth-http/src/errors.ts
@@ -1,0 +1,104 @@
+import type { OAuthSecretResolverContext } from "./index.js";
+
+export type OAuthHttpErrorCode =
+  | "OAUTH_TOKEN_EXCHANGE_FAILED"
+  | "OAUTH_TOKEN_REFRESH_FAILED"
+  | "PROVIDER_RATE_LIMITED"
+  | "VALIDATION_ERROR"
+  | "INTERNAL_ERROR"
+  | "OAUTH_RUNTIME_CONFIG_INVALID"
+  | "OAUTH_SECRET_RESOLUTION_FAILED";
+
+export interface OAuthHttpErrorOptions {
+  code: OAuthHttpErrorCode;
+  status?: number;
+  retryable?: boolean;
+  details?: Record<string, unknown>;
+  cause?: unknown;
+}
+
+export class OAuthHttpError extends Error {
+  readonly code: OAuthHttpErrorCode;
+  readonly status?: number;
+  readonly retryable: boolean;
+  readonly details?: Record<string, unknown>;
+  readonly cause?: unknown;
+
+  constructor(message: string, options: OAuthHttpErrorOptions) {
+    super(message);
+    this.name = "OAuthHttpError";
+    this.code = options.code;
+    this.status = options.status;
+    this.retryable = options.retryable ?? false;
+    this.details = options.details;
+    this.cause = options.cause;
+  }
+}
+
+export function unsupportedTokenAuthMethodError(tokenAuthMethod: string): OAuthHttpError {
+  return new OAuthHttpError("unsupported token auth method", {
+    code: "VALIDATION_ERROR",
+    status: 400,
+    retryable: false,
+    details: { tokenAuthMethod }
+  });
+}
+
+export function invalidRuntimeConfigError(message: string, details?: Record<string, unknown>): OAuthHttpError {
+  return new OAuthHttpError(message, {
+    code: "OAUTH_RUNTIME_CONFIG_INVALID",
+    status: 500,
+    retryable: false,
+    details
+  });
+}
+
+export function secretResolutionFailedError(
+  context: OAuthSecretResolverContext,
+  cause?: unknown,
+  message: string = "failed to resolve OAuth client secret"
+): OAuthHttpError {
+  return new OAuthHttpError(message, {
+    code: "OAUTH_SECRET_RESOLUTION_FAILED",
+    status: 500,
+    retryable: false,
+    cause,
+    details: {
+      providerId: context.provider.id,
+      operation: context.operation,
+      grantType: context.grantType,
+      hasResolver: true
+    }
+  });
+}
+
+export function normalizeOAuthErrorBody(rawBody: unknown): { message: string; details?: Record<string, unknown> } {
+  if (!rawBody || typeof rawBody !== "object") {
+    return { message: "OAuth provider request failed" };
+  }
+
+  const payload = rawBody as Record<string, unknown>;
+  const description =
+    asString(payload.error_description) ??
+    asString(payload.message) ??
+    asString(payload.error) ??
+    asString(payload.detail) ??
+    "OAuth provider request failed";
+  const details = Object.fromEntries(
+    Object.entries({
+      error: asString(payload.error),
+      error_description: asString(payload.error_description),
+      error_uri: asString(payload.error_uri),
+      detail: asString(payload.detail)
+    }).filter(([, value]) => value !== undefined)
+  );
+
+  return {
+    message: description,
+    details: Object.keys(details).length > 0 ? details : undefined
+  };
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/oauth-http/src/index.ts
+++ b/packages/oauth-http/src/index.ts
@@ -1,0 +1,68 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+
+export type OAuthTokenGrantType =
+  | "authorization_code"
+  | "refresh_token"
+  | "client_credentials";
+
+export type OAuthTokenAuthMethod = "client_secret_post" | "client_secret_basic";
+
+export interface OAuthResolvedClientSecret {
+  clientSecret: string;
+  tokenAuthMethod?: OAuthTokenAuthMethod;
+}
+
+export interface OAuthSecretResolverContext {
+  provider: OAuthProviderDescriptor;
+  operation: "exchange" | "revoke";
+  clientId: string;
+  grantType?: OAuthTokenGrantType;
+  redirectUri?: string;
+  scopes?: string[];
+  tokenTypeHint?: "access_token" | "refresh_token";
+}
+
+export type OAuthClientSecretResolver = (
+  input: OAuthSecretResolverContext
+) => Promise<OAuthResolvedClientSecret> | OAuthResolvedClientSecret;
+
+export interface OAuthTokenEndpointRequest {
+  provider: OAuthProviderDescriptor;
+  grantType: OAuthTokenGrantType;
+  clientId: string;
+  clientSecret?: string;
+  clientSecretResolver?: OAuthClientSecretResolver;
+  redirectUri?: string;
+  code?: string;
+  codeVerifier?: string;
+  refreshToken?: string;
+  scopes?: string[];
+}
+
+export interface OAuthTokenEndpointResponse {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  tokenType?: string;
+  scope?: string;
+  idToken?: string;
+  raw?: unknown;
+}
+
+export interface OAuthRevocationRequest {
+  provider: OAuthProviderDescriptor;
+  clientId: string;
+  clientSecret?: string;
+  clientSecretResolver?: OAuthClientSecretResolver;
+  token: string;
+  tokenTypeHint?: "access_token" | "refresh_token";
+}
+
+export interface OAuthTokenHttpClient {
+  exchangeToken(input: OAuthTokenEndpointRequest): Promise<OAuthTokenEndpointResponse>;
+  revokeToken(input: OAuthRevocationRequest): Promise<void>;
+}
+
+export * from "./errors.js";
+export * from "./retry-policy.js";
+export * from "./token-client.js";

--- a/packages/oauth-http/src/retry-policy.ts
+++ b/packages/oauth-http/src/retry-policy.ts
@@ -1,0 +1,83 @@
+export interface OAuthRetryPolicy {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  jitterRatio: number;
+  random: () => number;
+}
+
+export interface RetryDecisionInput {
+  attempt: number;
+  status?: number;
+  retryAfterHeader?: string | null;
+}
+
+export interface RetryDecision {
+  retry: boolean;
+  delayMs: number;
+}
+
+export const DEFAULT_OAUTH_RETRY_POLICY: OAuthRetryPolicy = {
+  maxAttempts: 5,
+  baseDelayMs: 250,
+  maxDelayMs: 10_000,
+  jitterRatio: 0.2,
+  random: Math.random
+};
+
+export function decideRetry(
+  input: RetryDecisionInput,
+  policy: OAuthRetryPolicy = DEFAULT_OAUTH_RETRY_POLICY
+): RetryDecision {
+  if (!shouldRetryStatus(input.status)) {
+    return { retry: false, delayMs: 0 };
+  }
+
+  if (input.attempt >= policy.maxAttempts) {
+    return { retry: false, delayMs: 0 };
+  }
+
+  const retryAfterMs = parseRetryAfter(input.retryAfterHeader);
+  if (retryAfterMs !== null) {
+    return { retry: true, delayMs: retryAfterMs };
+  }
+
+  const exponentialDelay = Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** (input.attempt - 1));
+  const jitter = Math.floor(exponentialDelay * policy.jitterRatio * policy.random());
+  return { retry: true, delayMs: exponentialDelay + jitter };
+}
+
+export function parseRetryAfter(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const seconds = Number(value);
+  if (!Number.isNaN(seconds) && Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  const dateValue = Date.parse(value);
+  if (Number.isNaN(dateValue)) {
+    return null;
+  }
+
+  const now = Date.now();
+  if (dateValue <= now) {
+    return 0;
+  }
+
+  return dateValue - now;
+}
+
+function shouldRetryStatus(status?: number): boolean {
+  if (status === undefined) {
+    return false;
+  }
+
+  if (status === 429) {
+    return true;
+  }
+
+  return status >= 500 && status <= 599;
+}

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -1,0 +1,560 @@
+import type {
+  OAuthClientSecretResolver,
+  OAuthResolvedClientSecret,
+  OAuthRevocationRequest,
+  OAuthSecretResolverContext,
+  OAuthTokenAuthMethod,
+  OAuthTokenEndpointRequest,
+  OAuthTokenEndpointResponse,
+  OAuthTokenGrantType,
+  OAuthTokenHttpClient
+} from "./index.js";
+import {
+  OAuthHttpError,
+  invalidRuntimeConfigError,
+  normalizeOAuthErrorBody,
+  secretResolutionFailedError,
+  unsupportedTokenAuthMethodError
+} from "./errors.js";
+import { DEFAULT_OAUTH_RETRY_POLICY, decideRetry, type OAuthRetryPolicy } from "./retry-policy.js";
+
+interface HeadersLike {
+  get(name: string): string | null;
+}
+
+interface ResponseLike {
+  ok: boolean;
+  status: number;
+  headers: HeadersLike;
+  text(): Promise<string>;
+}
+
+export interface RequestInitLike {
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export type OAuthFetchLike = (url: string, init: RequestInitLike) => Promise<ResponseLike>;
+
+export interface OAuthTokenClientOptions {
+  fetcher?: OAuthFetchLike;
+  retryPolicy?: OAuthRetryPolicy;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+export interface DisconnectWithRevokeInput {
+  revokeSupported: boolean;
+  revokeRequest: OAuthRevocationRequest;
+  deleteLocalTokenRecord: () => Promise<void>;
+  deleteConnectionRecord: () => Promise<void>;
+  onRevocationFailure?: (error: OAuthHttpError) => Promise<void> | void;
+}
+
+export interface DisconnectWithRevokeResult {
+  remoteRevokeAttempted: boolean;
+  localTokenDeleted: boolean;
+  connectionDeleted: boolean;
+}
+
+interface ResolvedRequestCredentials {
+  clientId: string;
+  clientSecret: string;
+  tokenAuthMethod: OAuthTokenAuthMethod;
+}
+
+export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
+  private readonly fetcher: OAuthFetchLike;
+  private readonly retryPolicy: OAuthRetryPolicy;
+  private readonly sleep: (delayMs: number) => Promise<void>;
+
+  constructor(options: OAuthTokenClientOptions = {}) {
+    this.fetcher = options.fetcher ?? getGlobalFetch();
+    this.retryPolicy = options.retryPolicy ?? DEFAULT_OAUTH_RETRY_POLICY;
+    this.sleep = options.sleep ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  }
+
+  async exchangeToken(input: OAuthTokenEndpointRequest): Promise<OAuthTokenEndpointResponse> {
+    const credentials = await resolveRequestCredentials(input, {
+      provider: input.provider,
+      operation: "exchange",
+      clientId: input.clientId,
+      grantType: input.grantType,
+      redirectUri: input.redirectUri,
+      scopes: input.scopes
+    });
+    const endpointRequest = createTokenRequest(input, credentials);
+    const response = await this.executeWithRetry(input.provider.tokenUrl, endpointRequest);
+    const contentType = response.headers.get("content-type");
+    const rawBodyText = await response.text();
+    const parsedBody = parseResponseBody(rawBodyText, contentType);
+
+    if (!response.ok) {
+      throw createTokenEndpointError({
+        status: response.status,
+        grantType: input.grantType,
+        providerId: input.provider.id,
+        parsedBody
+      });
+    }
+
+    return normalizeTokenResponse(parsedBody);
+  }
+
+  async revokeToken(input: OAuthRevocationRequest): Promise<void> {
+    if (!input.provider.revocationUrl) {
+      return;
+    }
+
+    const credentials = await resolveRequestCredentials(input, {
+      provider: input.provider,
+      operation: "revoke",
+      clientId: input.clientId,
+      tokenTypeHint: input.tokenTypeHint
+    });
+    const endpointRequest = createRevokeRequest(input, credentials);
+    const response = await this.executeWithRetry(input.provider.revocationUrl, endpointRequest);
+    if (response.ok) {
+      return;
+    }
+
+    const contentType = response.headers.get("content-type");
+    const rawBodyText = await response.text();
+    const parsedBody = parseResponseBody(rawBodyText, contentType);
+    const normalized = normalizeOAuthErrorBody(parsedBody);
+    const retryable = response.status === 429 || (response.status >= 500 && response.status <= 599);
+    throw new OAuthHttpError(normalized.message, {
+      code: response.status === 429 ? "PROVIDER_RATE_LIMITED" : "INTERNAL_ERROR",
+      status: response.status,
+      retryable,
+      details: {
+        providerId: input.provider.id,
+        operation: "revoke",
+        ...normalized.details
+      }
+    });
+  }
+
+  private async executeWithRetry(url: string, init: RequestInitLike): Promise<ResponseLike> {
+    let attempt = 1;
+    while (true) {
+      let response: ResponseLike;
+      try {
+        response = await this.fetcher(url, init);
+      } catch (error) {
+        const decision = decideRetry(
+          {
+            attempt,
+            status: 503
+          },
+          this.retryPolicy
+        );
+
+        if (!decision.retry) {
+          throw new OAuthHttpError("OAuth provider request failed", {
+            code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+            status: 502,
+            retryable: false,
+            cause: error,
+            details: {
+              transportFailure: true
+            }
+          });
+        }
+
+        await this.sleep(decision.delayMs);
+        attempt += 1;
+        continue;
+      }
+
+      const decision = decideRetry(
+        {
+          attempt,
+          status: response.status,
+          retryAfterHeader: response.headers.get("retry-after")
+        },
+        this.retryPolicy
+      );
+
+      if (!decision.retry) {
+        return response;
+      }
+
+      await this.sleep(decision.delayMs);
+      attempt += 1;
+    }
+  }
+}
+
+export async function disconnectWithRevoke(
+  client: OAuthTokenHttpClient,
+  input: DisconnectWithRevokeInput
+): Promise<DisconnectWithRevokeResult> {
+  let revokeError: OAuthHttpError | null = null;
+  let localTokenDeleted = false;
+  let connectionDeleted = false;
+
+  if (input.revokeSupported) {
+    try {
+      await client.revokeToken(input.revokeRequest);
+    } catch (error) {
+      revokeError = ensureOAuthHttpError(error);
+      if (input.onRevocationFailure) {
+        await input.onRevocationFailure(revokeError);
+      }
+    }
+  }
+
+  await input.deleteLocalTokenRecord();
+  localTokenDeleted = true;
+  await input.deleteConnectionRecord();
+  connectionDeleted = true;
+
+  if (revokeError) {
+    throw new OAuthHttpError("provider revoke failed after local cleanup", {
+      code: "INTERNAL_ERROR",
+      status: 502,
+      retryable: false,
+      cause: revokeError,
+      details: {
+        remoteRevokeAttempted: true,
+        localTokenDeleted,
+        connectionDeleted,
+        revokeErrorCode: revokeError.code
+      }
+    });
+  }
+
+  return {
+    remoteRevokeAttempted: input.revokeSupported,
+    localTokenDeleted,
+    connectionDeleted
+  };
+}
+
+async function resolveRequestCredentials(
+  input: Pick<OAuthTokenEndpointRequest | OAuthRevocationRequest, "clientId" | "clientSecret" | "clientSecretResolver" | "provider">,
+  context: OAuthSecretResolverContext
+): Promise<ResolvedRequestCredentials> {
+  if (!input.clientId) {
+    throw invalidRuntimeConfigError("OAuth runtime config missing clientId", {
+      providerId: input.provider.id,
+      operation: context.operation
+    });
+  }
+
+  const tokenAuthMethod = getTokenAuthMethod(input.provider.tokenAuthMethod);
+  if (input.clientSecret) {
+    return {
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      tokenAuthMethod
+    };
+  }
+
+  const resolvedSecret = await resolveClientSecret(input.clientSecretResolver, context);
+  return {
+    clientId: input.clientId,
+    clientSecret: resolvedSecret.clientSecret,
+    tokenAuthMethod: resolvedSecret.tokenAuthMethod ?? tokenAuthMethod
+  };
+}
+
+async function resolveClientSecret(
+  resolver: OAuthClientSecretResolver | undefined,
+  context: OAuthSecretResolverContext
+): Promise<OAuthResolvedClientSecret> {
+  if (!resolver) {
+    throw invalidRuntimeConfigError("OAuth runtime config missing clientSecret or clientSecretResolver", {
+      providerId: context.provider.id,
+      operation: context.operation
+    });
+  }
+
+  let resolved: OAuthResolvedClientSecret;
+  try {
+    resolved = await resolver(context);
+  } catch (error) {
+    throw secretResolutionFailedError(context, error);
+  }
+
+  if (!resolved?.clientSecret) {
+    throw secretResolutionFailedError(context, undefined, "resolved OAuth client secret is empty");
+  }
+
+  return resolved;
+}
+
+function createTokenRequest(
+  input: OAuthTokenEndpointRequest,
+  credentials: ResolvedRequestCredentials
+): RequestInitLike {
+  const params = new URLSearchParams();
+  params.set("grant_type", input.grantType);
+
+  if (input.grantType === "authorization_code") {
+    if (!input.code) {
+      throw new OAuthHttpError("authorization code is required", {
+        code: "VALIDATION_ERROR",
+        status: 400
+      });
+    }
+
+    params.set("code", input.code);
+    if (input.redirectUri) {
+      params.set("redirect_uri", input.redirectUri);
+    }
+
+    if (input.codeVerifier) {
+      params.set("code_verifier", input.codeVerifier);
+    }
+  } else if (input.grantType === "refresh_token") {
+    if (!input.refreshToken) {
+      throw new OAuthHttpError("refresh token is required", {
+        code: "VALIDATION_ERROR",
+        status: 400
+      });
+    }
+
+    params.set("refresh_token", input.refreshToken);
+    if (input.redirectUri) {
+      params.set("redirect_uri", input.redirectUri);
+    }
+  }
+
+  if (input.scopes && input.scopes.length > 0) {
+    params.set("scope", input.scopes.join(input.provider.scopeSeparator ?? " "));
+  }
+
+  return {
+    method: "POST",
+    headers: createAuthHeaders(credentials, params),
+    body: params.toString()
+  };
+}
+
+function createRevokeRequest(
+  input: OAuthRevocationRequest,
+  credentials: ResolvedRequestCredentials
+): RequestInitLike {
+  const params = new URLSearchParams();
+  params.set("token", input.token);
+  if (input.tokenTypeHint) {
+    params.set("token_type_hint", input.tokenTypeHint);
+  }
+
+  return {
+    method: "POST",
+    headers: createAuthHeaders(credentials, params),
+    body: params.toString()
+  };
+}
+
+function createAuthHeaders(
+  credentials: ResolvedRequestCredentials,
+  params: URLSearchParams
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": "application/x-www-form-urlencoded",
+    accept: "application/json, application/x-www-form-urlencoded, text/plain"
+  };
+
+  if (credentials.tokenAuthMethod === "client_secret_post") {
+    params.set("client_id", credentials.clientId);
+    params.set("client_secret", credentials.clientSecret);
+  } else {
+    const authUser = encodeURIComponent(credentials.clientId);
+    const authPassword = encodeURIComponent(credentials.clientSecret);
+    const auth = Buffer.from(`${authUser}:${authPassword}`, "utf8").toString("base64");
+    headers.authorization = `Basic ${auth}`;
+  }
+
+  return headers;
+}
+
+function parseResponseBody(rawBodyText: string, contentType: string | null): unknown {
+  if (rawBodyText.length === 0) {
+    return {};
+  }
+
+  const normalizedContentType = contentType?.toLowerCase() ?? "";
+  if (normalizedContentType.includes("application/json")) {
+    return safeParseJson(rawBodyText);
+  }
+
+  if (
+    normalizedContentType.includes("application/x-www-form-urlencoded") ||
+    normalizedContentType.includes("text/plain")
+  ) {
+    return parseFormBody(rawBodyText);
+  }
+
+  const maybeJson = safeParseJson(rawBodyText);
+  if (maybeJson !== null) {
+    return maybeJson;
+  }
+
+  return parseFormBody(rawBodyText);
+}
+
+function normalizeTokenResponse(parsedBody: unknown): OAuthTokenEndpointResponse {
+  if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
+    throw new OAuthHttpError("OAuth token response body must be a JSON object", {
+      code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+      status: 502,
+      retryable: false,
+      details: { parsedBodyKeys: [] }
+    });
+  }
+
+  const payload = parsedBody as Record<string, unknown>;
+  const accessToken = asString(payload.access_token);
+  if (!accessToken) {
+    throw new OAuthHttpError("OAuth token response missing access_token", {
+      code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+      status: 502,
+      retryable: false,
+      details: { parsedBodyKeys: Object.keys(payload).slice(0, 10) }
+    });
+  }
+
+  const result: OAuthTokenEndpointResponse = {
+    accessToken,
+    refreshToken: asString(payload.refresh_token),
+    tokenType: asString(payload.token_type),
+    scope: asString(payload.scope),
+    idToken: asString(payload.id_token),
+    raw: payload
+  };
+
+  const expiresIn = asNumber(payload.expires_in);
+  if (expiresIn !== undefined) {
+    result.expiresIn = expiresIn;
+  }
+
+  return result;
+}
+
+function createTokenEndpointError(input: {
+  status: number;
+  grantType: OAuthTokenGrantType;
+  providerId: string;
+  parsedBody: unknown;
+}): OAuthHttpError {
+  const normalized = normalizeOAuthErrorBody(input.parsedBody);
+  const retryable = input.status === 429 || (input.status >= 500 && input.status <= 599);
+  if (input.status === 429) {
+    return new OAuthHttpError(normalized.message, {
+      code: "PROVIDER_RATE_LIMITED",
+      status: input.status,
+      retryable: true,
+      details: {
+        providerId: input.providerId,
+        grantType: input.grantType,
+        ...normalized.details
+      }
+    });
+  }
+
+  return new OAuthHttpError(normalized.message, {
+    code: input.grantType === "refresh_token" ? "OAUTH_TOKEN_REFRESH_FAILED" : "OAUTH_TOKEN_EXCHANGE_FAILED",
+    status: input.status,
+    retryable,
+    details: {
+      providerId: input.providerId,
+      grantType: input.grantType,
+      ...normalized.details
+    }
+  });
+}
+
+function getTokenAuthMethod(tokenAuthMethod: string | undefined): OAuthTokenAuthMethod {
+  if (!tokenAuthMethod) {
+    return "client_secret_post";
+  }
+
+  if (tokenAuthMethod === "client_secret_post" || tokenAuthMethod === "client_secret_basic") {
+    return tokenAuthMethod;
+  }
+
+  throw unsupportedTokenAuthMethodError(tokenAuthMethod);
+}
+
+function parseFormBody(rawBodyText: string): Record<string, string> {
+  const params = new URLSearchParams(rawBodyText);
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of params.entries()) {
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function safeParseJson(rawBodyText: string): unknown {
+  try {
+    return JSON.parse(rawBodyText) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  return undefined;
+}
+
+function ensureOAuthHttpError(error: unknown): OAuthHttpError {
+  if (error instanceof OAuthHttpError) {
+    return error;
+  }
+
+  return new OAuthHttpError(error instanceof Error ? error.message : "OAuth HTTP request failed", {
+    code: "INTERNAL_ERROR",
+    status: 500,
+    retryable: false,
+    cause: error
+  });
+}
+
+function getGlobalFetch(): OAuthFetchLike {
+  const fetcher = globalThis.fetch;
+  if (!fetcher) {
+    throw new OAuthHttpError("global fetch is not available", {
+      code: "INTERNAL_ERROR",
+      status: 500,
+      retryable: false
+    });
+  }
+
+  return async (url, init) => {
+    const response = await fetcher(url, {
+      method: init.method,
+      headers: init.headers,
+      body: init.body
+    });
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      headers: {
+        get(name: string) {
+          return response.headers.get(name);
+        }
+      },
+      text: () => response.text()
+    };
+  };
+}

--- a/packages/oauth-http/tests/token-client.test.ts
+++ b/packages/oauth-http/tests/token-client.test.ts
@@ -1,0 +1,620 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DefaultOAuthTokenHttpClient,
+  OAuthHttpError,
+  disconnectWithRevoke,
+  type OAuthFetchLike,
+  type RequestInitLike
+} from "../src/index.js";
+
+const googleProvider = {
+  id: "google",
+  authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenUrl: "https://oauth2.googleapis.com/token",
+  revocationUrl: "https://oauth2.googleapis.com/revoke",
+  defaultScopes: ["openid", "email", "profile"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post" as const
+};
+
+describe("oauth-http token client", () => {
+  it("serializes token exchange as form-encoded for client_secret_post", async () => {
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (_url, init) => {
+      capturedInit = init;
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          access_token: "at_123",
+          refresh_token: "rt_123",
+          token_type: "bearer",
+          expires_in: 3600
+        })
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    const response = await client.exchangeToken({
+      provider: googleProvider,
+      grantType: "authorization_code",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      code: "code-123",
+      redirectUri: "https://app/callback",
+      codeVerifier: "verifier-123",
+      scopes: ["scope:a", "scope:b"]
+    });
+
+    expect(response.accessToken).toBe("at_123");
+    expect(response.refreshToken).toBe("rt_123");
+    expect(response.tokenType).toBe("bearer");
+    expect(response.expiresIn).toBe(3600);
+
+    expect(capturedInit?.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+    const params = new URLSearchParams(capturedInit?.body);
+    expect(params.get("grant_type")).toBe("authorization_code");
+    expect(params.get("code")).toBe("code-123");
+    expect(params.get("redirect_uri")).toBe("https://app/callback");
+    expect(params.get("code_verifier")).toBe("verifier-123");
+    expect(params.get("scope")).toBe("scope:a scope:b");
+    expect(params.get("client_id")).toBe("client-id");
+    expect(params.get("client_secret")).toBe("client-secret");
+  });
+
+  it("supports client_secret_basic and form-like token responses", async () => {
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (_url, init) => {
+      capturedInit = init;
+      return createResponse({
+        status: 200,
+        contentType: "application/x-www-form-urlencoded",
+        body: "access_token=at_form&refresh_token=rt_form&token_type=bearer&expires_in=1200"
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    const response = await client.exchangeToken({
+      provider: {
+        ...googleProvider,
+        tokenAuthMethod: "client_secret_basic"
+      },
+      grantType: "authorization_code",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      code: "code-basic",
+      redirectUri: "https://app/callback"
+    });
+
+    expect(response.accessToken).toBe("at_form");
+    expect(response.refreshToken).toBe("rt_form");
+    expect(response.expiresIn).toBe(1200);
+
+    expect(capturedInit?.headers.authorization).toMatch(/^Basic /);
+    const params = new URLSearchParams(capturedInit?.body);
+    expect(params.get("client_id")).toBeNull();
+    expect(params.get("client_secret")).toBeNull();
+  });
+
+  it("percent-encodes client_secret_basic credentials and redacts token payloads from error details", async () => {
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (_url, init) => {
+      capturedInit = init;
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          refresh_token: "rt_secret",
+          id_token: "id_secret"
+        })
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await expect(
+      client.exchangeToken({
+        provider: {
+          ...googleProvider,
+          tokenAuthMethod: "client_secret_basic"
+        },
+        grantType: "authorization_code",
+        clientId: "client:id",
+        clientSecret: "secret+value",
+        code: "code-basic",
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+      details: {
+        parsedBodyKeys: ["refresh_token", "id_token"]
+      }
+    });
+
+    const encodedCredentials = Buffer.from("client%3Aid:secret%2Bvalue").toString("base64");
+    expect(capturedInit?.headers.authorization).toBe(`Basic ${encodedCredentials}`);
+  });
+
+  it("resolves client secrets at runtime for Apple-compatible providers", async () => {
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (_url, init) => {
+      capturedInit = init;
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "at_apple", token_type: "bearer" })
+      });
+    };
+
+    const clientSecretResolver = vi.fn(async () => ({
+      clientSecret: "generated-apple-client-secret"
+    }));
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    const response = await client.exchangeToken({
+      provider: {
+        ...googleProvider,
+        id: "apple",
+        tokenAuthMethod: "client_secret_post"
+      },
+      grantType: "authorization_code",
+      clientId: "apple-client-id",
+      clientSecretResolver,
+      code: "apple-code",
+      redirectUri: "https://app/callback"
+    });
+
+    expect(response.accessToken).toBe("at_apple");
+    expect(clientSecretResolver).toHaveBeenCalledTimes(1);
+    const params = new URLSearchParams(capturedInit?.body);
+    expect(params.get("client_secret")).toBe("generated-apple-client-secret");
+  });
+
+  it("fails with OAUTH_SECRET_RESOLUTION_FAILED when runtime secret resolution throws", async () => {
+    const fetcher: OAuthFetchLike = async () => {
+      throw new Error("should not call fetch");
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await expect(
+      client.exchangeToken({
+        provider: googleProvider,
+        grantType: "authorization_code",
+        clientId: "client-id",
+        clientSecretResolver: async () => {
+          throw new Error("kms unavailable");
+        },
+        code: "code-secret-error",
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_SECRET_RESOLUTION_FAILED",
+      details: {
+        providerId: "google",
+        operation: "exchange"
+      }
+    });
+  });
+
+  it("does not leak resolver failure messages into structured error details", async () => {
+    const client = new DefaultOAuthTokenHttpClient({
+      fetcher: async () => {
+        throw new Error("should not call fetch");
+      }
+    });
+
+    await expect(
+      client.exchangeToken({
+        provider: googleProvider,
+        grantType: "authorization_code",
+        clientId: "client-id",
+        clientSecretResolver: async () => {
+          throw new Error("kms://secret?token=top-secret");
+        },
+        code: "code-secret-error",
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_SECRET_RESOLUTION_FAILED",
+      details: {
+        providerId: "google",
+        operation: "exchange",
+        hasResolver: true
+      }
+    });
+  });
+
+  it("fails with OAUTH_RUNTIME_CONFIG_INVALID when no client secret path is configured", async () => {
+    const fetcher: OAuthFetchLike = async () => {
+      throw new Error("should not call fetch");
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await expect(
+      client.exchangeToken({
+        provider: googleProvider,
+        grantType: "authorization_code",
+        clientId: "client-id",
+        code: "code-no-secret",
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_RUNTIME_CONFIG_INVALID"
+    });
+  });
+
+  it("rejects unsupported token auth method with deterministic validation error", async () => {
+    const fetcher: OAuthFetchLike = async () => {
+      throw new Error("should not call fetch");
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await expect(
+      client.exchangeToken({
+        provider: {
+          ...googleProvider,
+          tokenAuthMethod: "private_key_jwt" as unknown as "client_secret_post"
+        },
+        grantType: "authorization_code",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        code: "code-unsupported",
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "unsupported token auth method"
+    });
+  });
+
+  it("retries token exchange using Retry-After hints", async () => {
+    const sleep = vi.fn(async () => undefined);
+    let calls = 0;
+    const fetcher: OAuthFetchLike = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return createResponse({
+          status: 429,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "rate_limited" }),
+          headers: { "retry-after": "7" }
+        });
+      }
+
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "at_after_retry", token_type: "bearer" })
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher, sleep });
+    const response = await client.exchangeToken({
+      provider: googleProvider,
+      grantType: "authorization_code",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      code: "code-retry",
+      redirectUri: "https://app/callback"
+    });
+
+    expect(calls).toBe(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(7000);
+    expect(response.accessToken).toBe("at_after_retry");
+  });
+
+  it("honors server-provided Retry-After delays even when they exceed the local backoff ceiling", async () => {
+    const sleep = vi.fn(async () => undefined);
+    let calls = 0;
+    const fetcher: OAuthFetchLike = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return createResponse({
+          status: 429,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "rate_limited" }),
+          headers: { "retry-after": "120" }
+        });
+      }
+
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "at_after_retry", token_type: "bearer" })
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({
+      fetcher,
+      sleep,
+      retryPolicy: {
+        maxAttempts: 3,
+        baseDelayMs: 250,
+        maxDelayMs: 5_000,
+        jitterRatio: 0,
+        random: () => 0
+      }
+    });
+
+    await client.exchangeToken({
+      provider: googleProvider,
+      grantType: "authorization_code",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      code: "code-retry",
+      redirectUri: "https://app/callback"
+    });
+
+    expect(sleep).toHaveBeenCalledWith(120_000);
+  });
+
+  it("retries transient fetch exceptions during token exchange", async () => {
+    const sleep = vi.fn(async () => undefined);
+    let calls = 0;
+    const fetcher: OAuthFetchLike = async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("socket hang up");
+      }
+
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "at_after_retry", token_type: "bearer" })
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher, sleep });
+    const response = await client.exchangeToken({
+      provider: googleProvider,
+      grantType: "authorization_code",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      code: "code-retry",
+      redirectUri: "https://app/callback"
+    });
+
+    expect(calls).toBe(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(response.accessToken).toBe("at_after_retry");
+  });
+
+  it("wraps exhausted fetch exceptions in OAuthHttpError after retry attempts are spent", async () => {
+    const sleep = vi.fn(async () => undefined);
+    const client = new DefaultOAuthTokenHttpClient({
+      fetcher: async () => {
+        throw new Error("socket hang up");
+      },
+      sleep,
+      retryPolicy: {
+        maxAttempts: 1,
+        baseDelayMs: 10,
+        maxDelayMs: 10,
+        jitterRatio: 0,
+        random: () => 0,
+      },
+    });
+
+    await expect(
+      client.exchangeToken({
+        provider: googleProvider,
+        grantType: "authorization_code",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        code: "code-fail",
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+      details: {
+        transportFailure: true
+      }
+    });
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("fails deterministically when a JSON token body is malformed", async () => {
+    const client = new DefaultOAuthTokenHttpClient({
+      fetcher: async () =>
+        createResponse({
+          status: 200,
+          contentType: "application/json",
+          body: "{not-json"
+        })
+    });
+
+    await expect(
+      client.exchangeToken({
+        provider: googleProvider,
+        grantType: "authorization_code",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        code: "code-malformed",
+        redirectUri: "https://app/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+      message: "OAuth token response body must be a JSON object"
+    });
+  });
+
+  it("maps refresh endpoint failures to OAUTH_TOKEN_REFRESH_FAILED", async () => {
+    const fetcher: OAuthFetchLike = async () =>
+      createResponse({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "invalid_grant", error_description: "refresh token expired" })
+      });
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await expect(
+      client.exchangeToken({
+        provider: googleProvider,
+        grantType: "refresh_token",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        refreshToken: "rt_expired"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_REFRESH_FAILED",
+      message: "refresh token expired"
+    });
+  });
+
+  it("calls provider revocation endpoint when supported", async () => {
+    const calledUrls: string[] = [];
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (url, init) => {
+      calledUrls.push(url);
+      capturedInit = init;
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: "{}"
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await client.revokeToken({
+      provider: googleProvider,
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      token: "token-to-revoke",
+      tokenTypeHint: "access_token"
+    });
+
+    expect(calledUrls).toEqual([googleProvider.revocationUrl]);
+    const body = new URLSearchParams(capturedInit?.body);
+    expect(body.get("token")).toBe("token-to-revoke");
+    expect(body.get("token_type_hint")).toBe("access_token");
+  });
+
+  it("skips remote revoke when provider has no revocation URL", async () => {
+    const fetcher = vi.fn(async () =>
+      createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: "{}"
+      })
+    );
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await client.revokeToken({
+      provider: {
+        ...googleProvider,
+        revocationUrl: undefined
+      },
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      token: "token-to-revoke"
+    });
+
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("attempts remote revoke and always performs local cleanup on failure", async () => {
+    const failingClient = {
+      async exchangeToken() {
+        throw new Error("not implemented");
+      },
+      async revokeToken() {
+        throw new OAuthHttpError("provider revoke failed", {
+          code: "INTERNAL_ERROR",
+          status: 502
+        });
+      }
+    };
+
+    const deleteLocalTokenRecord = vi.fn(async () => undefined);
+    const deleteConnectionRecord = vi.fn(async () => undefined);
+    const onRevocationFailure = vi.fn(async () => undefined);
+
+    await expect(
+      disconnectWithRevoke(failingClient, {
+        revokeSupported: true,
+        revokeRequest: {
+          provider: googleProvider,
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          token: "at_123"
+        },
+        deleteLocalTokenRecord,
+        deleteConnectionRecord,
+        onRevocationFailure
+      })
+    ).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+      details: {
+        remoteRevokeAttempted: true,
+        localTokenDeleted: true,
+        connectionDeleted: true
+      }
+    });
+
+    expect(deleteLocalTokenRecord).toHaveBeenCalledTimes(1);
+    expect(deleteConnectionRecord).toHaveBeenCalledTimes(1);
+    expect(onRevocationFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("attempts remote revoke and returns cleanup result on success", async () => {
+    const successfulClient = {
+      async exchangeToken() {
+        throw new Error("not implemented");
+      },
+      async revokeToken() {
+        return;
+      }
+    };
+
+    const deleteLocalTokenRecord = vi.fn(async () => undefined);
+    const deleteConnectionRecord = vi.fn(async () => undefined);
+
+    const result = await disconnectWithRevoke(successfulClient, {
+      revokeSupported: true,
+      revokeRequest: {
+        provider: googleProvider,
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        token: "at_123"
+      },
+      deleteLocalTokenRecord,
+      deleteConnectionRecord
+    });
+
+    expect(result).toEqual({
+      remoteRevokeAttempted: true,
+      localTokenDeleted: true,
+      connectionDeleted: true
+    });
+    expect(deleteLocalTokenRecord).toHaveBeenCalledTimes(1);
+    expect(deleteConnectionRecord).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createResponse(input: {
+  status: number;
+  contentType: string;
+  body: string;
+  headers?: Record<string, string>;
+}) {
+  const headerMap = new Map<string, string>();
+  headerMap.set("content-type", input.contentType);
+  for (const [key, value] of Object.entries(input.headers ?? {})) {
+    headerMap.set(key.toLowerCase(), value);
+  }
+
+  return {
+    ok: input.status >= 200 && input.status <= 299,
+    status: input.status,
+    headers: {
+      get(name: string) {
+        return headerMap.get(name.toLowerCase()) ?? null;
+      }
+    },
+    async text() {
+      return input.body;
+    }
+  };
+}

--- a/packages/oauth-http/tsconfig.json
+++ b/packages/oauth-http/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-http/vitest.config.ts
+++ b/packages/oauth-http/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createOAuthSharedVitestConfig } from "../../scripts/vitest-oauth-shared.mjs";
+
+export default createOAuthSharedVitestConfig();

--- a/packages/oauth-providers/README.md
+++ b/packages/oauth-providers/README.md
@@ -1,0 +1,52 @@
+# @superfunctions/oauth-providers
+
+Curated OAuth provider descriptors plus a shared provider-policy registry.
+
+## Install
+
+```bash
+npm install @superfunctions/oauth-providers @superfunctions/oauth-core
+```
+
+## Quick Start
+
+```ts
+import {
+  createDefaultProviderPolicyRegistry,
+  getOAuthProviderDescriptor,
+} from "@superfunctions/oauth-providers";
+
+const github = getOAuthProviderDescriptor("github");
+const registry = createDefaultProviderPolicyRegistry();
+
+const consent = await registry.validateScopes({
+  providerId: "github",
+  feature: "profile.basic",
+  requestedScopes: github.defaultScopes,
+  tenantId: "tenant_1",
+  userId: "user_1",
+  purpose: "Connect a GitHub account",
+});
+```
+
+## Package Boundary
+
+`@superfunctions/oauth-providers` owns:
+
+- curated provider descriptors
+- provider capability and scope policies
+- consent and policy-audit registry contracts
+
+It does not perform token exchange, persist OAuth tokens, or expose routes.
+
+## Production Notes
+
+- `createDefaultProviderPolicyRegistry()` is an in-memory convenience path, not a durable compliance boundary.
+- For production consent/audit retention, pass explicit `consentStore` and `auditStore`.
+- Registry methods that persist policy state are async because store writes are now part of the contract.
+- If you need a provider not bundled here, pass your own descriptor into `@superfunctions/oauth-core` or `@superfunctions/oauth-flow`.
+
+## Docs
+
+- Canonical docs: [docs/content/docs/authentication/oauth-providers.mdx](../../docs/content/docs/authentication/oauth-providers.mdx)
+- Stack overview: [docs/content/docs/architecture/oauth-flow-architecture.mdx](../../docs/content/docs/architecture/oauth-flow-architecture.mdx)

--- a/packages/oauth-providers/package.json
+++ b/packages/oauth-providers/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@superfunctions/oauth-providers",
+  "version": "0.0.1",
+  "description": "OAuth provider descriptors for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --config ./vitest.config.ts --run",
+    "test:watch": "vitest --config ./vitest.config.ts --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "oauth",
+    "providers",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/oauth-providers"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/oauth-core": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/oauth-providers/src/__tests__/exports.test.ts
+++ b/packages/oauth-providers/src/__tests__/exports.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  getOAuthProviderDescriptor,
+  getProviderPolicy,
+  listOAuthProviderDescriptors,
+} from "../index.js";
+
+describe("oauth-providers exports", () => {
+  it("returns known providers", () => {
+    expect(getOAuthProviderDescriptor("google").id).toBe("google");
+    expect(listOAuthProviderDescriptors().length).toBeGreaterThan(0);
+  });
+
+  it("returns cloned provider descriptors so callers cannot mutate shared registry state", () => {
+    const descriptor = getOAuthProviderDescriptor("google");
+    descriptor.defaultScopes.push("mutated");
+    descriptor.extraAuthParams = { prompt: "consent" };
+
+    expect(getOAuthProviderDescriptor("google").defaultScopes).toEqual(["openid", "email", "profile"]);
+    expect(getOAuthProviderDescriptor("google").extraAuthParams).toBeUndefined();
+  });
+
+  it("returns cloned provider policies so callers cannot mutate shared policy state", () => {
+    const policy = getProviderPolicy("google");
+    policy.operationPolicies["mail.send"]!.allowed = false;
+    policy.featureScopes["mail.send"]!.allowedScopes.push("mutated");
+
+    expect(getProviderPolicy("google").operationPolicies["mail.send"]?.allowed).toBe(true);
+    expect(getProviderPolicy("google").featureScopes["mail.send"]?.allowedScopes).not.toContain("mutated");
+  });
+});

--- a/packages/oauth-providers/src/index.ts
+++ b/packages/oauth-providers/src/index.ts
@@ -1,0 +1,84 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import { appleOAuthProviderDescriptor, appleProviderPolicy } from "./providers/apple.js";
+import { githubOAuthProviderDescriptor, githubProviderPolicy } from "./providers/github.js";
+import { googleOAuthProviderDescriptor, googleProviderPolicy } from "./providers/google.js";
+import { microsoftOAuthProviderDescriptor, microsoftProviderPolicy } from "./providers/microsoft.js";
+import { yahooOAuthProviderDescriptor, yahooProviderPolicy } from "./providers/yahoo.js";
+import {
+  ProviderPolicyRegistry,
+  type OAuthProviderId,
+  type ProviderPolicyDefinition,
+  type ProviderPolicyRegistryOptions,
+  clonePolicy,
+} from "./policy-registry.js";
+import { MemoryProviderPolicyAuditStore, MemoryProviderPolicyConsentStore } from "./stores.js";
+
+export const authOAuthProviderIds = ["google", "apple", "github"] as const;
+export type AuthOAuthProviderId = (typeof authOAuthProviderIds)[number];
+
+export const oauthProviderDescriptors: Record<OAuthProviderId, OAuthProviderDescriptor> = {
+  google: googleOAuthProviderDescriptor,
+  microsoft: microsoftOAuthProviderDescriptor,
+  yahoo: yahooOAuthProviderDescriptor,
+  apple: appleOAuthProviderDescriptor,
+  github: githubOAuthProviderDescriptor
+};
+
+export const oauthProviderPolicies: Record<OAuthProviderId, ProviderPolicyDefinition> = {
+  google: googleProviderPolicy,
+  microsoft: microsoftProviderPolicy,
+  yahoo: yahooProviderPolicy,
+  apple: appleProviderPolicy,
+  github: githubProviderPolicy
+};
+
+function cloneOAuthProviderDescriptor(provider: OAuthProviderDescriptor): OAuthProviderDescriptor {
+  return {
+    ...provider,
+    defaultScopes: [...provider.defaultScopes],
+    extraAuthParams: provider.extraAuthParams ? { ...provider.extraAuthParams } : undefined,
+  };
+}
+
+export function getOAuthProviderDescriptor(providerId: OAuthProviderId): OAuthProviderDescriptor {
+  return cloneOAuthProviderDescriptor(oauthProviderDescriptors[providerId]);
+}
+
+export function listOAuthProviderDescriptors(): OAuthProviderDescriptor[] {
+  return Object.values(oauthProviderDescriptors).map((provider) => cloneOAuthProviderDescriptor(provider));
+}
+
+export function listAuthOAuthProviderDescriptors(): OAuthProviderDescriptor[] {
+  return authOAuthProviderIds.map((providerId) => cloneOAuthProviderDescriptor(oauthProviderDescriptors[providerId]));
+}
+
+export function getProviderPolicy(providerId: OAuthProviderId): ProviderPolicyDefinition {
+  return clonePolicy(oauthProviderPolicies[providerId]);
+}
+
+export function listProviderPolicies(): ProviderPolicyDefinition[] {
+  return Object.values(oauthProviderPolicies).map((policy) => clonePolicy(policy));
+}
+
+export function listAuthProviderPolicies(): ProviderPolicyDefinition[] {
+  return authOAuthProviderIds.map((providerId) => clonePolicy(oauthProviderPolicies[providerId]));
+}
+
+export function createDefaultProviderPolicyRegistry(
+  options?: ProviderPolicyRegistryOptions | (() => string)
+): ProviderPolicyRegistry {
+  const resolvedOptions = typeof options === "function" ? { now: options } : options;
+  return new ProviderPolicyRegistry(listProviderPolicies(), {
+    ...resolvedOptions,
+    consentStore: resolvedOptions?.consentStore ?? new MemoryProviderPolicyConsentStore(),
+    auditStore: resolvedOptions?.auditStore ?? new MemoryProviderPolicyAuditStore()
+  });
+}
+
+export * from "./policy-registry.js";
+export * from "./stores.js";
+export * from "./providers/google.js";
+export * from "./providers/microsoft.js";
+export * from "./providers/yahoo.js";
+export * from "./providers/apple.js";
+export * from "./providers/github.js";

--- a/packages/oauth-providers/src/policy-registry.ts
+++ b/packages/oauth-providers/src/policy-registry.ts
@@ -1,0 +1,361 @@
+import { randomUUID } from "node:crypto";
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import { MemoryProviderPolicyAuditStore, MemoryProviderPolicyConsentStore } from "./stores.js";
+import type { ProviderPolicyAuditStore, ProviderPolicyConsentStore } from "./stores.js";
+
+export type OAuthProviderId = "google" | "microsoft" | "yahoo" | "apple" | "github";
+export type ProviderFeatureMode = "metadata-only" | "snippet" | "full-body";
+
+export interface ProviderCapabilityPolicy {
+  supportsMailRead: boolean;
+  supportsMailSend: boolean;
+  supportsWatch: boolean;
+  supportsRevoke: boolean;
+  supportsManagedMailbox: boolean;
+  allowedFeatureModes: ProviderFeatureMode[];
+}
+
+export interface ProviderAuthPolicy {
+  supportsSocialLogin: boolean;
+  supportsAccountLinking: boolean;
+  defaultScopes: string[];
+  availableClaims: Array<"email" | "name" | "profile">;
+}
+
+export type ProviderClientSecretMode = "static-allowed" | "resolver-allowed" | "resolver-required";
+
+export interface ProviderRuntimePolicy {
+  clientSecretMode: ProviderClientSecretMode;
+  clientSecretResolverHint?: "apple-client-secret-jwt" | "runtime-client-secret";
+}
+
+export interface ProviderFeatureScopePolicy {
+  allowedScopes: string[];
+  restrictedScopes?: string[];
+}
+
+export interface ProviderOperationPolicy {
+  allowed: boolean;
+  reason?: string;
+  requiredFeatureMode?: ProviderFeatureMode;
+}
+
+export interface ProviderPolicyDefinition {
+  providerId: OAuthProviderId;
+  policyVersion: string;
+  descriptor: OAuthProviderDescriptor;
+  capabilities: ProviderCapabilityPolicy;
+  auth?: ProviderAuthPolicy;
+  runtime?: ProviderRuntimePolicy;
+  featureScopes: Record<string, ProviderFeatureScopePolicy>;
+  operationPolicies: Record<string, ProviderOperationPolicy>;
+}
+
+export interface ScopeValidationInput {
+  providerId: OAuthProviderId;
+  feature: string;
+  requestedScopes: string[];
+  tenantId: string;
+  userId: string;
+  purpose: string;
+}
+
+export interface ScopeValidationResult {
+  authorized: true;
+  consentRecord: ConsentRecord;
+}
+
+export interface ConsentRecord {
+  consentId: string;
+  tenantId: string;
+  userId: string;
+  providerId: OAuthProviderId;
+  feature: string;
+  scopes: string[];
+  purpose: string;
+  grantedAt: string;
+  policyVersion: string;
+}
+
+export interface OperationCheckInput {
+  providerId: OAuthProviderId;
+  operation: string;
+  featureMode?: ProviderFeatureMode;
+}
+
+export interface OperationCheckResult {
+  allowed: true;
+  policyVersion: string;
+}
+
+export interface PolicyVersionUpdateInput {
+  providerId: OAuthProviderId;
+  newVersion: string;
+  actor: string;
+  reason: string;
+  changedAt?: string;
+}
+
+export interface PolicyAuditEvent {
+  auditEventId: string;
+  providerId: OAuthProviderId;
+  fromVersion: string;
+  toVersion: string;
+  actor: string;
+  reason: string;
+  changedAt: string;
+}
+
+export type ProviderPolicyIdKind = "consent" | "audit";
+export type ProviderPolicyIdGenerator = (kind: ProviderPolicyIdKind) => string;
+
+export interface ProviderPolicyRegistryOptions {
+  consentStore?: ProviderPolicyConsentStore;
+  auditStore?: ProviderPolicyAuditStore;
+  idGenerator?: ProviderPolicyIdGenerator;
+  now?: () => string;
+}
+
+export class ProviderPolicyError extends Error {
+  readonly code:
+    | "OAUTH_SCOPE_DISALLOWED"
+    | "PROVIDER_POLICY_BLOCKED"
+    | "PROVIDER_POLICY_STORE_FAILED"
+    | "VALIDATION_ERROR";
+  readonly details?: Record<string, unknown>;
+
+  constructor(
+    code:
+      | "OAUTH_SCOPE_DISALLOWED"
+      | "PROVIDER_POLICY_BLOCKED"
+      | "PROVIDER_POLICY_STORE_FAILED"
+      | "VALIDATION_ERROR",
+    message: string,
+    details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = "ProviderPolicyError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export class ProviderPolicyRegistry {
+  private readonly policies = new Map<OAuthProviderId, ProviderPolicyDefinition>();
+  private readonly consentStore: ProviderPolicyConsentStore;
+  private readonly auditStore: ProviderPolicyAuditStore;
+  private readonly now: () => string;
+  private readonly idGenerator: ProviderPolicyIdGenerator;
+
+  constructor(policies: ReadonlyArray<ProviderPolicyDefinition>, options: ProviderPolicyRegistryOptions = {}) {
+    for (const policy of policies) {
+      this.policies.set(policy.providerId, clonePolicy(policy));
+    }
+
+    this.consentStore = options.consentStore ?? new MemoryProviderPolicyConsentStore();
+    this.auditStore = options.auditStore ?? new MemoryProviderPolicyAuditStore();
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.idGenerator = options.idGenerator ?? defaultProviderPolicyIdGenerator;
+  }
+
+  getPolicy(providerId: OAuthProviderId): ProviderPolicyDefinition {
+    const policy = this.policies.get(providerId);
+    if (!policy) {
+      throw new ProviderPolicyError("VALIDATION_ERROR", `provider policy not found: ${providerId}`);
+    }
+
+    return clonePolicy(policy);
+  }
+
+  listPolicies(): ProviderPolicyDefinition[] {
+    return [...this.policies.values()].map((policy) => clonePolicy(policy));
+  }
+
+  async validateScopes(input: ScopeValidationInput): Promise<ScopeValidationResult> {
+    const policy = this.getPolicy(input.providerId);
+    const featurePolicy = policy.featureScopes[input.feature];
+    if (!featurePolicy) {
+      throw new ProviderPolicyError("VALIDATION_ERROR", "feature scope policy not found", {
+        providerId: input.providerId,
+        feature: input.feature
+      });
+    }
+
+    const disallowedScope = input.requestedScopes.find((scope) => !featurePolicy.allowedScopes.includes(scope));
+    if (disallowedScope) {
+      throw new ProviderPolicyError("OAUTH_SCOPE_DISALLOWED", "requested scope not allowed for feature", {
+        providerId: input.providerId,
+        feature: input.feature,
+        scope: disallowedScope
+      });
+    }
+
+    const restrictedScope = input.requestedScopes.find((scope) => featurePolicy.restrictedScopes?.includes(scope));
+    if (restrictedScope) {
+      throw new ProviderPolicyError("OAUTH_SCOPE_DISALLOWED", "requested scope requires additional approval", {
+        providerId: input.providerId,
+        feature: input.feature,
+        scope: restrictedScope
+      });
+    }
+
+    const consentRecord: ConsentRecord = {
+      consentId: this.idGenerator("consent"),
+      tenantId: input.tenantId,
+      userId: input.userId,
+      providerId: input.providerId,
+      feature: input.feature,
+      scopes: [...input.requestedScopes],
+      purpose: input.purpose,
+      grantedAt: this.now(),
+      policyVersion: policy.policyVersion
+    };
+
+    try {
+      await this.consentStore.put(consentRecord);
+    } catch (error) {
+      throw new ProviderPolicyError(
+        "PROVIDER_POLICY_STORE_FAILED",
+        "failed to persist provider policy consent record",
+        {
+          providerId: input.providerId,
+          feature: input.feature,
+          cause: error instanceof Error ? error.message : String(error)
+        }
+      );
+    }
+
+    return {
+      authorized: true,
+      consentRecord: cloneConsent(consentRecord)
+    };
+  }
+
+  assertOperationAllowed(input: OperationCheckInput): OperationCheckResult {
+    const policy = this.getPolicy(input.providerId);
+    const operationPolicy = policy.operationPolicies[input.operation];
+    if (!operationPolicy || !operationPolicy.allowed) {
+      throw new ProviderPolicyError("PROVIDER_POLICY_BLOCKED", "operation not allowed by policy", {
+        providerId: input.providerId,
+        operation: input.operation,
+        policyVersion: policy.policyVersion
+      });
+    }
+
+    if (operationPolicy.requiredFeatureMode && input.featureMode !== operationPolicy.requiredFeatureMode) {
+      throw new ProviderPolicyError("PROVIDER_POLICY_BLOCKED", "operation not allowed by policy", {
+        providerId: input.providerId,
+        operation: input.operation,
+        policyVersion: policy.policyVersion,
+        requiredFeatureMode: operationPolicy.requiredFeatureMode,
+        featureMode: input.featureMode
+      });
+    }
+
+    return {
+      allowed: true,
+      policyVersion: policy.policyVersion
+    };
+  }
+
+  async recordPolicyVersionUpdate(input: PolicyVersionUpdateInput): Promise<PolicyAuditEvent> {
+    const currentPolicy = this.policies.get(input.providerId);
+    if (!currentPolicy) {
+      throw new ProviderPolicyError("VALIDATION_ERROR", `provider policy not found: ${input.providerId}`);
+    }
+
+    const changedAt = input.changedAt ?? this.now();
+    const updated: ProviderPolicyDefinition = {
+      ...currentPolicy,
+      policyVersion: input.newVersion
+    };
+    const auditEvent: PolicyAuditEvent = {
+      auditEventId: this.idGenerator("audit"),
+      providerId: input.providerId,
+      fromVersion: currentPolicy.policyVersion,
+      toVersion: input.newVersion,
+      actor: input.actor,
+      reason: input.reason,
+      changedAt
+    };
+
+    try {
+      await this.auditStore.put(auditEvent);
+    } catch (error) {
+      throw new ProviderPolicyError(
+        "PROVIDER_POLICY_STORE_FAILED",
+        "failed to persist provider policy audit event",
+        {
+          providerId: input.providerId,
+          fromVersion: currentPolicy.policyVersion,
+          toVersion: input.newVersion,
+          cause: error instanceof Error ? error.message : String(error)
+        }
+      );
+    }
+
+    this.policies.set(input.providerId, updated);
+    return cloneAuditEvent(auditEvent);
+  }
+
+  async getConsentRecords(): Promise<ConsentRecord[]> {
+    const records = await this.consentStore.list();
+    return records.map((record) => cloneConsent(record));
+  }
+
+  async getPolicyAuditEvents(): Promise<PolicyAuditEvent[]> {
+    const events = await this.auditStore.list();
+    return events.map((event) => cloneAuditEvent(event));
+  }
+}
+
+function defaultProviderPolicyIdGenerator(kind: ProviderPolicyIdKind): string {
+  return `${kind}_${randomUUID()}`;
+}
+
+export function clonePolicy(policy: ProviderPolicyDefinition): ProviderPolicyDefinition {
+  return {
+    providerId: policy.providerId,
+    policyVersion: policy.policyVersion,
+    descriptor: {
+      ...policy.descriptor,
+      defaultScopes: [...policy.descriptor.defaultScopes],
+      extraAuthParams: policy.descriptor.extraAuthParams ? { ...policy.descriptor.extraAuthParams } : undefined
+    },
+    capabilities: {
+      ...policy.capabilities,
+      allowedFeatureModes: [...policy.capabilities.allowedFeatureModes]
+    },
+    auth: policy.auth
+      ? {
+          ...policy.auth,
+          defaultScopes: [...policy.auth.defaultScopes],
+          availableClaims: [...policy.auth.availableClaims]
+        }
+      : undefined,
+    runtime: policy.runtime ? { ...policy.runtime } : undefined,
+    featureScopes: Object.fromEntries(
+      Object.entries(policy.featureScopes).map(([feature, value]) => [
+        feature,
+        {
+          allowedScopes: [...value.allowedScopes],
+          restrictedScopes: value.restrictedScopes ? [...value.restrictedScopes] : undefined
+        }
+      ])
+    ),
+    operationPolicies: Object.fromEntries(
+      Object.entries(policy.operationPolicies).map(([operation, value]) => [operation, { ...value }])
+    )
+  };
+}
+
+function cloneConsent(record: ConsentRecord): ConsentRecord {
+  return {
+    ...record,
+    scopes: [...record.scopes]
+  };
+}
+
+function cloneAuditEvent(event: PolicyAuditEvent): PolicyAuditEvent {
+  return { ...event };
+}

--- a/packages/oauth-providers/src/providers/apple.ts
+++ b/packages/oauth-providers/src/providers/apple.ts
@@ -1,0 +1,73 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import type { ProviderPolicyDefinition } from "../policy-registry.js";
+
+export const appleOAuthProviderDescriptor: OAuthProviderDescriptor = {
+  id: "apple",
+  authorizationUrl: "https://appleid.apple.com/auth/authorize",
+  tokenUrl: "https://appleid.apple.com/auth/token",
+  revocationUrl: "https://appleid.apple.com/auth/revoke",
+  defaultScopes: ["name", "email"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+export const appleProviderPolicy: ProviderPolicyDefinition = {
+  providerId: "apple",
+  policyVersion: "2026-03-11",
+  descriptor: appleOAuthProviderDescriptor,
+  capabilities: {
+    supportsMailRead: false,
+    supportsMailSend: false,
+    supportsWatch: false,
+    supportsRevoke: true,
+    supportsManagedMailbox: false,
+    allowedFeatureModes: ["metadata-only"]
+  },
+  auth: {
+    supportsSocialLogin: true,
+    supportsAccountLinking: true,
+    defaultScopes: ["name", "email"],
+    availableClaims: ["email", "name"]
+  },
+  runtime: {
+    clientSecretMode: "resolver-required",
+    clientSecretResolverHint: "apple-client-secret-jwt"
+  },
+  featureScopes: {
+    "auth.social.profile": {
+      allowedScopes: ["name", "email"]
+    },
+    "profile.basic": {
+      allowedScopes: ["name", "email"]
+    }
+  },
+  operationPolicies: {
+    "auth.account.link": {
+      allowed: true
+    },
+    "auth.signin": {
+      allowed: true
+    },
+    "mail.watch.create": {
+      allowed: false,
+      reason: "Apple OAuth descriptor is social-only in shared registry"
+    },
+    "mail.read.metadata": {
+      allowed: false,
+      reason: "Apple OAuth descriptor is social-only in shared registry"
+    },
+    "mail.read.fullbody": {
+      allowed: false,
+      reason: "Apple OAuth descriptor is social-only in shared registry"
+    },
+    "mail.send": {
+      allowed: false,
+      reason: "Apple OAuth descriptor is social-only in shared registry"
+    },
+    "oauth.revoke": {
+      allowed: true
+    }
+  }
+};

--- a/packages/oauth-providers/src/providers/github.ts
+++ b/packages/oauth-providers/src/providers/github.ts
@@ -1,0 +1,73 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import type { ProviderPolicyDefinition } from "../policy-registry.js";
+
+export const githubOAuthProviderDescriptor: OAuthProviderDescriptor = {
+  id: "github",
+  authorizationUrl: "https://github.com/login/oauth/authorize",
+  tokenUrl: "https://github.com/login/oauth/access_token",
+  revocationUrl: "https://api.github.com/applications/{client_id}/token",
+  defaultScopes: ["read:user", "user:email"],
+  supportsPkce: true,
+  supportsRefreshToken: false,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+export const githubProviderPolicy: ProviderPolicyDefinition = {
+  providerId: "github",
+  policyVersion: "2026-03-11",
+  descriptor: githubOAuthProviderDescriptor,
+  capabilities: {
+    supportsMailRead: false,
+    supportsMailSend: false,
+    supportsWatch: false,
+    supportsRevoke: true,
+    supportsManagedMailbox: false,
+    allowedFeatureModes: ["metadata-only"]
+  },
+  auth: {
+    supportsSocialLogin: true,
+    supportsAccountLinking: true,
+    defaultScopes: ["read:user", "user:email"],
+    availableClaims: ["email", "name", "profile"]
+  },
+  runtime: {
+    clientSecretMode: "resolver-allowed",
+    clientSecretResolverHint: "runtime-client-secret"
+  },
+  featureScopes: {
+    "auth.social.profile": {
+      allowedScopes: ["read:user", "user:email"]
+    },
+    "profile.basic": {
+      allowedScopes: ["read:user", "user:email"]
+    }
+  },
+  operationPolicies: {
+    "auth.account.link": {
+      allowed: true
+    },
+    "auth.signin": {
+      allowed: true
+    },
+    "mail.watch.create": {
+      allowed: false,
+      reason: "GitHub OAuth descriptor is social-only in shared registry"
+    },
+    "mail.read.metadata": {
+      allowed: false,
+      reason: "GitHub OAuth descriptor is social-only in shared registry"
+    },
+    "mail.read.fullbody": {
+      allowed: false,
+      reason: "GitHub OAuth descriptor is social-only in shared registry"
+    },
+    "mail.send": {
+      allowed: false,
+      reason: "GitHub OAuth descriptor is social-only in shared registry"
+    },
+    "oauth.revoke": {
+      allowed: true
+    }
+  }
+};

--- a/packages/oauth-providers/src/providers/google.ts
+++ b/packages/oauth-providers/src/providers/google.ts
@@ -1,0 +1,80 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import type { ProviderPolicyDefinition } from "../policy-registry.js";
+
+export const googleOAuthProviderDescriptor: OAuthProviderDescriptor = {
+  id: "google",
+  authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenUrl: "https://oauth2.googleapis.com/token",
+  revocationUrl: "https://oauth2.googleapis.com/revoke",
+  defaultScopes: ["openid", "email", "profile"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+export const googleProviderPolicy: ProviderPolicyDefinition = {
+  providerId: "google",
+  policyVersion: "2026-03-11",
+  descriptor: googleOAuthProviderDescriptor,
+  capabilities: {
+    supportsMailRead: true,
+    supportsMailSend: true,
+    supportsWatch: true,
+    supportsRevoke: true,
+    supportsManagedMailbox: true,
+    allowedFeatureModes: ["metadata-only", "snippet", "full-body"]
+  },
+  auth: {
+    supportsSocialLogin: true,
+    supportsAccountLinking: true,
+    defaultScopes: ["openid", "email", "profile"],
+    availableClaims: ["email", "name", "profile"]
+  },
+  runtime: {
+    clientSecretMode: "resolver-allowed",
+    clientSecretResolverHint: "runtime-client-secret"
+  },
+  featureScopes: {
+    "auth.social.profile": {
+      allowedScopes: ["openid", "email", "profile"]
+    },
+    "mail.read.metadata": {
+      allowedScopes: ["https://www.googleapis.com/auth/gmail.readonly"]
+    },
+    "mail.read.fullbody": {
+      allowedScopes: ["https://mail.google.com/"],
+      restrictedScopes: ["https://mail.google.com/"]
+    },
+    "mail.send": {
+      allowedScopes: ["https://www.googleapis.com/auth/gmail.send"]
+    },
+    "profile.basic": {
+      allowedScopes: ["openid", "email", "profile"]
+    }
+  },
+  operationPolicies: {
+    "auth.account.link": {
+      allowed: true
+    },
+    "auth.signin": {
+      allowed: true
+    },
+    "mail.watch.create": {
+      allowed: true
+    },
+    "mail.read.metadata": {
+      allowed: true
+    },
+    "mail.read.fullbody": {
+      allowed: true,
+      requiredFeatureMode: "full-body"
+    },
+    "mail.send": {
+      allowed: true
+    },
+    "oauth.revoke": {
+      allowed: true
+    }
+  }
+};

--- a/packages/oauth-providers/src/providers/microsoft.ts
+++ b/packages/oauth-providers/src/providers/microsoft.ts
@@ -1,0 +1,61 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import type { ProviderPolicyDefinition } from "../policy-registry.js";
+
+export const microsoftOAuthProviderDescriptor: OAuthProviderDescriptor = {
+  id: "microsoft",
+  authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+  tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+  revocationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/logout",
+  defaultScopes: ["openid", "email", "profile", "offline_access"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+export const microsoftProviderPolicy: ProviderPolicyDefinition = {
+  providerId: "microsoft",
+  policyVersion: "2026-03-11",
+  descriptor: microsoftOAuthProviderDescriptor,
+  capabilities: {
+    supportsMailRead: true,
+    supportsMailSend: true,
+    supportsWatch: true,
+    supportsRevoke: true,
+    supportsManagedMailbox: true,
+    allowedFeatureModes: ["metadata-only", "snippet", "full-body"]
+  },
+  featureScopes: {
+    "mail.read.metadata": {
+      allowedScopes: ["Mail.Read", "offline_access"]
+    },
+    "mail.read.fullbody": {
+      allowedScopes: ["Mail.Read", "offline_access"],
+      restrictedScopes: ["Mail.ReadWrite"]
+    },
+    "mail.send": {
+      allowedScopes: ["Mail.Send", "offline_access"]
+    },
+    "profile.basic": {
+      allowedScopes: ["openid", "email", "profile", "offline_access"]
+    }
+  },
+  operationPolicies: {
+    "mail.watch.create": {
+      allowed: true
+    },
+    "mail.read.metadata": {
+      allowed: true
+    },
+    "mail.read.fullbody": {
+      allowed: true,
+      requiredFeatureMode: "full-body"
+    },
+    "mail.send": {
+      allowed: true
+    },
+    "oauth.revoke": {
+      allowed: true
+    }
+  }
+};

--- a/packages/oauth-providers/src/providers/yahoo.ts
+++ b/packages/oauth-providers/src/providers/yahoo.ts
@@ -1,0 +1,61 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+import type { ProviderPolicyDefinition } from "../policy-registry.js";
+
+export const yahooOAuthProviderDescriptor: OAuthProviderDescriptor = {
+  id: "yahoo",
+  authorizationUrl: "https://api.login.yahoo.com/oauth2/request_auth",
+  tokenUrl: "https://api.login.yahoo.com/oauth2/get_token",
+  revocationUrl: "https://api.login.yahoo.com/oauth2/revoke",
+  defaultScopes: ["openid", "profile", "email"],
+  supportsPkce: true,
+  supportsRefreshToken: true,
+  scopeSeparator: " ",
+  tokenAuthMethod: "client_secret_post"
+};
+
+export const yahooProviderPolicy: ProviderPolicyDefinition = {
+  providerId: "yahoo",
+  policyVersion: "2026-03-11",
+  descriptor: yahooOAuthProviderDescriptor,
+  capabilities: {
+    supportsMailRead: true,
+    supportsMailSend: true,
+    supportsWatch: false,
+    supportsRevoke: true,
+    supportsManagedMailbox: false,
+    allowedFeatureModes: ["metadata-only", "snippet", "full-body"]
+  },
+  featureScopes: {
+    "mail.read.metadata": {
+      allowedScopes: ["mail-r", "openid", "email", "profile"]
+    },
+    "mail.read.fullbody": {
+      allowedScopes: ["mail-r", "openid", "email", "profile"]
+    },
+    "mail.send": {
+      allowedScopes: ["mail-w", "openid", "email", "profile"]
+    },
+    "profile.basic": {
+      allowedScopes: ["openid", "email", "profile"]
+    }
+  },
+  operationPolicies: {
+    "mail.watch.create": {
+      allowed: false,
+      reason: "Yahoo does not support webhook watch creation"
+    },
+    "mail.read.metadata": {
+      allowed: true
+    },
+    "mail.read.fullbody": {
+      allowed: true,
+      requiredFeatureMode: "full-body"
+    },
+    "mail.send": {
+      allowed: true
+    },
+    "oauth.revoke": {
+      allowed: true
+    }
+  }
+};

--- a/packages/oauth-providers/src/stores.ts
+++ b/packages/oauth-providers/src/stores.ts
@@ -1,0 +1,46 @@
+import type { ConsentRecord, PolicyAuditEvent } from "./policy-registry.js";
+
+export interface ProviderPolicyConsentStore {
+  put(record: ConsentRecord): Promise<void>;
+  list(): Promise<ConsentRecord[]>;
+}
+
+export interface ProviderPolicyAuditStore {
+  put(event: PolicyAuditEvent): Promise<void>;
+  list(): Promise<PolicyAuditEvent[]>;
+}
+
+export class MemoryProviderPolicyConsentStore implements ProviderPolicyConsentStore {
+  private readonly records: ConsentRecord[] = [];
+
+  async put(record: ConsentRecord): Promise<void> {
+    this.records.push(cloneConsent(record));
+  }
+
+  async list(): Promise<ConsentRecord[]> {
+    return this.records.map((record) => cloneConsent(record));
+  }
+}
+
+export class MemoryProviderPolicyAuditStore implements ProviderPolicyAuditStore {
+  private readonly events: PolicyAuditEvent[] = [];
+
+  async put(event: PolicyAuditEvent): Promise<void> {
+    this.events.push(cloneAuditEvent(event));
+  }
+
+  async list(): Promise<PolicyAuditEvent[]> {
+    return this.events.map((event) => cloneAuditEvent(event));
+  }
+}
+
+function cloneConsent(record: ConsentRecord): ConsentRecord {
+  return {
+    ...record,
+    scopes: [...record.scopes]
+  };
+}
+
+function cloneAuditEvent(event: PolicyAuditEvent): PolicyAuditEvent {
+  return { ...event };
+}

--- a/packages/oauth-providers/tests/policy-registry.test.ts
+++ b/packages/oauth-providers/tests/policy-registry.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import {
+  MemoryProviderPolicyAuditStore,
+  MemoryProviderPolicyConsentStore,
+  ProviderPolicyError,
+  ProviderPolicyRegistry,
+  createDefaultProviderPolicyRegistry,
+  listProviderPolicies
+} from "../src/index.js";
+
+describe("oauth-providers policy registry", () => {
+  it("writes durable consent and audit records through async stores", async () => {
+    const consentStore = new MemoryProviderPolicyConsentStore();
+    const auditStore = new MemoryProviderPolicyAuditStore();
+    const generatedIds = ["consent_fixed_01", "audit_fixed_01"];
+    const registry = new ProviderPolicyRegistry(listProviderPolicies(), {
+      consentStore,
+      auditStore,
+      idGenerator: () => {
+        const next = generatedIds.shift();
+        if (!next) {
+          throw new Error("unexpected id request");
+        }
+        return next;
+      },
+      now: () => "2026-03-27T00:00:00.000Z"
+    });
+
+    const result = await registry.validateScopes({
+      providerId: "google",
+      feature: "mail.read.metadata",
+      requestedScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+      tenantId: "tenant_1",
+      userId: "user_1",
+      purpose: "mail preview"
+    });
+
+    expect(result.authorized).toBe(true);
+    expect(result.consentRecord).toMatchObject({
+      consentId: "consent_fixed_01",
+      policyVersion: "2026-03-11"
+    });
+
+    const audit = await registry.recordPolicyVersionUpdate({
+      providerId: "google",
+      newVersion: "2026-03-27",
+      actor: "admin_1",
+      reason: "compliance-update"
+    });
+
+    expect(audit).toMatchObject({
+      auditEventId: "audit_fixed_01",
+      fromVersion: "2026-03-11",
+      toVersion: "2026-03-27"
+    });
+
+    await expect(consentStore.list()).resolves.toMatchObject([
+      {
+        consentId: "consent_fixed_01",
+        policyVersion: "2026-03-11"
+      }
+    ]);
+    await expect(auditStore.list()).resolves.toMatchObject([
+      {
+        auditEventId: "audit_fixed_01",
+        fromVersion: "2026-03-11",
+        toVersion: "2026-03-27"
+      }
+    ]);
+  });
+
+  it("surfaces deterministic store failures for consent persistence", async () => {
+    const registry = new ProviderPolicyRegistry(listProviderPolicies(), {
+      consentStore: {
+        async put() {
+          throw new Error("disk offline");
+        },
+        async list() {
+          return [];
+        }
+      },
+      auditStore: new MemoryProviderPolicyAuditStore(),
+      idGenerator: () => "consent_failure_01",
+      now: () => "2026-03-27T00:00:00.000Z"
+    });
+
+    await expect(
+      registry.validateScopes({
+        providerId: "google",
+        feature: "mail.read.metadata",
+        requestedScopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+        tenantId: "tenant_1",
+        userId: "user_1",
+        purpose: "mail preview"
+      })
+    ).rejects.toMatchObject({
+      code: "PROVIDER_POLICY_STORE_FAILED",
+      message: "failed to persist provider policy consent record"
+    });
+  });
+
+  it("keeps the default registry usable as an in-memory convenience path with injected ids", async () => {
+    const generatedIds = ["consent_test_01"];
+    const registry = createDefaultProviderPolicyRegistry({
+      idGenerator: () => {
+        const next = generatedIds.shift();
+        if (!next) {
+          throw new Error("unexpected id request");
+        }
+        return next;
+      },
+      now: () => "2026-03-27T00:00:00.000Z"
+    });
+
+    const result = await registry.validateScopes({
+      providerId: "github",
+      feature: "profile.basic",
+      requestedScopes: ["read:user", "user:email"],
+      tenantId: "tenant_1",
+      userId: "user_1",
+      purpose: "profile import"
+    });
+
+    expect(result.authorized).toBe(true);
+    expect(result.consentRecord.consentId).toBe("consent_test_01");
+    await expect(registry.getConsentRecords()).resolves.toMatchObject([
+      {
+        consentId: "consent_test_01"
+      }
+    ]);
+  });
+
+  it("rejects disallowed scopes with OAUTH_SCOPE_DISALLOWED", async () => {
+    const registry = createDefaultProviderPolicyRegistry(() => "2026-03-11T00:00:00.000Z");
+
+    await expect(
+      registry.validateScopes({
+        providerId: "google",
+        feature: "mail.read.metadata",
+        requestedScopes: ["https://mail.google.com/"],
+        tenantId: "t1",
+        userId: "u1",
+        purpose: "mail.read.metadata"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_SCOPE_DISALLOWED",
+      message: "requested scope not allowed for feature"
+    });
+  });
+
+  it("allows provider operation when policy permits it", () => {
+    const registry = createDefaultProviderPolicyRegistry();
+    const decision = registry.assertOperationAllowed({
+      providerId: "google",
+      operation: "mail.watch.create",
+      featureMode: "metadata-only"
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.policyVersion).toBe("2026-03-11");
+  });
+
+  it("blocks disallowed operation in metadata-only mode", () => {
+    const registry = createDefaultProviderPolicyRegistry();
+
+    expect(() =>
+      registry.assertOperationAllowed({
+        providerId: "google",
+        operation: "mail.read.fullbody",
+        featureMode: "metadata-only"
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        code: "PROVIDER_POLICY_BLOCKED",
+        message: "operation not allowed by policy"
+      })
+    );
+  });
+
+  it("throws validation error for unknown provider policy", () => {
+    const registry = createDefaultProviderPolicyRegistry();
+
+    expect(() => registry.getPolicy("unknown" as never)).toThrowError(ProviderPolicyError);
+  });
+});

--- a/packages/oauth-providers/tests/provider-runtime.test.ts
+++ b/packages/oauth-providers/tests/provider-runtime.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { DefaultOAuthTokenHttpClient, type OAuthFetchLike, type RequestInitLike } from "@superfunctions/oauth-http";
+import {
+  authOAuthProviderIds,
+  createDefaultProviderPolicyRegistry,
+  getOAuthProviderDescriptor,
+  getProviderPolicy,
+  listAuthOAuthProviderDescriptors,
+  listAuthProviderPolicies
+} from "../src/index.js";
+
+describe("oauth-providers auth runtime coverage", () => {
+  it("publishes deterministic auth provider descriptors for Google, Apple, and GitHub", () => {
+    expect(authOAuthProviderIds).toEqual(["google", "apple", "github"]);
+    expect(listAuthOAuthProviderDescriptors().map((provider) => provider.id)).toEqual(["google", "apple", "github"]);
+    expect(listAuthProviderPolicies().map((policy) => policy.providerId)).toEqual(["google", "apple", "github"]);
+
+    expect(getOAuthProviderDescriptor("google")).toMatchObject({
+      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+      revocationUrl: "https://oauth2.googleapis.com/revoke",
+      defaultScopes: ["openid", "email", "profile"],
+      tokenAuthMethod: "client_secret_post"
+    });
+
+    expect(getOAuthProviderDescriptor("apple")).toMatchObject({
+      authorizationUrl: "https://appleid.apple.com/auth/authorize",
+      tokenUrl: "https://appleid.apple.com/auth/token",
+      revocationUrl: "https://appleid.apple.com/auth/revoke",
+      defaultScopes: ["name", "email"],
+      tokenAuthMethod: "client_secret_post"
+    });
+
+    expect(getOAuthProviderDescriptor("github")).toMatchObject({
+      authorizationUrl: "https://github.com/login/oauth/authorize",
+      tokenUrl: "https://github.com/login/oauth/access_token",
+      revocationUrl: "https://api.github.com/applications/{client_id}/token",
+      defaultScopes: ["read:user", "user:email"],
+      tokenAuthMethod: "client_secret_post"
+    });
+  });
+
+  it("covers auth-oriented scope and operation policies deterministically", async () => {
+    const registry = createDefaultProviderPolicyRegistry(() => "2026-03-21T00:00:00.000Z");
+
+    const googleAuth = await registry.validateScopes({
+      providerId: "google",
+      feature: "auth.social.profile",
+      requestedScopes: ["openid", "email", "profile"],
+      tenantId: "tenant_1",
+      userId: "user_1",
+      purpose: "auth.signin"
+    });
+
+    expect(googleAuth.authorized).toBe(true);
+    expect(googleAuth.consentRecord.policyVersion).toBe("2026-03-11");
+
+    const applePolicy = registry.getPolicy("apple");
+    expect(applePolicy.auth).toEqual({
+      supportsSocialLogin: true,
+      supportsAccountLinking: true,
+      defaultScopes: ["name", "email"],
+      availableClaims: ["email", "name"]
+    });
+
+    expect(
+      registry.assertOperationAllowed({
+        providerId: "github",
+        operation: "auth.signin",
+        featureMode: "metadata-only"
+      })
+    ).toEqual({
+      allowed: true,
+      policyVersion: "2026-03-11"
+    });
+
+    expect(
+      registry.assertOperationAllowed({
+        providerId: "apple",
+        operation: "auth.account.link",
+        featureMode: "metadata-only"
+      })
+    ).toEqual({
+      allowed: true,
+      policyVersion: "2026-03-11"
+    });
+  });
+
+  it("represents Apple runtime behavior through resolver-required policy and oauth-http secret resolution", async () => {
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (_url, init) => {
+      capturedInit = init;
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          access_token: "at_apple_runtime",
+          refresh_token: "rt_apple_runtime",
+          token_type: "bearer"
+        })
+      });
+    };
+
+    const applePolicy = getProviderPolicy("apple");
+    expect(applePolicy.runtime).toEqual({
+      clientSecretMode: "resolver-required",
+      clientSecretResolverHint: "apple-client-secret-jwt"
+    });
+
+    const resolver = vi.fn(async () => ({
+      clientSecret: "generated-apple-jwt-client-secret"
+    }));
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    const response = await client.exchangeToken({
+      provider: getOAuthProviderDescriptor("apple"),
+      grantType: "authorization_code",
+      clientId: "apple-client-id",
+      clientSecretResolver: resolver,
+      code: "apple-code",
+      redirectUri: "https://app.example/callback"
+    });
+
+    expect(response.accessToken).toBe("at_apple_runtime");
+    expect(resolver).toHaveBeenCalledTimes(1);
+
+    const params = new URLSearchParams(capturedInit?.body);
+    expect(params.get("client_secret")).toBe("generated-apple-jwt-client-secret");
+
+    await expect(
+      client.exchangeToken({
+        provider: getOAuthProviderDescriptor("apple"),
+        grantType: "authorization_code",
+        clientId: "apple-client-id",
+        clientSecretResolver: async () => {
+          throw new Error("apple signing key unavailable");
+        },
+        code: "apple-code-failure",
+        redirectUri: "https://app.example/callback"
+      })
+    ).rejects.toMatchObject({
+      code: "OAUTH_SECRET_RESOLUTION_FAILED",
+      details: {
+        providerId: "apple",
+        operation: "exchange"
+      }
+    });
+  });
+});
+
+function createResponse(input: {
+  status: number;
+  contentType: string;
+  body: string;
+  headers?: Record<string, string>;
+}) {
+  return {
+    ok: input.status >= 200 && input.status < 300,
+    status: input.status,
+    headers: {
+      get(name: string) {
+        const entry = Object.entries({
+          "content-type": input.contentType,
+          ...input.headers
+        }).find(([key]) => key.toLowerCase() === name.toLowerCase());
+        return entry?.[1] ?? null;
+      }
+    },
+    async text() {
+      return input.body;
+    }
+  };
+}

--- a/packages/oauth-providers/tsconfig.json
+++ b/packages/oauth-providers/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-providers/vitest.config.ts
+++ b/packages/oauth-providers/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createOAuthSharedVitestConfig } from "../../scripts/vitest-oauth-shared.mjs";
+
+export default createOAuthSharedVitestConfig();

--- a/packages/oauth-router/README.md
+++ b/packages/oauth-router/README.md
@@ -1,0 +1,48 @@
+# @superfunctions/oauth-router
+
+Reusable OAuth route factories for browser-auth and connection-management flows.
+
+## Install
+
+```bash
+npm install @superfunctions/oauth-router @superfunctions/oauth-flow @superfunctions/http
+```
+
+Use an HTTP adapter such as `@superfunctions/http-express`, `@superfunctions/http-fastify`, or `@superfunctions/http-hono` in the consuming app.
+
+## Quick Start
+
+```ts
+import { createOAuthBrowserRoutes } from "@superfunctions/oauth-router";
+
+const routes = createOAuthBrowserRoutes({
+  basePath: "/auth/social",
+  flowService,
+  async resolveStartInput(request) {
+    return (await request.json()) as never;
+  },
+});
+```
+
+## Package Boundary
+
+`@superfunctions/oauth-router` owns route factories only:
+
+- `createOAuthBrowserRoutes(...)`
+- `createOAuthConnectionRoutes(...)`
+- secure default route metadata
+- per-route `routeMeta` overrides
+
+It does not create framework servers, resolve sessions, or persist OAuth state by itself.
+
+## Production Notes
+
+- Browser routes default to `start=none`, `callback=none`, `disconnect=hybrid`.
+- Connection routes default to `start=hybrid`, `callback=none`, `disconnect=hybrid`.
+- Override route metadata explicitly when your app requires stronger auth or different OpenAPI annotations.
+- Keep callback routes reachable without session enforcement unless your app handles provider callbacks through another trust boundary.
+
+## Docs
+
+- Canonical docs: [docs/content/docs/authentication/oauth-router.mdx](../../docs/content/docs/authentication/oauth-router.mdx)
+- Stack overview: [docs/content/docs/architecture/oauth-flow-architecture.mdx](../../docs/content/docs/architecture/oauth-flow-architecture.mdx)

--- a/packages/oauth-router/package.json
+++ b/packages/oauth-router/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@superfunctions/oauth-router",
+  "version": "0.0.1",
+  "description": "Reusable OAuth route factories for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --config ./vitest.config.ts --run",
+    "test:watch": "vitest --config ./vitest.config.ts --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "oauth",
+    "router",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/oauth-router"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/http": "*",
+    "@superfunctions/oauth-flow": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/oauth-router/src/__tests__/routes.test.ts
+++ b/packages/oauth-router/src/__tests__/routes.test.ts
@@ -1,0 +1,501 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRouter } from "@superfunctions/http";
+import type {
+  OAuthFlowCallbackResult,
+  OAuthFlowConnectionCleanup,
+  OAuthFlowDisconnectResult,
+  OAuthFlowService,
+  OAuthFlowStartResult
+} from "@superfunctions/oauth-flow";
+import { createOAuthBrowserRoutes, createOAuthConnectionRoutes } from "../index.js";
+
+function createFlowServiceMocks() {
+  const start = vi.fn(async () => ({
+    providerId: "google",
+    authorizationUrl: "https://accounts.google.example/auth?state=st_01",
+    stateId: "st_01",
+    expiresAt: "2026-01-01T00:10:00.000Z"
+  } satisfies OAuthFlowStartResult));
+
+  const handleCallback = vi.fn(async () => ({
+    providerId: "google",
+    subject: {
+      kind: "browser-auth",
+      intentId: "intent_01",
+      returnTo: "https://app.example/post-auth"
+    },
+    tokenSet: {
+      accessToken: "access_01"
+    }
+  } satisfies OAuthFlowCallbackResult));
+
+  const disconnect = vi.fn(async () => ({
+    disconnected: true,
+    remoteRevokeAttempted: true,
+    localTokenDeleted: true,
+    connectionCleanup: {
+      attempted: true,
+      deleted: true,
+      reason: "deleted"
+    } satisfies OAuthFlowConnectionCleanup,
+    connectionDeleted: true
+  } satisfies OAuthFlowDisconnectResult));
+
+  const refresh = vi.fn(async () => ({
+    accessToken: "access_refreshed"
+  }));
+
+  return {
+    service: {
+      start,
+      handleCallback,
+      disconnect,
+      refresh
+    } satisfies OAuthFlowService,
+    start,
+    handleCallback,
+    disconnect
+  };
+}
+
+describe("oauth-router route factories", () => {
+  it("creates reusable browser-auth routes with the expected path inventory", () => {
+    const { service } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+
+    expect(routes.map((route) => route.path)).toEqual([
+      "/auth/social/start",
+      "/auth/social/callback/:provider",
+      "/auth/social/disconnect/:provider"
+    ]);
+    expect(routes.map((route) => route.meta?.auth?.mode)).toEqual(["none", "none", "hybrid"]);
+  });
+
+  it("applies secure default auth metadata for connection routes", () => {
+    const { service } = createFlowServiceMocks();
+    const routes = createOAuthConnectionRoutes({
+      basePath: "/oauth/connections",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+
+    expect(routes.map((route) => route.path)).toEqual([
+      "/oauth/connections/start",
+      "/oauth/connections/callback/:provider",
+      "/oauth/connections/disconnect/:provider"
+    ]);
+    expect(routes.map((route) => route.meta?.auth?.mode)).toEqual(["hybrid", "none", "hybrid"]);
+  });
+
+  it("allows explicit per-route auth metadata overrides", () => {
+    const { service } = createFlowServiceMocks();
+    const browserRoutes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      routeMeta: {
+        disconnect: {
+          auth: {
+            mode: "none"
+          }
+        }
+      }
+    });
+    const connectionRoutes = createOAuthConnectionRoutes({
+      basePath: "/oauth/connections",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      routeMeta: {
+        start: {
+          auth: {
+            mode: "bearer",
+            scopes: ["connections:write"]
+          }
+        },
+        disconnect: {
+          auth: {
+            mode: "cookie-session",
+            csrf: true
+          }
+        }
+      }
+    });
+
+    expect(browserRoutes.map((route) => route.meta?.auth?.mode)).toEqual(["none", "none", "none"]);
+    expect(connectionRoutes.map((route) => route.meta?.auth?.mode)).toEqual(["bearer", "none", "cookie-session"]);
+    expect(connectionRoutes[0]?.meta?.auth?.scopes).toEqual(["connections:write"]);
+    expect(connectionRoutes[2]?.meta?.auth?.csrf).toBe(true);
+  });
+
+  it("supports browser callback JSON completion mode and propagates request ids", async () => {
+    const { service, start, handleCallback, disconnect } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+    const router = createRouter({ routes });
+
+    const startResponse = await router.handle(
+      new Request("http://localhost/auth/social/start", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "req_start_json"
+        },
+        body: JSON.stringify({
+          providerId: "google",
+          redirectUri: "https://app.example/callback",
+          subject: {
+            kind: "browser-auth",
+            intentId: "intent_01"
+          }
+        })
+      })
+    );
+
+    expect(startResponse.status).toBe(200);
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "google",
+        requestId: "req_start_json"
+      })
+    );
+
+    const callbackResponse = await router.handle(
+      new Request(
+        "http://localhost/auth/social/callback/google?code=code_01&state=st_01&redirectUri=https%3A%2F%2Fapp.example%2Fcallback",
+        {
+          headers: { "x-request-id": "req_callback_json" }
+        }
+      )
+    );
+
+    expect(callbackResponse.status).toBe(200);
+    expect(handleCallback).toHaveBeenCalledWith({
+      providerId: "google",
+      code: "code_01",
+      state: "st_01",
+      redirectUri: "https://app.example/callback",
+      requestId: "req_callback_json"
+    });
+
+    const callbackPayload = await callbackResponse.json();
+    expect(callbackPayload.providerId).toBe("google");
+
+    const disconnectResponse = await router.handle(
+      new Request("http://localhost/auth/social/disconnect/google", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "req_disconnect_json"
+        },
+        body: JSON.stringify({
+          connectionId: "conn_01",
+          revokeRemote: true
+        })
+      })
+    );
+
+    expect(disconnectResponse.status).toBe(200);
+    expect(disconnect).toHaveBeenCalledWith({
+      providerId: "google",
+      connectionId: "conn_01",
+      revokeRemote: true,
+      tokenTypeHint: undefined,
+      requestId: "req_disconnect_json"
+    });
+  });
+
+  it("supports browser callback redirect completion mode and plain connection routes", async () => {
+    const browser = createFlowServiceMocks();
+    const browserRoutes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: browser.service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      callbackMode: "redirect"
+    });
+    const browserRouter = createRouter({ routes: browserRoutes });
+
+    const redirectResponse = await browserRouter.handle(
+      new Request(
+        "http://localhost/auth/social/callback/google?code=code_02&state=st_01&redirectUri=https%3A%2F%2Fapp.example%2Fcallback"
+      )
+    );
+
+    expect(redirectResponse.status).toBe(302);
+    expect(redirectResponse.headers.get("location")).toBe("https://app.example/post-auth");
+
+    const connection = createFlowServiceMocks();
+    const connectionRoutes = createOAuthConnectionRoutes({
+      basePath: "/oauth/connections",
+      flowService: connection.service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+
+    expect(connectionRoutes.map((route) => route.path)).toEqual([
+      "/oauth/connections/start",
+      "/oauth/connections/callback/:provider",
+      "/oauth/connections/disconnect/:provider"
+    ]);
+    expect(connectionRoutes.map((route) => route.meta?.auth?.mode)).toEqual(["hybrid", "none", "hybrid"]);
+  });
+
+  it("uses an absolute fallback redirect URL when browser callback completion has no returnTo", async () => {
+    const browser = createFlowServiceMocks();
+    browser.handleCallback.mockResolvedValue({
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_01"
+      },
+      tokenSet: {
+        accessToken: "access_01"
+      }
+    } satisfies OAuthFlowCallbackResult);
+
+    const browserRoutes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: browser.service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      callbackMode: "redirect"
+    });
+    const browserRouter = createRouter({ routes: browserRoutes });
+
+    const redirectResponse = await browserRouter.handle(
+      new Request("https://app.example/auth/social/callback/google?code=code_02&state=st_01")
+    );
+
+    expect(redirectResponse.status).toBe(302);
+    expect(redirectResponse.headers.get("location")).toBe("https://app.example/");
+  });
+
+  it("preserves resolver-provided requestId when the start header is absent", async () => {
+    const { service, start } = createFlowServiceMocks();
+    const routes = createOAuthConnectionRoutes({
+      basePath: "/oauth/connections",
+      flowService: service,
+      resolveStartInput: async () => ({
+        providerId: "google",
+        tenantId: "tenant_1",
+        userId: "user_1",
+        redirectUri: "https://app.example/callback",
+        requestId: "req_from_resolver"
+      })
+    });
+    const router = createRouter({ routes });
+
+    const response = await router.handle(
+      new Request("http://localhost/oauth/connections/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}"
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "req_from_resolver"
+      })
+    );
+  });
+
+  it("preserves resolver-provided requestId for browser start routes when the header is absent", async () => {
+    const { service, start } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async () => ({
+        providerId: "google",
+        subject: {
+          kind: "browser-auth",
+          intentId: "intent_01",
+          returnTo: "https://app.example/post-auth",
+        },
+        redirectUri: "https://app.example/callback",
+        requestId: "req_from_browser_resolver",
+      }),
+    });
+    const router = createRouter({ routes });
+
+    const response = await router.handle(
+      new Request("http://localhost/auth/social/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: "req_from_browser_resolver",
+      })
+    );
+  });
+
+  it("derives callback redirectUri from the current request URL when none is provided explicitly", async () => {
+    const { service, handleCallback } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+    const router = createRouter({ routes });
+
+    const response = await router.handle(
+      new Request("https://app.example/auth/social/callback/google?code=code_03&state=st_03")
+    );
+
+    expect(response.status).toBe(200);
+    expect(handleCallback).toHaveBeenCalledWith({
+      providerId: "google",
+      code: "code_03",
+      state: "st_03",
+      redirectUri: "https://app.example/auth/social/callback/google",
+      requestId: undefined
+    });
+  });
+
+  it("preserves non-transient callback query params when inferring redirectUri", async () => {
+    const { service, handleCallback } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+    const router = createRouter({ routes });
+
+    const response = await router.handle(
+      new Request(
+        "https://app.example/auth/social/callback/google?tenant=tenant_01&code=code_05&state=st_05"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(handleCallback).toHaveBeenCalledWith({
+      providerId: "google",
+      code: "code_05",
+      state: "st_05",
+      redirectUri: "https://app.example/auth/social/callback/google?tenant=tenant_01",
+      requestId: undefined
+    });
+  });
+
+  it("rejects explicitly empty callback redirectUri values", async () => {
+    const { service } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      resolveCallbackInput: async () => ({
+        code: "code_04",
+        state: "st_04",
+        redirectUri: ""
+      })
+    });
+    const router = createRouter({ routes });
+
+    await expect(
+      router.handle(new Request("https://app.example/auth/social/callback/google"))
+    ).rejects.toThrow("redirectUri");
+  });
+
+  it("rejects invalid disconnect payload fields before calling disconnect", async () => {
+    const { service, disconnect } = createFlowServiceMocks();
+    const routes = createOAuthConnectionRoutes({
+      basePath: "/oauth/connections",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+    const router = createRouter({ routes });
+
+    await expect(
+      router.handle(
+        new Request("http://localhost/oauth/connections/disconnect/google", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            connectionId: "conn_01",
+            revokeRemote: "false"
+          })
+        })
+      )
+    ).rejects.toThrow("revokeRemote");
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-string required route fields before calling disconnect", async () => {
+    const { service, disconnect } = createFlowServiceMocks();
+    const routes = createOAuthConnectionRoutes({
+      basePath: "/oauth/connections",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+    const router = createRouter({ routes });
+
+    await expect(
+      router.handle(
+        new Request("http://localhost/oauth/connections/disconnect/google", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            connectionId: 123,
+            revokeRemote: true
+          })
+        })
+      )
+    ).rejects.toThrow("connectionId");
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid browser disconnect payload fields before calling disconnect", async () => {
+    const { service, disconnect } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+    const router = createRouter({ routes });
+
+    await expect(
+      router.handle(
+        new Request("http://localhost/auth/social/disconnect/google", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            connectionId: "conn_01",
+            tokenTypeHint: "bad_hint"
+          })
+        })
+      )
+    ).rejects.toThrow("tokenTypeHint");
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it("rejects null browser disconnect payloads before calling disconnect", async () => {
+    const { service, disconnect } = createFlowServiceMocks();
+    const routes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: service,
+      resolveStartInput: async (request) => (await request.json()) as never
+    });
+    const router = createRouter({ routes });
+
+    await expect(
+      router.handle(
+        new Request("http://localhost/auth/social/disconnect/google", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "null"
+        })
+      )
+    ).rejects.toThrow("disconnect body");
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/oauth-router/src/browser-routes.ts
+++ b/packages/oauth-router/src/browser-routes.ts
@@ -1,0 +1,274 @@
+import { BadRequestError } from "@superfunctions/http";
+import type { AuthRouteMeta, HttpRouteMeta, OpenApiRouteMeta, Route, RouteContext } from "@superfunctions/http";
+import type {
+  OAuthFlowCallbackInput,
+  OAuthFlowCallbackResult,
+  OAuthFlowDisconnectInput,
+  OAuthFlowService,
+  OAuthFlowStartInput
+} from "@superfunctions/oauth-flow";
+
+export type OAuthBrowserCallbackMode = "redirect" | "json";
+
+export type OAuthBrowserRouteMetaOverrides = {
+  start?: HttpRouteMeta;
+  callback?: HttpRouteMeta;
+  disconnect?: HttpRouteMeta;
+};
+
+export interface OAuthBrowserRouteConfig {
+  basePath: string;
+  flowService: OAuthFlowService;
+  resolveStartInput: (request: Request, context: RouteContext) => Promise<OAuthFlowStartInput> | OAuthFlowStartInput;
+  resolveDisconnectInput?: (
+    request: Request,
+    context: RouteContext
+  ) => Promise<Omit<OAuthFlowDisconnectInput, "providerId" | "requestId">> | Omit<OAuthFlowDisconnectInput, "providerId" | "requestId">;
+  resolveCallbackInput?: (
+    request: Request,
+    context: RouteContext
+  ) => Promise<Partial<Omit<OAuthFlowCallbackInput, "providerId" | "requestId">>> | Partial<Omit<OAuthFlowCallbackInput, "providerId" | "requestId">>;
+  callbackMode?: OAuthBrowserCallbackMode | ((
+    result: OAuthFlowCallbackResult,
+    request: Request,
+    context: RouteContext
+  ) => Promise<OAuthBrowserCallbackMode> | OAuthBrowserCallbackMode);
+  getRedirectLocation?: (
+    result: OAuthFlowCallbackResult,
+    request: Request,
+    context: RouteContext
+  ) => Promise<string> | string;
+  serializeCallbackResult?: (
+    result: OAuthFlowCallbackResult,
+    request: Request,
+    context: RouteContext
+  ) => Promise<unknown> | unknown;
+  routeMeta?: OAuthBrowserRouteMetaOverrides;
+  requestIdHeader?: string;
+}
+
+export function createOAuthBrowserRoutes(config: OAuthBrowserRouteConfig): Route[] {
+  const requestIdHeader = (config.requestIdHeader ?? "x-request-id").toLowerCase();
+
+  return [
+    {
+      method: "POST",
+      path: joinPath(config.basePath, "start"),
+      meta: resolveRouteMeta({ auth: { mode: "none" } }, config.routeMeta?.start),
+      handler: async (request, context) => {
+        const requestId = request.headers.get(requestIdHeader) ?? undefined;
+        const input = await config.resolveStartInput(request, context);
+        const result = await config.flowService.start({
+          ...input,
+          requestId: requestId ?? input.requestId
+        });
+        return Response.json(result);
+      }
+    },
+    {
+      method: "GET",
+      path: joinPath(config.basePath, "callback/:provider"),
+      meta: resolveRouteMeta({ auth: { mode: "none" } }, config.routeMeta?.callback),
+      handler: async (request, context) => {
+        const requestId = request.headers.get(requestIdHeader) ?? undefined;
+        const resolvedInput = (await config.resolveCallbackInput?.(request, context)) ?? {};
+        const url = new URL(request.url);
+        const callbackResult = await config.flowService.handleCallback({
+          providerId: context.params.provider,
+          code: asRequiredString(resolvedInput.code ?? url.searchParams.get("code"), "code"),
+          state: asRequiredString(resolvedInput.state ?? url.searchParams.get("state"), "state"),
+          redirectUri: asRequiredString(
+            resolvedInput.redirectUri ??
+              url.searchParams.get("redirectUri") ??
+              inferCallbackRedirectUri(url),
+            "redirectUri"
+          ),
+          requestId
+        });
+
+        const mode = await resolveCallbackMode(config.callbackMode, callbackResult, request, context);
+        if (mode === "redirect") {
+          const location = await resolveRedirectLocation(config, callbackResult, request, context);
+          return Response.redirect(location, 302);
+        }
+
+        const payload = config.serializeCallbackResult
+          ? await config.serializeCallbackResult(callbackResult, request, context)
+          : callbackResult;
+        return Response.json(payload);
+      }
+    },
+    {
+      method: "POST",
+      path: joinPath(config.basePath, "disconnect/:provider"),
+      meta: resolveRouteMeta({ auth: { mode: "hybrid" } }, config.routeMeta?.disconnect),
+      handler: async (request, context) => {
+        const requestId = request.headers.get(requestIdHeader) ?? undefined;
+        const input =
+          (await config.resolveDisconnectInput?.(request, context)) ??
+          (await parseDisconnectBody(request));
+
+        const result = await config.flowService.disconnect({
+          ...input,
+          providerId: context.params.provider,
+          requestId
+        });
+        return Response.json(result);
+      }
+    }
+  ];
+}
+
+function resolveRouteMeta(defaultMeta: HttpRouteMeta, overrideMeta: HttpRouteMeta | undefined): HttpRouteMeta {
+  if (!overrideMeta) {
+    return defaultMeta;
+  }
+
+  return {
+    ...defaultMeta,
+    ...overrideMeta,
+    auth: mergeAuthMeta(defaultMeta.auth, overrideMeta.auth),
+    openapi: mergeOpenApiMeta(defaultMeta.openapi, overrideMeta.openapi)
+  };
+}
+
+function mergeAuthMeta(
+  defaultMeta: AuthRouteMeta | undefined,
+  overrideMeta: AuthRouteMeta | undefined
+): AuthRouteMeta | undefined {
+  if (!defaultMeta) {
+    return overrideMeta ? { ...overrideMeta } : undefined;
+  }
+
+  if (!overrideMeta) {
+    return { ...defaultMeta };
+  }
+
+  return {
+    ...defaultMeta,
+    ...overrideMeta
+  };
+}
+
+function mergeOpenApiMeta(
+  defaultMeta: OpenApiRouteMeta | undefined,
+  overrideMeta: OpenApiRouteMeta | undefined
+): OpenApiRouteMeta | undefined {
+  if (!defaultMeta) {
+    return overrideMeta ? { ...overrideMeta } : undefined;
+  }
+
+  if (!overrideMeta) {
+    return { ...defaultMeta };
+  }
+
+  return {
+    ...defaultMeta,
+    ...overrideMeta
+  };
+}
+
+function joinPath(basePath: string, suffix: string): string {
+  const normalizedBase = basePath.startsWith("/") ? basePath : `/${basePath}`;
+  return `${normalizedBase.replace(/\/$/, "")}/${suffix.replace(/^\//, "")}`;
+}
+
+function asRequiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new BadRequestError(`${field} is required`, "OAUTH_ROUTE_INVALID_INPUT");
+  }
+  return value;
+}
+
+async function resolveCallbackMode(
+  mode: OAuthBrowserRouteConfig["callbackMode"],
+  result: OAuthFlowCallbackResult,
+  request: Request,
+  context: RouteContext
+): Promise<OAuthBrowserCallbackMode> {
+  if (!mode) {
+    return "json";
+  }
+
+  if (typeof mode === "function") {
+    return mode(result, request, context);
+  }
+
+  return mode;
+}
+
+async function resolveRedirectLocation(
+  config: OAuthBrowserRouteConfig,
+  result: OAuthFlowCallbackResult,
+  request: Request,
+  context: RouteContext
+): Promise<string> {
+  if (config.getRedirectLocation) {
+    return config.getRedirectLocation(result, request, context);
+  }
+
+  if (result.subject.kind === "browser-auth" && result.subject.returnTo) {
+    return result.subject.returnTo;
+  }
+
+  return new URL("/", request.url).toString();
+}
+
+async function parseDisconnectBody(
+  request: Request
+): Promise<Omit<OAuthFlowDisconnectInput, "providerId" | "requestId">> {
+  const body = asJsonObject(await parseJsonBody(request), "disconnect body") as {
+    connectionId?: string;
+    revokeRemote?: unknown;
+    tokenTypeHint?: unknown;
+  };
+
+  return {
+    connectionId: asRequiredString(body.connectionId, "connectionId"),
+    revokeRemote: asOptionalBoolean(body.revokeRemote, "revokeRemote"),
+    tokenTypeHint: asTokenTypeHint(body.tokenTypeHint)
+  };
+}
+
+async function parseJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    throw new BadRequestError("disconnect body must be valid JSON", "OAUTH_ROUTE_INVALID_INPUT");
+  }
+}
+
+function inferCallbackRedirectUri(url: URL): string {
+  const redirectUrl = new URL(url.toString());
+  for (const transientParam of ["code", "state", "redirectUri", "error", "error_description", "error_uri"]) {
+    redirectUrl.searchParams.delete(transientParam);
+  }
+  return redirectUrl.toString();
+}
+
+function asJsonObject(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new BadRequestError(`${field} must be a JSON object`, "OAUTH_ROUTE_INVALID_INPUT");
+  }
+  return value as Record<string, unknown>;
+}
+
+function asOptionalBoolean(value: unknown, field: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new BadRequestError(`${field} must be a boolean`, "OAUTH_ROUTE_INVALID_INPUT");
+  }
+  return value;
+}
+
+function asTokenTypeHint(value: unknown): "access_token" | "refresh_token" | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === "access_token" || value === "refresh_token") {
+    return value;
+  }
+  throw new BadRequestError("tokenTypeHint must be access_token or refresh_token", "OAUTH_ROUTE_INVALID_INPUT");
+}

--- a/packages/oauth-router/src/connection-routes.ts
+++ b/packages/oauth-router/src/connection-routes.ts
@@ -1,0 +1,222 @@
+import { BadRequestError } from "@superfunctions/http";
+import type { AuthRouteMeta, HttpRouteMeta, OpenApiRouteMeta, Route, RouteContext } from "@superfunctions/http";
+import type {
+  OAuthFlowCallbackInput,
+  OAuthFlowCallbackResult,
+  OAuthFlowDisconnectInput,
+  OAuthFlowService,
+  OAuthFlowStartInput
+} from "@superfunctions/oauth-flow";
+
+export type OAuthConnectionRouteMetaOverrides = {
+  start?: HttpRouteMeta;
+  callback?: HttpRouteMeta;
+  disconnect?: HttpRouteMeta;
+};
+
+export interface OAuthConnectionRouteConfig {
+  basePath: string;
+  flowService: OAuthFlowService;
+  resolveStartInput: (request: Request, context: RouteContext) => Promise<OAuthFlowStartInput> | OAuthFlowStartInput;
+  resolveDisconnectInput?: (
+    request: Request,
+    context: RouteContext
+  ) => Promise<Omit<OAuthFlowDisconnectInput, "providerId" | "requestId">> | Omit<OAuthFlowDisconnectInput, "providerId" | "requestId">;
+  resolveCallbackInput?: (
+    request: Request,
+    context: RouteContext
+  ) => Promise<Partial<Omit<OAuthFlowCallbackInput, "providerId" | "requestId">>> | Partial<Omit<OAuthFlowCallbackInput, "providerId" | "requestId">>;
+  serializeCallbackResult?: (
+    result: OAuthFlowCallbackResult,
+    request: Request,
+    context: RouteContext
+  ) => Promise<unknown> | unknown;
+  routeMeta?: OAuthConnectionRouteMetaOverrides;
+  requestIdHeader?: string;
+}
+
+export function createOAuthConnectionRoutes(config: OAuthConnectionRouteConfig): Route[] {
+  const requestIdHeader = (config.requestIdHeader ?? "x-request-id").toLowerCase();
+
+  return [
+    {
+      method: "POST",
+      path: joinPath(config.basePath, "start"),
+      meta: resolveRouteMeta({ auth: { mode: "hybrid" } }, config.routeMeta?.start),
+      handler: async (request, context) => {
+        const requestId = request.headers.get(requestIdHeader) ?? undefined;
+        const input = await config.resolveStartInput(request, context);
+        const result = await config.flowService.start({
+          ...input,
+          requestId: requestId ?? input.requestId
+        });
+        return Response.json(result);
+      }
+    },
+    {
+      method: "GET",
+      path: joinPath(config.basePath, "callback/:provider"),
+      meta: resolveRouteMeta({ auth: { mode: "none" } }, config.routeMeta?.callback),
+      handler: async (request, context) => {
+        const requestId = request.headers.get(requestIdHeader) ?? undefined;
+        const resolvedInput = (await config.resolveCallbackInput?.(request, context)) ?? {};
+        const url = new URL(request.url);
+        const callbackResult = await config.flowService.handleCallback({
+          providerId: context.params.provider,
+          code: asRequiredString(resolvedInput.code ?? url.searchParams.get("code"), "code"),
+          state: asRequiredString(resolvedInput.state ?? url.searchParams.get("state"), "state"),
+          redirectUri: asRequiredString(
+            resolvedInput.redirectUri ??
+              url.searchParams.get("redirectUri") ??
+              inferCallbackRedirectUri(url),
+            "redirectUri"
+          ),
+          requestId
+        });
+
+        const payload = config.serializeCallbackResult
+          ? await config.serializeCallbackResult(callbackResult, request, context)
+          : callbackResult;
+        return Response.json(payload);
+      }
+    },
+    {
+      method: "POST",
+      path: joinPath(config.basePath, "disconnect/:provider"),
+      meta: resolveRouteMeta({ auth: { mode: "hybrid" } }, config.routeMeta?.disconnect),
+      handler: async (request, context) => {
+        const requestId = request.headers.get(requestIdHeader) ?? undefined;
+        const input =
+          (await config.resolveDisconnectInput?.(request, context)) ??
+          (await parseDisconnectBody(request));
+
+        const result = await config.flowService.disconnect({
+          ...input,
+          providerId: context.params.provider,
+          requestId
+        });
+        return Response.json(result);
+      }
+    }
+  ];
+}
+
+function resolveRouteMeta(defaultMeta: HttpRouteMeta, overrideMeta: HttpRouteMeta | undefined): HttpRouteMeta {
+  if (!overrideMeta) {
+    return defaultMeta;
+  }
+
+  return {
+    ...defaultMeta,
+    ...overrideMeta,
+    auth: mergeAuthMeta(defaultMeta.auth, overrideMeta.auth),
+    openapi: mergeOpenApiMeta(defaultMeta.openapi, overrideMeta.openapi)
+  };
+}
+
+function mergeAuthMeta(
+  defaultMeta: AuthRouteMeta | undefined,
+  overrideMeta: AuthRouteMeta | undefined
+): AuthRouteMeta | undefined {
+  if (!defaultMeta) {
+    return overrideMeta ? { ...overrideMeta } : undefined;
+  }
+
+  if (!overrideMeta) {
+    return { ...defaultMeta };
+  }
+
+  return {
+    ...defaultMeta,
+    ...overrideMeta
+  };
+}
+
+function mergeOpenApiMeta(
+  defaultMeta: OpenApiRouteMeta | undefined,
+  overrideMeta: OpenApiRouteMeta | undefined
+): OpenApiRouteMeta | undefined {
+  if (!defaultMeta) {
+    return overrideMeta ? { ...overrideMeta } : undefined;
+  }
+
+  if (!overrideMeta) {
+    return { ...defaultMeta };
+  }
+
+  return {
+    ...defaultMeta,
+    ...overrideMeta
+  };
+}
+
+function joinPath(basePath: string, suffix: string): string {
+  const normalizedBase = basePath.startsWith("/") ? basePath : `/${basePath}`;
+  return `${normalizedBase.replace(/\/$/, "")}/${suffix.replace(/^\//, "")}`;
+}
+
+function asRequiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new BadRequestError(`${field} is required`, "OAUTH_ROUTE_INVALID_INPUT");
+  }
+  return value;
+}
+
+async function parseDisconnectBody(
+  request: Request
+): Promise<Omit<OAuthFlowDisconnectInput, "providerId" | "requestId">> {
+  const body = asJsonObject(await parseJsonBody(request), "disconnect body") as {
+    connectionId?: string;
+    revokeRemote?: unknown;
+    tokenTypeHint?: unknown;
+  };
+
+  return {
+    connectionId: asRequiredString(body.connectionId, "connectionId"),
+    revokeRemote: asOptionalBoolean(body.revokeRemote, "revokeRemote"),
+    tokenTypeHint: asTokenTypeHint(body.tokenTypeHint)
+  };
+}
+
+async function parseJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    throw new BadRequestError("disconnect body must be valid JSON", "OAUTH_ROUTE_INVALID_INPUT");
+  }
+}
+
+function inferCallbackRedirectUri(url: URL): string {
+  const redirectUrl = new URL(url.toString());
+  for (const transientParam of ["code", "state", "redirectUri", "error", "error_description", "error_uri"]) {
+    redirectUrl.searchParams.delete(transientParam);
+  }
+  return redirectUrl.toString();
+}
+
+function asJsonObject(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new BadRequestError(`${field} must be a JSON object`, "OAUTH_ROUTE_INVALID_INPUT");
+  }
+  return value as Record<string, unknown>;
+}
+
+function asOptionalBoolean(value: unknown, field: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new BadRequestError(`${field} must be a boolean`, "OAUTH_ROUTE_INVALID_INPUT");
+  }
+  return value;
+}
+
+function asTokenTypeHint(value: unknown): "access_token" | "refresh_token" | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === "access_token" || value === "refresh_token") {
+    return value;
+  }
+  throw new BadRequestError("tokenTypeHint must be access_token or refresh_token", "OAUTH_ROUTE_INVALID_INPUT");
+}

--- a/packages/oauth-router/src/index.ts
+++ b/packages/oauth-router/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./browser-routes.js";
+export * from "./connection-routes.js";

--- a/packages/oauth-router/tsconfig.json
+++ b/packages/oauth-router/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-router/vitest.config.ts
+++ b/packages/oauth-router/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createOAuthSharedVitestConfig } from "../../scripts/vitest-oauth-shared.mjs";
+
+export default createOAuthSharedVitestConfig();

--- a/packages/oauth-storage/README.md
+++ b/packages/oauth-storage/README.md
@@ -1,0 +1,70 @@
+# @superfunctions/oauth-storage
+
+Shared OAuth state and token persistence contracts, adapters, and encryption helpers.
+
+## Install
+
+```bash
+npm install @superfunctions/oauth-storage @superfunctions/db
+```
+
+## Quick Start
+
+Production code should persist tokens through `EncryptedTokenVault`.
+
+```ts
+import {
+  AesGcmTokenCipher,
+  EncryptedTokenVault,
+  MemoryOAuthStateStore,
+  MemoryTokenVault,
+} from "@superfunctions/oauth-storage";
+
+const stateStore = new MemoryOAuthStateStore();
+const cipher = new AesGcmTokenCipher((keyRef) => {
+  if (keyRef !== "oauth-default") {
+    throw new Error("unknown keyRef");
+  }
+
+  return Buffer.alloc(32, 7);
+});
+
+const tokenVault = new EncryptedTokenVault(new MemoryTokenVault(), cipher);
+```
+
+If you want the shared DB abstraction, `createOAuthDbStorage(...)` builds the stores with the correct default model names:
+
+```ts
+import { createOAuthDbStorage } from "@superfunctions/oauth-storage";
+
+const { stateStore, tokenVault, models } = createOAuthDbStorage({
+  adapter,
+});
+
+console.log(models.oauthStates); // oauth_states
+console.log(models.oauthTokenVault); // oauth_tokens
+```
+
+## Package Boundary
+
+`@superfunctions/oauth-storage` owns:
+
+- `OAuthStateStore` for short-lived redirect state
+- `TokenVault` for connection-bound token records
+- consent and revocation-failure stores
+- in-memory, SQL, and `@superfunctions/db` adapters
+- `EncryptedTokenVault`, `TokenCipher`, and `AesGcmTokenCipher`
+
+It does not decide when to start OAuth, exchange tokens, or expose HTTP endpoints.
+
+## Production Notes
+
+- The default SQL/DB token model name is `oauth_tokens`.
+- `MemoryOAuthStateStore` and `MemoryTokenVault` are fine for tests and small prototypes, but not for multi-instance production deployments.
+- Prefer `EncryptedTokenVault` for durable token storage so plaintext token JSON never becomes the long-lived record format.
+- If you already use a custom token table/model name, keep passing `models.oauthTokenVault` until your schema migration is complete.
+
+## Docs
+
+- Canonical docs: [docs/content/docs/authentication/oauth-storage.mdx](../../docs/content/docs/authentication/oauth-storage.mdx)
+- Stack overview: [docs/content/docs/architecture/oauth-flow-architecture.mdx](../../docs/content/docs/architecture/oauth-flow-architecture.mdx)

--- a/packages/oauth-storage/package.json
+++ b/packages/oauth-storage/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@superfunctions/oauth-storage",
+  "version": "0.0.1",
+  "description": "OAuth state and token storage contracts for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --config ./vitest.config.ts --run",
+    "test:watch": "vitest --config ./vitest.config.ts --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "oauth",
+    "storage",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/oauth-storage"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/db": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/oauth-storage/src/__tests__/exports.test.ts
+++ b/packages/oauth-storage/src/__tests__/exports.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { OAuthStateRecord, TokenRecord } from "../index.js";
+
+describe("oauth-storage exports", () => {
+  it("exposes state and token records", () => {
+    const state: OAuthStateRecord = {
+      stateId: "st_1",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      providerId: "google",
+      redirectUri: "https://app.example/callback",
+      requestedScopes: ["scope"],
+      createdAt: "2026-01-01T00:00:00Z",
+      expiresAt: "2026-01-01T00:10:00Z"
+    };
+
+    const token: TokenRecord = {
+      tokenId: "tok_1",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      providerId: "google",
+      connectionId: "conn_1",
+      encryptedPayload: "cipher",
+      keyRef: "kms_1",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z"
+    };
+
+    expect(state.providerId).toBe("google");
+    expect(token.connectionId).toBe("conn_1");
+  });
+});

--- a/packages/oauth-storage/src/adapters/db.ts
+++ b/packages/oauth-storage/src/adapters/db.ts
@@ -1,0 +1,548 @@
+import { NotFoundError } from "@superfunctions/db";
+import type { Adapter, WhereClause } from "@superfunctions/db";
+import type {
+  OAuthConsentRecord,
+  OAuthConsentStore,
+  OAuthRevocationFailureRecord,
+  OAuthRevocationFailureStore,
+  OAuthStateRecord,
+  OAuthStateStore,
+  OAuthStoredSubject,
+  TokenRecord,
+  TokenVault
+} from "../index.js";
+import {
+  applySubjectToStateRecord,
+  cloneOAuthStoredSubject,
+  getOAuthSubjectKey,
+  validateOAuthConsentRecord,
+  validateOAuthRevocationFailureRecord,
+  validateOAuthStateRecord,
+  validateOAuthStoredSubject
+} from "../state-store.js";
+
+export interface OAuthDbModelMapping {
+  oauthStates: string;
+  oauthTokenVault: string;
+  oauthConsents: string;
+  oauthRevocationFailures: string;
+}
+
+export interface OAuthDbAdapterOptions {
+  adapter: Adapter;
+  models?: Partial<OAuthDbModelMapping>;
+}
+
+export type OAuthDbAdapterErrorCode = "SCHEMA_MISSING" | "INTERNAL_ERROR";
+
+export class OAuthDbAdapterError extends Error {
+  readonly code: OAuthDbAdapterErrorCode;
+  readonly status: number;
+  readonly retryable: boolean;
+
+  constructor(code: OAuthDbAdapterErrorCode, message: string) {
+    super(message);
+    this.name = "OAuthDbAdapterError";
+    this.code = code;
+    this.status = 500;
+    this.retryable = false;
+  }
+}
+
+const DEFAULT_MODELS: OAuthDbModelMapping = {
+  oauthStates: "oauth_states",
+  oauthTokenVault: "oauth_tokens",
+  oauthConsents: "oauth_consents",
+  oauthRevocationFailures: "oauth_revocation_failures"
+};
+
+type StateRow = {
+  state_id: string;
+  provider_id: string;
+  subject_kind: string;
+  subject_key: string;
+  subject_payload: unknown;
+  redirect_uri: string;
+  requested_scopes: unknown;
+  code_verifier?: string | null;
+  nonce?: string | null;
+  created_at: string;
+  expires_at: string;
+  consumed_at?: string | null;
+};
+
+type TokenRow = {
+  token_id: string;
+  tenant_id: string;
+  user_id: string;
+  provider_id: string;
+  connection_id: string;
+  encrypted_payload: string;
+  key_ref: string;
+  created_at: string;
+  updated_at: string;
+  expires_at?: string | null;
+};
+
+type ConsentRow = {
+  consent_id: string;
+  provider_id: string;
+  subject_kind: string;
+  subject_key: string;
+  subject_payload: unknown;
+  scope_set: unknown;
+  granted_at: string;
+  updated_at: string;
+  metadata?: unknown;
+};
+
+type RevocationFailureRow = {
+  failure_id: string;
+  provider_id: string;
+  subject_kind: string;
+  subject_key: string;
+  subject_payload: unknown;
+  token_id?: string | null;
+  token_type_hint?: string | null;
+  error_code: string;
+  error_message: string;
+  retryable: boolean;
+  occurred_at: string;
+  metadata?: unknown;
+};
+
+export class DbAdapterOAuthStateStore implements OAuthStateStore {
+  private readonly adapter: Adapter;
+  private readonly model: string;
+
+  constructor(adapter: Adapter, model = DEFAULT_MODELS.oauthStates) {
+    this.adapter = adapter;
+    this.model = model;
+  }
+
+  async put(record: OAuthStateRecord): Promise<void> {
+    validateOAuthStateRecord(record);
+    await this.adapter.upsert({
+      model: this.model,
+      where: [{ field: "state_id", operator: "eq", value: record.stateId }],
+      create: mapStateRecordToRow(record),
+      update: mapStateRecordToRow(record),
+      conflictTarget: "state_id"
+    });
+  }
+
+  async get(stateId: string): Promise<OAuthStateRecord | null> {
+    const row = await this.adapter.findOne<StateRow>({
+      model: this.model,
+      where: [{ field: "state_id", operator: "eq", value: stateId }]
+    });
+
+    return row ? mapStateRowToRecord(row) : null;
+  }
+
+  async consume(stateId: string, consumedAt: string): Promise<OAuthStateRecord | null> {
+    const where: WhereClause[] = [
+      { field: "state_id", operator: "eq", value: stateId },
+      { field: "consumed_at", operator: "eq", value: null },
+      { field: "expires_at", operator: "gt", value: consumedAt }
+    ];
+
+    try {
+      const updated = await this.adapter.update<StateRow>({
+        model: this.model,
+        where,
+        data: { consumed_at: consumedAt }
+      });
+
+      return mapStateRowToRecord(updated);
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async deleteExpired(before: string): Promise<number> {
+    return this.adapter.deleteMany({
+      model: this.model,
+      where: [{ field: "expires_at", operator: "lt", value: before }]
+    });
+  }
+}
+
+export class DbAdapterTokenVault implements TokenVault {
+  private readonly adapter: Adapter;
+  private readonly model: string;
+
+  constructor(adapter: Adapter, model = DEFAULT_MODELS.oauthTokenVault) {
+    this.adapter = adapter;
+    this.model = model;
+  }
+
+  async put(record: TokenRecord): Promise<void> {
+    await this.adapter.upsert({
+      model: this.model,
+      where: [{ field: "token_id", operator: "eq", value: record.tokenId }],
+      create: mapTokenRecordToRow(record),
+      update: mapTokenRecordToRow(record),
+      conflictTarget: "token_id"
+    });
+  }
+
+  async get(tokenId: string): Promise<TokenRecord | null> {
+    const row = await this.adapter.findOne<TokenRow>({
+      model: this.model,
+      where: [{ field: "token_id", operator: "eq", value: tokenId }]
+    });
+
+    return row ? mapTokenRowToRecord(row) : null;
+  }
+
+  async getByConnection(connectionId: string): Promise<TokenRecord | null> {
+    const row = await this.adapter.findOne<TokenRow>({
+      model: this.model,
+      where: [{ field: "connection_id", operator: "eq", value: connectionId }]
+    });
+
+    return row ? mapTokenRowToRecord(row) : null;
+  }
+
+  async rotateKey(tokenId: string, newKeyRef: string): Promise<void> {
+    const existing = await this.get(tokenId);
+    if (!existing || existing.keyRef === newKeyRef) {
+      return;
+    }
+
+    throw new OAuthDbAdapterError(
+      "INTERNAL_ERROR",
+      "Token key rotation requires re-encryption; use EncryptedTokenVault.rotateKey"
+    );
+  }
+
+  async deleteByConnection(connectionId: string): Promise<void> {
+    await this.adapter.deleteMany({
+      model: this.model,
+      where: [{ field: "connection_id", operator: "eq", value: connectionId }]
+    });
+  }
+}
+
+export class DbAdapterOAuthConsentStore implements OAuthConsentStore {
+  private readonly adapter: Adapter;
+  private readonly model: string;
+
+  constructor(adapter: Adapter, model = DEFAULT_MODELS.oauthConsents) {
+    this.adapter = adapter;
+    this.model = model;
+  }
+
+  async put(record: OAuthConsentRecord): Promise<void> {
+    validateOAuthConsentRecord(record);
+    await this.adapter.upsert({
+      model: this.model,
+      where: [{ field: "consent_id", operator: "eq", value: record.consentId }],
+      create: mapConsentRecordToRow(record),
+      update: mapConsentRecordToRow(record),
+      conflictTarget: "consent_id"
+    });
+  }
+
+  async get(consentId: string): Promise<OAuthConsentRecord | null> {
+    const row = await this.adapter.findOne<ConsentRow>({
+      model: this.model,
+      where: [{ field: "consent_id", operator: "eq", value: consentId }]
+    });
+
+    return row ? mapConsentRowToRecord(row) : null;
+  }
+
+  async listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthConsentRecord[]> {
+    validateOAuthStoredSubject(subject);
+    const rows = await this.adapter.findMany<ConsentRow>({
+      model: this.model,
+      where: [
+        { field: "provider_id", operator: "eq", value: providerId },
+        { field: "subject_key", operator: "eq", value: getOAuthSubjectKey(subject) }
+      ]
+    });
+
+    return rows.map(mapConsentRowToRecord);
+  }
+
+  async delete(consentId: string): Promise<void> {
+    await this.adapter.deleteMany({
+      model: this.model,
+      where: [{ field: "consent_id", operator: "eq", value: consentId }]
+    });
+  }
+}
+
+export class DbAdapterOAuthRevocationFailureStore implements OAuthRevocationFailureStore {
+  private readonly adapter: Adapter;
+  private readonly model: string;
+
+  constructor(adapter: Adapter, model = DEFAULT_MODELS.oauthRevocationFailures) {
+    this.adapter = adapter;
+    this.model = model;
+  }
+
+  async put(record: OAuthRevocationFailureRecord): Promise<void> {
+    validateOAuthRevocationFailureRecord(record);
+    await this.adapter.upsert({
+      model: this.model,
+      where: [{ field: "failure_id", operator: "eq", value: record.failureId }],
+      create: mapRevocationFailureRecordToRow(record),
+      update: mapRevocationFailureRecordToRow(record),
+      conflictTarget: "failure_id"
+    });
+  }
+
+  async get(failureId: string): Promise<OAuthRevocationFailureRecord | null> {
+    const row = await this.adapter.findOne<RevocationFailureRow>({
+      model: this.model,
+      where: [{ field: "failure_id", operator: "eq", value: failureId }]
+    });
+
+    return row ? mapRevocationFailureRowToRecord(row) : null;
+  }
+
+  async listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthRevocationFailureRecord[]> {
+    validateOAuthStoredSubject(subject);
+    const rows = await this.adapter.findMany<RevocationFailureRow>({
+      model: this.model,
+      where: [
+        { field: "provider_id", operator: "eq", value: providerId },
+        { field: "subject_key", operator: "eq", value: getOAuthSubjectKey(subject) }
+      ]
+    });
+
+    return rows.map(mapRevocationFailureRowToRecord);
+  }
+
+  async delete(failureId: string): Promise<void> {
+    await this.adapter.deleteMany({
+      model: this.model,
+      where: [{ field: "failure_id", operator: "eq", value: failureId }]
+    });
+  }
+}
+
+export function createOAuthDbStorage(options: OAuthDbAdapterOptions): {
+  stateStore: OAuthStateStore;
+  tokenVault: TokenVault;
+  consentStore: OAuthConsentStore;
+  revocationFailureStore: OAuthRevocationFailureStore;
+  models: OAuthDbModelMapping;
+} {
+  const models = resolveModelMapping(options.models);
+  return {
+    stateStore: new DbAdapterOAuthStateStore(options.adapter, models.oauthStates),
+    tokenVault: new DbAdapterTokenVault(options.adapter, models.oauthTokenVault),
+    consentStore: new DbAdapterOAuthConsentStore(options.adapter, models.oauthConsents),
+    revocationFailureStore: new DbAdapterOAuthRevocationFailureStore(
+      options.adapter,
+      models.oauthRevocationFailures
+    ),
+    models
+  };
+}
+
+function resolveModelMapping(mapping: Partial<OAuthDbModelMapping> | undefined): OAuthDbModelMapping {
+  const models: OAuthDbModelMapping = {
+    oauthStates: mapping?.oauthStates ?? DEFAULT_MODELS.oauthStates,
+    oauthTokenVault: mapping?.oauthTokenVault ?? DEFAULT_MODELS.oauthTokenVault,
+    oauthConsents: mapping?.oauthConsents ?? DEFAULT_MODELS.oauthConsents,
+    oauthRevocationFailures: mapping?.oauthRevocationFailures ?? DEFAULT_MODELS.oauthRevocationFailures
+  };
+
+  if (!models.oauthStates) {
+    throw new OAuthDbAdapterError("SCHEMA_MISSING", "oauth_states model mapping required");
+  }
+
+  if (!models.oauthTokenVault) {
+    throw new OAuthDbAdapterError("SCHEMA_MISSING", "oauth_tokens model mapping required");
+  }
+
+  if (!models.oauthConsents) {
+    throw new OAuthDbAdapterError("SCHEMA_MISSING", "oauth_consents model mapping required");
+  }
+
+  if (!models.oauthRevocationFailures) {
+    throw new OAuthDbAdapterError("SCHEMA_MISSING", "oauth_revocation_failures model mapping required");
+  }
+
+  return models;
+}
+
+function mapStateRecordToRow(record: OAuthStateRecord): StateRow {
+  const normalized = applySubjectToStateRecord(record);
+  return {
+    state_id: normalized.stateId,
+    provider_id: normalized.providerId,
+    subject_kind: normalized.subject!.kind,
+    subject_key: getOAuthSubjectKey(normalized.subject!),
+    subject_payload: JSON.stringify(normalized.subject),
+    redirect_uri: normalized.redirectUri,
+    requested_scopes: JSON.stringify(normalized.requestedScopes),
+    code_verifier: normalized.codeVerifier ?? null,
+    nonce: normalized.nonce ?? null,
+    created_at: normalized.createdAt,
+    expires_at: normalized.expiresAt,
+    consumed_at: normalized.consumedAt ?? null
+  };
+}
+
+function mapStateRowToRecord(row: StateRow): OAuthStateRecord {
+  const subject = parseSubject(row.subject_payload);
+  return applySubjectToStateRecord({
+    stateId: row.state_id,
+    providerId: row.provider_id,
+    subject,
+    redirectUri: row.redirect_uri,
+    requestedScopes: parseStringArrayValue(row.requested_scopes, "requested_scopes"),
+    codeVerifier: row.code_verifier ?? undefined,
+    nonce: row.nonce ?? undefined,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    consumedAt: row.consumed_at ?? undefined
+  });
+}
+
+function mapTokenRecordToRow(record: TokenRecord): TokenRow {
+  return {
+    token_id: record.tokenId,
+    tenant_id: record.tenantId,
+    user_id: record.userId,
+    provider_id: record.providerId,
+    connection_id: record.connectionId,
+    encrypted_payload: record.encryptedPayload,
+    key_ref: record.keyRef,
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+    expires_at: record.expiresAt ?? null
+  };
+}
+
+function mapTokenRowToRecord(row: TokenRow): TokenRecord {
+  return {
+    tokenId: row.token_id,
+    tenantId: row.tenant_id,
+    userId: row.user_id,
+    providerId: row.provider_id,
+    connectionId: row.connection_id,
+    encryptedPayload: row.encrypted_payload,
+    keyRef: row.key_ref,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    expiresAt: row.expires_at ?? undefined
+  };
+}
+
+function mapConsentRecordToRow(record: OAuthConsentRecord): ConsentRow {
+  return {
+    consent_id: record.consentId,
+    provider_id: record.providerId,
+    subject_kind: record.subject.kind,
+    subject_key: getOAuthSubjectKey(record.subject),
+    subject_payload: JSON.stringify(record.subject),
+    scope_set: JSON.stringify(record.scopes),
+    granted_at: record.grantedAt,
+    updated_at: record.updatedAt,
+    metadata: record.metadata ? JSON.stringify(record.metadata) : null
+  };
+}
+
+function mapConsentRowToRecord(row: ConsentRow): OAuthConsentRecord {
+  return {
+    consentId: row.consent_id,
+    providerId: row.provider_id,
+    subject: parseSubject(row.subject_payload),
+    scopes: parseStringArrayValue(row.scope_set, "scope_set"),
+    grantedAt: row.granted_at,
+    updatedAt: row.updated_at,
+    metadata: row.metadata ? parseRecordValue(row.metadata, "metadata") : undefined
+  };
+}
+
+function mapRevocationFailureRecordToRow(record: OAuthRevocationFailureRecord): RevocationFailureRow {
+  return {
+    failure_id: record.failureId,
+    provider_id: record.providerId,
+    subject_kind: record.subject.kind,
+    subject_key: getOAuthSubjectKey(record.subject),
+    subject_payload: JSON.stringify(record.subject),
+    token_id: record.tokenId ?? null,
+    token_type_hint: record.tokenTypeHint ?? null,
+    error_code: record.errorCode,
+    error_message: record.errorMessage,
+    retryable: record.retryable,
+    occurred_at: record.occurredAt,
+    metadata: record.metadata ? JSON.stringify(record.metadata) : null
+  };
+}
+
+function mapRevocationFailureRowToRecord(row: RevocationFailureRow): OAuthRevocationFailureRecord {
+  return {
+    failureId: row.failure_id,
+    providerId: row.provider_id,
+    subject: parseSubject(row.subject_payload),
+    tokenId: row.token_id ?? undefined,
+    tokenTypeHint: parseTokenTypeHint(row.token_type_hint),
+    errorCode: row.error_code,
+    errorMessage: row.error_message,
+    retryable: row.retryable,
+    occurredAt: row.occurred_at,
+    metadata: row.metadata ? parseRecordValue(row.metadata, "metadata") : undefined
+  };
+}
+
+function parseSubject(raw: unknown): OAuthStoredSubject {
+  const subject = parseJsonValue<OAuthStoredSubject>(raw);
+  validateOAuthStoredSubject(subject);
+  return cloneOAuthStoredSubject(subject);
+}
+
+function parseJsonValue<T>(raw: unknown): T {
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      throw new OAuthDbAdapterError("INTERNAL_ERROR", "persisted JSON value must be valid JSON");
+    }
+  }
+
+  return raw as T;
+}
+
+function parseStringArrayValue(raw: unknown, fieldName: string): string[] {
+  const value = parseJsonValue<unknown>(raw);
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new OAuthDbAdapterError("INTERNAL_ERROR", `${fieldName} must be an array of strings`);
+  }
+
+  return [...value];
+}
+
+function parseRecordValue(raw: unknown, fieldName: string): Record<string, unknown> {
+  const value = parseJsonValue<unknown>(raw);
+  if (!isPlainRecord(value)) {
+    throw new OAuthDbAdapterError("INTERNAL_ERROR", `${fieldName} must be an object`);
+  }
+
+  return { ...value };
+}
+
+function parseTokenTypeHint(value: string | null | undefined): "access_token" | "refresh_token" | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (value === "access_token" || value === "refresh_token") {
+    return value;
+  }
+  throw new OAuthDbAdapterError("INTERNAL_ERROR", "token_type_hint must be access_token or refresh_token");
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/oauth-storage/src/adapters/memory.ts
+++ b/packages/oauth-storage/src/adapters/memory.ts
@@ -1,0 +1,199 @@
+import type {
+  OAuthConsentRecord,
+  OAuthConsentStore,
+  OAuthRevocationFailureRecord,
+  OAuthRevocationFailureStore,
+  OAuthStateRecord,
+  OAuthStateStore,
+  OAuthStoredSubject,
+  TokenRecord,
+  TokenVault
+} from "../index.js";
+import {
+  cloneOAuthStateRecord,
+  cloneOAuthStoredSubject,
+  getOAuthSubjectKey,
+  validateOAuthConsentRecord,
+  validateOAuthRevocationFailureRecord,
+  validateOAuthStateRecord
+} from "../state-store.js";
+
+export class MemoryOAuthStateStore implements OAuthStateStore {
+  private readonly records = new Map<string, OAuthStateRecord>();
+
+  async put(record: OAuthStateRecord): Promise<void> {
+    validateOAuthStateRecord(record);
+    this.records.set(record.stateId, cloneOAuthStateRecord(record));
+  }
+
+  async get(stateId: string): Promise<OAuthStateRecord | null> {
+    const record = this.records.get(stateId);
+    return record ? cloneOAuthStateRecord(record) : null;
+  }
+
+  async consume(stateId: string, consumedAt: string): Promise<OAuthStateRecord | null> {
+    const record = this.records.get(stateId);
+    if (!record) {
+      return null;
+    }
+
+    if (record.consumedAt) {
+      return null;
+    }
+
+    if (Date.parse(record.expiresAt) <= Date.parse(consumedAt)) {
+      return null;
+    }
+
+    const consumed: OAuthStateRecord = { ...record, consumedAt };
+    this.records.set(stateId, consumed);
+    return cloneOAuthStateRecord(consumed);
+  }
+
+  async deleteExpired(before: string): Promise<number> {
+    const checkpoint = Date.parse(before);
+    let deleted = 0;
+
+    for (const [stateId, record] of this.records.entries()) {
+      if (Date.parse(record.expiresAt) < checkpoint) {
+        this.records.delete(stateId);
+        deleted += 1;
+      }
+    }
+
+    return deleted;
+  }
+}
+
+export class MemoryTokenVault implements TokenVault {
+  private readonly tokensById = new Map<string, TokenRecord>();
+  private readonly tokenByConnection = new Map<string, string>();
+
+  async put(record: TokenRecord): Promise<void> {
+    const previousRecord = this.tokensById.get(record.tokenId);
+    if (previousRecord && previousRecord.connectionId !== record.connectionId) {
+      this.tokenByConnection.delete(previousRecord.connectionId);
+    }
+
+    const existingTokenId = this.tokenByConnection.get(record.connectionId);
+    if (existingTokenId && existingTokenId !== record.tokenId) {
+      this.tokensById.delete(existingTokenId);
+    }
+
+    this.tokensById.set(record.tokenId, cloneTokenRecord(record));
+    this.tokenByConnection.set(record.connectionId, record.tokenId);
+  }
+
+  async get(tokenId: string): Promise<TokenRecord | null> {
+    const record = this.tokensById.get(tokenId);
+    return record ? cloneTokenRecord(record) : null;
+  }
+
+  async getByConnection(connectionId: string): Promise<TokenRecord | null> {
+    const tokenId = this.tokenByConnection.get(connectionId);
+    if (!tokenId) {
+      return null;
+    }
+
+    const record = this.tokensById.get(tokenId);
+    if (!record) {
+      this.tokenByConnection.delete(connectionId);
+      return null;
+    }
+    if (record.connectionId !== connectionId) {
+      this.tokenByConnection.delete(connectionId);
+      return null;
+    }
+    return record ? cloneTokenRecord(record) : null;
+  }
+
+  async rotateKey(tokenId: string, newKeyRef: string): Promise<void> {
+    const existing = this.tokensById.get(tokenId);
+    if (!existing || existing.keyRef === newKeyRef) {
+      return;
+    }
+
+    throw new Error("Token key rotation requires re-encryption; use EncryptedTokenVault.rotateKey");
+  }
+
+  async deleteByConnection(connectionId: string): Promise<void> {
+    const tokenId = this.tokenByConnection.get(connectionId);
+    if (!tokenId) {
+      return;
+    }
+
+    this.tokenByConnection.delete(connectionId);
+    this.tokensById.delete(tokenId);
+  }
+}
+
+export class MemoryOAuthConsentStore implements OAuthConsentStore {
+  private readonly consentsById = new Map<string, OAuthConsentRecord>();
+
+  async put(record: OAuthConsentRecord): Promise<void> {
+    validateOAuthConsentRecord(record);
+    this.consentsById.set(record.consentId, cloneConsentRecord(record));
+  }
+
+  async get(consentId: string): Promise<OAuthConsentRecord | null> {
+    const record = this.consentsById.get(consentId);
+    return record ? cloneConsentRecord(record) : null;
+  }
+
+  async listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthConsentRecord[]> {
+    const subjectKey = getOAuthSubjectKey(subject);
+    return [...this.consentsById.values()]
+      .filter((record) => record.providerId === providerId && getOAuthSubjectKey(record.subject) === subjectKey)
+      .map(cloneConsentRecord);
+  }
+
+  async delete(consentId: string): Promise<void> {
+    this.consentsById.delete(consentId);
+  }
+}
+
+export class MemoryOAuthRevocationFailureStore implements OAuthRevocationFailureStore {
+  private readonly failuresById = new Map<string, OAuthRevocationFailureRecord>();
+
+  async put(record: OAuthRevocationFailureRecord): Promise<void> {
+    validateOAuthRevocationFailureRecord(record);
+    this.failuresById.set(record.failureId, cloneRevocationFailureRecord(record));
+  }
+
+  async get(failureId: string): Promise<OAuthRevocationFailureRecord | null> {
+    const record = this.failuresById.get(failureId);
+    return record ? cloneRevocationFailureRecord(record) : null;
+  }
+
+  async listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthRevocationFailureRecord[]> {
+    const subjectKey = getOAuthSubjectKey(subject);
+    return [...this.failuresById.values()]
+      .filter((record) => record.providerId === providerId && getOAuthSubjectKey(record.subject) === subjectKey)
+      .map(cloneRevocationFailureRecord);
+  }
+
+  async delete(failureId: string): Promise<void> {
+    this.failuresById.delete(failureId);
+  }
+}
+
+function cloneTokenRecord(record: TokenRecord): TokenRecord {
+  return { ...record };
+}
+
+function cloneConsentRecord(record: OAuthConsentRecord): OAuthConsentRecord {
+  return {
+    ...record,
+    scopes: [...record.scopes],
+    subject: cloneOAuthStoredSubject(record.subject),
+    metadata: record.metadata ? { ...record.metadata } : undefined
+  };
+}
+
+function cloneRevocationFailureRecord(record: OAuthRevocationFailureRecord): OAuthRevocationFailureRecord {
+  return {
+    ...record,
+    subject: cloneOAuthStoredSubject(record.subject),
+    metadata: record.metadata ? { ...record.metadata } : undefined
+  };
+}

--- a/packages/oauth-storage/src/adapters/sql.ts
+++ b/packages/oauth-storage/src/adapters/sql.ts
@@ -1,0 +1,766 @@
+import type {
+  OAuthConsentRecord,
+  OAuthConsentStore,
+  OAuthRevocationFailureRecord,
+  OAuthRevocationFailureStore,
+  OAuthStateRecord,
+  OAuthStateStore,
+  OAuthStorageTableDefinition,
+  OAuthStoredSubject,
+  TokenRecord,
+  TokenVault
+} from "../index.js";
+import {
+  applySubjectToStateRecord,
+  cloneOAuthStoredSubject,
+  getOAuthSubjectKey,
+  validateOAuthConsentRecord,
+  validateOAuthRevocationFailureRecord,
+  validateOAuthStateRecord,
+  validateOAuthStoredSubject
+} from "../state-store.js";
+
+export interface SqlResult {
+  rowsAffected?: number;
+}
+
+export interface SqlClient {
+  query<TRow = unknown>(statement: string, params?: readonly unknown[]): Promise<TRow[]>;
+  execute(statement: string, params?: readonly unknown[]): Promise<SqlResult>;
+}
+
+interface OAuthStateRow {
+  state_id: string;
+  provider_id: string;
+  subject_kind: string;
+  subject_key: string;
+  subject_payload: string;
+  redirect_uri: string;
+  requested_scopes: string;
+  code_verifier: string | null;
+  nonce: string | null;
+  created_at: string;
+  expires_at: string;
+  consumed_at: string | null;
+}
+
+interface TokenRow {
+  token_id: string;
+  tenant_id: string;
+  user_id: string;
+  provider_id: string;
+  connection_id: string;
+  encrypted_payload: string;
+  key_ref: string;
+  created_at: string;
+  updated_at: string;
+  expires_at: string | null;
+}
+
+interface ConsentRow {
+  consent_id: string;
+  provider_id: string;
+  subject_kind: string;
+  subject_key: string;
+  subject_payload: string;
+  scope_set: string;
+  granted_at: string;
+  updated_at: string;
+  metadata: string | null;
+}
+
+interface RevocationFailureRow {
+  failure_id: string;
+  provider_id: string;
+  subject_kind: string;
+  subject_key: string;
+  subject_payload: string;
+  token_id: string | null;
+  token_type_hint: string | null;
+  error_code: string;
+  error_message: string;
+  retryable: boolean;
+  occurred_at: string;
+  metadata: string | null;
+}
+
+const STATE_COLUMNS = `
+  state_id,
+  provider_id,
+  subject_kind,
+  subject_key,
+  subject_payload,
+  redirect_uri,
+  requested_scopes,
+  code_verifier,
+  nonce,
+  created_at,
+  expires_at,
+  consumed_at
+`;
+
+const TOKEN_COLUMNS = `
+  token_id,
+  tenant_id,
+  user_id,
+  provider_id,
+  connection_id,
+  encrypted_payload,
+  key_ref,
+  created_at,
+  updated_at,
+  expires_at
+`;
+
+const CONSENT_COLUMNS = `
+  consent_id,
+  provider_id,
+  subject_kind,
+  subject_key,
+  subject_payload,
+  scope_set,
+  granted_at,
+  updated_at,
+  metadata
+`;
+
+const REVOCATION_FAILURE_COLUMNS = `
+  failure_id,
+  provider_id,
+  subject_kind,
+  subject_key,
+  subject_payload,
+  token_id,
+  token_type_hint,
+  error_code,
+  error_message,
+  retryable,
+  occurred_at,
+  metadata
+`;
+
+export class SqlOAuthStateStore implements OAuthStateStore {
+  private readonly client: SqlClient;
+  private readonly tableName: string;
+
+  constructor(client: SqlClient, tableName = "oauth_states") {
+    this.client = client;
+    this.tableName = validateSqlIdentifier(tableName, "tableName");
+  }
+
+  async put(record: OAuthStateRecord): Promise<void> {
+    validateOAuthStateRecord(record);
+    const normalized = applySubjectToStateRecord(record);
+    await this.client.execute(
+      `
+      INSERT INTO ${this.tableName} (
+        state_id,
+        provider_id,
+        subject_kind,
+        subject_key,
+        subject_payload,
+        redirect_uri,
+        requested_scopes,
+        code_verifier,
+        nonce,
+        created_at,
+        expires_at,
+        consumed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(state_id) DO UPDATE SET
+        provider_id = excluded.provider_id,
+        subject_kind = excluded.subject_kind,
+        subject_key = excluded.subject_key,
+        subject_payload = excluded.subject_payload,
+        redirect_uri = excluded.redirect_uri,
+        requested_scopes = excluded.requested_scopes,
+        code_verifier = excluded.code_verifier,
+        nonce = excluded.nonce,
+        created_at = excluded.created_at,
+        expires_at = excluded.expires_at,
+        consumed_at = excluded.consumed_at
+      `,
+      [
+        normalized.stateId,
+        normalized.providerId,
+        normalized.subject!.kind,
+        getOAuthSubjectKey(normalized.subject!),
+        JSON.stringify(normalized.subject),
+        normalized.redirectUri,
+        JSON.stringify(normalized.requestedScopes),
+        normalized.codeVerifier ?? null,
+        normalized.nonce ?? null,
+        normalized.createdAt,
+        normalized.expiresAt,
+        normalized.consumedAt ?? null
+      ]
+    );
+  }
+
+  async get(stateId: string): Promise<OAuthStateRecord | null> {
+    const rows = await this.client.query<OAuthStateRow>(
+      `SELECT ${STATE_COLUMNS} FROM ${this.tableName} WHERE state_id = ? LIMIT 1`,
+      [stateId]
+    );
+
+    return rows[0] ? mapStateRow(rows[0]) : null;
+  }
+
+  async consume(stateId: string, consumedAt: string): Promise<OAuthStateRecord | null> {
+    const rows = await this.client.query<OAuthStateRow>(
+      `
+      SELECT ${STATE_COLUMNS}
+      FROM ${this.tableName}
+      WHERE state_id = ?
+        AND consumed_at IS NULL
+        AND expires_at > ?
+      LIMIT 1
+      `,
+      [stateId, consumedAt]
+    );
+
+    const row = rows[0];
+    if (!row) {
+      return null;
+    }
+
+    const result = await this.client.execute(
+      `
+      UPDATE ${this.tableName}
+      SET consumed_at = ?
+      WHERE state_id = ?
+        AND consumed_at IS NULL
+        AND expires_at > ?
+      `,
+      [consumedAt, stateId, consumedAt]
+    );
+
+    if ((result.rowsAffected ?? 0) === 0) {
+      return null;
+    }
+
+    return mapStateRow({
+      ...row,
+      consumed_at: consumedAt
+    });
+  }
+
+  async deleteExpired(before: string): Promise<number> {
+    const result = await this.client.execute(`DELETE FROM ${this.tableName} WHERE expires_at < ?`, [before]);
+    return result.rowsAffected ?? 0;
+  }
+}
+
+export class SqlTokenVault implements TokenVault {
+  private readonly client: SqlClient;
+  private readonly tableName: string;
+
+  constructor(client: SqlClient, tableName = "oauth_tokens") {
+    this.client = client;
+    this.tableName = validateSqlIdentifier(tableName, "tableName");
+  }
+
+  async put(record: TokenRecord): Promise<void> {
+    await this.client.execute(
+      `
+      INSERT INTO ${this.tableName} (
+        token_id,
+        tenant_id,
+        user_id,
+        provider_id,
+        connection_id,
+        encrypted_payload,
+        key_ref,
+        created_at,
+        updated_at,
+        expires_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(token_id) DO UPDATE SET
+        tenant_id = excluded.tenant_id,
+        user_id = excluded.user_id,
+        provider_id = excluded.provider_id,
+        connection_id = excluded.connection_id,
+        encrypted_payload = excluded.encrypted_payload,
+        key_ref = excluded.key_ref,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        expires_at = excluded.expires_at
+      `,
+      [
+        record.tokenId,
+        record.tenantId,
+        record.userId,
+        record.providerId,
+        record.connectionId,
+        record.encryptedPayload,
+        record.keyRef,
+        record.createdAt,
+        record.updatedAt,
+        record.expiresAt ?? null
+      ]
+    );
+  }
+
+  async get(tokenId: string): Promise<TokenRecord | null> {
+    const rows = await this.client.query<TokenRow>(
+      `SELECT ${TOKEN_COLUMNS} FROM ${this.tableName} WHERE token_id = ? LIMIT 1`,
+      [tokenId]
+    );
+
+    return rows[0] ? mapTokenRow(rows[0]) : null;
+  }
+
+  async getByConnection(connectionId: string): Promise<TokenRecord | null> {
+    const rows = await this.client.query<TokenRow>(
+      `SELECT ${TOKEN_COLUMNS} FROM ${this.tableName} WHERE connection_id = ? LIMIT 1`,
+      [connectionId]
+    );
+
+    return rows[0] ? mapTokenRow(rows[0]) : null;
+  }
+
+  async rotateKey(tokenId: string, newKeyRef: string): Promise<void> {
+    const existing = await this.get(tokenId);
+    if (!existing || existing.keyRef === newKeyRef) {
+      return;
+    }
+
+    throw new Error("Token key rotation requires re-encryption; use EncryptedTokenVault.rotateKey");
+  }
+
+  async deleteByConnection(connectionId: string): Promise<void> {
+    await this.client.execute(`DELETE FROM ${this.tableName} WHERE connection_id = ?`, [connectionId]);
+  }
+}
+
+export class SqlOAuthConsentStore implements OAuthConsentStore {
+  private readonly client: SqlClient;
+  private readonly tableName: string;
+
+  constructor(client: SqlClient, tableName = "oauth_consents") {
+    this.client = client;
+    this.tableName = validateSqlIdentifier(tableName, "tableName");
+  }
+
+  async put(record: OAuthConsentRecord): Promise<void> {
+    validateOAuthConsentRecord(record);
+    await this.client.execute(
+      `
+      INSERT INTO ${this.tableName} (
+        consent_id,
+        provider_id,
+        subject_kind,
+        subject_key,
+        subject_payload,
+        scope_set,
+        granted_at,
+        updated_at,
+        metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(consent_id) DO UPDATE SET
+        provider_id = excluded.provider_id,
+        subject_kind = excluded.subject_kind,
+        subject_key = excluded.subject_key,
+        subject_payload = excluded.subject_payload,
+        scope_set = excluded.scope_set,
+        granted_at = excluded.granted_at,
+        updated_at = excluded.updated_at,
+        metadata = excluded.metadata
+      `,
+      [
+        record.consentId,
+        record.providerId,
+        record.subject.kind,
+        getOAuthSubjectKey(record.subject),
+        JSON.stringify(record.subject),
+        JSON.stringify(record.scopes),
+        record.grantedAt,
+        record.updatedAt,
+        record.metadata ? JSON.stringify(record.metadata) : null
+      ]
+    );
+  }
+
+  async get(consentId: string): Promise<OAuthConsentRecord | null> {
+    const rows = await this.client.query<ConsentRow>(
+      `SELECT ${CONSENT_COLUMNS} FROM ${this.tableName} WHERE consent_id = ? LIMIT 1`,
+      [consentId]
+    );
+
+    return rows[0] ? mapConsentRow(rows[0]) : null;
+  }
+
+  async listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthConsentRecord[]> {
+    validateOAuthStoredSubject(subject);
+    const rows = await this.client.query<ConsentRow>(
+      `SELECT ${CONSENT_COLUMNS} FROM ${this.tableName} WHERE provider_id = ? AND subject_key = ?`,
+      [providerId, getOAuthSubjectKey(subject)]
+    );
+
+    return rows.map(mapConsentRow);
+  }
+
+  async delete(consentId: string): Promise<void> {
+    await this.client.execute(`DELETE FROM ${this.tableName} WHERE consent_id = ?`, [consentId]);
+  }
+}
+
+export class SqlOAuthRevocationFailureStore implements OAuthRevocationFailureStore {
+  private readonly client: SqlClient;
+  private readonly tableName: string;
+
+  constructor(client: SqlClient, tableName = "oauth_revocation_failures") {
+    this.client = client;
+    this.tableName = validateSqlIdentifier(tableName, "tableName");
+  }
+
+  async put(record: OAuthRevocationFailureRecord): Promise<void> {
+    validateOAuthRevocationFailureRecord(record);
+    await this.client.execute(
+      `
+      INSERT INTO ${this.tableName} (
+        failure_id,
+        provider_id,
+        subject_kind,
+        subject_key,
+        subject_payload,
+        token_id,
+        token_type_hint,
+        error_code,
+        error_message,
+        retryable,
+        occurred_at,
+        metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(failure_id) DO UPDATE SET
+        provider_id = excluded.provider_id,
+        subject_kind = excluded.subject_kind,
+        subject_key = excluded.subject_key,
+        subject_payload = excluded.subject_payload,
+        token_id = excluded.token_id,
+        token_type_hint = excluded.token_type_hint,
+        error_code = excluded.error_code,
+        error_message = excluded.error_message,
+        retryable = excluded.retryable,
+        occurred_at = excluded.occurred_at,
+        metadata = excluded.metadata
+      `,
+      [
+        record.failureId,
+        record.providerId,
+        record.subject.kind,
+        getOAuthSubjectKey(record.subject),
+        JSON.stringify(record.subject),
+        record.tokenId ?? null,
+        record.tokenTypeHint ?? null,
+        record.errorCode,
+        record.errorMessage,
+        record.retryable,
+        record.occurredAt,
+        record.metadata ? JSON.stringify(record.metadata) : null
+      ]
+    );
+  }
+
+  async get(failureId: string): Promise<OAuthRevocationFailureRecord | null> {
+    const rows = await this.client.query<RevocationFailureRow>(
+      `SELECT ${REVOCATION_FAILURE_COLUMNS} FROM ${this.tableName} WHERE failure_id = ? LIMIT 1`,
+      [failureId]
+    );
+
+    return rows[0] ? mapRevocationFailureRow(rows[0]) : null;
+  }
+
+  async listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthRevocationFailureRecord[]> {
+    validateOAuthStoredSubject(subject);
+    const rows = await this.client.query<RevocationFailureRow>(
+      `SELECT ${REVOCATION_FAILURE_COLUMNS} FROM ${this.tableName} WHERE provider_id = ? AND subject_key = ?`,
+      [providerId, getOAuthSubjectKey(subject)]
+    );
+
+    return rows.map(mapRevocationFailureRow);
+  }
+
+  async delete(failureId: string): Promise<void> {
+    await this.client.execute(`DELETE FROM ${this.tableName} WHERE failure_id = ?`, [failureId]);
+  }
+}
+
+export function getOAuthStorageTableDefinitions(): ReadonlyArray<OAuthStorageTableDefinition> {
+  return [
+    {
+      name: "oauth_states",
+      fields: [
+        { name: "state_id", type: "text", primaryKey: true },
+        { name: "provider_id", type: "text" },
+        { name: "subject_kind", type: "text" },
+        { name: "subject_key", type: "text" },
+        { name: "subject_payload", type: "json" },
+        { name: "redirect_uri", type: "text" },
+        { name: "requested_scopes", type: "json" },
+        { name: "code_verifier", type: "text", nullable: true },
+        { name: "nonce", type: "text", nullable: true },
+        { name: "created_at", type: "text" },
+        { name: "expires_at", type: "text" },
+        { name: "consumed_at", type: "text", nullable: true }
+      ],
+      indexes: [{ name: "idx_oauth_states_expires_at", fields: ["expires_at"] }]
+    },
+    {
+      name: "oauth_tokens",
+      fields: [
+        { name: "token_id", type: "text", primaryKey: true },
+        { name: "tenant_id", type: "text" },
+        { name: "user_id", type: "text" },
+        { name: "provider_id", type: "text" },
+        { name: "connection_id", type: "text", unique: true },
+        { name: "encrypted_payload", type: "text" },
+        { name: "key_ref", type: "text" },
+        { name: "created_at", type: "text" },
+        { name: "updated_at", type: "text" },
+        { name: "expires_at", type: "text", nullable: true }
+      ],
+      indexes: [{ name: "idx_oauth_tokens_connection", fields: ["connection_id"] }]
+    },
+    {
+      name: "oauth_consents",
+      fields: [
+        { name: "consent_id", type: "text", primaryKey: true },
+        { name: "provider_id", type: "text" },
+        { name: "subject_kind", type: "text" },
+        { name: "subject_key", type: "text" },
+        { name: "subject_payload", type: "json" },
+        { name: "scope_set", type: "json" },
+        { name: "granted_at", type: "text" },
+        { name: "updated_at", type: "text" },
+        { name: "metadata", type: "json", nullable: true }
+      ],
+      indexes: [{ name: "idx_oauth_consents_provider_subject", fields: ["provider_id", "subject_key"] }]
+    },
+    {
+      name: "oauth_revocation_failures",
+      fields: [
+        { name: "failure_id", type: "text", primaryKey: true },
+        { name: "provider_id", type: "text" },
+        { name: "subject_kind", type: "text" },
+        { name: "subject_key", type: "text" },
+        { name: "subject_payload", type: "json" },
+        { name: "token_id", type: "text", nullable: true },
+        { name: "token_type_hint", type: "text", nullable: true },
+        { name: "error_code", type: "text" },
+        { name: "error_message", type: "text" },
+        { name: "retryable", type: "boolean" },
+        { name: "occurred_at", type: "text" },
+        { name: "metadata", type: "json", nullable: true }
+      ],
+      indexes: [{ name: "idx_oauth_revocation_failures_provider_subject", fields: ["provider_id", "subject_key"] }]
+    }
+  ];
+}
+
+export function getOAuthStorageSchema(
+  stateTable = "oauth_states",
+  tokenTable = "oauth_tokens",
+  consentTable = "oauth_consents",
+  revocationFailureTable = "oauth_revocation_failures"
+): ReadonlyArray<string> {
+  const safeStateTable = validateSqlIdentifier(stateTable, "stateTable");
+  const safeTokenTable = validateSqlIdentifier(tokenTable, "tokenTable");
+  const safeConsentTable = validateSqlIdentifier(consentTable, "consentTable");
+  const safeRevocationFailureTable = validateSqlIdentifier(revocationFailureTable, "revocationFailureTable");
+
+  return [
+    `
+    CREATE TABLE IF NOT EXISTS ${safeStateTable} (
+      state_id TEXT PRIMARY KEY,
+      provider_id TEXT NOT NULL,
+      subject_kind TEXT NOT NULL,
+      subject_key TEXT NOT NULL,
+      subject_payload TEXT NOT NULL,
+      redirect_uri TEXT NOT NULL,
+      requested_scopes TEXT NOT NULL,
+      code_verifier TEXT,
+      nonce TEXT,
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      consumed_at TEXT
+    )
+    `,
+    `
+    CREATE INDEX IF NOT EXISTS idx_${safeStateTable}_expires_at
+    ON ${safeStateTable}(expires_at)
+    `,
+    `
+    CREATE TABLE IF NOT EXISTS ${safeTokenTable} (
+      token_id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      provider_id TEXT NOT NULL,
+      connection_id TEXT NOT NULL UNIQUE,
+      encrypted_payload TEXT NOT NULL,
+      key_ref TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      expires_at TEXT
+    )
+    `,
+    `
+    CREATE INDEX IF NOT EXISTS idx_${safeTokenTable}_connection
+    ON ${safeTokenTable}(connection_id)
+    `,
+    `
+    CREATE TABLE IF NOT EXISTS ${safeConsentTable} (
+      consent_id TEXT PRIMARY KEY,
+      provider_id TEXT NOT NULL,
+      subject_kind TEXT NOT NULL,
+      subject_key TEXT NOT NULL,
+      subject_payload TEXT NOT NULL,
+      scope_set TEXT NOT NULL,
+      granted_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      metadata TEXT
+    )
+    `,
+    `
+    CREATE INDEX IF NOT EXISTS idx_${safeConsentTable}_provider_subject
+    ON ${safeConsentTable}(provider_id, subject_key)
+    `,
+    `
+    CREATE TABLE IF NOT EXISTS ${safeRevocationFailureTable} (
+      failure_id TEXT PRIMARY KEY,
+      provider_id TEXT NOT NULL,
+      subject_kind TEXT NOT NULL,
+      subject_key TEXT NOT NULL,
+      subject_payload TEXT NOT NULL,
+      token_id TEXT,
+      token_type_hint TEXT,
+      error_code TEXT NOT NULL,
+      error_message TEXT NOT NULL,
+      retryable INTEGER NOT NULL,
+      occurred_at TEXT NOT NULL,
+      metadata TEXT
+    )
+    `,
+    `
+    CREATE INDEX IF NOT EXISTS idx_${safeRevocationFailureTable}_provider_subject
+    ON ${safeRevocationFailureTable}(provider_id, subject_key)
+    `
+  ];
+}
+
+function mapStateRow(row: OAuthStateRow): OAuthStateRecord {
+  const subject = parseSubject(row.subject_payload);
+  return applySubjectToStateRecord({
+    stateId: row.state_id,
+    providerId: row.provider_id,
+    subject,
+    redirectUri: row.redirect_uri,
+    requestedScopes: parseStringArray(row.requested_scopes, "requested_scopes"),
+    codeVerifier: row.code_verifier ?? undefined,
+    nonce: row.nonce ?? undefined,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    consumedAt: row.consumed_at ?? undefined
+  });
+}
+
+function mapTokenRow(row: TokenRow): TokenRecord {
+  return {
+    tokenId: row.token_id,
+    tenantId: row.tenant_id,
+    userId: row.user_id,
+    providerId: row.provider_id,
+    connectionId: row.connection_id,
+    encryptedPayload: row.encrypted_payload,
+    keyRef: row.key_ref,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    expiresAt: row.expires_at ?? undefined
+  };
+}
+
+function mapConsentRow(row: ConsentRow): OAuthConsentRecord {
+  return {
+    consentId: row.consent_id,
+    providerId: row.provider_id,
+    subject: parseSubject(row.subject_payload),
+    scopes: parseStringArray(row.scope_set, "scope_set"),
+    grantedAt: row.granted_at,
+    updatedAt: row.updated_at,
+    metadata: row.metadata ? parseRecord(row.metadata, "metadata") : undefined
+  };
+}
+
+function mapRevocationFailureRow(row: RevocationFailureRow): OAuthRevocationFailureRecord {
+  return {
+    failureId: row.failure_id,
+    providerId: row.provider_id,
+    subject: parseSubject(row.subject_payload),
+    tokenId: row.token_id ?? undefined,
+    tokenTypeHint: parseTokenTypeHint(row.token_type_hint),
+    errorCode: row.error_code,
+    errorMessage: row.error_message,
+    retryable: parseRetryable(row.retryable),
+    occurredAt: row.occurred_at,
+    metadata: row.metadata ? parseRecord(row.metadata, "metadata") : undefined
+  };
+}
+
+function parseSubject(raw: string): OAuthStoredSubject {
+  const subject = parseJsonValue<OAuthStoredSubject>(raw, "subject_payload");
+  validateOAuthStoredSubject(subject);
+  return cloneOAuthStoredSubject(subject);
+}
+
+function parseJsonValue<T>(raw: string, fieldName: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new Error(`${fieldName} must be valid JSON`);
+  }
+}
+
+function parseStringArray(raw: string, fieldName: string): string[] {
+  const value = parseJsonValue<unknown>(raw, fieldName);
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error(`${fieldName} must be an array of strings`);
+  }
+  return [...value];
+}
+
+function parseRecord(raw: string, fieldName: string): Record<string, unknown> {
+  const value = parseJsonValue<unknown>(raw, fieldName);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${fieldName} must be an object`);
+  }
+  return { ...value };
+}
+
+function parseTokenTypeHint(value: string | null): "access_token" | "refresh_token" | undefined {
+  if (value === null) {
+    return undefined;
+  }
+  if (value === "access_token" || value === "refresh_token") {
+    return value;
+  }
+  throw new Error("token_type_hint must be access_token or refresh_token");
+}
+
+function parseRetryable(value: boolean): boolean;
+function parseRetryable(value: number): boolean;
+function parseRetryable(value: boolean | number): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (value === 0 || value === 1) {
+    return value === 1;
+  }
+  throw new Error("retryable must be a boolean or 0/1");
+}
+
+function validateSqlIdentifier(value: string, fieldName: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new Error(`${fieldName} must contain only letters, numbers, and underscores`);
+  }
+  return value;
+}

--- a/packages/oauth-storage/src/index.ts
+++ b/packages/oauth-storage/src/index.ts
@@ -1,0 +1,128 @@
+export interface OAuthConnectionSubject {
+  kind: "connection";
+  tenantId: string;
+  userId: string;
+  connectionId?: string;
+}
+
+export interface OAuthBrowserAuthSubject {
+  kind: "browser-auth";
+  intentId: string;
+  tenantId?: string;
+  regionId?: string;
+  returnTo?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type OAuthStoredSubject = OAuthConnectionSubject | OAuthBrowserAuthSubject;
+
+export interface OAuthStateRecord {
+  stateId: string;
+  providerId: string;
+  redirectUri: string;
+  requestedScopes: string[];
+  subject?: OAuthStoredSubject;
+  tenantId?: string;
+  userId?: string;
+  connectionId?: string;
+  intentId?: string;
+  regionId?: string;
+  returnTo?: string;
+  metadata?: Record<string, unknown>;
+  codeVerifier?: string;
+  nonce?: string;
+  createdAt: string;
+  expiresAt: string;
+  consumedAt?: string;
+}
+
+export interface TokenRecord {
+  tokenId: string;
+  tenantId: string;
+  userId: string;
+  providerId: string;
+  connectionId: string;
+  encryptedPayload: string;
+  keyRef: string;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt?: string;
+}
+
+export interface OAuthConsentRecord {
+  consentId: string;
+  providerId: string;
+  subject: OAuthStoredSubject;
+  scopes: string[];
+  grantedAt: string;
+  updatedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OAuthRevocationFailureRecord {
+  failureId: string;
+  providerId: string;
+  subject: OAuthStoredSubject;
+  tokenId?: string;
+  tokenTypeHint?: "access_token" | "refresh_token";
+  errorCode: string;
+  errorMessage: string;
+  retryable: boolean;
+  occurredAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OAuthStateStore {
+  put(record: OAuthStateRecord): Promise<void>;
+  get(stateId: string): Promise<OAuthStateRecord | null>;
+  consume(stateId: string, consumedAt: string): Promise<OAuthStateRecord | null>;
+  deleteExpired(before: string): Promise<number>;
+}
+
+export interface TokenVault {
+  put(record: TokenRecord): Promise<void>;
+  get(tokenId: string): Promise<TokenRecord | null>;
+  getByConnection(connectionId: string): Promise<TokenRecord | null>;
+  rotateKey(tokenId: string, newKeyRef: string): Promise<void>;
+  deleteByConnection(connectionId: string): Promise<void>;
+}
+
+export interface OAuthConsentStore {
+  put(record: OAuthConsentRecord): Promise<void>;
+  get(consentId: string): Promise<OAuthConsentRecord | null>;
+  listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthConsentRecord[]>;
+  delete(consentId: string): Promise<void>;
+}
+
+export interface OAuthRevocationFailureStore {
+  put(record: OAuthRevocationFailureRecord): Promise<void>;
+  get(failureId: string): Promise<OAuthRevocationFailureRecord | null>;
+  listBySubject(providerId: string, subject: OAuthStoredSubject): Promise<OAuthRevocationFailureRecord[]>;
+  delete(failureId: string): Promise<void>;
+}
+
+export interface OAuthStorageFieldDefinition {
+  name: string;
+  type: "text" | "json" | "boolean";
+  nullable?: boolean;
+  primaryKey?: boolean;
+  unique?: boolean;
+}
+
+export interface OAuthStorageIndexDefinition {
+  name: string;
+  fields: string[];
+  unique?: boolean;
+}
+
+export interface OAuthStorageTableDefinition {
+  name: string;
+  fields: OAuthStorageFieldDefinition[];
+  indexes?: OAuthStorageIndexDefinition[];
+}
+
+export * from "./state-store.js";
+export * from "./token-vault.js";
+export * from "./adapters/memory.js";
+export * from "./adapters/sql.js";
+export * from "./adapters/db.js";

--- a/packages/oauth-storage/src/state-store.ts
+++ b/packages/oauth-storage/src/state-store.ts
@@ -1,0 +1,247 @@
+import type {
+  OAuthBrowserAuthSubject,
+  OAuthConnectionSubject,
+  OAuthConsentRecord,
+  OAuthRevocationFailureRecord,
+  OAuthStateRecord,
+  OAuthStateStore,
+  OAuthStoredSubject
+} from "./index.js";
+
+export class OAuthStateStoreError extends Error {
+  readonly code: "VALIDATION_ERROR" | "OAUTH_STATE_INVALID";
+
+  constructor(code: "VALIDATION_ERROR" | "OAUTH_STATE_INVALID", message: string) {
+    super(message);
+    this.name = "OAuthStateStoreError";
+    this.code = code;
+  }
+}
+
+export function validateOAuthStateRecord(record: OAuthStateRecord): void {
+  if (!record.stateId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "stateId is required");
+  }
+
+  if (!record.providerId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "providerId is required");
+  }
+
+  if (!record.redirectUri) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "redirectUri is required");
+  }
+
+  if (!Array.isArray(record.requestedScopes)) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "requestedScopes must be an array");
+  }
+
+  resolveOAuthStoredSubject(record);
+  assertIsoTimestamp("createdAt", record.createdAt);
+  assertIsoTimestamp("expiresAt", record.expiresAt);
+
+  if (record.consumedAt) {
+    assertIsoTimestamp("consumedAt", record.consumedAt);
+  }
+}
+
+export function validateOAuthConsentRecord(record: OAuthConsentRecord): void {
+  if (!record.consentId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "consentId is required");
+  }
+
+  if (!record.providerId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "providerId is required");
+  }
+
+  if (!Array.isArray(record.scopes)) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "scopes must be an array");
+  }
+
+  validateOAuthStoredSubject(record.subject);
+  assertIsoTimestamp("grantedAt", record.grantedAt);
+  assertIsoTimestamp("updatedAt", record.updatedAt);
+
+  if (record.metadata !== undefined && !isRecord(record.metadata)) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "metadata must be an object");
+  }
+}
+
+export function validateOAuthRevocationFailureRecord(record: OAuthRevocationFailureRecord): void {
+  if (!record.failureId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "failureId is required");
+  }
+
+  if (!record.providerId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "providerId is required");
+  }
+
+  if (!record.errorCode || !record.errorMessage) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "errorCode and errorMessage are required");
+  }
+
+  validateOAuthStoredSubject(record.subject);
+  assertIsoTimestamp("occurredAt", record.occurredAt);
+
+  if (record.metadata !== undefined && !isRecord(record.metadata)) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "metadata must be an object");
+  }
+}
+
+export function resolveOAuthStoredSubject(
+  record: Pick<
+    OAuthStateRecord,
+    "subject" | "tenantId" | "userId" | "connectionId" | "intentId" | "regionId" | "returnTo" | "metadata"
+  >
+): OAuthStoredSubject {
+  const subject =
+    record.subject ??
+    (record.intentId
+      ? {
+          kind: "browser-auth" as const,
+          intentId: record.intentId,
+          tenantId: record.tenantId,
+          regionId: record.regionId,
+          returnTo: record.returnTo,
+          metadata: record.metadata
+        }
+      : record.tenantId && record.userId
+        ? {
+            kind: "connection" as const,
+            tenantId: record.tenantId,
+            userId: record.userId,
+            connectionId: record.connectionId
+          }
+        : null);
+
+  if (!subject) {
+    throw new OAuthStateStoreError(
+      "VALIDATION_ERROR",
+      "subject is required or tenantId/userId or intentId must be provided"
+    );
+  }
+
+  validateOAuthStoredSubject(subject);
+  return subject;
+}
+
+export function validateOAuthStoredSubject(subject: OAuthStoredSubject): void {
+  if (subject.kind === "connection") {
+    validateConnectionSubject(subject);
+    return;
+  }
+
+  validateBrowserAuthSubject(subject);
+}
+
+export function getOAuthSubjectKey(subject: OAuthStoredSubject): string {
+  if (subject.kind === "connection") {
+    return subject.connectionId ? `connection:${subject.connectionId}` : `connection:${subject.tenantId}:${subject.userId}`;
+  }
+
+  return `browser-auth:${subject.intentId}`;
+}
+
+export function applySubjectToStateRecord(record: OAuthStateRecord): OAuthStateRecord {
+  const subject = resolveOAuthStoredSubject(record);
+  return {
+    ...record,
+    subject: cloneOAuthStoredSubject(subject),
+    tenantId: subject.kind === "connection" ? subject.tenantId : subject.tenantId,
+    userId: subject.kind === "connection" ? subject.userId : undefined,
+    connectionId: subject.kind === "connection" ? subject.connectionId : undefined,
+    intentId: subject.kind === "browser-auth" ? subject.intentId : undefined,
+    regionId: subject.kind === "browser-auth" ? subject.regionId : undefined,
+    returnTo: subject.kind === "browser-auth" ? subject.returnTo : undefined,
+    metadata: subject.kind === "browser-auth" ? cloneUnknownRecord(subject.metadata) : undefined
+  };
+}
+
+export function cloneOAuthStoredSubject(subject: OAuthStoredSubject): OAuthStoredSubject {
+  if (subject.kind === "connection") {
+    return { ...subject };
+  }
+
+  return {
+    ...subject,
+    metadata: cloneUnknownRecord(subject.metadata)
+  };
+}
+
+export function isOAuthStateExpired(record: Pick<OAuthStateRecord, "expiresAt">, at: string): boolean {
+  const expiresAt = parseIsoTimestamp("expiresAt", record.expiresAt);
+  const checkpoint = parseIsoTimestamp("at", at);
+  return expiresAt <= checkpoint;
+}
+
+export async function consumeOAuthState(
+  store: OAuthStateStore,
+  stateId: string,
+  consumedAt: string
+): Promise<OAuthStateRecord | null> {
+  if (!stateId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "stateId is required");
+  }
+
+  assertIsoTimestamp("consumedAt", consumedAt);
+  const consumed = await store.consume(stateId, consumedAt);
+  if (!consumed) {
+    return null;
+  }
+
+  validateOAuthStateRecord(consumed);
+  return cloneOAuthStateRecord(consumed);
+}
+
+export async function purgeExpiredOAuthStates(store: OAuthStateStore, before: string): Promise<number> {
+  assertIsoTimestamp("before", before);
+  return store.deleteExpired(before);
+}
+
+export function cloneOAuthStateRecord(record: OAuthStateRecord): OAuthStateRecord {
+  const normalized = applySubjectToStateRecord(record);
+  return {
+    ...normalized,
+    requestedScopes: [...normalized.requestedScopes],
+    metadata: cloneUnknownRecord(normalized.metadata)
+  };
+}
+
+function validateConnectionSubject(subject: OAuthConnectionSubject): void {
+  if (!subject.tenantId || !subject.userId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "connection subjects require tenantId and userId");
+  }
+}
+
+function validateBrowserAuthSubject(subject: OAuthBrowserAuthSubject): void {
+  if (!subject.intentId) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "browser-auth subjects require intentId");
+  }
+
+  if (subject.metadata !== undefined && !isRecord(subject.metadata)) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", "browser-auth subject metadata must be an object");
+  }
+}
+
+function assertIsoTimestamp(fieldName: string, value: string): void {
+  parseIsoTimestamp(fieldName, value);
+}
+
+function parseIsoTimestamp(fieldName: string, value: string): number {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value)) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", `${fieldName} must be a valid ISO-8601 timestamp`);
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new OAuthStateStoreError("VALIDATION_ERROR", `${fieldName} must be a valid ISO-8601 timestamp`);
+  }
+
+  return timestamp;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneUnknownRecord(value: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  return value ? { ...value } : undefined;
+}

--- a/packages/oauth-storage/src/token-vault.ts
+++ b/packages/oauth-storage/src/token-vault.ts
@@ -1,0 +1,258 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import type { TokenRecord, TokenVault } from "./index.js";
+
+export interface OAuthTokenPayload {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: string;
+  scope?: string;
+  tokenType?: string;
+  idToken?: string;
+}
+
+export interface PersistTokenSetInput {
+  tokenId: string;
+  tenantId: string;
+  userId: string;
+  providerId: string;
+  connectionId: string;
+  tokenSet: OAuthTokenPayload;
+  keyRef: string;
+  createdAt?: string;
+  updatedAt?: string;
+  expiresAt?: string;
+}
+
+export interface DecryptedTokenRecord {
+  record: TokenRecord;
+  tokenSet: OAuthTokenPayload;
+}
+
+export interface TokenCipher {
+  encrypt(plaintext: string, keyRef: string): Promise<string>;
+  decrypt(ciphertext: string, keyRef: string): Promise<string>;
+}
+
+export type TokenKeyResolver = (keyRef: string) => Promise<Buffer> | Buffer;
+
+export class TokenVaultError extends Error {
+  readonly code: "VALIDATION_ERROR" | "INTERNAL_ERROR";
+
+  constructor(code: "VALIDATION_ERROR" | "INTERNAL_ERROR", message: string) {
+    super(message);
+    this.name = "TokenVaultError";
+    this.code = code;
+  }
+}
+
+export class AesGcmTokenCipher implements TokenCipher {
+  private readonly resolveKey: TokenKeyResolver;
+
+  constructor(resolveKey: TokenKeyResolver) {
+    this.resolveKey = resolveKey;
+  }
+
+  async encrypt(plaintext: string, keyRef: string): Promise<string> {
+    if (!keyRef) {
+      throw new TokenVaultError("VALIDATION_ERROR", "keyRef is required");
+    }
+
+    const key = await this.getKey(keyRef);
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    return ["v1", iv.toString("base64url"), authTag.toString("base64url"), encrypted.toString("base64url")].join(":");
+  }
+
+  async decrypt(ciphertext: string, keyRef: string): Promise<string> {
+    if (!keyRef) {
+      throw new TokenVaultError("VALIDATION_ERROR", "keyRef is required");
+    }
+
+    try {
+      const [version, ivPart, authTagPart, payloadPart] = ciphertext.split(":");
+      if (version !== "v1" || !ivPart || !authTagPart || !payloadPart) {
+        throw new TokenVaultError("INTERNAL_ERROR", "Invalid encrypted payload format");
+      }
+
+      const key = await this.getKey(keyRef);
+      const iv = Buffer.from(ivPart, "base64url");
+      const authTag = Buffer.from(authTagPart, "base64url");
+      const payload = Buffer.from(payloadPart, "base64url");
+      const decipher = createDecipheriv("aes-256-gcm", key, iv);
+      decipher.setAuthTag(authTag);
+      const decrypted = Buffer.concat([decipher.update(payload), decipher.final()]);
+      return decrypted.toString("utf8");
+    } catch (error) {
+      if (error instanceof TokenVaultError) {
+        throw error;
+      }
+
+      throw new TokenVaultError("INTERNAL_ERROR", "Failed to decrypt token payload");
+    }
+  }
+
+  private async getKey(keyRef: string): Promise<Buffer> {
+    try {
+      const key = await this.resolveKey(keyRef);
+      if (!Buffer.isBuffer(key) || key.length !== 32) {
+        throw new TokenVaultError("INTERNAL_ERROR", `Invalid key material for keyRef ${keyRef}`);
+      }
+
+      return key;
+    } catch (error) {
+      if (error instanceof TokenVaultError) {
+        throw error;
+      }
+
+      throw new TokenVaultError("INTERNAL_ERROR", `Key material unavailable for keyRef ${keyRef}`);
+    }
+  }
+}
+
+export class EncryptedTokenVault {
+  private readonly store: TokenVault;
+  private readonly cipher: TokenCipher;
+  private readonly now: () => string;
+
+  constructor(store: TokenVault, cipher: TokenCipher, now: () => string = () => new Date().toISOString()) {
+    this.store = store;
+    this.cipher = cipher;
+    this.now = now;
+  }
+
+  async putTokenSet(input: PersistTokenSetInput): Promise<TokenRecord> {
+    validatePersistTokenSetInput(input);
+
+    const createdAt = input.createdAt ?? this.now();
+    const updatedAt = input.updatedAt ?? createdAt;
+    assertIsoTimestamp("createdAt", createdAt);
+    assertIsoTimestamp("updatedAt", updatedAt);
+
+    if (input.expiresAt) {
+      assertIsoTimestamp("expiresAt", input.expiresAt);
+    }
+
+    const plaintext = JSON.stringify(input.tokenSet);
+    const encryptedPayload = await this.cipher.encrypt(plaintext, input.keyRef);
+    const record: TokenRecord = {
+      tokenId: input.tokenId,
+      tenantId: input.tenantId,
+      userId: input.userId,
+      providerId: input.providerId,
+      connectionId: input.connectionId,
+      encryptedPayload,
+      keyRef: input.keyRef,
+      createdAt,
+      updatedAt,
+      expiresAt: input.expiresAt
+    };
+
+    await this.store.put(record);
+    return record;
+  }
+
+  async getTokenSet(tokenId: string): Promise<DecryptedTokenRecord | null> {
+    const record = await this.store.get(tokenId);
+    if (!record) {
+      return null;
+    }
+
+    const tokenSet = await this.decryptTokenSet(record);
+    return { record: cloneTokenRecord(record), tokenSet };
+  }
+
+  async getTokenSetByConnection(connectionId: string): Promise<DecryptedTokenRecord | null> {
+    const record = await this.store.getByConnection(connectionId);
+    if (!record) {
+      return null;
+    }
+
+    const tokenSet = await this.decryptTokenSet(record);
+    return { record: cloneTokenRecord(record), tokenSet };
+  }
+
+  async rotateKey(tokenId: string, newKeyRef: string): Promise<void> {
+    if (!newKeyRef) {
+      throw new TokenVaultError("VALIDATION_ERROR", "newKeyRef is required");
+    }
+
+    const existing = await this.store.get(tokenId);
+    if (!existing) {
+      return;
+    }
+
+    const plaintext = await this.cipher.decrypt(existing.encryptedPayload, existing.keyRef);
+    const encryptedPayload = await this.cipher.encrypt(plaintext, newKeyRef);
+
+    await this.store.put({
+      ...existing,
+      encryptedPayload,
+      keyRef: newKeyRef,
+      updatedAt: this.now()
+    });
+  }
+
+  async deleteByConnection(connectionId: string): Promise<void> {
+    await this.store.deleteByConnection(connectionId);
+  }
+
+  private async decryptTokenSet(record: TokenRecord): Promise<OAuthTokenPayload> {
+    const plaintext = await this.cipher.decrypt(record.encryptedPayload, record.keyRef);
+
+    try {
+      const parsed = JSON.parse(plaintext) as Partial<OAuthTokenPayload>;
+      if (!parsed.accessToken || typeof parsed.accessToken !== "string") {
+        throw new TokenVaultError("INTERNAL_ERROR", "Token payload missing accessToken");
+      }
+
+      return {
+        accessToken: parsed.accessToken,
+        refreshToken: parsed.refreshToken,
+        expiresAt: parsed.expiresAt,
+        scope: parsed.scope,
+        tokenType: parsed.tokenType,
+        idToken: parsed.idToken
+      };
+    } catch (error) {
+      if (error instanceof TokenVaultError) {
+        throw error;
+      }
+
+      throw new TokenVaultError("INTERNAL_ERROR", "Failed to parse decrypted token payload");
+    }
+  }
+}
+
+function validatePersistTokenSetInput(input: PersistTokenSetInput): void {
+  if (!input.tokenId) {
+    throw new TokenVaultError("VALIDATION_ERROR", "tokenId is required");
+  }
+
+  if (!input.connectionId || !input.tenantId || !input.userId || !input.providerId) {
+    throw new TokenVaultError("VALIDATION_ERROR", "tenantId, userId, providerId, and connectionId are required");
+  }
+
+  if (!input.keyRef) {
+    throw new TokenVaultError("VALIDATION_ERROR", "keyRef is required");
+  }
+
+  if (!input.tokenSet || !input.tokenSet.accessToken) {
+    throw new TokenVaultError("VALIDATION_ERROR", "tokenSet.accessToken is required");
+  }
+}
+
+function assertIsoTimestamp(fieldName: string, value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value)) {
+    throw new TokenVaultError("VALIDATION_ERROR", `${fieldName} must be a valid ISO-8601 timestamp`);
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new TokenVaultError("VALIDATION_ERROR", `${fieldName} must be a valid ISO-8601 timestamp`);
+  }
+}
+
+function cloneTokenRecord(record: TokenRecord): TokenRecord {
+  return { ...record };
+}

--- a/packages/oauth-storage/tests/db-adapter.test.ts
+++ b/packages/oauth-storage/tests/db-adapter.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from "vitest";
+import { memoryAdapter } from "@superfunctions/db/adapters";
+import type { Adapter } from "@superfunctions/db";
+import { QueryFailedError } from "@superfunctions/db";
+import {
+  DbAdapterOAuthConsentStore,
+  DbAdapterOAuthRevocationFailureStore,
+  DbAdapterOAuthStateStore,
+  DbAdapterTokenVault,
+  OAuthDbAdapterError,
+  createOAuthDbStorage
+} from "../src/index.js";
+
+describe("oauth-storage db adapter bridge", () => {
+  it("supports oauth state, token, consent, and revocation-failure lifecycle via @superfunctions/db adapter", async () => {
+    const adapter = memoryAdapter();
+    await adapter.initialize();
+
+    const { stateStore, tokenVault, consentStore, revocationFailureStore, models } = createOAuthDbStorage({ adapter });
+    expect(models.oauthStates).toBe("oauth_states");
+    expect(models.oauthTokenVault).toBe("oauth_tokens");
+    expect(models.oauthConsents).toBe("oauth_consents");
+    expect(models.oauthRevocationFailures).toBe("oauth_revocation_failures");
+
+    await stateStore.put({
+      stateId: "st_db_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_db_1",
+        regionId: "eu-west-1"
+      },
+      redirectUri: "https://app.example/callback",
+      requestedScopes: ["openid"],
+      codeVerifier: "verifier",
+      nonce: "nonce",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:10:00.000Z"
+    });
+
+    const state = await stateStore.get("st_db_1");
+    expect(state?.subject).toMatchObject({
+      kind: "browser-auth",
+      intentId: "intent_db_1"
+    });
+
+    const consumed = await stateStore.consume("st_db_1", "2026-01-01T00:01:00.000Z");
+    expect(consumed?.consumedAt).toBe("2026-01-01T00:01:00.000Z");
+    const replay = await stateStore.consume("st_db_1", "2026-01-01T00:02:00.000Z");
+    expect(replay).toBeNull();
+
+    await tokenVault.put({
+      tokenId: "tok_db_1",
+      tenantId: "t1",
+      userId: "u1",
+      providerId: "google",
+      connectionId: "conn_db_1",
+      encryptedPayload: "{\"accessToken\":\"a1\"}",
+      keyRef: "kms_1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    const tokenById = await tokenVault.get("tok_db_1");
+    expect(tokenById?.connectionId).toBe("conn_db_1");
+
+    const tokenByConnection = await tokenVault.getByConnection("conn_db_1");
+    expect(tokenByConnection?.tokenId).toBe("tok_db_1");
+
+    await expect(tokenVault.rotateKey("tok_db_1", "kms_2")).rejects.toThrowError(
+      "Token key rotation requires re-encryption"
+    );
+    expect((await tokenVault.get("tok_db_1"))?.keyRef).toBe("kms_1");
+
+    await consentStore.put({
+      consentId: "consent_db_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_db_1"
+      },
+      scopes: ["openid"],
+      grantedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    const consents = await consentStore.listBySubject("google", {
+      kind: "browser-auth",
+      intentId: "intent_db_1"
+    });
+    expect(consents).toHaveLength(1);
+
+    await revocationFailureStore.put({
+      failureId: "revfail_db_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_db_1"
+      },
+      tokenId: "tok_db_1",
+      errorCode: "provider_revoke_failed",
+      errorMessage: "rate limited",
+      retryable: true,
+      occurredAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    const failures = await revocationFailureStore.listBySubject("google", {
+      kind: "browser-auth",
+      intentId: "intent_db_1"
+    });
+    expect(failures).toHaveLength(1);
+
+    await tokenVault.deleteByConnection("conn_db_1");
+    expect(await tokenVault.getByConnection("conn_db_1")).toBeNull();
+  });
+
+  it("supports explicit model mapping overrides", async () => {
+    const adapter = memoryAdapter();
+    await adapter.initialize();
+
+    const stateStore = new DbAdapterOAuthStateStore(adapter, "oauth_states_custom");
+    const tokenVault = new DbAdapterTokenVault(adapter, "oauth_tokens_custom");
+    const consentStore = new DbAdapterOAuthConsentStore(adapter, "oauth_consents_custom");
+    const revocationFailureStore = new DbAdapterOAuthRevocationFailureStore(
+      adapter,
+      "oauth_revocation_failures_custom"
+    );
+
+    await stateStore.put({
+      stateId: "st_custom_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_custom_1"
+      },
+      redirectUri: "https://app.example/callback",
+      requestedScopes: ["openid"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:05:00.000Z"
+    });
+
+    await tokenVault.put({
+      tokenId: "tok_custom_1",
+      tenantId: "t1",
+      userId: "u1",
+      providerId: "google",
+      connectionId: "conn_custom_1",
+      encryptedPayload: "{\"accessToken\":\"a1\"}",
+      keyRef: "kms_1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    await consentStore.put({
+      consentId: "consent_custom_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_custom_1"
+      },
+      scopes: ["openid"],
+      grantedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    await revocationFailureStore.put({
+      failureId: "revfail_custom_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_custom_1"
+      },
+      errorCode: "rate_limited",
+      errorMessage: "retry later",
+      retryable: true,
+      occurredAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    expect((await stateStore.get("st_custom_1"))?.stateId).toBe("st_custom_1");
+    expect((await tokenVault.getByConnection("conn_custom_1"))?.tokenId).toBe("tok_custom_1");
+    expect((await consentStore.get("consent_custom_1"))?.consentId).toBe("consent_custom_1");
+    expect((await revocationFailureStore.get("revfail_custom_1"))?.failureId).toBe("revfail_custom_1");
+  });
+
+  it("accepts parsed JSON objects from adapters like Drizzle", async () => {
+    const adapter = createParsedJsonAdapter();
+    await adapter.initialize?.();
+
+    const { stateStore, consentStore, revocationFailureStore } = createOAuthDbStorage({ adapter });
+
+    await stateStore.put({
+      stateId: "st_json_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_json_1"
+      },
+      redirectUri: "https://app.example/callback",
+      requestedScopes: ["openid", "profile"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:05:00.000Z"
+    });
+
+    await consentStore.put({
+      consentId: "consent_json_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_json_1"
+      },
+      scopes: ["openid"],
+      grantedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      metadata: {
+        mode: "parsed"
+      }
+    });
+
+    await revocationFailureStore.put({
+      failureId: "revfail_json_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_json_1"
+      },
+      errorCode: "rate_limited",
+      errorMessage: "retry later",
+      retryable: true,
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      metadata: {
+        reason: "parsed"
+      }
+    });
+
+    expect((await stateStore.get("st_json_1"))?.requestedScopes).toEqual(["openid", "profile"]);
+    expect((await consentStore.get("consent_json_1"))?.metadata).toEqual({ mode: "parsed" });
+    expect((await revocationFailureStore.get("revfail_json_1"))?.metadata).toEqual({ reason: "parsed" });
+  });
+
+  it("rethrows unexpected adapter failures during state consumption", async () => {
+    const adapter = memoryAdapter();
+    await adapter.initialize();
+
+    const stateStore = new DbAdapterOAuthStateStore(adapter);
+    await stateStore.put({
+      stateId: "st_db_error",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_db_error"
+      },
+      redirectUri: "https://app.example/callback",
+      requestedScopes: ["openid"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:10:00.000Z"
+    });
+
+    const failingAdapter: Adapter = {
+      ...adapter,
+      update: async () => {
+        throw new QueryFailedError("db unavailable");
+      }
+    };
+
+    await expect(
+      new DbAdapterOAuthStateStore(failingAdapter).consume("st_db_error", "2026-01-01T00:01:00.000Z")
+    ).rejects.toMatchObject({
+      message: "db unavailable"
+    });
+  });
+
+  it("rejects invalid parsed JSON values from adapters deterministically", async () => {
+    const adapter = createMalformedParsedJsonAdapter();
+    await adapter.initialize?.();
+
+    const { stateStore, consentStore } = createOAuthDbStorage({ adapter });
+
+    await stateStore.put({
+      stateId: "st_bad_json_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_bad_json_1"
+      },
+      redirectUri: "https://app.example/callback",
+      requestedScopes: ["openid"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:05:00.000Z"
+    });
+
+    await consentStore.put({
+      consentId: "consent_bad_json_1",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_bad_json_1"
+      },
+      scopes: ["openid"],
+      grantedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    await expect(stateStore.get("st_bad_json_1")).rejects.toThrowError(
+      "requested_scopes must be an array of strings"
+    );
+    await expect(consentStore.get("consent_bad_json_1")).rejects.toThrowError(
+      "metadata must be an object"
+    );
+  });
+
+  it("fails deterministically when required schema mapping is missing", async () => {
+    const adapter = memoryAdapter();
+    await adapter.initialize();
+
+    expect(() => createOAuthDbStorage({ adapter, models: { oauthStates: "" } })).toThrowError(OAuthDbAdapterError);
+    expect(() => createOAuthDbStorage({ adapter, models: { oauthTokenVault: "" } })).toThrowError(
+      "oauth_tokens model mapping required"
+    );
+    expect(() => createOAuthDbStorage({ adapter, models: { oauthConsents: "" } })).toThrowError(
+      "oauth_consents model mapping required"
+    );
+    expect(() => createOAuthDbStorage({ adapter, models: { oauthRevocationFailures: "" } })).toThrowError(
+      "oauth_revocation_failures model mapping required"
+    );
+  });
+});
+
+function createParsedJsonAdapter(): Adapter {
+  const adapter = memoryAdapter();
+  return {
+    ...adapter,
+    findOne: async (params) => {
+      const value = await adapter.findOne(params);
+      return value ? parseStoredJsonFields(value as Record<string, unknown>) : value;
+    },
+    findMany: async (params) =>
+      (await adapter.findMany(params)).map((value) => parseStoredJsonFields(value as Record<string, unknown>)),
+    update: async (params) => parseStoredJsonFields(await adapter.update(params) as Record<string, unknown>),
+    upsert: async (params) => parseStoredJsonFields(await adapter.upsert(params) as Record<string, unknown>)
+  };
+}
+
+function createMalformedParsedJsonAdapter(): Adapter {
+  const adapter = memoryAdapter();
+  return {
+    ...adapter,
+    findOne: async (params) => {
+      const value = await adapter.findOne(params);
+      if (!value) {
+        return value;
+      }
+
+      const record = parseStoredJsonFields(value as Record<string, unknown>);
+      if (record.state_id === "st_bad_json_1") {
+        record.requested_scopes = ["openid", 7];
+      }
+
+      if (record.consent_id === "consent_bad_json_1") {
+        record.metadata = ["not-an-object"];
+      }
+
+      return record;
+    }
+  };
+}
+
+function parseStoredJsonFields(record: Record<string, unknown>): Record<string, unknown> {
+  const nextRecord = { ...record };
+  for (const key of ["subject_payload", "requested_scopes", "scope_set", "metadata"]) {
+    const value = nextRecord[key];
+    if (typeof value === "string") {
+      nextRecord[key] = JSON.parse(value);
+    }
+  }
+  return nextRecord;
+}

--- a/packages/oauth-storage/tests/shared-schema.test.ts
+++ b/packages/oauth-storage/tests/shared-schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getOAuthStorageSchema, getOAuthStorageTableDefinitions } from "../src/index.js";
+
+describe("oauth-storage shared schema inventory", () => {
+  it("publishes deterministic abstract table definitions for shared OAuth stores", () => {
+    const definitions = getOAuthStorageTableDefinitions();
+    expect(definitions.map((definition) => definition.name)).toEqual([
+      "oauth_states",
+      "oauth_tokens",
+      "oauth_consents",
+      "oauth_revocation_failures"
+    ]);
+
+    expect(definitions.find((definition) => definition.name === "oauth_consents")?.indexes).toEqual([
+      {
+        name: "idx_oauth_consents_provider_subject",
+        fields: ["provider_id", "subject_key"]
+      }
+    ]);
+  });
+
+  it("renders deterministic SQL schema statements for all shared OAuth tables", () => {
+    const statements = getOAuthStorageSchema();
+
+    expect(statements.join("\n")).toContain("CREATE TABLE IF NOT EXISTS oauth_states");
+    expect(statements.join("\n")).toContain("CREATE TABLE IF NOT EXISTS oauth_tokens");
+    expect(statements.join("\n")).toContain("CREATE TABLE IF NOT EXISTS oauth_consents");
+    expect(statements.join("\n")).toContain("CREATE TABLE IF NOT EXISTS oauth_revocation_failures");
+  });
+});

--- a/packages/oauth-storage/tests/state-vault.test.ts
+++ b/packages/oauth-storage/tests/state-vault.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+import {
+  AesGcmTokenCipher,
+  EncryptedTokenVault,
+  MemoryOAuthConsentStore,
+  MemoryOAuthRevocationFailureStore,
+  MemoryOAuthStateStore,
+  MemoryTokenVault,
+  SqlOAuthStateStore,
+  type SqlClient
+} from "../src/index.js";
+
+type StateRow = {
+  state_id: string;
+  provider_id: string;
+  subject_kind: string;
+  subject_key: string;
+  subject_payload: string;
+  redirect_uri: string;
+  requested_scopes: string;
+  code_verifier: string | null;
+  nonce: string | null;
+  created_at: string;
+  expires_at: string;
+  consumed_at: string | null;
+};
+
+class InMemorySqlClient implements SqlClient {
+  private readonly states = new Map<string, StateRow>();
+
+  async query<TRow = unknown>(statement: string, params: readonly unknown[] = []): Promise<TRow[]> {
+    const normalized = normalizeSql(statement);
+
+    if (normalized.startsWith("SELECT") && normalized.includes("FROM OAUTH_STATES")) {
+      const stateId = params[0] as string;
+      const row = this.states.get(stateId);
+      return (row ? [row] : []) as TRow[];
+    }
+
+    if (normalized.startsWith("UPDATE OAUTH_STATES")) {
+      const consumedAt = params[0] as string;
+      const stateId = params[1] as string;
+      const cutoff = params[2] as string;
+      const row = this.states.get(stateId);
+      if (!row || row.consumed_at || Date.parse(row.expires_at) <= Date.parse(cutoff)) {
+        return [] as TRow[];
+      }
+
+      const updated: StateRow = { ...row, consumed_at: consumedAt };
+      this.states.set(stateId, updated);
+      return [updated] as TRow[];
+    }
+
+    return [] as TRow[];
+  }
+
+  async execute(statement: string, params: readonly unknown[] = []): Promise<{ rowsAffected?: number }> {
+    const normalized = normalizeSql(statement);
+
+    if (normalized.startsWith("INSERT INTO OAUTH_STATES")) {
+      const row: StateRow = {
+        state_id: params[0] as string,
+        provider_id: params[1] as string,
+        subject_kind: params[2] as string,
+        subject_key: params[3] as string,
+        subject_payload: params[4] as string,
+        redirect_uri: params[5] as string,
+        requested_scopes: params[6] as string,
+        code_verifier: (params[7] as string | null) ?? null,
+        nonce: (params[8] as string | null) ?? null,
+        created_at: params[9] as string,
+        expires_at: params[10] as string,
+        consumed_at: (params[11] as string | null) ?? null
+      };
+      this.states.set(row.state_id, row);
+      return { rowsAffected: 1 };
+    }
+
+    if (normalized.startsWith("DELETE FROM OAUTH_STATES")) {
+      const before = params[0] as string;
+      let deleted = 0;
+
+      for (const [stateId, row] of this.states.entries()) {
+        if (Date.parse(row.expires_at) < Date.parse(before)) {
+          this.states.delete(stateId);
+          deleted += 1;
+        }
+      }
+
+      return { rowsAffected: deleted };
+    }
+
+    if (normalized.startsWith("UPDATE OAUTH_STATES")) {
+      const consumedAt = params[0] as string;
+      const stateId = params[1] as string;
+      const cutoff = params[2] as string;
+      const row = this.states.get(stateId);
+      if (!row || row.consumed_at || Date.parse(row.expires_at) <= Date.parse(cutoff)) {
+        return { rowsAffected: 0 };
+      }
+
+      this.states.set(stateId, { ...row, consumed_at: consumedAt });
+      return { rowsAffected: 1 };
+    }
+
+    return { rowsAffected: 0 };
+  }
+}
+
+describe("oauth-storage state and vault", () => {
+  it("supports durable browser-auth state consumption across store instances with SQL adapter", async () => {
+    const sql = new InMemorySqlClient();
+    const storeA = new SqlOAuthStateStore(sql);
+    const storeB = new SqlOAuthStateStore(sql);
+
+    await storeA.put({
+      stateId: "st_browser_123",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_123",
+        regionId: "eu-west-1"
+      },
+      redirectUri: "https://app/callback",
+      requestedScopes: ["openid"],
+      codeVerifier: "verifier",
+      nonce: "nonce",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:10:00.000Z"
+    });
+
+    const recovered = await storeB.get("st_browser_123");
+    expect(recovered?.subject).toMatchObject({
+      kind: "browser-auth",
+      intentId: "intent_123",
+      regionId: "eu-west-1"
+    });
+
+    const consumed = await storeB.consume("st_browser_123", "2026-01-01T00:01:00.000Z");
+    expect(consumed?.consumedAt).toBe("2026-01-01T00:01:00.000Z");
+
+    const replay = await storeA.consume("st_browser_123", "2026-01-01T00:02:00.000Z");
+    expect(replay).toBeNull();
+  });
+
+  it("purges expired states and blocks expired consumption", async () => {
+    const store = new MemoryOAuthStateStore();
+    await store.put({
+      stateId: "st_expired",
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_expired"
+      },
+      redirectUri: "https://app/callback",
+      requestedScopes: ["openid"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-01T00:01:00.000Z"
+    });
+
+    const consumeExpired = await store.consume("st_expired", "2026-01-01T00:02:00.000Z");
+    expect(consumeExpired).toBeNull();
+
+    const removed = await store.deleteExpired("2026-01-01T00:02:00.000Z");
+    expect(removed).toBe(1);
+    expect(await store.get("st_expired")).toBeNull();
+  });
+
+  it("stores encrypted token payloads and never stores plaintext in token records", async () => {
+    const backingStore = new MemoryTokenVault();
+    const keys = createKeyResolver({
+      "kms-key-1": Buffer.from("11".repeat(32), "hex")
+    });
+    const cipher = new AesGcmTokenCipher(keys);
+    const vault = new EncryptedTokenVault(backingStore, cipher, () => "2026-01-01T00:00:00.000Z");
+
+    await vault.putTokenSet({
+      tokenId: "tok_1",
+      tenantId: "t1",
+      userId: "u1",
+      providerId: "google",
+      connectionId: "conn_1",
+      keyRef: "kms-key-1",
+      tokenSet: {
+        accessToken: "at_plaintext",
+        refreshToken: "rt_plaintext",
+        tokenType: "bearer"
+      }
+    });
+
+    const raw = await backingStore.get("tok_1");
+    expect(raw).not.toBeNull();
+    expect(raw?.encryptedPayload).not.toContain("at_plaintext");
+    expect(raw?.encryptedPayload).not.toContain("rt_plaintext");
+    expect(raw?.keyRef).toBe("kms-key-1");
+
+    const decrypted = await vault.getTokenSet("tok_1");
+    expect(decrypted?.tokenSet.accessToken).toBe("at_plaintext");
+    expect(decrypted?.tokenSet.refreshToken).toBe("rt_plaintext");
+  });
+
+  it("fails safely when key material is unavailable during decrypt", async () => {
+    const backingStore = new MemoryTokenVault();
+    const writeCipher = new AesGcmTokenCipher(
+      createKeyResolver({
+        "kms-key-1": Buffer.from("22".repeat(32), "hex")
+      })
+    );
+    const writeVault = new EncryptedTokenVault(backingStore, writeCipher, () => "2026-01-01T00:00:00.000Z");
+
+    await writeVault.putTokenSet({
+      tokenId: "tok_missing_key",
+      tenantId: "t1",
+      userId: "u1",
+      providerId: "google",
+      connectionId: "conn_missing_key",
+      keyRef: "kms-key-1",
+      tokenSet: {
+        accessToken: "at",
+        refreshToken: "rt"
+      }
+    });
+
+    const readCipher = new AesGcmTokenCipher(createKeyResolver({}));
+    const readVault = new EncryptedTokenVault(backingStore, readCipher);
+
+    await expect(readVault.getTokenSet("tok_missing_key")).rejects.toMatchObject({
+      code: "INTERNAL_ERROR"
+    });
+  });
+
+  it("re-encrypts token payload during key rotation without losing token semantics", async () => {
+    const backingStore = new MemoryTokenVault();
+    const cipher = new AesGcmTokenCipher(
+      createKeyResolver({
+        "kms-key-1": Buffer.from("33".repeat(32), "hex"),
+        "kms-key-2": Buffer.from("44".repeat(32), "hex")
+      })
+    );
+    const vault = new EncryptedTokenVault(backingStore, cipher, () => "2026-01-01T00:00:00.000Z");
+
+    await vault.putTokenSet({
+      tokenId: "tok_rotate",
+      tenantId: "t1",
+      userId: "u1",
+      providerId: "google",
+      connectionId: "conn_rotate",
+      keyRef: "kms-key-1",
+      tokenSet: {
+        accessToken: "at_rotate",
+        refreshToken: "rt_rotate",
+        tokenType: "bearer"
+      }
+    });
+
+    const beforeRotate = await backingStore.get("tok_rotate");
+    expect(beforeRotate).not.toBeNull();
+
+    await vault.rotateKey("tok_rotate", "kms-key-2");
+
+    const afterRotate = await backingStore.get("tok_rotate");
+    expect(afterRotate?.keyRef).toBe("kms-key-2");
+    expect(afterRotate?.encryptedPayload).not.toBe(beforeRotate?.encryptedPayload);
+
+    const decrypted = await vault.getTokenSet("tok_rotate");
+    expect(decrypted?.tokenSet.accessToken).toBe("at_rotate");
+    expect(decrypted?.tokenSet.refreshToken).toBe("rt_rotate");
+  });
+
+  it("removes stale connection indexes when reusing a token id for a new connection", async () => {
+    const vault = new MemoryTokenVault();
+
+    await vault.put({
+      tokenId: "tok_reused",
+      tenantId: "t1",
+      userId: "u1",
+      providerId: "google",
+      connectionId: "conn_old",
+      encryptedPayload: '{"accessToken":"old"}',
+      keyRef: "kms_1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    await vault.put({
+      tokenId: "tok_reused",
+      tenantId: "t1",
+      userId: "u1",
+      providerId: "google",
+      connectionId: "conn_new",
+      encryptedPayload: '{"accessToken":"new"}',
+      keyRef: "kms_1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:01:00.000Z"
+    });
+
+    expect(await vault.getByConnection("conn_old")).toBeNull();
+    expect((await vault.getByConnection("conn_new"))?.tokenId).toBe("tok_reused");
+  });
+
+  it("indexes shared consents and revocation failures by provider and subject", async () => {
+    const subject = {
+      kind: "browser-auth" as const,
+      intentId: "intent_consented",
+      regionId: "eu-west-1"
+    };
+    const consentStore = new MemoryOAuthConsentStore();
+    const revocationFailureStore = new MemoryOAuthRevocationFailureStore();
+
+    await consentStore.put({
+      consentId: "consent_1",
+      providerId: "google",
+      subject,
+      scopes: ["openid", "email"],
+      grantedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    });
+    await revocationFailureStore.put({
+      failureId: "revfail_1",
+      providerId: "google",
+      subject,
+      tokenId: "tok_1",
+      errorCode: "provider_revoke_failed",
+      errorMessage: "rate limited",
+      retryable: true,
+      occurredAt: "2026-01-01T00:00:00.000Z"
+    });
+
+    const consents = await consentStore.listBySubject("google", subject);
+    const failures = await revocationFailureStore.listBySubject("google", subject);
+
+    expect(consents).toHaveLength(1);
+    expect(consents[0]?.scopes).toEqual(["openid", "email"]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.tokenId).toBe("tok_1");
+  });
+});
+
+function createKeyResolver(map: Record<string, Buffer>) {
+  return async (keyRef: string): Promise<Buffer> => {
+    const key = map[keyRef];
+    if (!key) {
+      throw new Error(`missing key: ${keyRef}`);
+    }
+
+    return key;
+  };
+}
+
+function normalizeSql(statement: string): string {
+  return statement.replace(/\s+/g, " ").trim().toUpperCase();
+}

--- a/packages/oauth-storage/tsconfig.json
+++ b/packages/oauth-storage/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-storage/vitest.config.ts
+++ b/packages/oauth-storage/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createOAuthSharedVitestConfig } from "../../scripts/vitest-oauth-shared.mjs";
+
+export default createOAuthSharedVitestConfig();

--- a/packages/oauth-testing/CHANGELOG.md
+++ b/packages/oauth-testing/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.1
+
+- Added oauth-testing compatibility helpers aligned with shared oauth packages.
+- Migration: consume shared oauth state/token test helpers via package exports.
+- Compatibility timeline: legacy internal helpers are deprecated in favor of shared exports.

--- a/packages/oauth-testing/README.md
+++ b/packages/oauth-testing/README.md
@@ -1,0 +1,48 @@
+# @superfunctions/oauth-testing
+
+Deterministic OAuth testing helpers built on the shared in-memory storage contracts.
+
+## Install
+
+```bash
+npm install -D @superfunctions/oauth-testing vitest
+```
+
+## Quick Start
+
+```ts
+import {
+  InMemoryOAuthStateStore,
+  InMemoryTokenVault,
+  createMockOAuthProviderDescriptor,
+} from "@superfunctions/oauth-testing";
+
+const provider = createMockOAuthProviderDescriptor({
+  id: "mock-github",
+  defaultScopes: ["read:user"],
+});
+
+const stateStore = new InMemoryOAuthStateStore();
+const tokenVault = new InMemoryTokenVault();
+```
+
+## Package Boundary
+
+`@superfunctions/oauth-testing` owns test fixtures only:
+
+- `createMockOAuthProviderDescriptor()`
+- in-memory fixture aliases from `@superfunctions/oauth-storage`
+- browser-auth schema/composition fixtures
+
+It is not a production runtime package and should not be used as your durable OAuth storage layer.
+
+## Production Notes
+
+- Use this package only in tests or local harnesses.
+- If you need production routing, use `@superfunctions/oauth-router`.
+- If you need production token persistence, use `@superfunctions/oauth-storage` and prefer `EncryptedTokenVault`.
+
+## Docs
+
+- Canonical docs: [docs/content/docs/authentication/oauth-testing.mdx](../../docs/content/docs/authentication/oauth-testing.mdx)
+- Stack overview: [docs/content/docs/architecture/oauth-flow-architecture.mdx](../../docs/content/docs/architecture/oauth-flow-architecture.mdx)

--- a/packages/oauth-testing/package.json
+++ b/packages/oauth-testing/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@superfunctions/oauth-testing",
+  "version": "0.0.1",
+  "description": "OAuth testing utilities for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest --config ./vitest.config.ts --run",
+    "test:watch": "vitest --config ./vitest.config.ts --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "oauth",
+    "testing",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/oauth-testing"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@superfunctions/oauth-core": "*",
+    "@superfunctions/oauth-flow": "*",
+    "@superfunctions/oauth-storage": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/oauth-testing/src/__tests__/docs-inventory.test.ts
+++ b/packages/oauth-testing/src/__tests__/docs-inventory.test.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
+const docsInventory = [
+  "packages/oauth-core/README.md",
+  "packages/oauth-http/README.md",
+  "packages/oauth-storage/README.md",
+  "packages/oauth-providers/README.md",
+  "packages/oauth-flow/README.md",
+  "packages/oauth-testing/README.md",
+  "packages/oauth-router/README.md",
+  "docs/content/docs/authentication/oauth-storage.mdx",
+  "docs/content/docs/authentication/oauth-flow.mdx",
+  "docs/content/docs/authentication/oauth-providers.mdx",
+  "docs/content/docs/authentication/oauth-router.mdx",
+  "docs/content/docs/architecture/oauth-flow-architecture.mdx",
+];
+
+describe("shared OAuth docs inventory", () => {
+  it("keeps the audited README and docs set present and navigable", () => {
+    const missingFiles = docsInventory.filter((file) => !existsSync(resolve(repoRoot, file)));
+    expect(missingFiles).toEqual([]);
+
+    const nav = JSON.parse(
+      readFileSync(resolve(repoRoot, "docs/content/docs/authentication/meta.json"), "utf8"),
+    ) as { pages?: string[] };
+
+    expect(nav.pages).toContain("oauth-router");
+  });
+});

--- a/packages/oauth-testing/src/__tests__/exports.test.ts
+++ b/packages/oauth-testing/src/__tests__/exports.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  InMemoryOAuthStateStore,
+  InMemoryTokenVault,
+  createAuthFnSchemaCompositionFixture,
+  createBrowserAuthFixture,
+  createMockOAuthProviderDescriptor,
+  redactSecrets,
+} from "../index.js";
+import { MemoryOAuthStateStore, MemoryTokenVault } from "@superfunctions/oauth-storage";
+
+describe("oauth-testing exports", () => {
+  it("re-exports shared memory helpers", () => {
+    expect(InMemoryOAuthStateStore).toBe(MemoryOAuthStateStore);
+    expect(InMemoryTokenVault).toBe(MemoryTokenVault);
+  });
+
+  it("provides in-memory helpers", async () => {
+    const descriptor = createMockOAuthProviderDescriptor();
+    const store = new InMemoryOAuthStateStore();
+    const vault = new InMemoryTokenVault();
+
+    await store.put({
+      stateId: "st_1",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      providerId: descriptor.id,
+      redirectUri: "https://app.example/callback",
+      requestedScopes: ["read"],
+      createdAt: "2026-01-01T00:00:00Z",
+      expiresAt: "2099-01-01T00:00:00Z"
+    });
+
+    await vault.put({
+      tokenId: "tok_1",
+      tenantId: "tenant_1",
+      userId: "user_1",
+      providerId: descriptor.id,
+      connectionId: "conn_1",
+      encryptedPayload: "cipher",
+      keyRef: "key_1",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z"
+    });
+
+    expect((await store.get("st_1"))?.providerId).toBe("mock");
+    expect((await vault.getByConnection("conn_1"))?.tokenId).toBe("tok_1");
+  });
+
+  it("provides browser-auth fixtures with redacted snapshots", () => {
+    const fixture = createBrowserAuthFixture();
+
+    expect(fixture.startInput.subject).toMatchObject({
+      kind: "browser-auth",
+      intentId: "intent_browser_01",
+    });
+    expect(fixture.callbackInput.providerId).toBe("google");
+    expect(JSON.stringify(fixture.eventSnapshot)).not.toContain("access-secret-token");
+    expect(JSON.stringify(fixture.eventSnapshot)).not.toContain("refresh-secret-token");
+  });
+
+  it("provides authfn schema composition fixtures", () => {
+    const fixture = createAuthFnSchemaCompositionFixture();
+
+    expect(fixture.config.plugins).toEqual(["password", "emailOtp", "socialOAuth"]);
+    expect(fixture.expectedTables).toEqual([
+      "users",
+      "sessions",
+      "password_credentials",
+      "otp_challenges",
+      "oauth_accounts",
+    ]);
+  });
+
+  it("redacts secrets recursively for snapshots", () => {
+    const redacted = redactSecrets({
+      accessToken: "access-secret-token",
+      nested: {
+        clientSecret: "client-secret-value",
+      },
+      safe: "value",
+    });
+
+    expect(redacted).toEqual({
+      accessToken: "[REDACTED]",
+      nested: {
+        clientSecret: "[REDACTED]",
+      },
+      safe: "value",
+    });
+  });
+});

--- a/packages/oauth-testing/src/browser-auth-fixtures.ts
+++ b/packages/oauth-testing/src/browser-auth-fixtures.ts
@@ -1,0 +1,101 @@
+import type { OAuthTokenSet } from "@superfunctions/oauth-core";
+import type { OAuthFlowCallbackInput, OAuthFlowStartInput } from "@superfunctions/oauth-flow";
+
+export interface BrowserAuthFixture {
+  startInput: OAuthFlowStartInput;
+  callbackInput: OAuthFlowCallbackInput;
+  tokenSet: OAuthTokenSet;
+  eventSnapshot: Record<string, unknown>;
+}
+
+export interface AuthFnSchemaCompositionFixture {
+  config: {
+    namespace: string;
+    plugins: string[];
+  };
+  expectedTables: string[];
+}
+
+const REDACTED = "[REDACTED]";
+
+export function createBrowserAuthFixture(): BrowserAuthFixture {
+  const tokenSet: OAuthTokenSet = {
+    accessToken: "access-secret-token",
+    refreshToken: "refresh-secret-token",
+    tokenType: "Bearer",
+    expiresAt: "2026-03-22T00:00:00.000Z",
+    idToken: "id-secret-token",
+  };
+
+  return {
+    startInput: {
+      providerId: "google",
+      redirectUri: "https://app.example/callback",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_browser_01",
+        returnTo: "https://app.example/post-auth",
+      },
+      requestId: "req_browser_01",
+    },
+    callbackInput: {
+      providerId: "google",
+      code: "oauth-code-01",
+      state: "st_browser_01",
+      redirectUri: "https://app.example/callback",
+      requestId: "req_browser_02",
+    },
+    tokenSet,
+    eventSnapshot: redactSecrets({
+      name: "oauth.flow.callback.success",
+      requestId: "req_browser_02",
+      details: {
+        accessToken: tokenSet.accessToken,
+        refreshToken: tokenSet.refreshToken,
+        idToken: tokenSet.idToken,
+        providerId: "google",
+      },
+    }) as Record<string, unknown>,
+  };
+}
+
+export function createAuthFnSchemaCompositionFixture(): AuthFnSchemaCompositionFixture {
+  return {
+    config: {
+      namespace: "auth",
+      plugins: ["password", "emailOtp", "socialOAuth"],
+    },
+    expectedTables: [
+      "users",
+      "sessions",
+      "password_credentials",
+      "otp_challenges",
+      "oauth_accounts",
+    ],
+  };
+}
+
+export function redactSecrets<T>(value: T): T {
+  return redactValue(value) as T;
+}
+
+function redactValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entryValue]) => [
+        key,
+        shouldRedactKey(key) ? REDACTED : redactValue(entryValue),
+      ])
+    );
+  }
+
+  return value;
+}
+
+function shouldRedactKey(key: string): boolean {
+  return /(token|secret|authorization|bearer|password)/i.test(key);
+}

--- a/packages/oauth-testing/src/index.ts
+++ b/packages/oauth-testing/src/index.ts
@@ -1,0 +1,26 @@
+import type { OAuthProviderDescriptor } from "@superfunctions/oauth-core";
+export {
+  MemoryOAuthStateStore as InMemoryOAuthStateStore,
+  MemoryTokenVault as InMemoryTokenVault
+} from "@superfunctions/oauth-storage";
+export {
+  createAuthFnSchemaCompositionFixture,
+  createBrowserAuthFixture,
+  redactSecrets,
+} from "./browser-auth-fixtures.js";
+
+export function createMockOAuthProviderDescriptor(
+  overrides: Partial<OAuthProviderDescriptor> = {}
+): OAuthProviderDescriptor {
+  return {
+    id: "mock",
+    authorizationUrl: "https://mock.example/auth",
+    tokenUrl: "https://mock.example/token",
+    defaultScopes: ["read"],
+    supportsPkce: true,
+    supportsRefreshToken: true,
+    scopeSeparator: " ",
+    tokenAuthMethod: "client_secret_post",
+    ...overrides
+  };
+}

--- a/packages/oauth-testing/tsconfig.json
+++ b/packages/oauth-testing/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/oauth-testing/vitest.config.ts
+++ b/packages/oauth-testing/vitest.config.ts
@@ -1,0 +1,3 @@
+import { createOAuthSharedVitestConfig } from "../../scripts/vitest-oauth-shared.mjs";
+
+export default createOAuthSharedVitestConfig();

--- a/release-packages.json
+++ b/release-packages.json
@@ -31,8 +31,16 @@
   { "slug": "superfunctions-http-fastify", "path": "packages/http-fastify", "name": "@superfunctions/http-fastify" },
   { "slug": "superfunctions-http-hono", "path": "packages/http-hono", "name": "@superfunctions/http-hono" },
   { "slug": "superfunctions-http-next", "path": "packages/http-next", "name": "@superfunctions/http-next" },
+  { "slug": "superfunctions-http-openapi", "path": "packages/http-openapi", "name": "@superfunctions/http-openapi" },
   { "slug": "superfunctions-http-sveltekit", "path": "packages/http-sveltekit", "name": "@superfunctions/http-sveltekit" },
   { "slug": "superfunctions-metrics", "path": "packages/metrics", "name": "@superfunctions/metrics" },
+  { "slug": "superfunctions-oauth-core", "path": "packages/oauth-core", "name": "@superfunctions/oauth-core" },
+  { "slug": "superfunctions-oauth-flow", "path": "packages/oauth-flow", "name": "@superfunctions/oauth-flow" },
+  { "slug": "superfunctions-oauth-http", "path": "packages/oauth-http", "name": "@superfunctions/oauth-http" },
+  { "slug": "superfunctions-oauth-providers", "path": "packages/oauth-providers", "name": "@superfunctions/oauth-providers" },
+  { "slug": "superfunctions-oauth-router", "path": "packages/oauth-router", "name": "@superfunctions/oauth-router" },
+  { "slug": "superfunctions-oauth-storage", "path": "packages/oauth-storage", "name": "@superfunctions/oauth-storage" },
+  { "slug": "superfunctions-oauth-testing", "path": "packages/oauth-testing", "name": "@superfunctions/oauth-testing" },
   { "slug": "superfunctions-queue", "path": "packages/queue", "name": "@superfunctions/queue" },
   { "slug": "superfunctions-webhooks", "path": "packages/webhooks", "name": "@superfunctions/webhooks" }
 ]


### PR DESCRIPTION
## Summary
- add the missing shared OAuth and OpenAPI packages to `origin/dev`
- include the OAuth core, flow, http, provider, router, storage, and testing layers
- add the shared OpenAPI generation package used by auth-related packages

## Validation
- inspected the copied package set in a clean worktree created from `origin/dev`
- did not run a reliable monorepo validation pass in this worktree

## Notes
- no `.conduct` changes included
- opened directly against `origin/dev` with `GH_CONFIG_DIR=~/.config/gh-other`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared OAuth and OpenAPI packages with deterministic OpenAPI generation and a secure, tested OAuth stack across transport, storage, and routes. Completes SF-30.

- **New Features**
  - `@superfunctions/http-openapi`: Generates OpenAPI 3.1 from `@superfunctions/http` router metadata with stricter validation and a typed `OpenApiGenerationError`.
  - OAuth platform: `@superfunctions/oauth-core`, `@superfunctions/oauth-flow`, `@superfunctions/oauth-http`, `@superfunctions/oauth-providers`, `@superfunctions/oauth-storage`, `@superfunctions/oauth-router`, `@superfunctions/oauth-testing` with PKCE/state/nonce, curated provider registry (Google/Apple/GitHub/Microsoft/Yahoo), retry/backoff transport honoring `Retry-After`, encrypted token vault + memory/DB/SQL adapters, and secure route factories with OpenAPI metadata.

- **Bug Fixes**
  - OpenAPI: Correct path parameter emission; clearer metadata errors.
  - Storage: Stronger adapter validation, deterministic SQL schema, robust NotFound handling.
  - Router: Stricter input validation for start/callback/disconnect, preserved `requestId` on browser start, tighter callback parsing.
  - Transport: Fixed token client encoding/header edge cases, resilient non-JSON/empty body parsing, normalized errors, revocation respects `token_type_hint`.

<sup>Written for commit 12317f3fb7484589a91abe819267f83078d81399. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI 3.1 generator and published http-openapi package.
  * Full OAuth platform: oauth-core, oauth-flow, oauth-http (token exchange/refresh/revoke with retry), oauth-providers catalogue, oauth-router route factories, oauth-storage adapters (memory/SQL/DB) and encrypted token vault with key rotation.
  * Provider policy registry with scope validation, consent/audit persistence, and runtime config tooling.
  * OAuth testing utilities and fixtures.

* **Documentation**
  * READMEs and changelogs added across OAuth packages.

* **Tests**
  * Extensive unit and integration test coverage for all new packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->