### PR TITLE
SF-30 add runtime shared packages

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@superfunctions/config",
+  "version": "0.0.1",
+  "description": "Typed env loading helpers for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": ["config", "env", "superfunctions"],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/config"
+  },
+  "publishConfig": { "access": "public" },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/config/src/__tests__/config.test.ts
+++ b/packages/config/src/__tests__/config.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigError, readBooleanEnv, readIntEnv, readIntEnvOrDefault, readStringEnv } from '../index.js';
+
+describe('config', () => {
+  it('reads bounded integer env values', () => {
+    expect(
+      readIntEnv('RECFN_RATE_LIMIT_WINDOW_MS', {
+        env: { RECFN_RATE_LIMIT_WINDOW_MS: '2000' },
+        defaultValue: 1000,
+        min: 100,
+      })
+    ).toBe(2000);
+  });
+
+  it('throws ENV_VALUE_OUT_OF_RANGE for out of range integer', () => {
+    expect(() =>
+      readIntEnv('RECFN_RATE_LIMIT_WINDOW_MS', {
+        env: { RECFN_RATE_LIMIT_WINDOW_MS: '-1' },
+        defaultValue: 1000,
+        min: 100,
+      })
+    ).toThrowError(ConfigError);
+  });
+
+  it('rejects integers outside the JavaScript safe range', () => {
+    expect(() =>
+      readIntEnv('RECFN_RATE_LIMIT_WINDOW_MS', {
+        env: { RECFN_RATE_LIMIT_WINDOW_MS: '9007199254740993' },
+        defaultValue: 1000,
+      })
+    ).toThrowError(ConfigError);
+  });
+
+  it('can fallback deterministically using readIntEnvOrDefault', () => {
+    expect(
+      readIntEnvOrDefault('RECFN_RATE_LIMIT_WINDOW_MS', {
+        env: { RECFN_RATE_LIMIT_WINDOW_MS: '-1' },
+        defaultValue: 1000,
+        min: 100,
+      })
+    ).toBe(1000);
+  });
+
+  it('validates the default used by readIntEnvOrDefault', () => {
+    expect(() =>
+      readIntEnvOrDefault('RECFN_RATE_LIMIT_WINDOW_MS', {
+        env: { RECFN_RATE_LIMIT_WINDOW_MS: '-1' },
+        defaultValue: 50,
+        min: 100,
+      })
+    ).toThrowError(ConfigError);
+  });
+
+  it('reads strings and booleans', () => {
+    expect(readStringEnv('A', { env: { A: 'value' }, defaultValue: 'x' })).toBe('value');
+    expect(readBooleanEnv('B', { env: { B: 'true' }, defaultValue: false })).toBe(true);
+  });
+
+  it('uses the default for empty string values when empty strings are not allowed', () => {
+    expect(readStringEnv('A', { env: { A: '' }, defaultValue: 'fallback' })).toBe('fallback');
+    expect(readStringEnv('A', { env: { A: '' }, defaultValue: 'fallback', allowEmpty: true })).toBe('');
+  });
+
+  it('validates default string values when empty strings are not allowed', () => {
+    expect(() =>
+      readStringEnv('A', {
+        env: {},
+        defaultValue: '',
+        allowEmpty: false,
+      })
+    ).toThrowError(ConfigError);
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,103 @@
+export class ConfigError extends Error {
+  readonly code: 'ENV_VALUE_INVALID' | 'ENV_VALUE_OUT_OF_RANGE';
+
+  constructor(code: 'ENV_VALUE_INVALID' | 'ENV_VALUE_OUT_OF_RANGE', message: string) {
+    super(message);
+    this.name = 'ConfigError';
+    this.code = code;
+  }
+}
+
+function validateIntValue(
+  key: string,
+  value: number,
+  options: { min?: number; max?: number }
+): number {
+  if (!Number.isSafeInteger(value)) {
+    throw new ConfigError('ENV_VALUE_INVALID', `${key} must be an integer`);
+  }
+
+  if (options.min !== undefined && value < options.min) {
+    throw new ConfigError('ENV_VALUE_OUT_OF_RANGE', `${key} must be >= ${options.min}`);
+  }
+
+  if (options.max !== undefined && value > options.max) {
+    throw new ConfigError('ENV_VALUE_OUT_OF_RANGE', `${key} must be <= ${options.max}`);
+  }
+
+  return value;
+}
+
+export function readIntEnv(
+  key: string,
+  options: { defaultValue: number; min?: number; max?: number; env?: NodeJS.ProcessEnv }
+): number {
+  const env = options.env ?? process.env;
+  const raw = env[key];
+  if (raw === undefined || raw === '') {
+    return validateIntValue(key, options.defaultValue, options);
+  }
+
+  const normalized = raw.trim();
+  if (!/^-?\d+$/.test(normalized)) {
+    throw new ConfigError('ENV_VALUE_INVALID', `${key} must be an integer`);
+  }
+
+  return validateIntValue(key, Number.parseInt(normalized, 10), options);
+}
+
+export function readIntEnvOrDefault(
+  key: string,
+  options: { defaultValue: number; min?: number; max?: number; env?: NodeJS.ProcessEnv }
+): number {
+  try {
+    return readIntEnv(key, options);
+  } catch (error) {
+    if (!(error instanceof ConfigError)) {
+      throw error;
+    }
+    return validateIntValue(key, options.defaultValue, options);
+  }
+}
+
+export function readStringEnv(
+  key: string,
+  options: { defaultValue: string; allowEmpty?: boolean; env?: NodeJS.ProcessEnv }
+): string {
+  const env = options.env ?? process.env;
+  const raw = env[key];
+  const validateStringValue = (value: string): string => {
+    if (!options.allowEmpty && value.trim().length === 0) {
+      throw new ConfigError('ENV_VALUE_INVALID', `${key} must not be empty`);
+    }
+
+    return value;
+  };
+
+  if (raw === undefined || (!options.allowEmpty && raw === '')) {
+    return validateStringValue(options.defaultValue);
+  }
+
+  return validateStringValue(raw);
+}
+
+export function readBooleanEnv(
+  key: string,
+  options: { defaultValue: boolean; env?: NodeJS.ProcessEnv }
+): boolean {
+  const env = options.env ?? process.env;
+  const raw = env[key];
+  if (raw === undefined || raw === '') {
+    return options.defaultValue;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+    return false;
+  }
+
+  throw new ConfigError('ENV_VALUE_INVALID', `${key} must be a boolean-like value`);
+}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/envelope/package.json
+++ b/packages/envelope/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@superfunctions/envelope",
+  "version": "0.0.1",
+  "description": "Canonical response envelope constructors and compatibility helpers",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "envelope",
+    "response",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/envelope"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/envelope/src/__tests__/envelope.test.ts
+++ b/packages/envelope/src/__tests__/envelope.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  err,
+  normalizeLegacyEnvelope,
+  ok,
+  toLegacyDataEnvelope,
+  toLegacyResultEnvelope,
+} from '../index.js';
+
+describe('envelope', () => {
+  it('returns canonical ok/data/meta shape', () => {
+    const result = ok({ x: 1 }, { timestamp: '2026-03-12T00:00:00.000Z' });
+    expect(result).toEqual({
+      ok: true,
+      data: { x: 1 },
+      meta: { timestamp: '2026-03-12T00:00:00.000Z' },
+    });
+  });
+
+  it('returns INVALID_ENVELOPE_ERROR_SHAPE when retryable/status are missing', () => {
+    const result = err({ code: 'BAD_REQUEST', message: 'x', status: 400 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('INVALID_ENVELOPE_ERROR_SHAPE');
+    }
+  });
+
+  it('normalizes legacy {ok,result} and {ok,data} envelopes', () => {
+    const resultEnvelope = normalizeLegacyEnvelope({ ok: true, result: { a: 1 } }, { timestamp: 't1' });
+    const dataEnvelope = normalizeLegacyEnvelope({ ok: true, data: { a: 2 } }, { timestamp: 't2' });
+
+    expect(resultEnvelope.ok && resultEnvelope.data).toEqual({ a: 1 });
+    expect(dataEnvelope.ok && dataEnvelope.data).toEqual({ a: 2 });
+  });
+
+  it('does not treat malformed ok:false envelopes with data as successful payloads', () => {
+    const normalized = normalizeLegacyEnvelope(
+      {
+        ok: false,
+        data: { leaked: true },
+        error: { code: 'BAD', message: 'broken legacy envelope' },
+      } as never,
+      { timestamp: 't3', defaultStatus: 502, defaultRetryable: false }
+    );
+
+    expect(normalized.ok).toBe(false);
+    if (!normalized.ok) {
+      expect(normalized.error.code).toBe('BAD');
+      expect(normalized.error.status).toBe(502);
+    }
+  });
+
+  it('guards malformed legacy error envelopes that omit the error payload', () => {
+    const normalized = normalizeLegacyEnvelope(
+      { ok: false } as never,
+      { timestamp: 't4', defaultStatus: 503, defaultRetryable: true }
+    );
+
+    expect(normalized.ok).toBe(false);
+    if (!normalized.ok) {
+      expect(normalized.error.code).toBe('INVALID_ENVELOPE_ERROR_SHAPE');
+      expect(normalized.error.status).toBe(503);
+      expect(normalized.error.retryable).toBe(true);
+    }
+  });
+
+  it('guards malformed legacy error envelopes with non-string code or message fields', () => {
+    const normalized = normalizeLegacyEnvelope(
+      { ok: false, error: { code: 42, message: null } } as never,
+      { timestamp: 't5', defaultStatus: 422, defaultRetryable: false }
+    );
+
+    expect(normalized.ok).toBe(false);
+    if (!normalized.ok) {
+      expect(normalized.error.code).toBe('INVALID_ENVELOPE_ERROR_SHAPE');
+      expect(normalized.error.status).toBe(422);
+    }
+  });
+
+  it('converts canonical envelope back to legacy variants', () => {
+    const canonical = ok({ y: 2 }, { timestamp: '2026-03-12T00:00:00.000Z' });
+    expect(toLegacyDataEnvelope(canonical)).toEqual({ ok: true, data: { y: 2 } });
+    expect(toLegacyResultEnvelope(canonical)).toEqual({ ok: true, result: { y: 2 } });
+  });
+});

--- a/packages/envelope/src/index.ts
+++ b/packages/envelope/src/index.ts
@@ -1,0 +1,212 @@
+export type EnvelopeMeta = {
+  timestamp: string;
+};
+
+export type SuccessEnvelope<T> = {
+  ok: true;
+  data: T;
+  meta: EnvelopeMeta;
+};
+
+export type CanonicalEnvelopeError = {
+  code: string;
+  message: string;
+  status: number;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+};
+
+export type ErrorEnvelope = {
+  ok: false;
+  error: CanonicalEnvelopeError;
+  meta: EnvelopeMeta;
+};
+
+export type Envelope<T> = SuccessEnvelope<T> | ErrorEnvelope;
+
+export type LegacySuccessEnvelope<T> =
+  | { ok: true; data: T }
+  | { ok: true; result: T }
+  | SuccessEnvelope<T>;
+
+export type LegacyErrorEnvelope =
+  | {
+      ok: false;
+      error: {
+        code: string;
+        message: string;
+        details?: Record<string, unknown>;
+        status?: number;
+        retryable?: boolean;
+      };
+    }
+  | ErrorEnvelope;
+
+export function ok<T>(data: T, options?: { timestamp?: string }): SuccessEnvelope<T> {
+  return {
+    ok: true,
+    data,
+    meta: {
+      timestamp: options?.timestamp ?? new Date().toISOString(),
+    },
+  };
+}
+
+export function err(
+  input: {
+    code: string;
+    message: string;
+    status?: number;
+    retryable?: boolean;
+    details?: Record<string, unknown>;
+  },
+  options?: { timestamp?: string }
+): ErrorEnvelope {
+  if (!isValidErrorShape(input)) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_ENVELOPE_ERROR_SHAPE',
+        message: 'Canonical error envelopes require numeric status and boolean retryable',
+        status: 500,
+        retryable: false,
+      },
+      meta: {
+        timestamp: options?.timestamp ?? new Date().toISOString(),
+      },
+    };
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: input.code,
+      message: input.message,
+      status: input.status,
+      retryable: input.retryable,
+      details: input.details,
+    },
+    meta: {
+      timestamp: options?.timestamp ?? new Date().toISOString(),
+    },
+  };
+}
+
+export function normalizeLegacyEnvelope<T>(
+  envelope: LegacySuccessEnvelope<T> | LegacyErrorEnvelope,
+  options?: { timestamp?: string; defaultStatus?: number; defaultRetryable?: boolean }
+): Envelope<T> {
+  if ('meta' in envelope && typeof envelope.meta?.timestamp === 'string') {
+    if (envelope.ok === true && 'data' in envelope) {
+      return envelope;
+    }
+    if (envelope.ok === false && 'error' in envelope && isValidErrorShape(envelope.error)) {
+      return envelope;
+    }
+  }
+
+  if (envelope.ok === true && 'data' in envelope) {
+    return ok(envelope.data, options);
+  }
+  if (envelope.ok === true && 'result' in envelope) {
+    return ok(envelope.result, options);
+  }
+  if (!('error' in envelope) || !envelope.error) {
+    return err(
+      {
+        code: 'INVALID_ENVELOPE_ERROR_SHAPE',
+        message: 'Legacy error envelopes require an error payload',
+        status: options?.defaultStatus ?? 500,
+        retryable: options?.defaultRetryable ?? false,
+      },
+      options
+    );
+  }
+  if (!isLegacyErrorInput(envelope.error)) {
+    return err(
+      {
+        code: 'INVALID_ENVELOPE_ERROR_SHAPE',
+        message: 'Legacy error envelopes require string code and message fields',
+        status: options?.defaultStatus ?? 500,
+        retryable: options?.defaultRetryable ?? false,
+      },
+      options
+    );
+  }
+
+  return err(
+    {
+      code: envelope.error.code,
+      message: envelope.error.message,
+      status: envelope.error.status ?? options?.defaultStatus ?? 500,
+      retryable: envelope.error.retryable ?? options?.defaultRetryable ?? false,
+      details: envelope.error.details,
+    },
+    options
+  );
+}
+
+export function toLegacyDataEnvelope<T>(envelope: Envelope<T>):
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string; details?: Record<string, unknown> } } {
+  if ('error' in envelope) {
+    return {
+      ok: false,
+      error: {
+        code: envelope.error.code,
+        message: envelope.error.message,
+        ...(envelope.error.details ? { details: envelope.error.details } : {}),
+      },
+    };
+  }
+
+  return { ok: true, data: envelope.data };
+}
+
+export function toLegacyResultEnvelope<T>(envelope: Envelope<T>):
+  | { ok: true; result: T }
+  | { ok: false; error: { code: string; message: string; details?: Record<string, unknown> } } {
+  if ('error' in envelope) {
+    return {
+      ok: false,
+      error: {
+        code: envelope.error.code,
+        message: envelope.error.message,
+        ...(envelope.error.details ? { details: envelope.error.details } : {}),
+      },
+    };
+  }
+
+  return { ok: true, result: envelope.data };
+}
+
+function isValidErrorShape(input: {
+  code: string;
+  message: string;
+  status?: number;
+  retryable?: boolean;
+  details?: Record<string, unknown>;
+}): input is {
+  code: string;
+  message: string;
+  status: number;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+} {
+  return typeof input.status === 'number' && Number.isFinite(input.status) && typeof input.retryable === 'boolean';
+}
+
+function isLegacyErrorInput(input: unknown): input is {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+  status?: number;
+  retryable?: boolean;
+} {
+  return (
+    typeof input === 'object' &&
+    input !== null &&
+    typeof (input as { code?: unknown }).code === 'string' &&
+    typeof (input as { message?: unknown }).message === 'string'
+  );
+}

