### PR TITLE
SF-30 add Python SQLAlchemy shared adapter

### DIFF
--- a/packages/python-sqlalchemy/README.md
+++ b/packages/python-sqlalchemy/README.md
@@ -1,0 +1,97 @@
+# superfunctions-sqlalchemy
+
+SQLAlchemy adapter for `superfunctions.db`
+
+**Location:** `packages/python-sqlalchemy/`  
+**Package:** `superfunctions-sqlalchemy`  
+**Import:** `from superfunctions_sqlalchemy import create_adapter`
+
+## Installation
+
+```bash
+pip install superfunctions-sqlalchemy
+
+# With PostgreSQL
+pip install superfunctions-sqlalchemy[postgres]
+
+# With MySQL
+pip install superfunctions-sqlalchemy[mysql]
+
+# Optional async driver dependency for applications that also use SQLAlchemy async APIs separately
+pip install superfunctions-sqlalchemy[asyncpg]
+```
+
+## Usage
+
+```python
+from sqlalchemy import create_engine
+from superfunctions_sqlalchemy import create_adapter
+
+# Create SQLAlchemy engine
+engine = create_engine("postgresql://user:password@localhost/dbname")
+
+# Create adapter
+adapter = create_adapter(engine)
+
+# Use with superfunctions libraries
+from authfn import create_authfn, AuthFnConfig
+
+auth = create_authfn(
+    AuthFnConfig(
+        database=adapter,
+        namespace="authfn",
+    )
+)
+```
+
+## Features
+
+- ✅ Full CRUD operations
+- ✅ Transaction support
+- ✅ Batch operations
+- ✅ Query builders (where, orderBy, limit, offset)
+- ✅ All SQL operators
+- ✅ Works with PostgreSQL, MySQL, SQLite
+- ✅ Sync SQLAlchemy engines
+
+## Example
+
+```python
+import asyncio
+
+from sqlalchemy import create_engine
+from superfunctions_sqlalchemy import create_adapter
+from superfunctions.db import CreateParams, FindManyParams, WhereClause, Operator
+
+async def main() -> None:
+    engine = create_engine("postgresql://localhost/mydb")
+    adapter = create_adapter(engine)
+
+    # Create
+    user = await adapter.create(
+        CreateParams(
+            model="users",
+            data={"name": "Alice", "email": "alice@example.com"},
+        )
+    )
+
+    # Query
+    users = await adapter.find_many(
+        FindManyParams(
+            model="users",
+            where=[
+                WhereClause(field="email", operator=Operator.LIKE, value="%@example.com")
+            ],
+            limit=10,
+        )
+    )
+
+    print(user, users)
+
+
+asyncio.run(main())
+```
+
+## License
+
+MIT

--- a/packages/python-sqlalchemy/pyproject.toml
+++ b/packages/python-sqlalchemy/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "superfunctions-sqlalchemy"
+version = "0.1.0"
+description = "SQLAlchemy adapter for superfunctions.db"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = ["superfunctions", "sqlalchemy", "database", "adapter", "orm"]
+authors = [{ name = "21n", email = "support@superfunctions.dev" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Database",
+]
+dependencies = [
+    "superfunctions>=0.1.0",
+    "sqlalchemy>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "mypy>=1.7.0",
+    "ruff>=0.1.6",
+]
+postgres = ["psycopg2-binary>=2.9.0"]
+asyncpg = ["asyncpg>=0.29.0"]
+mysql = ["pymysql>=1.1.0"]
+sqlite = []
+
+[project.urls]
+Documentation = "https://docs.superfunctions.dev/adapters/sqlalchemy"
+Repository = "https://github.com/21nCo/super-functions"
+Issues = "https://github.com/21nCo/super-functions/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["superfunctions_sqlalchemy"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4"]
+ignore = ["E501"]

--- a/packages/python-sqlalchemy/superfunctions_sqlalchemy/__init__.py
+++ b/packages/python-sqlalchemy/superfunctions_sqlalchemy/__init__.py
@@ -1,0 +1,19 @@
+"""
+SQLAlchemy adapter for superfunctions.db
+
+Example:
+    >>> from sqlalchemy import create_engine
+    >>> from superfunctions_sqlalchemy import create_adapter
+    >>> 
+    >>> engine = create_engine("postgresql://localhost/mydb")
+    >>> adapter = create_adapter(engine)
+    >>> 
+    >>> # Use with any superfunctions library
+    >>> from authfn import create_authfn, AuthFnConfig
+    >>> auth = create_authfn(AuthFnConfig(database=adapter))
+"""
+
+from .adapter import SQLAlchemyAdapter, create_adapter
+
+__version__ = "0.1.0"
+__all__ = ["SQLAlchemyAdapter", "create_adapter"]