--- a/packages/envelope/tsconfig.json
+++ b/packages/envelope/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@superfunctions/errors",
+  "version": "0.0.1",
+  "description": "Shared typed error registry and constructors",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "errors",
+    "registry",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/errors"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/errors/src/__tests__/errors.test.ts
+++ b/packages/errors/src/__tests__/errors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { SuperfunctionError, createErrorRegistry, createTypedError } from '../index.js';
+
+describe('errors', () => {
+  it('resolves registered error code metadata', () => {
+    const registry = createErrorRegistry([
+      { code: 'RATE_LIMIT_EXCEEDED', httpStatus: 429, retryable: true },
+    ]);
+
+    expect(registry.resolve('RATE_LIMIT_EXCEEDED')).toEqual({
+      code: 'RATE_LIMIT_EXCEEDED',
+      httpStatus: 429,
+      retryable: true,
+    });
+  });
+
+  it('throws ERROR_CODE_UNREGISTERED for unknown codes', () => {
+    const registry = createErrorRegistry();
+
+    expect(() => registry.resolve('UNKNOWN_CODE')).toThrowError(SuperfunctionError);
+    try {
+      registry.resolve('UNKNOWN_CODE');
+    } catch (error) {
+      const typed = error as SuperfunctionError;
+      expect(typed.code).toBe('ERROR_CODE_UNREGISTERED');
+    }
+  });
+
+  it('creates typed errors from registry metadata', () => {
+    const registry = createErrorRegistry([
+      { code: 'BAD_REQUEST', httpStatus: 400, retryable: false, defaultMessage: 'Bad request' },
+    ]);
+
+    const error = createTypedError({ code: 'BAD_REQUEST', registry, details: { field: 'name' } });
+    expect(error).toBeInstanceOf(SuperfunctionError);
+    expect(error.code).toBe('BAD_REQUEST');
+    expect(error.status).toBe(400);
+    expect(error.retryable).toBe(false);
+    expect(error.details).toEqual({ field: 'name' });
+  });
+});

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,0 +1,110 @@
+export type ErrorDefinition = {
+  code: string;
+  httpStatus: number;
+  retryable: boolean;
+  defaultMessage?: string;
+};
+
+export class SuperfunctionError extends Error {
+  readonly code: string;
+  readonly status: number;
+  readonly retryable: boolean;
+  readonly details?: Record<string, unknown>;
+
+  constructor(input: {
+    code: string;
+    message: string;
+    status: number;
+    retryable: boolean;
+    details?: Record<string, unknown>;
+  }) {
+    super(input.message);
+    this.name = 'SuperfunctionError';
+    this.code = input.code;
+    this.status = input.status;
+    this.retryable = input.retryable;
+    this.details = input.details;
+  }
+}
+
+export type ErrorRegistry = {
+  register(definition: ErrorDefinition): void;
+  registerMany(definitions: ErrorDefinition[]): void;
+  has(code: string): boolean;
+  resolve(code: string): ErrorDefinition;
+  resolveOrDefault(code: string, fallback: Omit<ErrorDefinition, 'code'>): ErrorDefinition;
+  list(): ErrorDefinition[];
+};
+
+export function createErrorRegistry(initialDefinitions: ErrorDefinition[] = []): ErrorRegistry {
+  const definitions = new Map<string, ErrorDefinition>();
+
+  for (const definition of initialDefinitions) {
+    definitions.set(definition.code, { ...definition });
+  }
+
+  return {
+    register(definition: ErrorDefinition): void {
+      definitions.set(definition.code, { ...definition });
+    },
+
+    registerMany(newDefinitions: ErrorDefinition[]): void {
+      for (const definition of newDefinitions) {
+        definitions.set(definition.code, { ...definition });
+      }
+    },
+
+    has(code: string): boolean {
+      return definitions.has(code);
+    },
+
+    resolve(code: string): ErrorDefinition {
+      const definition = definitions.get(code);
+      if (!definition) {
+        throw new SuperfunctionError({
+          code: 'ERROR_CODE_UNREGISTERED',
+          message: `Error code is not registered: ${code}`,
+          status: 500,
+          retryable: false,
+          details: { code },
+        });
+      }
+
+      return { ...definition };
+    },
+
+    resolveOrDefault(code: string, fallback: Omit<ErrorDefinition, 'code'>): ErrorDefinition {
+      const definition = definitions.get(code);
+      if (definition) {
+        return { ...definition };
+      }
+
+      return {
+        code,
+        httpStatus: fallback.httpStatus,
+        retryable: fallback.retryable,
+        defaultMessage: fallback.defaultMessage,
+      };
+    },
+
+    list(): ErrorDefinition[] {
+      return [...definitions.values()].map((definition) => ({ ...definition }));
+    },
+  };
+}
+
+export function createTypedError(input: {
+  code: string;
+  message?: string;
+  details?: Record<string, unknown>;
+  registry: ErrorRegistry;
+}): SuperfunctionError {
+  const definition = input.registry.resolve(input.code);
+  return new SuperfunctionError({
+    code: input.code,
+    message: input.message ?? definition.defaultMessage ?? input.code,
+    status: definition.httpStatus,
+    retryable: definition.retryable,
+    details: input.details,
+  });
+}

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@superfunctions/metrics",
+  "version": "0.0.1",
+  "description": "Shared metrics emitter helpers for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": ["metrics", "observability", "superfunctions"],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/metrics"
+  },
+  "publishConfig": { "access": "public" },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/metrics/src/__tests__/metrics.test.ts
+++ b/packages/metrics/src/__tests__/metrics.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { createMetricsEmitter, createNamespacedEmitter } from '../index.js';
+
+describe('metrics', () => {
+  it('creates no-op emitter', () => {
+    const metrics = createMetricsEmitter();
+    expect(() => metrics.track('api.request')).not.toThrow();
+  });
+
+  it('creates namespaced emitter', () => {
+    const events: string[] = [];
+    const base = createMetricsEmitter((event) => events.push(event));
+    const namespaced = createNamespacedEmitter('recfn', base);
+
+    namespaced.track('event');
+    expect(events).toEqual(['recfn.event']);
+  });
+});

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,0 +1,34 @@
+export interface MetricsEmitter {
+  track(event: string, properties?: Record<string, unknown>): void;
+}
+
+export function createMetricsEmitter(
+  trackFn?: (event: string, properties?: Record<string, unknown>) => void,
+): MetricsEmitter {
+  if (!trackFn) {
+    return {
+      track() {},
+    };
+  }
+
+  return {
+    track(event: string, properties?: Record<string, unknown>): void {
+      trackFn(event, properties);
+    },
+  };
+}
+
+export function createNamespacedEmitter(namespace: string, emitter: MetricsEmitter): MetricsEmitter {
+  const normalized = namespace.trim();
+  const segments = normalized.split('.');
+  if (!normalized || normalized.includes('..') || segments.some((segment) => segment.length === 0)) {
+    throw new Error('METRIC_NAMESPACE_INVALID');
+  }
+
+  return {
+    track(event: string, properties?: Record<string, unknown>): void {
+      const eventName = event.startsWith(`${normalized}.`) ? event : `${normalized}.${event}`;
+      emitter.track(eventName, properties);
+    },
+  };
+}

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@superfunctions/queue",
+  "version": "0.0.1",
+  "description": "Shared queue adapters for Superfunctions",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "queue",
+    "flowfn",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/queue"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/queue/src/__tests__/queue.test.ts
+++ b/packages/queue/src/__tests__/queue.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { FlowFnQueueAdapter, MemoryQueueAdapter } from '../index.js';
+
+describe('queue adapters', () => {
+  it('memory queue preserves FIFO order', async () => {
+    const queue = new MemoryQueueAdapter<string>();
+
+    await queue.enqueue('q', 'a');
+    await queue.enqueue('q', 'b');
+
+    expect(await queue.dequeue('q')).toBe('a');
+    expect(await queue.dequeue('q')).toBe('b');
+  });
+
+  it('dequeue on empty queue returns null', async () => {
+    const queue = new MemoryQueueAdapter<string>();
+    expect(await queue.dequeue('q')).toBeNull();
+  });
+
+  it('memory queue preserves undefined payloads', async () => {
+    const queue = new MemoryQueueAdapter<string | undefined>();
+
+    await queue.enqueue('q', undefined);
+
+    expect(await queue.dequeue('q')).toBeUndefined();
+    expect(await queue.dequeue('q')).toBeNull();
+  });
+
+  it('normalizes queue names consistently in memory adapter', async () => {
+    const queue = new MemoryQueueAdapter<string>();
+
+    await queue.enqueue(' jobs ', 'a');
+
+    expect(queue.peek('jobs')).toEqual(['a']);
+    expect(queue.size(' jobs ')).toBe(1);
+    expect(await queue.dequeue('jobs')).toBe('a');
+  });
+
+  it('rejects invalid queue names in memory adapter', async () => {
+    const queue = new MemoryQueueAdapter<string>();
+
+    await expect(queue.enqueue('../jobs', 'a')).rejects.toThrow('FLOWFN_QUEUE_NAME_INVALID');
+    expect(() => queue.peek('')).toThrow('FLOWFN_QUEUE_NAME_INVALID');
+  });
+
+  it('flowfn adapter sends authenticated enqueue/dequeue requests', async () => {
+    const calls: Array<{ url: string; method: string; auth?: string }> = [];
+
+    const adapter = new FlowFnQueueAdapter<{ id: string }>({
+      baseUrl: 'https://flowfn.example.com',
+      apiKey: 'flowfn-key',
+      fetch: (async (url, init) => {
+        calls.push({
+          url: String(url),
+          method: String(init?.method ?? 'GET'),
+          auth: (init?.headers as Record<string, string> | undefined)?.Authorization,
+        });
+
+        if (String(url).includes('/dequeue')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({ payload: { id: 'job_1' } }),
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({}),
+        } as Response;
+      }) as typeof globalThis.fetch,
+    });
+
+    await adapter.enqueue('jobs', { id: 'job_1' });
+    const payload = await adapter.dequeue('jobs');
+
+    expect(payload).toEqual({ id: 'job_1' });
+    expect(calls[0].url).toContain('/queues/jobs/enqueue');
+    expect(calls[1].url).toContain('/queues/jobs/dequeue');
+    expect(calls[0].auth).toBe('Bearer flowfn-key');
+    expect(calls[1].auth).toBe('Bearer flowfn-key');
+  });
+
+  it('flowfn adapter preserves an explicit undefined payload', async () => {
+    const adapter = new FlowFnQueueAdapter<string | undefined>({
+      baseUrl: 'https://flowfn.example.com',
+      apiKey: 'flowfn-key',
+      fetch: (async (_url) => {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({ payload: undefined }),
+        } as Response;
+      }) as typeof globalThis.fetch,
+    });
+
+    expect(await adapter.dequeue('jobs')).toBeUndefined();
+  });
+
+  it('flowfn adapter aborts stalled requests using timeoutMs', async () => {
+    const adapter = new FlowFnQueueAdapter<{ id: string }>({
+      baseUrl: 'https://flowfn.example.com',
+      apiKey: 'flowfn-key',
+      timeoutMs: 5,
+      fetch: (async (_url, init) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        });
+      }) as typeof globalThis.fetch,
+    });
+
+    await expect(adapter.enqueue('jobs', { id: 'job_1' })).rejects.toThrow('The operation was aborted.');
+  });
+
+  it('rejects a non-finite timeoutMs value', async () => {
+    expect(
+      () =>
+        new FlowFnQueueAdapter({
+          baseUrl: 'https://flowfn.example.com',
+          apiKey: 'flowfn-key',
+          timeoutMs: Number.NaN,
+        })
+    ).toThrow('FLOWFN_QUEUE_TIMEOUT_INVALID');
+  });
+
+  it('flowfn adapter normalizes a trailing slash in baseUrl', async () => {
+    const calls: string[] = [];
+    const adapter = new FlowFnQueueAdapter<{ id: string }>({
+      baseUrl: 'https://flowfn.example.com/',
+      apiKey: 'flowfn-key',
+      fetch: (async (url) => {
+        calls.push(String(url));
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({}),
+        } as Response;
+      }) as typeof globalThis.fetch,
+    });
+
+    await adapter.enqueue('jobs', { id: 'job_1' });
+
+    expect(calls).toEqual(['https://flowfn.example.com/queues/jobs/enqueue']);
+  });
+});

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -1,0 +1,173 @@
+export interface QueueAdapter<TPayload> {
+  enqueue(queueName: string, payload: TPayload): Promise<void>;
+  dequeue(queueName: string): Promise<TPayload | null>;
+  dequeueMatching(queueName: string, matcher: (payload: TPayload) => boolean): Promise<TPayload | null>;
+  peek(queueName: string): TPayload[];
+  size(queueName: string): number;
+}
+
+function normalizeQueueName(queueName: string): string {
+  const normalized = queueName.trim();
+  if (!normalized || normalized.includes('/') || normalized.includes('\\') || normalized.includes('..')) {
+    throw new Error('FLOWFN_QUEUE_NAME_INVALID');
+  }
+  return normalized;
+}
+
+export class MemoryQueueAdapter<TPayload> implements QueueAdapter<TPayload> {
+  private readonly queues = new Map<string, TPayload[]>();
+
+  async enqueue(queueName: string, payload: TPayload): Promise<void> {
+    const normalizedQueueName = normalizeQueueName(queueName);
+    const queue = this.queues.get(normalizedQueueName) ?? [];
+    queue.push(payload);
+    this.queues.set(normalizedQueueName, queue);
+  }
+
+  async dequeue(queueName: string): Promise<TPayload | null> {
+    const normalizedQueueName = normalizeQueueName(queueName);
+    const queue = this.queues.get(normalizedQueueName);
+    if (!queue || queue.length === 0) {
+      return null;
+    }
+
+    return queue.shift() as TPayload;
+  }
+
+  async dequeueMatching(queueName: string, matcher: (payload: TPayload) => boolean): Promise<TPayload | null> {
+    const normalizedQueueName = normalizeQueueName(queueName);
+    const queue = this.queues.get(normalizedQueueName);
+    if (!queue || queue.length === 0) {
+      return null;
+    }
+
+    const index = queue.findIndex(matcher);
+    if (index === -1) {
+      return null;
+    }
+
+    const [payload] = queue.splice(index, 1);
+    return payload as TPayload;
+  }
+
+  peek(queueName: string): TPayload[] {
+    const normalizedQueueName = normalizeQueueName(queueName);
+    return [...(this.queues.get(normalizedQueueName) ?? [])];
+  }
+
+  size(queueName: string): number {
+    const normalizedQueueName = normalizeQueueName(queueName);
+    return this.queues.get(normalizedQueueName)?.length ?? 0;
+  }
+}
+
+export interface FlowFnQueueAdapterConfig {
+  baseUrl: string;
+  apiKey: string;
+  fetch?: typeof globalThis.fetch;
+  timeoutMs?: number;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  let normalized = baseUrl;
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function encodeQueueName(queueName: string): string {
+  return encodeURIComponent(normalizeQueueName(queueName));
+}
+
+function normalizeTimeoutMs(value: number | undefined): number {
+  if (value === undefined) {
+    return 15_000;
+  }
+  if (!Number.isFinite(value)) {
+    throw new Error('FLOWFN_QUEUE_TIMEOUT_INVALID');
+  }
+  return Math.max(0, value);
+}
+
+export class FlowFnQueueAdapter<TPayload> implements QueueAdapter<TPayload> {
+  private readonly fetcher: typeof globalThis.fetch;
+  private readonly timeoutMs: number;
+  private readonly baseUrl: string;
+
+  constructor(private readonly config: FlowFnQueueAdapterConfig) {
+    this.fetcher = config.fetch ?? globalThis.fetch;
+    this.timeoutMs = normalizeTimeoutMs(config.timeoutMs);
+    this.baseUrl = normalizeBaseUrl(config.baseUrl);
+  }
+
+  async enqueue(queueName: string, payload: TPayload): Promise<void> {
+    const encodedQueueName = encodeQueueName(queueName);
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/queues/${encodedQueueName}/enqueue`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`FlowFn enqueue failed: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  async dequeue(queueName: string): Promise<TPayload | null> {
+    const encodedQueueName = encodeQueueName(queueName);
+    const response = await this.fetchWithTimeout(`${this.baseUrl}/queues/${encodedQueueName}/dequeue`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`FlowFn dequeue failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as { payload?: TPayload };
+    return 'payload' in data ? (data.payload as TPayload) : null;
+  }
+
+  async dequeueMatching(queueName: string, matcher: (payload: TPayload) => boolean): Promise<TPayload | null> {
+    void matcher;
+    encodeQueueName(queueName);
+    throw new Error('FLOWFN_QUEUE_MATCHING_UNSUPPORTED');
+  }
+
+  peek(queueName: string): TPayload[] {
+    encodeQueueName(queueName);
+    throw new Error('FLOWFN_QUEUE_PEEK_UNSUPPORTED');
+  }
+
+  size(queueName: string): number {
+    encodeQueueName(queueName);
+    throw new Error('FLOWFN_QUEUE_SIZE_UNSUPPORTED');
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = typeof AbortController === 'function' ? new AbortController() : undefined;
+    const timeoutId =
+      controller && this.timeoutMs > 0 ? setTimeout(() => controller.abort(), this.timeoutMs) : undefined;
+
+    try {
+      return await this.fetcher(url, {
+        ...init,
+        signal: controller?.signal,
+      });
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+}

--- a/packages/queue/tsconfig.json
+++ b/packages/queue/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@superfunctions/webhooks",
+  "version": "0.0.1",
+  "description": "Shared webhook signing, verification, and delivery primitives",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "echo 'lint not configured'",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "webhooks",
+    "hmac",
+    "superfunctions"
+  ],
+  "author": "21n",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "packages/webhooks"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi } from 'vitest';
+import { deliverWebhook, signWebhookPayload, verifyWebhookSignature } from '../index.js';
+
+describe('webhooks package exports', () => {
+  it('signs and verifies webhook payload using timing-safe verification path', () => {
+    const payload = JSON.stringify({ event: 'bot.joined', id: 'evt_1' });
+    const secret = 'whsec_test';
+
+    const signature = signWebhookPayload(payload, secret);
+    expect(signature).toMatch(/^[a-f0-9]+$/);
+    expect(verifyWebhookSignature(payload, signature, secret)).toBe(true);
+    expect(verifyWebhookSignature(payload, 'bad-signature', secret)).toBe(false);
+  });
+
+  it('supports prefixed signature verification', () => {
+    const payload = '{"ok":true}';
+    const secret = 'secret';
+    const signature = signWebhookPayload(payload, secret, { prefix: 'sha256=' });
+    expect(verifyWebhookSignature(payload, signature, secret, { prefix: 'sha256=' })).toBe(true);
+    expect(verifyWebhookSignature(payload, signature, secret)).toBe(false);
+  });
+
+  it('accepts canonical base64 signatures with or without padding', () => {
+    const payload = '{"ok":true}';
+    const secret = 'secret';
+    const signature = signWebhookPayload(payload, secret, { encoding: 'base64' });
+
+    expect(verifyWebhookSignature(payload, signature, secret, { encoding: 'base64' })).toBe(true);
+    expect(
+      verifyWebhookSignature(payload, signature.replace(/=+$/, ''), secret, { encoding: 'base64' })
+    ).toBe(true);
+    expect(
+      verifyWebhookSignature(payload, `${signature}!!`, secret, { encoding: 'base64' })
+    ).toBe(false);
+    expect(
+      verifyWebhookSignature(payload, `${signature}=`, secret, { encoding: 'base64' })
+    ).toBe(false);
+  });
+
+  it('delivers payload with bounded retries and returns structured attempts', async () => {
+    let attempt = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      attempt += 1;
+      if (attempt < 3) {
+        return { ok: false, status: 500 };
+      }
+
+      return { ok: true, status: 200 };
+    });
+
+    const result = await deliverWebhook(
+      {
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+        secret: 'whsec_test',
+        signatureHeader: 'X-Test-Signature',
+      },
+      {
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+        maxRetries: 3,
+        initialDelayMs: 1,
+        maxDelayMs: 2,
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts[0]).toMatchObject({ attempt: 1, ok: false, status: 500 });
+    expect(result.attempts[2]).toMatchObject({ attempt: 3, ok: true, status: 200 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns a structured failure when JSON serialization yields undefined', async () => {
+    const result = await deliverWebhook({
+      url: 'https://example.com/hook',
+      payload: undefined,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      attempts: [
+        {
+          attempt: 1,
+          ok: false,
+          error: 'Webhook payload must be JSON-serializable',
+        },
+      ],
+    });
+  });
+
+  it('does not retry non-transient HTTP failures', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 400 }));
+
+    const result = await deliverWebhook(
+      {
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+      },
+      {
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+        maxRetries: 3,
+        initialDelayMs: 1,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts a hanging attempt using the configured per-attempt timeout', async () => {
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+
+    const result = await deliverWebhook(
+      {
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+      },
+      {
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+        maxRetries: 1,
+        perAttemptTimeoutMs: 5,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]).toMatchObject({
+      attempt: 1,
+      ok: false,
+      error: 'The operation was aborted.',
+    });
+  });
+
+  it('canonicalizes content-type and signature headers before delivery', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      return {
+        ok: true,
+        status: 200,
+        headers: init?.headers,
+      } as Response;
+    });
+
+    await deliverWebhook(
+      {
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+        secret: 'whsec_test',
+        signatureHeader: 'X-Webhook-Signature',
+        headers: {
+          'content-type': 'application/cloudevents+json',
+          'Content-Type': 'application/problem+json',
+          'x-webhook-signature': 'stale-signature',
+          'X-WEBHOOK-SIGNATURE': 'staler-signature',
+        },
+      },
+      {
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      }
+    );
+
+    const sentHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(sentHeaders).toMatchObject({
+      'Content-Type': 'application/problem+json',
+      'X-Webhook-Signature': expect.any(String),
+    });
+    expect(Object.keys(sentHeaders).filter((key) => key.toLowerCase() === 'content-type')).toEqual(['Content-Type']);
+    expect(Object.keys(sentHeaders).filter((key) => key.toLowerCase() === 'x-webhook-signature')).toEqual([
+      'X-Webhook-Signature',
+    ]);
+  });
+
+  it('prefers the latest content-type variant when canonicalizing headers', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      return {
+        ok: true,
+        status: 200,
+        headers: init?.headers,
+      } as Response;
+    });
+
+    await deliverWebhook(
+      {
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+        headers: {
+          'Content-Type': 'application/problem+json',
+          'content-type': 'application/cloudevents+json',
+        },
+      },
+      {
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      }
+    );
+
+    const sentHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(sentHeaders['Content-Type']).toBe('application/cloudevents+json');
+  });
+
+  it('forces application/json when caller supplies a non-json content type', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      return {
+        ok: true,
+        status: 200,
+        headers: init?.headers,
+      } as Response;
+    });
+
+    await deliverWebhook(
+      {
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+        headers: {
+          'content-type': 'text/plain',
+        },
+      },
+      {
+        fetch: fetchMock as unknown as typeof globalThis.fetch,
+      }
+    );
+
+    const sentHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(sentHeaders['Content-Type']).toBe('application/json');
+  });
+
+  it('rejects non-finite maxRetries before skipping delivery attempts', async () => {
+    await expect(
+      deliverWebhook(
+        {
+          url: 'https://example.com/hook',
+          payload: { hello: 'world' },
+        },
+        {
+          maxRetries: Number.NaN,
+        }
+      )
+    ).rejects.toThrow('WEBHOOK_MAX_RETRIES_INVALID');
+  });
+
+  it('rejects non-finite webhook timing options before scheduling retries', async () => {
+    await expect(
+      deliverWebhook(
+        {
+          url: 'https://example.com/hook',
+          payload: { hello: 'world' },
+        },
+        {
+          initialDelayMs: Number.NaN,
+        }
+      )
+    ).rejects.toThrow('WEBHOOK_INITIAL_DELAY_INVALID');
+
+    await expect(
+      deliverWebhook(
+        {
+          url: 'https://example.com/hook',
+          payload: { hello: 'world' },
+        },
+        {
+          maxDelayMs: Number.NaN,
+        }
+      )
+    ).rejects.toThrow('WEBHOOK_MAX_DELAY_INVALID');
+
+    await expect(
+      deliverWebhook(
+        {
+          url: 'https://example.com/hook',
+          payload: { hello: 'world' },
+        },
+        {
+          perAttemptTimeoutMs: Number.NaN,
+        }
+      )
+    ).rejects.toThrow('WEBHOOK_PER_ATTEMPT_TIMEOUT_INVALID');
+  });
+
+  it('rejects an explicitly empty signing secret instead of sending an unsigned webhook', async () => {
+    await expect(
+      deliverWebhook({
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+        secret: '',
+      })
+    ).rejects.toThrow('WEBHOOK_SECRET_INVALID');
+  });
+
+  it('rejects blank signature header names before sending a signed webhook', async () => {
+    await expect(
+      deliverWebhook({
+        url: 'https://example.com/hook',
+        payload: { hello: 'world' },
+        secret: 'whsec_test',
+        signatureHeader: '   ',
+      })
+    ).rejects.toThrow('WEBHOOK_SIGNATURE_HEADER_INVALID');
+  });
+});

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -1,0 +1,318 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export type SignatureEncoding = 'hex' | 'base64';
+
+export type WebhookSignatureOptions = {
+  algorithm?: 'sha256' | 'sha1' | 'sha512';
+  encoding?: SignatureEncoding;
+  prefix?: string;
+};
+
+export function signWebhookPayload(
+  payload: string,
+  secret: string,
+  options: WebhookSignatureOptions = {}
+): string {
+  const algorithm = options.algorithm ?? 'sha256';
+  const encoding = options.encoding ?? 'hex';
+  const digest = createHmac(algorithm, secret).update(payload, 'utf8').digest(encoding);
+  const prefix = options.prefix ?? '';
+  return `${prefix}${digest}`;
+}
+
+export function verifyWebhookSignature(
+  payload: string,
+  providedSignature: string,
+  secret: string,
+  options: WebhookSignatureOptions = {}
+): boolean {
+  const algorithm = options.algorithm ?? 'sha256';
+  const encoding = options.encoding ?? 'hex';
+  const prefix = options.prefix ?? '';
+
+  if (prefix && !providedSignature.startsWith(prefix)) {
+    return false;
+  }
+
+  const providedDigest = prefix ? providedSignature.slice(prefix.length) : providedSignature;
+  const expectedDigest = createHmac(algorithm, secret).update(payload, 'utf8').digest(encoding);
+
+  const providedBuffer = decodeSignature(providedDigest, encoding);
+  const expectedBuffer = decodeSignature(expectedDigest, encoding);
+
+  if (!providedBuffer || !expectedBuffer) {
+    return false;
+  }
+
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+export type WebhookDeliveryInput = {
+  url: string;
+  payload: unknown;
+  secret?: string;
+  signatureHeader?: string;
+  headers?: Record<string, string>;
+  method?: 'POST' | 'PUT';
+};
+
+export type WebhookDeliveryAttempt = {
+  attempt: number;
+  ok: boolean;
+  status?: number;
+  error?: string;
+};
+
+export type WebhookDeliveryResult = {
+  ok: boolean;
+  attempts: WebhookDeliveryAttempt[];
+  responseStatus?: number;
+};
+
+export type WebhookDeliveryOptions = {
+  fetch?: typeof globalThis.fetch;
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  perAttemptTimeoutMs?: number;
+};
+
+function findHeaderKey(headers: Record<string, string>, headerName: string): string | undefined {
+  const target = headerName.toLowerCase();
+  const matches = Object.keys(headers).filter((key) => key.toLowerCase() === target);
+  return matches.at(-1);
+}
+
+function deleteHeaderVariants(headers: Record<string, string>, headerName: string): void {
+  const target = headerName.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === target) {
+      delete headers[key];
+    }
+  }
+}
+
+function setCanonicalHeader(headers: Record<string, string>, headerName: string, value: string): void {
+  deleteHeaderVariants(headers, headerName);
+  headers[headerName] = value;
+}
+
+function normalizeNonNegativeDuration(
+  value: number | undefined,
+  fallback: number,
+  errorCode: string
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (!Number.isFinite(value)) {
+    throw new Error(errorCode);
+  }
+  return Math.max(0, value);
+}
+
+export async function deliverWebhook(
+  input: WebhookDeliveryInput,
+  options: WebhookDeliveryOptions = {}
+): Promise<WebhookDeliveryResult> {
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  const maxRetries = normalizeRetryCount(options.maxRetries);
+  const initialDelayMs = normalizeNonNegativeDuration(
+    options.initialDelayMs,
+    1000,
+    'WEBHOOK_INITIAL_DELAY_INVALID'
+  );
+  const maxDelayMs = Math.max(
+    initialDelayMs,
+    normalizeNonNegativeDuration(options.maxDelayMs, 30_000, 'WEBHOOK_MAX_DELAY_INVALID')
+  );
+  const perAttemptTimeoutMs = normalizeNonNegativeDuration(
+    options.perAttemptTimeoutMs,
+    15_000,
+    'WEBHOOK_PER_ATTEMPT_TIMEOUT_INVALID'
+  );
+
+  let payloadString: string;
+  try {
+    payloadString = JSON.stringify(input.payload);
+  } catch (error) {
+    return {
+      ok: false,
+      attempts: [
+        {
+          attempt: 1,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    };
+  }
+  if (typeof payloadString !== 'string') {
+    return {
+      ok: false,
+      attempts: [
+        {
+          attempt: 1,
+          ok: false,
+          error: 'Webhook payload must be JSON-serializable',
+        },
+      ],
+    };
+  }
+  const headers: Record<string, string> = { ...(input.headers ?? {}) };
+
+  const existingContentType = headers[findHeaderKey(headers, 'Content-Type') ?? ''] ?? undefined;
+  const normalizedContentType =
+    typeof existingContentType === 'string' && existingContentType.toLowerCase().includes('json')
+      ? existingContentType
+      : 'application/json';
+  setCanonicalHeader(headers, 'Content-Type', normalizedContentType);
+
+  if (input.secret !== undefined) {
+    if (input.secret.length === 0) {
+      throw new Error('WEBHOOK_SECRET_INVALID');
+    }
+    if (input.signatureHeader !== undefined && input.signatureHeader.trim().length === 0) {
+      throw new Error('WEBHOOK_SIGNATURE_HEADER_INVALID');
+    }
+    setCanonicalHeader(
+      headers,
+      input.signatureHeader ?? 'X-Webhook-Signature',
+      signWebhookPayload(payloadString, input.secret)
+    );
+  }
+
+  const attempts: WebhookDeliveryAttempt[] = [];
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const controller = typeof AbortController === 'function' ? new AbortController() : undefined;
+    if (controller && perAttemptTimeoutMs > 0) {
+      timeoutId = setTimeout(() => controller.abort(), perAttemptTimeoutMs);
+    }
+    try {
+      const response = await fetchFn(input.url, {
+        method: input.method ?? 'POST',
+        headers,
+        body: payloadString,
+        signal: controller?.signal,
+      });
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      if (response.ok) {
+        attempts.push({
+          attempt,
+          ok: true,
+          status: response.status,
+        });
+
+        return {
+          ok: true,
+          attempts,
+          responseStatus: response.status,
+        };
+      }
+
+      attempts.push({
+        attempt,
+        ok: false,
+        status: response.status,
+        error: `HTTP ${response.status}`,
+      });
+
+      if (attempt >= maxRetries || !shouldRetryWebhookStatus(response.status)) {
+        return {
+          ok: false,
+          attempts,
+          responseStatus: response.status,
+        };
+      }
+    } catch (error) {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      attempts.push({
+        attempt,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      if (attempt >= maxRetries || !shouldRetryWebhookError(error)) {
+        return {
+          ok: false,
+          attempts,
+          responseStatus: attempts[attempts.length - 1]?.status,
+        };
+      }
+    }
+
+    if (attempt < maxRetries) {
+      const delay = Math.min(maxDelayMs, initialDelayMs * 2 ** (attempt - 1));
+      await sleep(delay);
+    }
+  }
+
+  return {
+    ok: false,
+    attempts,
+    responseStatus: attempts[attempts.length - 1]?.status,
+  };
+}
+
+function normalizeRetryCount(value: number | undefined): number {
+  if (value === undefined) {
+    return 3;
+  }
+  if (!Number.isFinite(value)) {
+    throw new Error('WEBHOOK_MAX_RETRIES_INVALID');
+  }
+  return Math.max(1, Math.trunc(value));
+}
+
+function decodeSignature(value: string, encoding: SignatureEncoding): Buffer | null {
+  if (encoding === 'hex') {
+    if (value.length === 0 || value.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(value)) {
+      return null;
+    }
+
+    return Buffer.from(value, 'hex');
+  }
+
+  try {
+    if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) {
+      return null;
+    }
+    const paddedValue = `${value}${'='.repeat((4 - (value.length % 4 || 4)) % 4)}`;
+    const decoded = Buffer.from(paddedValue, 'base64');
+    if (decoded.length === 0) {
+      return null;
+    }
+    const canonicalPadded = decoded.toString('base64');
+    const canonicalUnpadded = canonicalPadded.replace(/=+$/, '');
+    return value === canonicalPadded || value === canonicalUnpadded ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function shouldRetryWebhookStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+function shouldRetryWebhookError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return true;
+  }
+
+  return error.name === 'AbortError' || !('status' in error);
+}

--- a/packages/webhooks/tsconfig.json
+++ b/packages/webhooks/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/release-packages.json
+++ b/release-packages.json
@@ -19,6 +19,9 @@
   { "slug": "superfunctions-auth", "path": "packages/auth", "name": "@superfunctions/auth" },
   { "slug": "superfunctions-cli", "path": "packages/cli", "name": "@superfunctions/cli" },
   { "slug": "superfunctions-db", "path": "packages/db", "name": "@superfunctions/db" },
+  { "slug": "superfunctions-config", "path": "packages/config", "name": "@superfunctions/config" },
+  { "slug": "superfunctions-envelope", "path": "packages/envelope", "name": "@superfunctions/envelope" },
+  { "slug": "superfunctions-errors", "path": "packages/errors", "name": "@superfunctions/errors" },
   { "slug": "superfunctions-extfn", "path": "extfn/core", "name": "@superfunctions/extfn" },
   { "slug": "superfunctions-extfn-cli", "path": "extfn/cli", "name": "@superfunctions/extfn-cli" },
   { "slug": "superfunctions-extfn-svelte", "path": "extfn/svelte", "name": "@superfunctions/extfn-svelte" },
@@ -28,5 +31,8 @@
   { "slug": "superfunctions-http-fastify", "path": "packages/http-fastify", "name": "@superfunctions/http-fastify" },
   { "slug": "superfunctions-http-hono", "path": "packages/http-hono", "name": "@superfunctions/http-hono" },
   { "slug": "superfunctions-http-next", "path": "packages/http-next", "name": "@superfunctions/http-next" },
-  { "slug": "superfunctions-http-sveltekit", "path": "packages/http-sveltekit", "name": "@superfunctions/http-sveltekit" }
+  { "slug": "superfunctions-http-sveltekit", "path": "packages/http-sveltekit", "name": "@superfunctions/http-sveltekit" },
+  { "slug": "superfunctions-metrics", "path": "packages/metrics", "name": "@superfunctions/metrics" },
+  { "slug": "superfunctions-queue", "path": "packages/queue", "name": "@superfunctions/queue" },
+  { "slug": "superfunctions-webhooks", "path": "packages/webhooks", "name": "@superfunctions/webhooks" }
 ]


### PR DESCRIPTION
## Summary
- add the missing shared runtime packages to `origin/dev`
- include config, envelope, errors, metrics, queue, and webhooks foundations
- keep the PR limited to the shared package layer used by multiple downstream functions

## Validation
- inspected the copied package set in a clean worktree created from `origin/dev`
- did not run a reliable monorepo validation pass in this worktree

## Notes
- no `.conduct` changes included
- opened directly against `origin/dev` with `GH_CONFIG_DIR=~/.config/gh-other`

## Summary by Sourcery

Introduce shared runtime utility packages for envelopes, errors, config, metrics, queues, and webhooks to be reused across Superfunctions services.

New Features:
- Add a canonical response envelope package with helpers for constructing, normalizing, and converting success/error envelopes.
- Add a shared typed error package providing an error registry and strongly-typed SuperfunctionError constructor.
- Add a shared config package exposing typed environment variable readers for ints, strings, and booleans.
- Add a shared metrics package with pluggable and namespaced metrics emitters.
- Add a shared queue package with an in-memory adapter and a FlowFn-backed queue adapter interface.
- Add a shared webhooks package for HMAC signing/verification and retrying webhook delivery.

Build:
- Configure TypeScript build settings and package metadata for the new config, envelope, errors, metrics, queue, and webhooks packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared runtime packages for config, envelope, errors, metrics, queue, and webhooks. Registers them for release and hardens envelope normalization and webhook signing/delivery edge cases (SF-30).

- **New Features**
  - `@superfunctions/config`: int/string/boolean readers; safe-integer checks; min/max; validates defaults; empty strings off by default (`allowEmpty` opt‑in); booleans accept true/false, 1/0, yes/no; throws `ENV_VALUE_INVALID`/`ENV_VALUE_OUT_OF_RANGE`.
  - `@superfunctions/envelope`: canonical `ok`/`err` with timestamp; normalize legacy `{data}`/`{result}`; fill missing `status`/`retryable`; guard malformed legacy and `ok:false`+`data`; `err()` requires numeric `status` and boolean `retryable` or returns `INVALID_ENVELOPE_ERROR_SHAPE`.
  - `@superfunctions/errors`: registry; `SuperfunctionError`; `createTypedError`; unknown codes throw `ERROR_CODE_UNREGISTERED`.
  - `@superfunctions/metrics`: no‑op emitter; namespaced emitter with strict validation (`METRIC_NAMESPACE_INVALID`).
  - `@superfunctions/queue`: `MemoryQueueAdapter` with name normalization/validation (`FLOWFN_QUEUE_NAME_INVALID`); `FlowFnQueueAdapter` with Bearer auth, per‑request timeouts (`AbortController`), invalid timeout → `FLOWFN_QUEUE_TIMEOUT_INVALID`, trailing‑slash normalization; 404→null on dequeue; preserves explicit `undefined`; `peek`/`size`/`dequeueMatching` unsupported.
  - `@superfunctions/webhooks`: HMAC sign/verify (hex/base64) with strict decoding (accepts missing padding; rejects malformed) and optional prefix; delivery with retries/backoff, per‑attempt timeout, and validated timing opts (`WEBHOOK_MAX_RETRIES_INVALID`/`WEBHOOK_INITIAL_DELAY_INVALID`/`WEBHOOK_MAX_DELAY_INVALID`/`WEBHOOK_PER_ATTEMPT_TIMEOUT_INVALID`); rejects empty secrets (`WEBHOOK_SECRET_INVALID`) and blank signature header names; no retries on non‑transient 4xx; canonicalizes headers (case‑insensitive de‑dup, prefers latest, single `Content-Type` and signature header, force `application/json` for non‑JSON); validates JSON‑serializable payload; returns structured attempts with final `responseStatus`.

<sup>Written for commit 8ff8f78f37d65784a3370787cdd5586759ee5c5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration helpers for reading/validating env values (ints, strings, booleans).
  * Canonical envelope format with converters for legacy shapes.
  * Error registry and typed error construction utilities.
  * Metrics emitter with optional namespacing.
  * Queue abstraction with in-memory and remote adapters.
  * Webhook signing, verification, and delivery with retries/backoff and timeouts.

* **Tests**
  * Added comprehensive test suites covering the new packages and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->