--- a/packages/python-sqlalchemy/superfunctions_sqlalchemy/adapter.py
+++ b/packages/python-sqlalchemy/superfunctions_sqlalchemy/adapter.py
@@ -1,0 +1,652 @@
+"""SQLAlchemy adapter implementation."""
+
+import inspect
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy import MetaData, Table, and_, delete, func, insert, or_, select, text, update
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError, OperationalError
+from superfunctions.db import (
+    Adapter,
+    AdapterCapabilities,
+    ConnectionError,
+    ConstraintViolationError,
+    CountParams,
+    CreateManyParams,
+    CreateParams,
+    CreateSchemaParams,
+    DeleteManyParams,
+    DeleteParams,
+    DuplicateKeyError,
+    FindManyParams,
+    FindOneParams,
+    HealthStatus,
+    NotFoundError,
+    Operator,
+    QueryFailedError,
+    SchemaCreation,
+    TableSchema,
+    UpdateManyParams,
+    UpdateParams,
+    UpsertParams,
+    ValidationResult,
+    WhereClause,
+)
+
+
+class SQLAlchemyAdapter:
+    """SQLAlchemy adapter for superfunctions.db"""
+
+    def __init__(self, engine: Engine, namespace_prefix: str = ""):
+        """
+        Initialize SQLAlchemy adapter.
+        
+        Args:
+            engine: SQLAlchemy Engine
+            namespace_prefix: Prefix for table names (for namespacing)
+        """
+        self.engine = engine
+        self.namespace_prefix = namespace_prefix
+        self.metadata = MetaData()
+        self._start_time = time.time()
+        
+        # Metadata
+        self.id = "sqlalchemy"
+        self.name = "SQLAlchemy Adapter"
+        self.version = "0.1.0"
+        self.capabilities = AdapterCapabilities(
+            transactions=True,
+            nested_transactions=False,
+            joins=False,
+            full_text_search=False,
+            json_operations=True,
+            schema_management=False,
+            migration_support=False,
+            batch_operations=True,
+        )
+
+    def _get_table_name(self, model: str, namespace: Optional[str] = None) -> str:
+        """Get full table name with namespace."""
+        parts = [part for part in (self.namespace_prefix, namespace, model) if part]
+        return "_".join(parts)
+
+    def _build_where_clause(self, table: Table, where: List[WhereClause]) -> Any:
+        """Build SQLAlchemy where clause from WhereClause list."""
+        if not where:
+            return None
+
+        conditions = []
+        for clause in where:
+            column = self._get_column(table, clause.field, "where clause")
+
+            if clause.operator == Operator.EQ:
+                conditions.append(column == clause.value)
+            elif clause.operator == Operator.NE:
+                conditions.append(column != clause.value)
+            elif clause.operator == Operator.GT:
+                conditions.append(column > clause.value)
+            elif clause.operator == Operator.GTE:
+                conditions.append(column >= clause.value)
+            elif clause.operator == Operator.LT:
+                conditions.append(column < clause.value)
+            elif clause.operator == Operator.LTE:
+                conditions.append(column <= clause.value)
+            elif clause.operator == Operator.IN:
+                conditions.append(column.in_(clause.value))
+            elif clause.operator == Operator.NOT_IN:
+                conditions.append(column.notin_(clause.value))
+            elif clause.operator == Operator.LIKE:
+                conditions.append(column.like(clause.value))
+            elif clause.operator == Operator.ILIKE:
+                conditions.append(column.ilike(clause.value))
+            elif clause.operator == Operator.IS_NULL:
+                conditions.append(column.is_(None))
+            elif clause.operator == Operator.IS_NOT_NULL:
+                conditions.append(column.isnot(None))
+            elif clause.operator == Operator.CONTAINS:
+                conditions.append(column.contains(clause.value))
+            elif clause.operator == Operator.STARTS_WITH:
+                conditions.append(column.startswith(clause.value))
+            elif clause.operator == Operator.ENDS_WITH:
+                conditions.append(column.endswith(clause.value))
+            else:
+                raise QueryFailedError(f"Unsupported operator in where clause: {clause.operator}")
+
+        combined = conditions[0]
+        for i in range(1, len(conditions)):
+            connector = getattr(where[i], "connector", "AND") or "AND"
+            combined = or_(combined, conditions[i]) if connector == "OR" else and_(combined, conditions[i])
+
+        return combined
+
+    def _get_table(self, model: str, namespace: Optional[str] = None) -> Table:
+        """Get or reflect table from database."""
+        table_name = self._get_table_name(model, namespace)
+        
+        if table_name in self.metadata.tables:
+            return self.metadata.tables[table_name]
+        
+        # Reflect table from database
+        return Table(table_name, self.metadata, autoload_with=self.engine)
+
+    def _apply_where(self, query: Any, where_clause: Any) -> Any:
+        if where_clause is None:
+            return query
+        return query.where(where_clause)
+
+    def _get_column(self, table: Table, field: str, context: str) -> Any:
+        try:
+            return table.c[field]
+        except KeyError as exc:
+            raise QueryFailedError(f"Unknown field in {context}: {field}") from exc
+
+    def _project_row(self, row: Dict[str, Any], select_fields: Optional[List[str]]) -> Dict[str, Any]:
+        if not select_fields:
+            return row
+        return {field: row.get(field) for field in select_fields}
+
+    def _apply_select(self, table: Table, params: FindOneParams | FindManyParams) -> Any:
+        columns = [self._get_column(table, field, "select projection") for field in params.select] if params.select else [table]
+        return select(*columns).select_from(table)
+
+    def _build_data_where_clause(self, table: Table, data: Dict[str, Any]) -> Any:
+        conditions = [self._get_column(table, key, "data lookup") == value for key, value in data.items() if key in table.c]
+        if not conditions:
+            return None
+        return and_(*conditions) if len(conditions) > 1 else conditions[0]
+
+    def _fetch_one_by_clause(
+        self,
+        connection: Any,
+        table: Table,
+        where_clause: Any,
+        select_fields: Optional[List[str]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        if where_clause is None:
+            return None
+
+        query = self._apply_where(
+            select(*[self._get_column(table, field, "select projection") for field in select_fields]).select_from(table)
+            if select_fields
+            else select(table),
+            where_clause,
+        )
+        row = connection.execute(query).fetchone()
+        return dict(row._mapping) if row else None
+
+    def _fetch_one_by_primary_key(
+        self,
+        connection: Any,
+        table: Table,
+        row_data: Dict[str, Any],
+        select_fields: Optional[List[str]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        primary_key_columns = list(table.primary_key.columns)
+        if not primary_key_columns:
+            return None
+
+        conditions = []
+        for column in primary_key_columns:
+            value = row_data.get(column.name)
+            if value is None:
+                return None
+            conditions.append(column == value)
+
+        where_clause = and_(*conditions) if len(conditions) > 1 else conditions[0]
+        return self._fetch_one_by_clause(connection, table, where_clause, select_fields)
+
+    def _build_primary_key_where_clause(self, table: Table, row_data: Dict[str, Any]) -> Any:
+        primary_key_columns = list(table.primary_key.columns)
+        if not primary_key_columns:
+            return None
+
+        conditions = []
+        for column in primary_key_columns:
+            value = row_data.get(column.name)
+            if value is None:
+                return None
+            conditions.append(column == value)
+
+        return and_(*conditions) if len(conditions) > 1 else conditions[0]
+
+    def _coerce_params(self, param_type: Any, params: Any = None, kwargs: Optional[Dict[str, Any]] = None) -> Any:
+        kwargs = kwargs or {}
+        if params is not None and kwargs:
+            raise TypeError("Pass either a params object or keyword arguments, not both")
+        if params is None:
+            if not kwargs:
+                raise TypeError(f"{param_type.__name__} params are required")
+            return param_type(**kwargs)
+        if isinstance(params, param_type):
+            return params
+        if isinstance(params, dict):
+            return param_type(**params)
+        if hasattr(params, "model_dump"):
+            return param_type(**params.model_dump())
+        raise TypeError(f"Unsupported params type for {param_type.__name__}")
+
+    async def _create(self, params: CreateParams, connection=None) -> Dict[str, Any]:
+        """Create a single record."""
+        try:
+            table = self._get_table(params.model, params.namespace)
+            conn = connection
+            if conn is not None:
+                result = conn.execute(insert(table).values(**params.data))
+                inserted = None
+                inserted_primary_key = list(getattr(result, "inserted_primary_key", ()) or [])
+                if inserted_primary_key:
+                    inserted = self._fetch_one_by_primary_key(
+                        conn,
+                        table,
+                        {
+                            column.name: value
+                            for column, value in zip(table.primary_key.columns, inserted_primary_key, strict=True)
+                        },
+                        params.select,
+                    )
+                if inserted is None:
+                    inserted = self._fetch_one_by_clause(
+                        conn,
+                        table,
+                        self._build_data_where_clause(table, params.data),
+                        params.select,
+                    )
+                return inserted if inserted is not None else self._project_row(dict(params.data), params.select)
+
+            with self.engine.begin() as managed_conn:
+                return await self._create(params, managed_conn)
+        
+        except IntegrityError as e:
+            if "unique" in str(e).lower() or "duplicate" in str(e).lower():
+                raise DuplicateKeyError(str(e), cause=e)
+            raise ConstraintViolationError(str(e), cause=e)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except (DuplicateKeyError, ConstraintViolationError, ConnectionError, QueryFailedError):
+            raise
+        except Exception as e:
+            raise QueryFailedError(f"Create failed: {str(e)}", cause=e)
+
+    async def create(self, params: Optional[CreateParams] = None, **kwargs: Any) -> Dict[str, Any]:
+        return await self._create(self._coerce_params(CreateParams, params, kwargs))
+
+    async def _find_one(self, params: FindOneParams, connection=None) -> Optional[Dict[str, Any]]:
+        """Find a single record."""
+        try:
+            table = self._get_table(params.model, params.namespace)
+            where_clause = self._build_where_clause(table, params.where) if params.where else None
+            query = self._apply_where(self._apply_select(table, params), where_clause)
+
+            conn = connection
+            if conn is not None:
+                row = conn.execute(query).fetchone()
+                return dict(row._mapping) if row else None
+
+            with self.engine.connect() as managed_conn:
+                return await self._find_one(params, managed_conn)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except (ConnectionError, QueryFailedError):
+            raise
+        except Exception as e:
+            raise QueryFailedError(f"FindOne failed: {str(e)}", cause=e)
+
+    async def find_one(self, params: Optional[FindOneParams] = None, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        return await self._find_one(self._coerce_params(FindOneParams, params, kwargs))
+
+    async def _find_many(self, params: FindManyParams, connection=None) -> List[Dict[str, Any]]:
+        """Find multiple records."""
+        try:
+            table = self._get_table(params.model, params.namespace)
+            where_clause = self._build_where_clause(table, params.where) if params.where else None
+            query = self._apply_where(self._apply_select(table, params), where_clause)
+            
+            if params.order_by:
+                for order in params.order_by:
+                    column = self._get_column(table, order.field, "order by")
+                    query = query.order_by(column.desc() if order.direction == "desc" else column)
+            
+            if params.limit is not None:
+                query = query.limit(params.limit)
+            
+            if params.offset is not None:
+                query = query.offset(params.offset)
+
+            conn = connection
+            if conn is not None:
+                result = conn.execute(query)
+                return [dict(row._mapping) for row in result.fetchall()]
+
+            with self.engine.connect() as managed_conn:
+                return await self._find_many(params, managed_conn)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except (ConnectionError, QueryFailedError):
+            raise
+        except Exception as e:
+            raise QueryFailedError(f"FindMany failed: {str(e)}", cause=e)
+
+    async def find_many(self, params: Optional[FindManyParams] = None, **kwargs: Any) -> List[Dict[str, Any]]:
+        return await self._find_many(self._coerce_params(FindManyParams, params, kwargs))
+
+    async def _update(self, params: UpdateParams, connection=None) -> Dict[str, Any]:
+        """Update a single record."""
+        try:
+            table = self._get_table(params.model, params.namespace)
+            where_clause = self._build_where_clause(table, params.where)
+
+            conn = connection
+            if conn is not None:
+                existing = self._fetch_one_by_clause(conn, table, where_clause)
+                if existing is None:
+                    raise NotFoundError("Record not found for update")
+                target_where_clause = (
+                    self._build_primary_key_where_clause(table, existing)
+                    or self._build_data_where_clause(table, existing)
+                    or where_clause
+                )
+                conn.execute(update(table).where(target_where_clause).values(**params.data))
+                updated_row = {**existing, **params.data}
+                refreshed = self._fetch_one_by_primary_key(conn, table, updated_row, params.select)
+                if refreshed is not None:
+                    return refreshed
+                return self._project_row(updated_row, params.select)
+
+            with self.engine.begin() as managed_conn:
+                return await self._update(params, managed_conn)
+        
+        except NotFoundError:
+            raise
+        except IntegrityError as e:
+            raise ConstraintViolationError(str(e), cause=e)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except (ConstraintViolationError, ConnectionError, QueryFailedError):
+            raise
+        except Exception as e:
+            raise QueryFailedError(f"Update failed: {str(e)}", cause=e)
+
+    async def update(self, params: Optional[UpdateParams] = None, **kwargs: Any) -> Dict[str, Any]:
+        return await self._update(self._coerce_params(UpdateParams, params, kwargs))
+
+    async def _delete(self, params: DeleteParams, connection=None) -> None:
+        """Delete a single record."""
+        try:
+            table = self._get_table(params.model, params.namespace)
+            where_clause = self._build_where_clause(table, params.where)
+
+            conn = connection
+            if conn is not None:
+                existing = self._fetch_one_by_clause(conn, table, where_clause)
+                if existing is None:
+                    raise NotFoundError("Record not found for deletion")
+                target_where_clause = (
+                    self._build_primary_key_where_clause(table, existing)
+                    or self._build_data_where_clause(table, existing)
+                    or where_clause
+                )
+                result = conn.execute(delete(table).where(target_where_clause))
+                if result.rowcount == 0:
+                    raise NotFoundError("Record not found for deletion")
+
+            else:
+                with self.engine.begin() as managed_conn:
+                    await self._delete(params, managed_conn)
+        
+        except NotFoundError:
+            raise
+        except IntegrityError as e:
+            raise ConstraintViolationError(str(e), cause=e)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except ConnectionError:
+            raise
+        except Exception as e:
+            raise QueryFailedError(f"Delete failed: {str(e)}", cause=e)
+
+    async def delete(self, params: Optional[DeleteParams] = None, **kwargs: Any) -> None:
+        await self._delete(self._coerce_params(DeleteParams, params, kwargs))
+
+    async def create_many(self, params: Optional[CreateManyParams] = None, **kwargs: Any) -> List[Dict[str, Any]]:
+        """Create multiple records."""
+        normalized = self._coerce_params(CreateManyParams, params, kwargs)
+        try:
+            with self.engine.begin() as conn:
+                created_rows: List[Dict[str, Any]] = []
+                for row in normalized.data:
+                    created_rows.append(
+                        await self._create(
+                            CreateParams(
+                                model=normalized.model,
+                                data=row,
+                                select=normalized.select,
+                                namespace=normalized.namespace,
+                            ),
+                            conn,
+                        )
+                    )
+                return created_rows
+        
+        except (DuplicateKeyError, ConstraintViolationError, ConnectionError, QueryFailedError):
+            raise
+        except IntegrityError as e:
+            raise ConstraintViolationError(str(e), cause=e)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except Exception as e:
+            raise QueryFailedError(f"CreateMany failed: {str(e)}", cause=e)
+
+    async def update_many(self, params: Optional[UpdateManyParams] = None, **kwargs: Any) -> int:
+        """Update multiple records."""
+        normalized = self._coerce_params(UpdateManyParams, params, kwargs)
+        try:
+            table = self._get_table(normalized.model, normalized.namespace)
+            where_clause = self._build_where_clause(table, normalized.where)
+            if where_clause is None:
+                raise QueryFailedError("UpdateMany failed: update_many requires a where clause")
+            
+            with self.engine.begin() as conn:
+                result = conn.execute(update(table).where(where_clause).values(**normalized.data))
+                return result.rowcount
+        
+        except QueryFailedError:
+            raise
+        except IntegrityError as e:
+            raise ConstraintViolationError(str(e), cause=e)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except Exception as e:
+            raise QueryFailedError(f"UpdateMany failed: {str(e)}", cause=e)
+
+    async def delete_many(self, params: Optional[DeleteManyParams] = None, **kwargs: Any) -> int:
+        """Delete multiple records."""
+        normalized = self._coerce_params(DeleteManyParams, params, kwargs)
+        try:
+            table = self._get_table(normalized.model, normalized.namespace)
+            where_clause = self._build_where_clause(table, normalized.where)
+            if where_clause is None:
+                raise QueryFailedError("DeleteMany failed: delete_many requires a where clause")
+            
+            with self.engine.begin() as conn:
+                result = conn.execute(delete(table).where(where_clause))
+                return result.rowcount
+        
+        except QueryFailedError:
+            raise
+        except IntegrityError as e:
+            raise ConstraintViolationError(str(e), cause=e)
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except Exception as e:
+            raise QueryFailedError(f"DeleteMany failed: {str(e)}", cause=e)
+
+    async def upsert(self, params: Optional[UpsertParams] = None, **kwargs: Any) -> Dict[str, Any]:
+        """Upsert a record."""
+        normalized = self._coerce_params(UpsertParams, params, kwargs)
+        # Try to find existing record
+        existing = await self.find_one(
+            FindOneParams(
+                model=normalized.model,
+                where=normalized.where,
+                select=normalized.select,
+                namespace=normalized.namespace,
+            )
+        )
+        
+        if existing:
+            return await self.update(
+                UpdateParams(
+                    model=normalized.model,
+                    where=normalized.where,
+                    data=normalized.update,
+                    select=normalized.select,
+                    namespace=normalized.namespace,
+                )
+            )
+        try:
+            return await self.create(
+                CreateParams(
+                    model=normalized.model,
+                    data=normalized.create,
+                    select=normalized.select,
+                    namespace=normalized.namespace,
+                )
+            )
+        except DuplicateKeyError:
+            return await self.update(
+                UpdateParams(
+                    model=normalized.model,
+                    where=normalized.where,
+                    data=normalized.update,
+                    select=normalized.select,
+                    namespace=normalized.namespace,
+                )
+            )
+
+    async def count(self, params: Optional[CountParams] = None, **kwargs: Any) -> int:
+        """Count records."""
+        normalized = self._coerce_params(CountParams, params, kwargs)
+        try:
+            table = self._get_table(normalized.model, normalized.namespace)
+            query = select(func.count()).select_from(table)
+            
+            if normalized.where:
+                where_clause = self._build_where_clause(table, normalized.where)
+                query = query.where(where_clause)
+            
+            with self.engine.connect() as conn:
+                result = conn.execute(query)
+                return result.scalar() or 0
+        except OperationalError as e:
+            raise ConnectionError(str(e), cause=e)
+        except (ConnectionError, QueryFailedError):
+            raise
+        except Exception as e:
+            raise QueryFailedError(f"Count failed: {str(e)}", cause=e)
+
+    async def transaction(self, callback: Callable) -> Any:
+        """Execute operations within a transaction."""
+        with self.engine.begin() as conn:
+            # Create transaction adapter
+            trx_adapter = SQLAlchemyTransactionAdapter(conn, self)
+            result = callback(trx_adapter)
+            return await result if inspect.isawaitable(result) else result
+
+    async def initialize(self) -> None:
+        """Initialize the adapter."""
+        # Test connection
+        try:
+            with self.engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+        except Exception as e:
+            raise ConnectionError(f"Failed to initialize: {str(e)}", cause=e)
+
+    async def is_healthy(self) -> HealthStatus:
+        """Check adapter health."""
+        try:
+            with self.engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            
+            return HealthStatus(
+                healthy=True,
+                uptime=int(time.time() - self._start_time),
+            )
+        except Exception as e:
+            return HealthStatus(
+                healthy=False,
+                last_error=str(e),
+                uptime=int(time.time() - self._start_time),
+            )
+
+    async def close(self) -> None:
+        """Close the adapter."""
+        self.engine.dispose()
+
+    async def get_schema_version(self, namespace: str) -> int:
+        """Get the current schema version."""
+        return 0  # TODO: Implement schema versioning
+
+    async def set_schema_version(self, namespace: str, version: int) -> None:
+        """Set the schema version."""
+        pass  # TODO: Implement schema versioning
+
+    async def validate_schema(self, schema: TableSchema) -> ValidationResult:
+        """Validate a schema."""
+        return ValidationResult(valid=True)  # TODO: Implement validation
+
+    async def create_schema(self, params: CreateSchemaParams) -> SchemaCreation:
+        """Create database schema."""
+        return SchemaCreation(success=False, errors=["Schema creation not yet implemented"])
+
+
+class SQLAlchemyTransactionAdapter:
+    """Transaction adapter for SQLAlchemy."""
+
+    def __init__(self, connection, parent_adapter: SQLAlchemyAdapter):
+        self.connection = connection
+        self.parent = parent_adapter
+
+    async def commit(self) -> None:
+        """Commit handled by context manager."""
+        pass
+
+    async def rollback(self) -> None:
+        """Rollback the transaction."""
+        self.connection.rollback()
+
+    async def create(self, params: Optional[CreateParams] = None, **kwargs: Any) -> Dict[str, Any]:
+        return await self.parent._create(self.parent._coerce_params(CreateParams, params, kwargs), self.connection)
+
+    async def find_one(self, params: Optional[FindOneParams] = None, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        return await self.parent._find_one(self.parent._coerce_params(FindOneParams, params, kwargs), self.connection)
+
+    async def find_many(self, params: Optional[FindManyParams] = None, **kwargs: Any) -> List[Dict[str, Any]]:
+        return await self.parent._find_many(self.parent._coerce_params(FindManyParams, params, kwargs), self.connection)
+
+    async def update(self, params: Optional[UpdateParams] = None, **kwargs: Any) -> Dict[str, Any]:
+        return await self.parent._update(self.parent._coerce_params(UpdateParams, params, kwargs), self.connection)
+
+    async def delete(self, params: Optional[DeleteParams] = None, **kwargs: Any) -> None:
+        await self.parent._delete(self.parent._coerce_params(DeleteParams, params, kwargs), self.connection)
+
+
+def create_adapter(engine: Engine, namespace_prefix: str = "") -> Adapter:
+    """
+    Create a SQLAlchemy adapter.
+    
+    Args:
+        engine: SQLAlchemy Engine
+        namespace_prefix: Optional prefix for table names
+    
+    Returns:
+        SQLAlchemy adapter instance
+    
+    Example:
+        >>> from sqlalchemy import create_engine
+        >>> from superfunctions_sqlalchemy import create_adapter
+        >>> 
+        >>> engine = create_engine("postgresql://localhost/mydb")
+        >>> adapter = create_adapter(engine)
+    """
+    return SQLAlchemyAdapter(engine, namespace_prefix)

--- a/packages/python-sqlalchemy/tests/test_adapter.py
+++ b/packages/python-sqlalchemy/tests/test_adapter.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, String, Table, create_engine, event
+from sqlalchemy.exc import OperationalError
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+package_root_str = str(PACKAGE_ROOT)
+if package_root_str not in sys.path:
+    sys.path.insert(0, package_root_str)
+
+from superfunctions.db import (  # noqa: E402
+    ConnectionError,
+    ConstraintViolationError,
+    DeleteParams,
+    DuplicateKeyError,
+    Operator,
+    QueryFailedError,
+    UpdateParams,
+    WhereClause,
+)
+from superfunctions_sqlalchemy import create_adapter  # noqa: E402
+
+
+@pytest.fixture()
+def adapter():
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    metadata = MetaData()
+    Table(
+        "users",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("email", String, unique=True),
+        Column("name", String),
+    )
+    metadata.create_all(engine)
+    return create_adapter(engine)
+
+
+@pytest.fixture()
+def weird_adapter():
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    metadata = MetaData()
+    Table(
+        "weird",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("keys", String),
+        Column("values", String),
+    )
+    metadata.create_all(engine)
+    return create_adapter(engine)
+
+
+@pytest.fixture()
+def no_pk_adapter():
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    metadata = MetaData()
+    Table(
+        "events",
+        metadata,
+        Column("email", String),
+        Column("name", String),
+        Column("kind", String),
+    )
+    metadata.create_all(engine)
+    return create_adapter(engine)
+
+
+def _create_foreign_key_engine():
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+
+    @event.listens_for(engine, "connect")
+    def _enable_foreign_keys(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
+
+
+@pytest.fixture()
+def referential_adapter():
+    engine = _create_foreign_key_engine()
+    metadata = MetaData()
+    Table(
+        "parents",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("name", String, unique=True),
+    )
+    Table(
+        "children",
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("parent_id", Integer, ForeignKey("parents.id", ondelete="RESTRICT")),
+        Column("name", String),
+    )
+    metadata.create_all(engine)
+    return create_adapter(engine)
+
+
+@pytest.mark.asyncio
+async def test_create_and_create_many_support_keyword_args_and_return_inserted_rows(adapter) -> None:
+    created = await adapter.create(model="users", data={"email": "alice@example.com", "name": "Alice"})
+    created_many = await adapter.create_many(
+        model="users",
+        data=[
+            {"email": "bob@example.com", "name": "Bob"},
+            {"email": "cara@example.com", "name": "Cara"},
+        ],
+    )
+
+    assert created["id"] == 1
+    assert [row["id"] for row in created_many] == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_update_reselects_using_primary_key_when_where_fields_change(adapter) -> None:
+    created = await adapter.create(model="users", data={"email": "before@example.com", "name": "Alice"})
+
+    updated = await adapter.update(
+        model="users",
+        where=[WhereClause(field="email", operator=Operator.EQ, value="before@example.com")],
+        data={"email": "after@example.com"},
+    )
+
+    assert updated["id"] == created["id"]
+    assert updated["email"] == "after@example.com"
+
+
+@pytest.mark.asyncio
+async def test_upsert_retries_update_after_duplicate_create(adapter, monkeypatch) -> None:
+    async def fake_find_one(*args, **kwargs):
+        return None
+
+    async def fake_create(*args, **kwargs):
+        raise DuplicateKeyError("duplicate")
+
+    async def fake_update(*args, **kwargs):
+        return {"id": 1, "email": "after@example.com"}
+
+    monkeypatch.setattr(adapter, "find_one", fake_find_one)
+    monkeypatch.setattr(adapter, "create", fake_create)
+    monkeypatch.setattr(adapter, "update", fake_update)
+
+    result = await adapter.upsert(
+        model="users",
+        where=[WhereClause(field="email", operator=Operator.EQ, value="before@example.com")],
+        create={"email": "before@example.com", "name": "Alice"},
+        update={"email": "after@example.com"},
+    )
+
+    assert result == {"id": 1, "email": "after@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_find_many_supports_keyword_args(adapter) -> None:
+    await adapter.create(model="users", data={"email": "alice@example.com", "name": "Alice"})
+    rows = await adapter.find_many(
+        model="users",
+        where=[WhereClause(field="email", operator=Operator.EQ, value="alice@example.com")],
+    )
+
+    assert [row["email"] for row in rows] == ["alice@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_find_many_respects_or_connectors(adapter) -> None:
+    await adapter.create(model="users", data={"email": "alice@example.com", "name": "Alice"})
+    await adapter.create(model="users", data={"email": "bob@example.com", "name": "Bob"})
+    await adapter.create(model="users", data={"email": "cara@example.com", "name": "Cara"})
+
+    rows = await adapter.find_many(
+        model="users",
+        where=[
+            WhereClause(field="email", operator=Operator.EQ, value="alice@example.com"),
+            WhereClause(field="email", operator=Operator.EQ, value="bob@example.com", connector="OR"),
+        ],
+    )
+
+    assert sorted(row["email"] for row in rows) == ["alice@example.com", "bob@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_update_many_requires_where_clause(adapter) -> None:
+    await adapter.create(model="users", data={"email": "alice@example.com", "name": "Alice"})
+
+    with pytest.raises(QueryFailedError, match="update_many requires a where clause"):
+        await adapter.update_many(model="users", where=None, data={"name": "Updated"})
+
+
+@pytest.mark.asyncio
+async def test_find_many_rejects_unknown_where_fields(adapter) -> None:
+    with pytest.raises(QueryFailedError, match="Unknown field in where clause"):
+        await adapter.find_many(
+            model="users",
+            where=[WhereClause(field="missing", operator=Operator.EQ, value="x")],
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_touches_only_one_row_when_where_matches_multiple(adapter) -> None:
+    await adapter.create(model="users", data={"email": "a@example.com", "name": "same"})
+    await adapter.create(model="users", data={"email": "b@example.com", "name": "same"})
+
+    updated = await adapter.update(
+        model="users",
+        where=[WhereClause(field="name", operator=Operator.EQ, value="same")],
+        data={"name": "changed"},
+    )
+
+    assert updated["name"] == "changed"
+    rows = await adapter.find_many(model="users", where=[])
+    assert sorted(row["name"] for row in rows) == ["changed", "same"]
+
+
+@pytest.mark.asyncio
+async def test_create_many_preserves_constraint_errors(adapter) -> None:
+    await adapter.create(model="users", data={"email": "dupe@example.com", "name": "Alice"})
+
+    with pytest.raises((DuplicateKeyError, ConstraintViolationError)):
+        await adapter.create_many(
+            model="users",
+            data=[
+                {"email": "dupe@example.com", "name": "Bob"},
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_preserves_duplicate_key_errors(adapter) -> None:
+    await adapter.create(model="users", data={"email": "dupe@example.com", "name": "Alice"})
+
+    with pytest.raises(DuplicateKeyError):
+        await adapter.create(model="users", data={"email": "dupe@example.com", "name": "Bob"})
+
+
+@pytest.mark.asyncio
+async def test_update_many_preserves_constraint_errors(adapter) -> None:
+    await adapter.create(model="users", data={"email": "alice@example.com", "name": "Alice"})
+    await adapter.create(model="users", data={"email": "bob@example.com", "name": "Bob"})
+
+    with pytest.raises(ConstraintViolationError):
+        await adapter.update_many(
+            model="users",
+            where=[WhereClause(field="email", operator=Operator.EQ, value="bob@example.com")],
+            data={"email": "alice@example.com"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_preserves_connection_errors(adapter, monkeypatch) -> None:
+    def fake_fetch_one_by_clause(*_args, **_kwargs):
+        return {"id": 1, "email": "alice@example.com", "name": "Alice"}
+
+    class FailingConnection:
+        def execute(self, _query):
+            raise OperationalError("UPDATE users", {}, Exception("connection dropped"))
+
+    monkeypatch.setattr(adapter, "_fetch_one_by_clause", fake_fetch_one_by_clause)
+
+    with pytest.raises(ConnectionError):
+        await adapter._update(
+            UpdateParams(
+                model="users",
+                where=[WhereClause(field="id", operator=Operator.EQ, value=1)],
+                data={"name": "Updated"},
+            ),
+            FailingConnection(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_many_preserves_connection_errors(adapter, monkeypatch) -> None:
+    async def fake_create(*_args, **_kwargs):
+        raise OperationalError("INSERT INTO users", {}, Exception("connection dropped"))
+
+    monkeypatch.setattr(adapter, "_create", fake_create)
+
+    with pytest.raises(ConnectionError):
+        await adapter.create_many(
+            model="users",
+            data=[{"email": "alice@example.com", "name": "Alice"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_transaction_accepts_sync_callbacks(adapter) -> None:
+    result = await adapter.transaction(lambda trx: "ok")
+
+    assert result == "ok"
+
+
+def test_adapter_reports_nested_transactions_as_unsupported(adapter) -> None:
+    assert adapter.capabilities.nested_transactions is False
+    assert adapter.capabilities.joins is False
+
+
+@pytest.mark.asyncio
+async def test_field_lookups_use_column_keys_for_reserved_names(weird_adapter) -> None:
+    await weird_adapter.create(model="weird", data={"keys": "alpha", "values": "one"})
+
+    rows = await weird_adapter.find_many(
+        model="weird",
+        where=[WhereClause(field="keys", operator=Operator.EQ, value="alpha")],
+        select=["keys", "values"],
+    )
+
+    assert rows == [{"keys": "alpha", "values": "one"}]
+
+
+@pytest.mark.asyncio
+async def test_update_without_primary_key_falls_back_to_existing_row_values(no_pk_adapter) -> None:
+    await no_pk_adapter.create(model="events", data={"email": "a@example.com", "name": "same", "kind": "first"})
+    await no_pk_adapter.create(model="events", data={"email": "b@example.com", "name": "same", "kind": "second"})
+
+    updated = await no_pk_adapter.update(
+        model="events",
+        where=[WhereClause(field="name", operator=Operator.EQ, value="same")],
+        data={"name": "changed"},
+    )
+
+    assert updated["email"] == "a@example.com"
+    rows = await no_pk_adapter.find_many(model="events", where=[])
+    assert sorted((row["email"], row["name"]) for row in rows) == [
+        ("a@example.com", "changed"),
+        ("b@example.com", "same"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_preserves_constraint_errors(referential_adapter) -> None:
+    parent = await referential_adapter.create(model="parents", data={"name": "parent-1"})
+    await referential_adapter.create(
+        model="children",
+        data={"parent_id": parent["id"], "name": "child-1"},
+    )
+
+    with pytest.raises(ConstraintViolationError):
+        await referential_adapter.delete(
+            model="parents",
+            where=[WhereClause(field="id", operator=Operator.EQ, value=parent["id"])],
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_many_preserves_constraint_errors(referential_adapter) -> None:
+    parent = await referential_adapter.create(model="parents", data={"name": "parent-2"})
+    await referential_adapter.create(
+        model="children",
+        data={"parent_id": parent["id"], "name": "child-2"},
+    )
+
+    with pytest.raises(ConstraintViolationError):
+        await referential_adapter.delete_many(
+            model="parents",
+            where=[WhereClause(field="id", operator=Operator.EQ, value=parent["id"])],
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_preserves_connection_errors(adapter, monkeypatch) -> None:
+    def fake_fetch_one_by_clause(*_args, **_kwargs):
+        return {"id": 1, "email": "alice@example.com", "name": "Alice"}
+
+    class FailingConnection:
+        def execute(self, _query):
+            raise OperationalError("DELETE FROM users", {}, Exception("connection dropped"))
+
+    monkeypatch.setattr(adapter, "_fetch_one_by_clause", fake_fetch_one_by_clause)
+
+    with pytest.raises(ConnectionError):
+        await adapter._delete(
+            DeleteParams(
+                model="users",
+                where=[WhereClause(field="id", operator=Operator.EQ, value=1)],
+            ),
+            FailingConnection(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_does_not_treat_no_op_rowcount_as_missing(adapter, monkeypatch) -> None:
+    def fake_fetch_one_by_clause(*_args, **_kwargs):
+        return {"id": 1, "email": "alice@example.com", "name": "Alice"}
+
+    class NoOpUpdateConnection:
+        def execute(self, _query):
+            class Result:
+                rowcount = 0
+
+            return Result()
+
+    monkeypatch.setattr(adapter, "_fetch_one_by_clause", fake_fetch_one_by_clause)
+    monkeypatch.setattr(adapter, "_fetch_one_by_primary_key", lambda *_args, **_kwargs: None)
+
+    updated = await adapter._update(
+        UpdateParams(
+            model="users",
+            where=[WhereClause(field="id", operator=Operator.EQ, value=1)],
+            data={"name": "Alice"},
+        ),
+        NoOpUpdateConnection(),
+    )
+
+    assert updated == {"id": 1, "email": "alice@example.com", "name": "Alice"}


### PR DESCRIPTION
## Summary
- add the missing shared SQLAlchemy adapter package to `origin/dev`
- bring over the Python adapter package as a standalone PR so Python dependency review stays focused

## Validation
- inspected the copied package contents in a clean worktree created from `origin/dev`
- did not run a reliable Python package validation pass in this worktree

## Notes
- no `.conduct` changes included
- opened directly against `origin/dev` with `GH_CONFIG_DIR=~/.config/gh-other`

## Summary by Sourcery

Add a new Python SQLAlchemy adapter package integrating superfunctions.db with SQLAlchemy-based databases.

New Features:
- Introduce a SQLAlchemy-backed Adapter implementation providing CRUD, batch, counting, transactions, health checks, and basic schema hooks for superfunctions.db.
- Expose a create_adapter factory and package initializer to simplify constructing the SQLAlchemy adapter from a SQLAlchemy Engine or AsyncEngine.

Enhancements:
- Document installation, supported databases, and example usage for the new superfunctions-sqlalchemy package in a dedicated README.
- Define packaging metadata, optional DB-specific extras, and development tooling configuration for the superfunctions-sqlalchemy Python package via pyproject.toml.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the shared Python SQLAlchemy adapter `superfunctions-sqlalchemy` for `superfunctions.db`, providing CRUD, batch ops, upserts, counts, and transactions (sync/async callbacks) on Postgres/MySQL/SQLite using sync SQLAlchemy engines. Tightens capability flags and single‑row semantics, validates `where` clauses, maps SQL errors to typed errors, and fixes edge cases per SF‑30.

- **New Features**
  - New adapter package (`packages/python-sqlalchemy/`) exporting `create_adapter`/`SQLAlchemyAdapter`, with init/health/close and optional `namespace_prefix`; includes README usage docs and `pyproject.toml` with extras (`postgres`, `mysql`, `asyncpg`).
  - Full CRUD, `create_many`/`upsert`/`count`, query builders (`where` with AND/OR, `order_by`/`limit`/`offset`), transactions that accept sync or async callbacks, and APIs that take params objects or kwargs.
  - Explicit column-key lookups for field resolution, including reserved names.
  - Capability metadata tightened: transactions/batch ops enabled; nested transactions, joins, full‑text search, schema management, and migrations disabled.

- **Bug Fixes**
  - Safe single-row update/delete: find by `where`, target via primary key or fall back to existing row values; reselect by primary key when filters change; treat no‑op updates as success.
  - Strict `where` validation and OR support: require `where` for `update_many`/`delete_many`, reject unknown fields with clear errors, and honor OR connectors.
  - Preserve typed errors and bulk semantics: map duplicates/constraints to `DuplicateKeyError`/`ConstraintViolationError`, surface `ConnectionError` on drops, run `create_many` in a transaction and return inserted rows, and retry update on upsert duplicate.
  - Fix delete path connection typing to avoid type issues during execution.

<sup>Written for commit 8c9d5112e24c506d2a1c1f08d561e71a6e350d1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new SQLAlchemy adapter package offering async-capable CRUD, batch operations, upserts, counting, transactions, and optional namespacing for SQL databases.

* **Documentation**
  * Included comprehensive package docs with installation, sync/async usage examples, configuration, and feature checklist.

* **Tests**
  * Added tests covering create/create_many, update behavior, upsert retry, find_many filtering, transactions, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->