### PR TITLE
SF-17: feat(hostfn): add docs package and workspace deploy fixes

### DIFF
--- a/hostfn/cli/README.md
+++ b/hostfn/cli/README.md
@@ -178,7 +178,7 @@ Create `hostfn.config.json` in your project root:
   "build": {
     "command": "npm run build",
     "directory": "dist",
-    "nodeModules": "production"
+    "nodeModules": "all"
   },
   "start": {
     "command": "npm start",
@@ -1130,7 +1130,6 @@ hostfn --help
 ## License
 
 MIT
-
 
 
 

--- a/hostfn/cli/package.json
+++ b/hostfn/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hostfn",
-  "version": "0.1.5",
-  "license": "Apache-2.0",
+  "version": "0.1.7",
+  "license": "MIT",
   "description": "Universal application deployment CLI",
   "type": "module",
   "bin": {
@@ -21,6 +21,7 @@
     "chalk": "^5.3.0",
     "ora": "^7.0.1",
     "inquirer": "^9.2.12",
+    "semver": "^7.7.2",
     "zod": "^3.22.4",
     "ssh2": "^1.15.0",
     "dotenv": "^16.3.1",
@@ -39,7 +40,8 @@
   "author": "21n",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/21nCo/super-functions.git"
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "hostfn/cli"
   },
   "bugs": {
     "url": "https://github.com/21nCo/super-functions/issues"
@@ -50,5 +52,13 @@
   ],
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "superfunctions": {
+    "initFunction": "hostFn",
+    "schemaVersion": 1,
+    "namespace": "hostfn"
   }
 }

--- a/hostfn/cli/src/__tests__/core/sync.test.ts
+++ b/hostfn/cli/src/__tests__/core/sync.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { FileSync } from '../../core/sync.js';
+
+const { execaMock } = vi.hoisted(() => ({
+  execaMock: vi.fn(),
+}));
+
+vi.mock('execa', () => ({
+  execa: execaMock,
+}));
+
+describe('FileSync.syncLocal', () => {
+  beforeEach(() => {
+    execaMock.mockReset();
+    execaMock.mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+  });
+
+  it('applies include filters before exclude filters so rsync overrides work', async () => {
+    await FileSync.syncLocal('/tmp/source', '/tmp/destination', {
+      include: ['.env.production'],
+      exclude: ['.env.*'],
+    });
+
+    expect(execaMock).toHaveBeenCalledWith(
+      'rsync',
+      expect.arrayContaining([
+        '--include',
+        '.env.production',
+        '--exclude',
+        '.env.*',
+      ]),
+      expect.any(Object),
+    );
+
+    const args = execaMock.mock.calls[0][1] as string[];
+    expect(args.indexOf('--include')).toBeLessThan(args.indexOf('--exclude'));
+  });
+});

--- a/hostfn/cli/src/__tests__/core/workspace.test.ts
+++ b/hostfn/cli/src/__tests__/core/workspace.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { WorkspaceManager } from '../../core/workspace.js';
+
+const execSyncMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  execSync: execSyncMock,
+}));
+
+describe('WorkspaceManager.generateLockfile', () => {
+  let rootDir: string;
+  let serviceDir: string;
+  let targetDir: string;
+
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    rootDir = mkdtempSync(join(tmpdir(), 'hostfn-workspace-root-'));
+    serviceDir = join(rootDir, 'services', 'api');
+    targetDir = mkdtempSync(join(tmpdir(), 'hostfn-workspace-target-'));
+
+    mkdirSync(serviceDir, { recursive: true });
+
+    writeFileSync(
+      join(rootDir, 'package.json'),
+      JSON.stringify({
+        private: true,
+        workspaces: ['services/*'],
+      }, null, 2),
+    );
+
+    writeFileSync(
+      join(serviceDir, 'package.json'),
+      JSON.stringify({
+        name: '@hostfn/api',
+        dependencies: {
+          commander: '^12.0.0',
+          chalk: '^5.0.0',
+          'zero-lib': '^0.2.3',
+        },
+      }, null, 2),
+    );
+
+    writeFileSync(
+      join(rootDir, 'package-lock.json'),
+      JSON.stringify({
+        name: 'workspace-root',
+        lockfileVersion: 3,
+        packages: {
+          '': { name: 'workspace-root' },
+          'node_modules/commander': { version: '4.1.1', name: 'commander' },
+          'services/api/node_modules/commander': { version: '12.1.0', name: 'commander' },
+          'node_modules/chalk': { version: '5.3.0', name: 'chalk' },
+          'node_modules/zero-lib': { version: '0.5.0', name: 'zero-lib' },
+          'services/api/node_modules/zero-lib': { version: '0.2.8', name: 'zero-lib' },
+        },
+      }, null, 2),
+    );
+
+    writeFileSync(
+      join(targetDir, 'package.json'),
+      JSON.stringify({
+        name: '@hostfn/api',
+        dependencies: {
+          commander: '^12.0.0',
+          chalk: '^5.0.0',
+          'zero-lib': '^0.2.3',
+        },
+      }, null, 2),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(targetDir, { recursive: true, force: true });
+  });
+
+  it('pins package.json to the exact workspace-scoped versions used for lockfile generation', async () => {
+    execSyncMock.mockImplementation(() => {
+      const pinnedPackageJson = JSON.parse(readFileSync(join(targetDir, 'package.json'), 'utf-8'));
+      expect(pinnedPackageJson.dependencies.commander).toBe('12.1.0');
+      expect(pinnedPackageJson.dependencies.chalk).toBe('5.3.0');
+      expect(pinnedPackageJson.dependencies['zero-lib']).toBe('0.2.8');
+    });
+
+    const manager = new WorkspaceManager();
+    await manager.detectWorkspace(serviceDir);
+    await manager.generateLockfile(targetDir, serviceDir);
+
+    expect(execSyncMock).toHaveBeenCalledWith(
+      'npm install --package-lock-only --ignore-scripts',
+      expect.objectContaining({
+        cwd: targetDir,
+        stdio: 'ignore',
+      }),
+    );
+
+    const deployedPackageJson = JSON.parse(readFileSync(join(targetDir, 'package.json'), 'utf-8'));
+    expect(deployedPackageJson.dependencies.commander).toBe('12.1.0');
+    expect(deployedPackageJson.dependencies.chalk).toBe('5.3.0');
+    expect(deployedPackageJson.dependencies['zero-lib']).toBe('0.2.8');
+  });
+});
+
+describe('WorkspaceManager.rewritePackageJson', () => {
+  let rootDir: string;
+  let serviceDir: string;
+  let toolingDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    rootDir = mkdtempSync(join(tmpdir(), 'hostfn-workspace-root-'));
+    serviceDir = join(rootDir, 'services', 'api');
+    toolingDir = join(rootDir, 'services', 'tooling');
+    targetDir = mkdtempSync(join(tmpdir(), 'hostfn-workspace-target-'));
+
+    mkdirSync(serviceDir, { recursive: true });
+    mkdirSync(toolingDir, { recursive: true });
+
+    writeFileSync(
+      join(rootDir, 'package.json'),
+      JSON.stringify({
+        private: true,
+        workspaces: ['services/*'],
+      }, null, 2),
+    );
+
+    writeFileSync(
+      join(toolingDir, 'package.json'),
+      JSON.stringify({
+        name: '@hostfn/tooling',
+        version: '1.0.0',
+      }, null, 2),
+    );
+
+    writeFileSync(
+      join(serviceDir, 'package.json'),
+      JSON.stringify({
+        name: '@hostfn/api',
+        dependencies: {
+          '@hostfn/tooling': 'workspace:*',
+        },
+        devDependencies: {
+          '@hostfn/tooling': 'workspace:*',
+        },
+      }, null, 2),
+    );
+
+    writeFileSync(
+      join(targetDir, 'package.json'),
+      JSON.stringify({
+        name: '@hostfn/api',
+        dependencies: {
+          '@hostfn/tooling': 'workspace:*',
+        },
+        devDependencies: {
+          '@hostfn/tooling': 'workspace:*',
+        },
+      }, null, 2),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+    rmSync(targetDir, { recursive: true, force: true });
+  });
+
+  it('preserves workspace devDependencies as file references in the deployment bundle', async () => {
+    const manager = new WorkspaceManager();
+    await manager.detectWorkspace(serviceDir);
+
+    manager.rewritePackageJson(serviceDir, targetDir);
+
+    const rewrittenPackageJson = JSON.parse(readFileSync(join(targetDir, 'package.json'), 'utf-8'));
+    expect(rewrittenPackageJson.dependencies['@hostfn/tooling']).toBe('file:./__workspace__/@hostfn/tooling');
+    expect(rewrittenPackageJson.devDependencies['@hostfn/tooling']).toBe('file:./__workspace__/@hostfn/tooling');
+  });
+});

--- a/hostfn/cli/src/commands/deploy.ts
+++ b/hostfn/cli/src/commands/deploy.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { mkdtempSync, rmSync, cpSync } from 'fs';
+import { mkdtempSync, rmSync, cpSync, existsSync } from 'fs';
 import { Logger } from '../utils/logger.js';
 import { ConfigLoader } from '../config/loader.js';
 import { createSSHConnection, SSHConnection } from '../core/ssh.js';
@@ -23,6 +23,37 @@ interface DeployOptions {
   dryRun: boolean;
   service?: string;
   all?: boolean;
+}
+
+interface InstallPlan {
+  nodeModulesMode: 'all' | 'production' | 'none';
+  useCi: boolean;
+  installCmd: string | null;
+}
+
+function computeInstallPlan(
+  config: HostfnConfig,
+  hasLockFile: boolean,
+): InstallPlan {
+  const nodeModulesMode =
+    config.build?.nodeModules ?? (config.build?.command ? 'all' : 'production');
+
+  const installCmd =
+    nodeModulesMode === 'none'
+      ? null
+      : hasLockFile
+        ? (nodeModulesMode === 'all'
+            ? 'npm ci --install-links'
+            : 'npm ci --production --install-links')
+        : (nodeModulesMode === 'all'
+            ? 'npm install --install-links'
+            : 'npm install --production --install-links');
+
+  return {
+    nodeModulesMode,
+    useCi: hasLockFile,
+    installCmd,
+  };
 }
 
 export async function deployCommand(
@@ -310,8 +341,16 @@ async function deploySingleService(
     Logger.section('Pre-flight Checks');
     Logger.br();
 
-    // For local mode, skip rsync and SSH connection
+    // Local mode still relies on rsync so include the same pre-flight check.
     if (options.local) {
+      const rsyncSpinner = ora('Checking rsync availability...').start();
+      const hasRsync = await FileSync.isRsyncAvailable();
+      if (!hasRsync) {
+        rsyncSpinner.fail('rsync not installed');
+        throw new Error('rsync is required for deployment. Please install it first.');
+      }
+      rsyncSpinner.succeed('rsync available');
+
       const localSpinner = ora('Initializing local deployment...').start();
       ssh = new LocalExecutor();
       localSpinner.succeed('Local mode ready');
@@ -404,6 +443,19 @@ async function deploySingleService(
         bundleSpinner.text = 'Bundling workspace dependencies...';
         await workspaceManager.bundleWorkspaceDependencies(sourceDir, bundleDir);
         
+        // Rewrite package.json to use file: references for workspace deps
+        workspaceManager.rewritePackageJson(sourceDir, bundleDir);
+
+        const { nodeModulesMode } = computeInstallPlan(
+          config,
+          existsSync(join(bundleDir, 'package-lock.json')),
+        );
+
+        if (nodeModulesMode !== 'none') {
+          bundleSpinner.text = 'Generating lockfile...';
+          await workspaceManager.generateLockfile(bundleDir, sourceDir);
+        }
+        
         bundleSpinner.succeed('Workspace dependencies bundled');
         Logger.br();
         
@@ -416,84 +468,58 @@ async function deploySingleService(
     Logger.br();
 
     if (options.local) {
-      // Local mode: copy files directly
+      // Local mode: use rsync locally so include/exclude behavior stays aligned
+      // with the remote deploy path.
       const syncSpinner = ora('Copying files locally...').start();
-      
-      cpSync(actualSourceDir, remoteDir, {
-        recursive: true,
-        filter: (src) => {
-          const relativePath = src.replace(actualSourceDir, '');
-          const excludePatterns = config.sync?.exclude || [
-            'node_modules',
-            '.git',
-            'dist',
-            '.env',
-            '*.log',
-          ];
-          return !excludePatterns.some(pattern => relativePath.includes(pattern));
-        },
+      const rawExcludes = config.sync?.exclude || [
+        'node_modules',
+        '.git',
+        '.github',
+        'dist',
+        'build',
+        '.env',
+        '.env.*',
+        '*.log',
+        '.turbo',
+        '.wrangler',
+      ];
+      const localExcludes = bundleDir
+        ? rawExcludes.map((pattern) => (pattern === 'dist' || pattern === 'build') ? `/${pattern}` : pattern)
+        : rawExcludes;
+
+      await FileSync.syncLocal(actualSourceDir, remoteDir, {
+        exclude: localExcludes,
+        include: config.sync?.include,
+        verbose: false,
       });
       
       syncSpinner.succeed('Files copied successfully');
-      
-      // Copy workspace dependencies if they exist
-      if (bundleDir) {
-        const bundledNodeModules = join(bundleDir, 'node_modules');
-        const { existsSync } = await import('fs');
-        
-        if (existsSync(bundledNodeModules)) {
-          const uploadSpinner = ora('Copying workspace dependencies...').start();
-          cpSync(bundledNodeModules, join(remoteDir, 'node_modules'), { recursive: true });
-          uploadSpinner.succeed('Workspace dependencies copied');
-        }
-      }
     } else {
       // Remote mode: use rsync
       const syncSpinner = ora('Syncing files to server...').start();
+
+      // When syncing a workspace bundle, anchor 'dist' to root (/dist) so it only
+      // excludes the service's own dist folder and not workspace deps' compiled output
+      // (e.g. __workspace__/@21n/email/dist which is needed for type declarations).
+      const rawExcludes = config.sync?.exclude || [
+        'node_modules', '.git', '.github', 'dist', 'build', '.env', '.env.*', '*.log', '.turbo', '.wrangler',
+      ];
+      const syncExcludes = bundleDir
+        ? rawExcludes.map(p => (p === 'dist' || p === 'build') ? `/${p}` : p)
+        : rawExcludes;
       
       await FileSync.sync(
         actualSourceDir,
         remoteDir,
         host,
         {
-          exclude: config.sync?.exclude || [
-            'node_modules',
-            '.git',
-            'dist',
-            '.env',
-            '*.log',
-          ],
+          exclude: syncExcludes,
+          include: config.sync?.include,
           verbose: false,
         }
       );
 
       syncSpinner.succeed('Files synced successfully');
-      
-      // Upload bundled workspace dependencies if they exist (before npm install)
-      if (bundleDir) {
-        const bundledNodeModules = join(bundleDir, 'node_modules');
-        const { existsSync } = await import('fs');
-        
-        if (existsSync(bundledNodeModules)) {
-          Logger.section('Uploading Workspace Dependencies');
-          Logger.br();
-          
-          const uploadSpinner = ora('Uploading bundled workspace dependencies...').start();
-          
-          await FileSync.sync(
-            bundledNodeModules,
-            join(remoteDir, 'node_modules'),
-            host,
-            {
-              exclude: [],
-              verbose: false,
-            }
-          );
-          
-          uploadSpinner.succeed('Workspace dependencies uploaded');
-          Logger.br();
-        }
-      }
     }
     
     Logger.br();
@@ -504,30 +530,31 @@ async function deploySingleService(
 
     // Install dependencies
     const installSpinner = ora('Installing dependencies...').start();
-    
+
     // Check if package-lock.json exists, use npm ci if available, otherwise npm install
     const lockFileCheck = await ssh.exec(
       'test -f package-lock.json && echo "exists"',
       { cwd: remoteDir, streaming: false }
     );
     const hasLockFile = lockFileCheck.stdout.trim() === 'exists';
-    
-    // If build command exists, install all dependencies (including dev); otherwise production only
-    const needsDevDeps = !!config.build?.command;
-    const installCmd = hasLockFile 
-      ? (needsDevDeps ? 'npm ci --install-links' : 'npm ci --production --install-links')
-      : (needsDevDeps ? 'npm install --install-links' : 'npm install --production --install-links');
-    
-    const installResult = await ssh.exec(
-      installCmd,
-      { cwd: remoteDir, streaming: false }
-    );
-    
-    if (installResult.exitCode !== 0) {
-      installSpinner.fail('Dependency installation failed');
-      throw new Error(`${installCmd} failed: ${installResult.stderr}`);
+
+    const { installCmd } = computeInstallPlan(config, hasLockFile);
+
+    if (installCmd) {
+      const installResult = await ssh.exec(
+        installCmd,
+        { cwd: remoteDir, streaming: false }
+      );
+
+      if (installResult.exitCode !== 0) {
+        installSpinner.fail('Dependency installation failed');
+        const errorOutput = installResult.stderr || installResult.stdout;
+        throw new Error(`${installCmd} failed: ${errorOutput}`);
+      }
+      installSpinner.succeed('Dependencies installed');
+    } else {
+      installSpinner.info('Skipping dependency installation (build.nodeModules=none)');
     }
-    installSpinner.succeed('Dependencies installed');
 
     // Build application
     if (config.build?.command) {
@@ -684,8 +711,9 @@ EOF`);
 
     const healthSpinner = ora('Waiting for service to be ready...').start();
     const healthPath = config.health?.path || '/health';
+    const timeout = config.health?.timeout || 60;
     const retries = config.health?.retries || 10;
-    const interval = config.health?.interval || 3000;
+    const interval = config.health?.interval || 3;
     
     let healthy = false;
     for (let i = 0; i < retries; i++) {
@@ -693,7 +721,7 @@ EOF`);
       
       // Check health via SSH using curl on localhost
       const healthCheckResult = await ssh.exec(
-        `curl -sf http://localhost:${envConfig.port}${healthPath}`,
+        `curl --max-time ${timeout} -sf http://localhost:${envConfig.port}${healthPath}`,
         { cwd: remoteDir, streaming: false }
       );
       
@@ -704,7 +732,7 @@ EOF`);
       }
       
       if (i < retries - 1) {
-        await new Promise(resolve => setTimeout(resolve, interval));
+        await new Promise(resolve => setTimeout(resolve, interval * 1000));
       }
     }
     
@@ -804,8 +832,19 @@ async function dryRunDeploy(
   Logger.log(`   → Exclude: ${config.sync?.exclude?.join(', ')}`);
   Logger.br();
   
+  const hasLocalLockFile = existsSync(join(process.cwd(), 'package-lock.json'));
+  const workspaceManager = new WorkspaceManager();
+  const isWorkspace = await workspaceManager.detectWorkspace(process.cwd());
+  const hasBundledWorkspaceDeps =
+    isWorkspace && workspaceManager.getWorkspaceDependencies(process.cwd()).length > 0;
+  const { installCmd } = computeInstallPlan(config, hasLocalLockFile || hasBundledWorkspaceDeps);
+
   Logger.log('3. Remote Build');
-  Logger.log('   → npm ci --production');
+  if (installCmd) {
+    Logger.log(`   → ${installCmd}`);
+  } else {
+    Logger.log('   → Skip dependency installation (build.nodeModules=none)');
+  }
   if (config.build?.command) {
     Logger.log(`   → ${config.build.command}`);
   }

--- a/hostfn/cli/src/commands/init.ts
+++ b/hostfn/cli/src/commands/init.ts
@@ -134,7 +134,7 @@ export async function initCommand(): Promise<void> {
     build: {
       command: buildAnswers.buildCommand,
       directory: 'dist',
-      nodeModules: 'production',
+      nodeModules: 'all',
     },
     start: {
       command: buildAnswers.startCommand,

--- a/hostfn/cli/src/config/schema.ts
+++ b/hostfn/cli/src/config/schema.ts
@@ -19,7 +19,7 @@ export type EnvironmentConfig = z.infer<typeof EnvironmentConfigSchema>;
 export const BuildConfigSchema = z.object({
   command: z.string().describe('Build command to run'),
   directory: z.string().default('dist').describe('Output directory'),
-  nodeModules: z.enum(['all', 'production', 'none']).default('production'),
+  nodeModules: z.enum(['all', 'production', 'none']).optional(),
 }).optional();
 
 export type BuildConfig = z.infer<typeof BuildConfigSchema>;

--- a/hostfn/cli/src/core/ssh.ts
+++ b/hostfn/cli/src/core/ssh.ts
@@ -35,6 +35,8 @@ export class SSHConnection {
       host: options.host,
       port: options.port || 22,
       username: options.username,
+      keepaliveInterval: 30000,  // Send keepalive every 30s to survive long npm installs
+      keepaliveCountMax: 10,
     };
 
     // Add authentication method

--- a/hostfn/cli/src/core/sync.ts
+++ b/hostfn/cli/src/core/sync.ts
@@ -12,6 +12,31 @@ export interface SyncOptions {
  * Sync files to remote server using rsync
  */
 export class FileSync {
+  private static buildBaseArgs(options: SyncOptions = {}): string[] {
+    const args = [
+      '-avz',
+      '--delete',
+    ];
+
+    if (options.dryRun) {
+      args.push('--dry-run');
+    }
+
+    if (options.include && options.include.length > 0) {
+      for (const pattern of options.include) {
+        args.push('--include', pattern);
+      }
+    }
+
+    if (options.exclude && options.exclude.length > 0) {
+      for (const pattern of options.exclude) {
+        args.push('--exclude', pattern);
+      }
+    }
+
+    return args;
+  }
+
   /**
    * Sync local directory to remote server
    */
@@ -21,10 +46,7 @@ export class FileSync {
     sshConnection: string, // user@host
     options: SyncOptions = {}
   ): Promise<void> {
-    const args = [
-      '-avz', // archive, verbose, compress
-      '--delete', // delete files on remote that don't exist locally
-    ];
+    const args = this.buildBaseArgs(options);
 
     // Handle SSH authentication for CI/CD mode
     let tempKeyPath: string | undefined;
@@ -47,25 +69,6 @@ export class FileSync {
     } else {
       // Local mode: use default SSH config (respects ~/.ssh/config and ssh-agent)
       args.push('-e', 'ssh -o StrictHostKeyChecking=no -o BatchMode=yes');
-    }
-
-    // Add dry-run flag
-    if (options.dryRun) {
-      args.push('--dry-run');
-    }
-
-    // Add exclude patterns
-    if (options.exclude && options.exclude.length > 0) {
-      for (const pattern of options.exclude) {
-        args.push('--exclude', pattern);
-      }
-    }
-
-    // Add include patterns
-    if (options.include && options.include.length > 0) {
-      for (const pattern of options.include) {
-        args.push('--include', pattern);
-      }
     }
 
     // Ensure trailing slash on source (rsync behavior)
@@ -108,6 +111,44 @@ export class FileSync {
           // Ignore cleanup errors
         }
       }
+    }
+  }
+
+  /**
+   * Sync local directory to another local directory using the same rsync rules
+   * as remote deploys.
+   */
+  static async syncLocal(
+    sourcePath: string,
+    destinationPath: string,
+    options: SyncOptions = {}
+  ): Promise<void> {
+    const args = this.buildBaseArgs(options);
+    const source = sourcePath.endsWith('/') ? sourcePath : `${sourcePath}/`;
+
+    args.push(source, destinationPath);
+
+    try {
+      const result = await execa('rsync', args, {
+        stdio: options.verbose ? 'inherit' : 'pipe',
+      });
+
+      if (result.exitCode !== 0) {
+        throw new Error(`rsync failed with exit code ${result.exitCode}`);
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('ENOENT') || error.message.includes('not found')) {
+          throw new Error(
+            'rsync is not installed on your system.\n' +
+            'Please install it:\n' +
+            '  - macOS: brew install rsync\n' +
+            '  - Ubuntu/Debian: apt-get install rsync\n' +
+            '  - Windows: Install via WSL or use Git Bash'
+          );
+        }
+      }
+      throw error;
     }
   }
 

--- a/hostfn/cli/src/core/workspace.ts
+++ b/hostfn/cli/src/core/workspace.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, cpSync, mkdirSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, resolve, relative, sep } from 'path';
+import { valid, validRange, satisfies } from 'semver';
 import { Logger } from '../utils/logger.js';
 
 interface PackageJson {
@@ -95,8 +96,11 @@ export class WorkspaceManager {
 
     Logger.info(`Bundling ${workspaceDeps.length} workspace dependencies...`);
 
-    const nodeModulesDir = join(targetDir, 'node_modules');
-    mkdirSync(nodeModulesDir, { recursive: true });
+    // Store workspace deps in __workspace__/ (not node_modules/) so they are:
+    // 1. Included in the main rsync (not excluded like node_modules)
+    // 2. Not wiped out when npm ci/install cleans node_modules
+    const workspaceDir = join(targetDir, '__workspace__');
+    mkdirSync(workspaceDir, { recursive: true });
     
     for (const depName of workspaceDeps) {
       const depPath = this.workspacePackages.get(depName);
@@ -113,7 +117,7 @@ export class WorkspaceManager {
         }
       }
 
-      const targetDepDir = join(nodeModulesDir, depName);
+      const targetDepDir = join(workspaceDir, depName);
       
       mkdirSync(dirname(targetDepDir), { recursive: true });
 
@@ -130,6 +134,55 @@ export class WorkspaceManager {
     }
   }
 
+  async generateLockfile(targetDir: string, servicePath?: string): Promise<void> {
+    const { execSync } = await import('child_process');
+    const pkgJsonPath = join(targetDir, 'package.json');
+
+    // Temporarily pin direct dependencies to their exact resolved versions from the
+    // root monorepo lockfile. Without this, `npm install --package-lock-only` would
+    // re-resolve all dependencies from the npm registry and may pick up newer
+    // (potentially breaking) versions (e.g. better-auth 1.3.x → 1.5.x).
+    //
+    // We pin direct deps only (not transitive). Overriding transitive deps causes
+    // EUSAGE errors from `npm ci` because the lockfile's transitive versions may no
+    // longer match what the pinned direct dep's own package.json requires.
+    if (this.workspaceRoot) {
+      const rootLockfilePath = join(this.workspaceRoot, 'package-lock.json');
+      if (existsSync(rootLockfilePath)) {
+        try {
+          const rootLockfile = JSON.parse(readFileSync(rootLockfilePath, 'utf-8'));
+          const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+
+          // Replace semver ranges in direct deps with the exact resolved version.
+          // This prevents npm from upgrading direct deps when generating the lockfile.
+          for (const depGroup of ['dependencies', 'devDependencies'] as const) {
+            for (const depName of Object.keys(pkg[depGroup] || {})) {
+              const declaredVersion = pkg[depGroup]![depName];
+              const exactVersion = this.getResolvedVersionForDependency(
+                rootLockfile.packages || {},
+                servicePath,
+                depName,
+                declaredVersion,
+              );
+              if (exactVersion) {
+                pkg[depGroup]![depName] = exactVersion;
+              }
+            }
+          }
+
+          writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2));
+        } catch {
+          // Fall through without pinning
+        }
+      }
+    }
+
+    execSync('npm install --package-lock-only --ignore-scripts', {
+      cwd: targetDir,
+      stdio: 'ignore',
+    });
+  }
+
   rewritePackageJson(servicePath: string, targetDir: string): void {
     const workspaceDeps = this.getWorkspaceDependencies(servicePath);
     
@@ -143,7 +196,7 @@ export class WorkspaceManager {
     if (pkg.dependencies) {
       for (const depName of workspaceDeps) {
         if (pkg.dependencies[depName]) {
-          pkg.dependencies[depName] = `file:./node_modules/${depName}`;
+          pkg.dependencies[depName] = `file:./__workspace__/${depName}`;
         }
       }
     }
@@ -151,7 +204,7 @@ export class WorkspaceManager {
     if (pkg.devDependencies) {
       for (const depName of workspaceDeps) {
         if (pkg.devDependencies[depName]) {
-          delete pkg.devDependencies[depName];
+          pkg.devDependencies[depName] = `file:./__workspace__/${depName}`;
         }
       }
     }
@@ -176,5 +229,57 @@ export class WorkspaceManager {
 
   isInWorkspace(): boolean {
     return this.workspaceRoot !== null;
+  }
+
+  private getResolvedVersionForDependency(
+    lockfilePackages: Record<string, { version?: string; name?: string }>,
+    servicePath: string | undefined,
+    depName: string,
+    declaredRange: string,
+  ): string | null {
+    const candidatePaths = this.getDependencyCandidatePaths(servicePath, depName);
+
+    for (const candidatePath of candidatePaths) {
+      const pkgEntry = lockfilePackages[candidatePath];
+      if (!pkgEntry?.version) continue;
+      if (pkgEntry.name !== undefined && pkgEntry.name !== depName) continue;
+      if (!this.isResolvedVersionCompatible(declaredRange, pkgEntry.version)) continue;
+      return pkgEntry.version;
+    }
+
+    return null;
+  }
+
+  private getDependencyCandidatePaths(servicePath: string | undefined, depName: string): string[] {
+    const candidates: string[] = [];
+
+    if (this.workspaceRoot && servicePath) {
+      const relativeServicePath = relative(this.workspaceRoot, servicePath).split(sep).join('/');
+      if (relativeServicePath && relativeServicePath !== '.') {
+        candidates.push(`${relativeServicePath}/node_modules/${depName}`);
+      }
+    }
+
+    candidates.push(`node_modules/${depName}`);
+    return candidates;
+  }
+
+  private isResolvedVersionCompatible(declaredRange: string, resolvedVersion: string): boolean {
+    const normalizedRange = declaredRange.startsWith('workspace:')
+      ? declaredRange.slice('workspace:'.length)
+      : declaredRange;
+
+    if (normalizedRange === '' || normalizedRange === '*') {
+      return true;
+    }
+
+    const validResolvedVersion = valid(resolvedVersion);
+    const validResolvedRange = validRange(normalizedRange);
+
+    if (!validResolvedVersion || !validResolvedRange) {
+      return false;
+    }
+
+    return satisfies(validResolvedVersion, validResolvedRange);
   }
 }

--- a/hostfn/docs/.gitignore
+++ b/hostfn/docs/.gitignore
@@ -1,0 +1,3 @@
+.vercel
+.next
+.source

--- a/hostfn/docs/app/docs/[[...slug]]/page.tsx
+++ b/hostfn/docs/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,84 @@
+import { source } from "@/lib/source";
+import {
+  DocsBody,
+  DocsDescription,
+  DocsPage,
+  DocsTitle,
+} from "fumadocs-ui/page";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { notFound } from "next/navigation";
+import { gitConfig } from "@/app/layout.config";
+import { Mermaid } from "@/components/mdx/mermaid";
+
+export default async function Page(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const params = await props.params;
+  const page = source.getPage(params.slug);
+  if (!page) notFound();
+
+  const data = page.data as any;
+  const MDX = data.body;
+
+  return (
+    <DocsPage
+      toc={data.toc}
+      full={data.full}
+      editOnGithub={{
+        owner: gitConfig.user,
+        repo: gitConfig.repo,
+        path: `hostfn/docs/content/docs/${page.path}`,
+        sha: gitConfig.branch,
+      }}
+    >
+      <DocsTitle>{data.title}</DocsTitle>
+      <DocsDescription>{data.description}</DocsDescription>
+      <DocsBody>
+        <MDX components={{ ...defaultMdxComponents, Mermaid }} />
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export async function generateStaticParams() {
+  return source.generateParams();
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const params = await props.params;
+  const page = source.getPage(params.slug);
+  if (!page) notFound();
+
+  const data = page.data as any;
+  const docsPath = params.slug?.length ? `/docs/${params.slug.join("/")}` : "/docs";
+  const image = "/opengraph-image";
+
+  return {
+    title: data.title,
+    description: data.description,
+    alternates: {
+      canonical: docsPath,
+    },
+    openGraph: {
+      title: data.title,
+      description: data.description,
+      url: docsPath,
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: `${data.title} | HostFn Docs`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: data.title,
+      description: data.description,
+      images: [image],
+    },
+  };
+}

--- a/hostfn/docs/app/docs/layout.tsx
+++ b/hostfn/docs/app/docs/layout.tsx
@@ -1,0 +1,31 @@
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { baseOptions } from "@/app/layout.config";
+import { source } from "@/lib/source";
+
+type DocsLayoutProps = Parameters<typeof DocsLayout>[0];
+
+export default function Layout({ children }: { children: DocsLayoutProps["children"] }) {
+  const pageTree = source.getPageTree() as DocsLayoutProps["tree"];
+
+  return (
+    <DocsLayout
+      tree={pageTree}
+      {...baseOptions()}
+      sidebar={{
+        footer: (
+          <a
+            href="https://21n.co"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="flex items-center w-full justify-center gap-2 px-2 pt-6 text-sm text-fd-muted-foreground hover:text-fd-foreground text-center"
+          >
+            Built at 21n.co
+          </a>
+        ),
+        banner: null,
+      }}
+    >
+      {children}
+    </DocsLayout>
+  );
+}

--- a/hostfn/docs/app/global.css
+++ b/hostfn/docs/app/global.css
@@ -1,0 +1,6 @@
+@import "tailwindcss";
+@import "fumadocs-ui/css/neutral.css";
+@import "fumadocs-ui/css/preset.css";
+
+/* Shared theme package entrypoint */
+@import "@superfunctions/docs-theme/tokens.css";

--- a/hostfn/docs/app/layout.config.tsx
+++ b/hostfn/docs/app/layout.config.tsx
@@ -1,0 +1,14 @@
+import {
+  createBaseLayoutOptions,
+  type DocsGitConfig,
+} from "@superfunctions/docs-theme";
+
+export const gitConfig: DocsGitConfig = {
+  user: "21nCo",
+  repo: "super-functions",
+  branch: "dev",
+};
+
+export function baseOptions() {
+  return createBaseLayoutOptions("HostFn", gitConfig);
+}

--- a/hostfn/docs/app/layout.tsx
+++ b/hostfn/docs/app/layout.tsx
@@ -1,0 +1,59 @@
+import "./global.css";
+import "@21n/fonts/styles.css";
+import { RootProvider } from "fumadocs-ui/provider";
+import { DocsRootLayout } from "@superfunctions/docs-theme";
+import type { Metadata } from "next";
+
+const rawSiteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : "http://localhost:6003");
+
+const siteUrl = rawSiteUrl.match(/^https?:\/\//i)
+  ? rawSiteUrl
+  : `https://${rawSiteUrl}`;
+
+export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: "HostFn Docs",
+    template: "%s | HostFn Docs",
+  },
+  description:
+    "Documentation for HostFn, deployment and server management tooling in Superfunctions.",
+  openGraph: {
+    type: "website",
+    url: siteUrl,
+    siteName: "HostFn Docs",
+    title: "HostFn Docs",
+    description:
+      "Documentation for HostFn, deployment and server management tooling in Superfunctions.",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "HostFn Docs",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "HostFn Docs",
+    description:
+      "Documentation for HostFn, deployment and server management tooling in Superfunctions.",
+    images: ["/opengraph-image"],
+  },
+};
+
+type DocsRootLayoutProps = Parameters<typeof DocsRootLayout>[0];
+type RootProviderProps = Parameters<typeof RootProvider>[0];
+
+export default function Layout({ children }: { children: DocsRootLayoutProps["children"] }) {
+  return (
+    <DocsRootLayout>
+      <RootProvider>{children as RootProviderProps["children"]}</RootProvider>
+    </DocsRootLayout>
+  );
+}

--- a/hostfn/docs/app/not-found.tsx
+++ b/hostfn/docs/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div style={{ textAlign: "center", padding: "4rem" }}>
+      <h1>404 - Page Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  );
+}

--- a/hostfn/docs/app/opengraph-image.tsx
+++ b/hostfn/docs/app/opengraph-image.tsx
@@ -1,0 +1,46 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "linear-gradient(120deg, #111827, #0f172a)",
+          color: "#e5e7eb",
+          padding: "64px 72px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 38,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "#f59e0b",
+          }}
+        >
+          Superfunctions
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+          <div style={{ fontSize: 88, fontWeight: 700, color: "#f9fafb" }}>HostFn Docs</div>
+          <div style={{ fontSize: 34, color: "#d1d5db" }}>
+            Deployment and server management utilities
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/hostfn/docs/app/page.tsx
+++ b/hostfn/docs/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function HomePage() {
+  redirect("/docs");
+}

--- a/hostfn/docs/components/mdx/mermaid.tsx
+++ b/hostfn/docs/components/mdx/mermaid.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { use, useEffect, useId, useState } from 'react';
+import { useTheme } from 'next-themes';
+
+export function Mermaid({ chart }: { chart: string }) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+  return <MermaidContent chart={chart} />;
+}
+
+const cache = new Map<string, Promise<unknown>>();
+
+function cachePromise<T>(key: string, setPromise: () => Promise<T>): Promise<T> {
+  const cached = cache.get(key);
+  if (cached) return cached as Promise<T>;
+
+  const promise = setPromise();
+  cache.set(key, promise);
+  return promise;
+}
+
+function MermaidContent({ chart }: { chart: string }) {
+  const id = useId();
+  const { resolvedTheme } = useTheme();
+  const { default: mermaid } = use(cachePromise('mermaid', () => import('mermaid')));
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: 'loose',
+    fontFamily: 'inherit',
+    themeCSS: 'margin: 1.5rem auto 0;',
+    theme: resolvedTheme === 'dark' ? 'dark' : 'default',
+  });
+
+  const { svg, bindFunctions } = use(
+    cachePromise(`${id}-${chart}-${resolvedTheme}`, () => {
+      return mermaid.render(id, chart.replaceAll('\\n', '\n'));
+    }),
+  );
+
+  return (
+    <div
+      ref={(container) => {
+        if (container) bindFunctions?.(container);
+      }}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/hostfn/docs/content/docs/cli/deploy.mdx
+++ b/hostfn/docs/content/docs/cli/deploy.mdx
@@ -1,0 +1,78 @@
+---
+title: hostfn deploy
+description: Deploy your application to a remote server.
+---
+
+## Usage
+
+```bash
+hostfn deploy [environment] [options]
+```
+
+## Arguments
+
+| Argument | Description | Default |
+|---|---|---|
+| `environment` | Environment to deploy to | `production` |
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--host <host>` | Override server host from config | From config |
+| `--ci` | CI/CD mode (non-interactive) | `false` |
+| `--local` | Local deployment mode (skip SSH, for self-hosted runners) | `false` |
+| `--dry-run` | Show what would be deployed without executing | `false` |
+| `--service <name>` | Deploy specific service in monorepo | All services |
+| `--all` | Deploy all services in monorepo (default behavior) | `false` |
+
+## Description
+
+Deploys your application to the configured server. The deployment follows an 8-phase lifecycle:
+
+1. **Pre-flight Checks** - Validates config, checks rsync, connects to server, verifies Node.js version, acquires deployment lock
+2. **Workspace Bundling** - (Monorepos only) Bundles workspace dependencies
+3. **File Sync** - Syncs project files via rsync
+4. **Build** - Installs dependencies and runs build command
+5. **Backup** - Creates timestamped backup of current deployment
+6. **PM2 Deploy** - Starts or reloads PM2 process with zero downtime
+7. **Health Check** - Polls health endpoint until service responds
+8. **Cleanup** - Removes old backups, releases lock
+
+If any step fails after backup, the deployment is automatically rolled back.
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `HOSTFN_HOST` | Override server host (useful in CI/CD) |
+| `HOSTFN_SSH_KEY` | Base64-encoded SSH private key |
+| `HOSTFN_SSH_PASSWORD` | SSH password authentication |
+
+## Examples
+
+```bash
+# Deploy to production
+hostfn deploy production
+
+# Deploy to staging
+hostfn deploy staging
+
+# Deploy with custom host
+hostfn deploy production --host ubuntu@custom-server.com
+
+# Dry run (show plan without executing)
+hostfn deploy production --dry-run
+
+# CI/CD mode
+hostfn deploy production --ci
+
+# Local mode (self-hosted runner)
+hostfn deploy production --local
+
+# Deploy specific monorepo service
+hostfn deploy production --service api
+
+# Deploy all monorepo services
+hostfn deploy production --all
+```

--- a/hostfn/docs/content/docs/cli/env.mdx
+++ b/hostfn/docs/content/docs/cli/env.mdx
@@ -1,0 +1,79 @@
+---
+title: hostfn env
+description: Manage environment variables on the server.
+---
+
+The `hostfn env` command group manages environment variables stored on the remote server.
+
+## Subcommands
+
+### `hostfn env list <environment>`
+
+Lists all environment variables on the server with values masked.
+
+```bash
+$ hostfn env list production
+
+  ── Environment Variables ──
+    DATABASE_URL=***
+    JWT_SECRET=***
+    REDIS_URL=***
+
+  Total: 3 variable(s)
+```
+
+### `hostfn env set <environment> <key> <value>`
+
+Sets a single environment variable on the server. The `.env` file must already exist (use `env push` first).
+
+```bash
+hostfn env set production DATABASE_URL "postgresql://user:pass@host/db"
+```
+
+Key format requirements:
+- Uppercase letters, digits, and underscores only
+- Must start with a letter or underscore (e.g., `DATABASE_URL`, `_SECRET`)
+
+### `hostfn env push <environment> <file>`
+
+Uploads a local `.env` file to the server. Creates a backup of the existing `.env` file before overwriting.
+
+```bash
+hostfn env push production .env.production
+```
+
+This command requires confirmation before executing.
+
+### `hostfn env pull <environment> <file>`
+
+Downloads the `.env` file from the server to a local path.
+
+```bash
+hostfn env pull production .env.local
+```
+
+**Warning:** The downloaded file contains sensitive data. Do not commit it to git.
+
+### `hostfn env validate <environment>`
+
+Validates that all required environment variables (defined in `hostfn.config.json` under `env.required`) are set on the server.
+
+```bash
+$ hostfn env validate production
+
+  ── Validation Results ──
+    ✓ DATABASE_URL
+    ✓ JWT_SECRET
+    ✗ STRIPE_KEY (missing)
+
+  Missing 1 required variable(s)
+
+  Set missing variables:
+  $ hostfn env set production STRIPE_KEY "value"
+```
+
+## Important Notes
+
+- Environment variables are stored in `/var/www/{name}-{env}/.env` on the server
+- After changing variables, you need to redeploy for changes to take effect (variables are read during deployment and injected into PM2 config)
+- The `env push` command creates a backup at `.env.backup` before overwriting

--- a/hostfn/docs/content/docs/cli/expose.mdx
+++ b/hostfn/docs/content/docs/cli/expose.mdx
@@ -1,0 +1,99 @@
+---
+title: hostfn expose
+description: Configure Nginx reverse proxy and SSL certificates.
+---
+
+## Usage
+
+```bash
+hostfn expose [environment] [options]
+```
+
+## Arguments
+
+| Argument | Description | Default |
+|---|---|---|
+| `environment` | Environment to configure | `production` |
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--host <host>` | Override server host | From config |
+| `--skip-ssl` | Skip SSL certificate setup | `false` |
+| `--force` | Overwrite existing Nginx configuration | `false` |
+
+## Description
+
+Configures Nginx as a reverse proxy for your deployed services and optionally sets up SSL certificates via Let's Encrypt (certbot).
+
+### What It Does
+
+1. Connects to the server via SSH
+2. Checks that Nginx and certbot are installed
+3. Auto-detects `sites-available` vs `conf.d` Nginx configuration system
+4. Generates Nginx configuration with WebSocket support
+5. Writes the configuration and enables the site
+6. Tests and reloads Nginx
+7. Obtains SSL certificate via certbot (if domain and sslEmail are configured)
+
+### Single Service
+
+For single-service deployments, generates a configuration that proxies all traffic to your app:
+
+```nginx
+server {
+    listen 80;
+    server_name api.example.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+### Monorepo (Multiple Services)
+
+For monorepo deployments, routes traffic based on the `exposePath` configured for each service:
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+
+    # api service
+    location /api/ {
+        proxy_pass http://localhost:3001/;
+        ...
+    }
+
+    # web service (default)
+    location / {
+        proxy_pass http://localhost:3002;
+        ...
+    }
+}
+```
+
+## Examples
+
+```bash
+# Configure Nginx and SSL for production
+hostfn expose production
+
+# Skip SSL (HTTP only)
+hostfn expose production --skip-ssl
+
+# Force overwrite existing config
+hostfn expose production --force
+
+# Use custom host
+hostfn expose production --host ubuntu@other-server.com
+```

--- a/hostfn/docs/content/docs/cli/index.mdx
+++ b/hostfn/docs/content/docs/cli/index.mdx
@@ -1,0 +1,31 @@
+---
+title: CLI Reference
+description: Complete reference for all HostFn CLI commands.
+---
+
+HostFn provides a comprehensive CLI for managing application deployments. All commands are available after installing the `hostfn` package globally.
+
+```bash
+npm install -g hostfn
+```
+
+## Commands Overview
+
+| Command | Description |
+|---|---|
+| [`hostfn init`](/docs/cli/init) | Initialize HostFn configuration in current project |
+| [`hostfn deploy`](/docs/cli/deploy) | Deploy application to server |
+| [`hostfn expose`](/docs/cli/expose) | Configure Nginx and SSL for deployed services |
+| [`hostfn status`](/docs/cli/status) | Show application status |
+| [`hostfn logs`](/docs/cli/logs) | View application logs |
+| [`hostfn rollback`](/docs/cli/rollback) | Rollback to previous deployment |
+| [`hostfn env`](/docs/cli/env) | Manage environment variables |
+| [`hostfn server`](/docs/cli/server) | Server management commands |
+
+## Global Options
+
+```bash
+hostfn --version    # Show version number
+hostfn --help       # Show help
+hostfn <cmd> --help # Show help for a specific command
+```

--- a/hostfn/docs/content/docs/cli/init.mdx
+++ b/hostfn/docs/content/docs/cli/init.mdx
@@ -1,0 +1,67 @@
+---
+title: hostfn init
+description: Initialize HostFn configuration in your project.
+---
+
+## Usage
+
+```bash
+hostfn init
+```
+
+## Description
+
+Initializes a new `hostfn.config.json` configuration file in the current directory. This is an interactive command that:
+
+1. **Detects the project runtime** by scanning for `package.json` and other Node.js project signals
+2. **Prompts for project settings** including name, version, server, port, domain, build and start commands
+3. **Generates the configuration file** with smart defaults based on detection
+
+## Interactive Prompts
+
+| Prompt | Description | Default |
+|---|---|---|
+| Application name | Used for PM2 service name and remote directory | From `package.json` name |
+| Runtime version | Node.js major version | From `engines.node` or `18` |
+| Production server | SSH connection string | — |
+| Production port | Port the app listens on | `3000` |
+| Domain | Custom domain for Nginx | — |
+| Build command | Command to build the project | From `scripts.build` |
+| Start command | Command to start the project | From `scripts.start` |
+
+## Behavior
+
+- If `hostfn.config.json` already exists, prompts for confirmation before overwriting
+- Detects runtime with a confidence score (warns if below 80%)
+- Reads `package.json` to suggest smart defaults for Node.js projects
+
+## Example
+
+```bash
+$ hostfn init
+
+  Initialize hostfn
+
+  ✔ Detected nodejs (confidence: 95%)
+
+  ── Project Configuration ──
+  ? Application name: my-api
+  ? nodejs version: 20
+
+  ── Environment Configuration ──
+  ? Production server (user@host): ubuntu@my-server.com
+  ? Production port: 3000
+  ? Domain (optional): api.example.com
+
+  ── Build & Start Configuration ──
+  ? Build command: npm run build
+  ? Start command: npm start
+
+  ✔ Configuration created
+
+  ✅ hostfn initialized successfully!
+
+  Next steps:
+  $ hostfn server setup ubuntu@my-server.com
+  $ hostfn deploy production
+```

--- a/hostfn/docs/content/docs/cli/logs.mdx
+++ b/hostfn/docs/content/docs/cli/logs.mdx
@@ -1,0 +1,60 @@
+---
+title: hostfn logs
+description: View application logs from the server.
+---
+
+## Usage
+
+```bash
+hostfn logs [environment] [options]
+```
+
+## Arguments
+
+| Argument | Description | Default |
+|---|---|---|
+| `environment` | Environment | `production` |
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--lines <n>` | Number of lines to show | `100` |
+| `--errors` | Show only error lines | `false` |
+| `--output <file>` | Save logs to a local file | — |
+| `--service <name>` | View logs for specific monorepo service | — |
+
+## Description
+
+Retrieves PM2 logs from the remote server. Logs are streamed to your terminal in real-time unless `--output` is specified.
+
+### Error Filtering
+
+The `--errors` flag filters output to only show lines containing: `error`, `Error`, `ERROR`, `fail`, `Fail`, `FAIL`, `exception`, or `Exception`.
+
+### Monorepo
+
+For monorepo deployments, you must specify `--service`:
+
+```bash
+hostfn logs production --service api
+```
+
+## Examples
+
+```bash
+# View last 100 lines of production logs
+hostfn logs production
+
+# View last 500 lines
+hostfn logs production --lines 500
+
+# View only errors
+hostfn logs production --errors
+
+# Save logs to file
+hostfn logs production --output app.log
+
+# View specific monorepo service logs
+hostfn logs production --service api
+```

--- a/hostfn/docs/content/docs/cli/meta.json
+++ b/hostfn/docs/content/docs/cli/meta.json
@@ -1,0 +1,16 @@
+{
+  "title": "CLI",
+  "description": "Command-line reference",
+  "root": true,
+  "pages": [
+    "index",
+    "init",
+    "deploy",
+    "expose",
+    "status",
+    "logs",
+    "rollback",
+    "env",
+    "server"
+  ]
+}

--- a/hostfn/docs/content/docs/cli/rollback.mdx
+++ b/hostfn/docs/content/docs/cli/rollback.mdx
@@ -1,0 +1,67 @@
+---
+title: hostfn rollback
+description: Rollback to a previous deployment.
+---
+
+## Usage
+
+```bash
+hostfn rollback [environment] [options]
+```
+
+## Arguments
+
+| Argument | Description | Default |
+|---|---|---|
+| `environment` | Environment to rollback | `production` |
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--to <timestamp>` | Rollback to a specific backup by name |
+
+## Description
+
+Restores a previous deployment from backup. HostFn creates a timestamped backup before each deployment, so you can easily go back to any recent version.
+
+### Interactive Mode
+
+Without `--to`, the command lists available backups and lets you choose:
+
+```
+  ── Available Backups ──
+    1. 2024-01-15T10-30-00-000Z
+    2. 2024-01-14T15-20-00-000Z
+    3. 2024-01-13T09-00-00-000Z
+
+  ? Select backup to restore: 1. 2024-01-15T10-30-00-000Z (latest)
+```
+
+### Rollback Process
+
+1. Fetches available backups from the server
+2. Restores the selected backup's `dist/` directory
+3. Reloads the PM2 process with the restored code
+
+## Examples
+
+```bash
+# Interactive rollback (select from list)
+hostfn rollback production
+
+# Rollback to specific backup
+hostfn rollback production --to 2024-01-15T10-30-00-000Z
+
+# Rollback staging
+hostfn rollback staging
+```
+
+## Automatic Rollback
+
+HostFn also performs automatic rollback during `hostfn deploy` when:
+
+- The health check fails after deployment
+- PM2 fails to start the service
+
+When rollback succeeds, this happens automatically. If rollback itself fails, HostFn reports that manual intervention is required.

--- a/hostfn/docs/content/docs/cli/server.mdx
+++ b/hostfn/docs/content/docs/cli/server.mdx
@@ -1,0 +1,91 @@
+---
+title: hostfn server
+description: Server management commands for setup and information.
+---
+
+The `hostfn server` command group manages remote server provisioning and information.
+
+## Subcommands
+
+### `hostfn server setup <host>`
+
+Sets up a new server for deployments. Installs all necessary software and configures the server.
+
+```bash
+hostfn server setup ubuntu@my-server.com
+```
+
+#### Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--env <environment>` | Environment name | `production` |
+| `--node-version <version>` | Node.js version to install | `20` |
+| `--port <port>` | Service port for Nginx config | `3000` |
+| `--redis` | Also install Redis | `false` |
+| `--password <password>` | SSH password (if not using key auth) | — |
+
+#### What Gets Installed
+
+| Software | Purpose |
+|---|---|
+| nvm + Node.js | JavaScript runtime |
+| PM2 | Process manager |
+| Nginx | Reverse proxy |
+| Certbot | SSL certificates |
+| rsync | File synchronization |
+| build-essential | Native npm module compilation |
+| UFW | Firewall (ports 22, 80, 443) |
+| Redis | (optional) In-memory data store |
+
+#### How It Works
+
+1. Generates a setup shell script based on your runtime and options
+2. Asks for confirmation to execute on the server
+3. Uploads and executes the script over SSH with streaming output
+4. If you decline, saves the script locally for manual execution
+
+The setup takes 2-5 minutes depending on your server's connection speed.
+
+---
+
+### `hostfn server info <host>`
+
+Displays comprehensive information about a remote server.
+
+```bash
+hostfn server info ubuntu@my-server.com
+```
+
+#### Information Displayed
+
+| Section | Details |
+|---|---|
+| **System** | OS name/version, disk usage, memory usage |
+| **Runtime** | Node.js version, PM2 version, Nginx status |
+| **Services** | All running PM2 services with status, memory, CPU, and uptime |
+
+#### Example Output
+
+```
+  Server Information
+
+  Host  ubuntu@my-server.com
+
+  ✔ Connected
+
+  ── System ──
+  OS      Ubuntu 22.04.3 LTS
+  Disk    12G used / 50G total (24% used)
+  Memory  1.2G used / 4.0G total
+
+  ── Runtime ──
+  Node.js  v20.11.0
+  PM2      5.3.0
+  Nginx    active
+
+  ── Services ──
+    my-api-production
+      Status: online
+      Memory: 85MB  CPU: 2%  Uptime: 3d 12h
+```

--- a/hostfn/docs/content/docs/cli/status.mdx
+++ b/hostfn/docs/content/docs/cli/status.mdx
@@ -1,0 +1,71 @@
+---
+title: hostfn status
+description: Show the status of your deployed application.
+---
+
+## Usage
+
+```bash
+hostfn status [environment] [options]
+```
+
+## Arguments
+
+| Argument | Description | Default |
+|---|---|---|
+| `environment` | Environment to check | `production` |
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--service <name>` | Show status for specific service in monorepo |
+
+## Description
+
+Connects to the server and displays the PM2 service status, including:
+
+- **Status** - online, stopped, errored
+- **PID** - Process ID
+- **Restarts** - Number of automatic restarts
+- **Memory** - Current memory usage
+- **CPU** - Current CPU usage
+- **Uptime** - Time since last restart
+- **Created** - When the service started
+
+For monorepo deployments without `--service`, shows status for all services.
+
+## Examples
+
+```bash
+# Check production status
+hostfn status production
+
+# Check specific monorepo service
+hostfn status production --service api
+
+# Check staging
+hostfn status staging
+```
+
+## Example Output
+
+```
+  Status - production
+
+  ✔ Connected
+
+  ── Service Information ──
+  Name      my-api-production
+  Status    online
+  PID       12345
+  Restarts  0
+
+  ── Resources ──
+  Memory    85MB
+  CPU       2%
+
+  ── Timing ──
+  Uptime    3d 12h 45m
+  Created   3/8/2026, 2:30:00 PM
+```

--- a/hostfn/docs/content/docs/documentation/advanced/backups.mdx
+++ b/hostfn/docs/content/docs/documentation/advanced/backups.mdx
@@ -1,0 +1,126 @@
+---
+title: Backups
+description: Understand how HostFn automatically backs up deployments and manages retention.
+---
+
+HostFn creates a timestamped backup before each deployment, giving you a safety net to roll back if something goes wrong. Backups are stored on the remote server and managed automatically.
+
+## How Backups Work
+
+During every deployment, HostFn creates a backup of the current `dist/` directory and `package.json` before replacing them with the new build. This happens in the backup phase of the deployment pipeline, after the build completes but before the PM2 process is restarted.
+
+```
+Phase 1: Pre-flight Checks
+Phase 2: File Sync
+Phase 3: Remote Build
+Phase 4: Install Dependencies
+Phase 5: Create Backup     ← backup happens here
+Phase 6: PM2 Deployment
+Phase 7: Health Check
+Phase 8: Cleanup
+```
+
+## Backup Storage Location
+
+Backups are stored on the remote server at:
+
+```
+/var/www/{name}-{env}/backups/{timestamp}/
+```
+
+For example, an application named `my-api` deployed to the `production` environment would store backups at:
+
+```
+/var/www/my-api-production/backups/2026-03-11T14-30-00-000Z/
+```
+
+Each backup directory contains:
+
+| File | Description |
+|---|---|
+| `dist/` | Complete copy of the build output directory |
+| `package.json` | Application manifest (if present) |
+
+## What Gets Backed Up
+
+HostFn backs up the files needed to restore a working deployment:
+
+- **`dist/` directory** -- the compiled build output that PM2 runs
+- **`package.json`** -- the dependency manifest (copied on a best-effort basis)
+
+Items that are **not** backed up:
+
+- `node_modules/` -- too large; rollback restores `dist/` only, so reinstall dependencies manually if your deployment state changed
+- `.env` files -- environment variables are managed separately
+- Nginx configuration -- server configuration is independent of deployments
+
+## Backup Retention
+
+By default, HostFn keeps the **5 most recent backups** and deletes older ones after each deployment. You can configure this with the `backup.keep` setting:
+
+```json title="hostfn.config.json"
+{
+  "backup": {
+    "keep": 10
+  }
+}
+```
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `backup.keep` | `number` | `5` | Number of backups to retain |
+
+Cleanup runs automatically at the end of each successful deployment. Backups are sorted by timestamp (most recent first), and any beyond the retention count are deleted.
+
+## Backup Naming
+
+Backup directories are named using ISO 8601 timestamps with special characters replaced by hyphens:
+
+```
+2026-03-11T14-30-00-000Z
+```
+
+This format ensures backups sort chronologically and are easy to identify. The most recent backup always appears first when listed.
+
+## Viewing Backups
+
+You can view available backups for an environment by starting the rollback command:
+
+```bash
+hostfn rollback production
+```
+
+This connects to the server and lists all available backups before prompting for selection.
+
+You can also check backups directly on the server:
+
+```bash
+ssh ubuntu@your-server.com "ls -la /var/www/my-api-production/backups/"
+```
+
+## First Deployment
+
+On the first deployment, there is no existing `dist/` directory to back up. HostFn detects this and skips the backup step:
+
+```
+  ── Creating Backup ──
+
+  ℹ No existing deployment to backup
+```
+
+This is normal and expected. Auto-rollback will not be available for the first deployment since there is no previous version to restore.
+
+## Manual Backup Management
+
+If you need to manually manage backups on the server, the backup directory structure is straightforward:
+
+```bash
+# List all backups
+ssh ubuntu@your-server.com "ls -la /var/www/my-api-production/backups/"
+
+# Delete a specific backup
+ssh ubuntu@your-server.com "rm -rf /var/www/my-api-production/backups/2026-03-07T08-20-33-000Z"
+
+# Delete all backups
+ssh ubuntu@your-server.com "rm -rf /var/www/my-api-production/backups/*"
+```

--- a/hostfn/docs/content/docs/documentation/advanced/deployment-locks.mdx
+++ b/hostfn/docs/content/docs/documentation/advanced/deployment-locks.mdx
@@ -1,0 +1,146 @@
+---
+title: Deployment Locks
+description: How HostFn prevents concurrent deployments from conflicting with each other.
+---
+
+HostFn uses a file-based locking mechanism to prevent concurrent deployments to the same environment. This ensures that two developers (or CI/CD pipelines) cannot deploy to the same server at the same time, which could cause corrupted builds or unpredictable state.
+
+## How Locks Work
+
+When a deployment starts, HostFn creates a lock file on the remote server. If a lock file already exists and is not stale, the deployment is rejected with an error. When the deployment finishes (whether it succeeds or fails), the lock is released.
+
+### Lock Lifecycle
+
+```
+1. Deploy starts      → Lock acquired
+2. Sync, build, etc.  → Lock held
+3. Deploy completes   → Lock released
+   OR
+3. Deploy fails       → Lock released (auto-rollback runs first)
+```
+
+## Lock File Location
+
+The lock file is stored on the remote server at:
+
+```
+/var/www/{name}-{env}/.hostfn-deploy.lock
+```
+
+For example:
+
+```
+/var/www/my-api-production/.hostfn-deploy.lock
+```
+
+## Lock File Contents
+
+The lock file contains a JSON object with information about the deployment that created it:
+
+```json title=".hostfn-deploy.lock"
+{
+  "pid": 12345,
+  "user": "developer",
+  "timestamp": 1741700000000,
+  "hostname": "dev-laptop"
+}
+```
+
+| Field | Description |
+|---|---|
+| `pid` | Process ID of the deploying CLI instance |
+| `user` | Username of the person running the deployment (from `$USER`) |
+| `timestamp` | Unix timestamp (milliseconds) when the lock was acquired |
+| `hostname` | Hostname of the machine running the deployment (from `$HOSTNAME`) |
+
+This information helps you identify who started the deployment and when, which is useful for debugging lock conflicts.
+
+## Stale Lock Detection
+
+Locks automatically expire after **5 minutes** (300 seconds). If HostFn encounters an existing lock file that is older than 5 minutes, it treats it as stale, removes it, and proceeds with the deployment.
+
+This handles cases where a deployment process was killed without releasing the lock (e.g., the developer's machine lost network connectivity or the process was terminated with `kill -9`).
+
+```
+  ⠋ Acquiring deployment lock...
+  ⚠ Found stale lock file, removing...
+  ✔ Deployment lock acquired
+```
+
+## Lock Conflict
+
+When a valid (non-stale) lock is in place, HostFn displays information about the existing deployment and exits:
+
+```
+  ✗ Could not acquire deployment lock
+
+  ✗ Deployment is already in progress
+  ℹ Started by: developer
+  ℹ Started at: 3/11/2026, 2:30:00 PM
+  ℹ Age: 2 minute(s)
+
+  ⚠ Wait for the current deployment to finish or:
+    1. Wait for lock to expire (5 minutes)
+    2. Manually remove: ssh <host> rm /var/www/my-api-production/.hostfn-deploy.lock
+```
+
+## Manual Lock Removal
+
+If you know that no deployment is actually running (e.g., the deploying machine crashed), you can manually remove the lock file:
+
+```bash
+ssh ubuntu@your-server.com "rm /var/www/my-api-production/.hostfn-deploy.lock"
+```
+
+After removing the lock, you can deploy normally.
+
+## Lock Behavior in Error Scenarios
+
+HostFn releases the lock in its `finally` block whenever the process can still run cleanup logic:
+
+| Scenario | Lock Released |
+|---|---|
+| Successful deployment | Yes |
+| Build failure (with auto-rollback) | Yes |
+| Health check failure (with auto-rollback) | Yes |
+| SSH connection lost | No (expires after 5 minutes) |
+| CLI process killed (SIGKILL) | No (expires after 5 minutes) |
+| Lock file manually deleted during deploy | Deployment continues normally |
+
+## CI/CD Considerations
+
+In CI/CD pipelines, lock conflicts are more common because multiple pipelines might try to deploy the same environment simultaneously. Consider the following approaches:
+
+### Serialize Deployments
+
+Most CI/CD systems support concurrency limits. For example, in GitHub Actions:
+
+```yaml title=".github/workflows/deploy.yml"
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+```
+
+This ensures only one deployment workflow runs at a time for the `production` group.
+
+### Retry on Lock Conflict
+
+If your CI/CD pipeline encounters a lock conflict, add retry logic around the deploy command:
+
+```yaml title=".github/workflows/deploy.yml"
+- name: Deploy with retry
+  run: |
+    for attempt in 1 2 3; do
+      if hostfn deploy production --ci; then
+        exit 0
+      fi
+      if [ "$attempt" -lt 3 ]; then
+        sleep 120
+      fi
+    done
+    exit 1
+  env:
+    HOSTFN_SSH_KEY: ${{ secrets.SSH_KEY }}
+```
+
+The 5-minute stale lock timeout means any lock conflict will resolve itself within that window.

--- a/hostfn/docs/content/docs/documentation/advanced/file-sync.mdx
+++ b/hostfn/docs/content/docs/documentation/advanced/file-sync.mdx
@@ -1,0 +1,144 @@
+---
+title: File Sync
+description: How HostFn transfers files to your server using rsync over SSH.
+---
+
+HostFn uses `rsync` to transfer your project files to the remote server. Rsync is efficient because it only transfers files that have changed, making subsequent deployments significantly faster than the first.
+
+## How File Sync Works
+
+During **Phase 2** of deployment, HostFn runs rsync to sync your local project directory to the remote server:
+
+```bash
+rsync -avz --delete -e "ssh -o StrictHostKeyChecking=no -o BatchMode=yes" \
+  /path/to/your/project/ \
+  ubuntu@your-server.com:/var/www/my-api-production
+```
+
+### Rsync Flags
+
+| Flag | Description |
+|---|---|
+| `-a` | Archive mode -- preserves permissions, timestamps, symlinks, and directory structure |
+| `-v` | Verbose -- shows transfer progress (captured internally, not displayed to user) |
+| `-z` | Compress -- compresses data during transfer to reduce bandwidth |
+| `--delete` | Deletes files on the remote that no longer exist locally |
+
+The `--delete` flag ensures the remote server mirrors your local project exactly. Files you remove locally are also removed from the server on the next deployment.
+
+## Exclude Patterns
+
+By default, HostFn excludes common files that should not be synced to the server. Configure exclude patterns in `hostfn.config.json`:
+
+```json title="hostfn.config.json"
+{
+  "sync": {
+    "exclude": [
+      "node_modules",
+      ".git",
+      ".github",
+      "dist",
+      "build",
+      ".env",
+      ".env.*",
+      "*.log",
+      ".turbo",
+      ".wrangler"
+    ]
+  }
+}
+```
+
+These are the default exclude patterns. You can override them by setting your own `sync.exclude` array.
+
+### Why Exclude `node_modules` and `dist`?
+
+- **`node_modules`** -- dependencies are installed on the server after syncing, ensuring platform-specific binaries (like `esbuild` or native addons) are compiled for the server's architecture
+- **`dist`** -- the build output is generated on the server after syncing source files, so there is no need to transfer it
+
+### Adding Custom Excludes
+
+Add any files or patterns you want to skip:
+
+```json title="hostfn.config.json"
+{
+  "sync": {
+    "exclude": [
+      "node_modules",
+      ".git",
+      ".github",
+      "dist",
+      "build",
+      ".env",
+      ".env.*",
+      "*.log",
+      "coverage",
+      "__tests__",
+      "*.test.ts",
+      "docs"
+    ]
+  }
+}
+```
+
+Patterns follow rsync's pattern matching rules. You can use `*` for wildcards and `**` for recursive matching.
+
+## Incremental Transfers
+
+Rsync is incremental by design. On the first deployment, all files are transferred. On subsequent deployments, only files that have changed (based on size and modification time) are sent. This makes deployments fast -- typically only a few seconds for the sync phase after the initial deployment.
+
+## Workspace Bundle Syncing
+
+When deploying from a monorepo with workspace dependencies, HostFn creates a temporary deployment bundle that includes the workspace packages your service depends on. During bundled syncing, the `dist` exclude pattern is anchored to the root (`/dist`) so it only excludes the service's own dist folder -- not the compiled output inside workspace dependencies that may be needed at runtime.
+
+For example, if your service depends on `@myorg/shared` which has compiled TypeScript in its `dist/` folder, the workspace bundle ensures that `@myorg/shared/dist/` is included in the sync while your service's root `dist/` is excluded (since it will be rebuilt on the server).
+
+## CI/CD Mode
+
+In CI/CD environments, HostFn creates a temporary SSH key file for rsync. When the `HOSTFN_SSH_KEY` environment variable is set:
+
+1. HostFn decodes the base64-encoded SSH key
+2. Writes it to a temporary file with `0600` permissions
+3. Passes it to rsync via the `-e` flag: `ssh -i /tmp/hostfn-ssh-xxxx/id_rsa`
+4. Cleans up the temporary key file after the sync completes (even if it fails)
+
+The SSH command in CI/CD mode also includes `-o StrictHostKeyChecking=no` and `-o UserKnownHostsFile=/dev/null` to avoid interactive prompts.
+
+## Rsync Installation
+
+Rsync must be installed on your **local machine** (where you run `hostfn deploy`). It is typically pre-installed on macOS and most Linux distributions.
+
+### Checking if rsync is installed
+
+HostFn checks for rsync availability during the pre-flight checks phase:
+
+```
+  ── Pre-flight Checks ──
+
+  ✔ rsync available
+```
+
+If rsync is not found:
+
+```
+  ✗ rsync not installed
+```
+
+### Installing rsync
+
+| Platform | Command |
+|---|---|
+| macOS | `brew install rsync` |
+| Ubuntu / Debian | `sudo apt-get install rsync` |
+| CentOS / RHEL | `sudo yum install rsync` |
+| Windows (WSL) | `sudo apt-get install rsync` |
+
+## Dry Run
+
+Use the `--dry-run` flag to see what would be synced without actually transferring files:
+
+```bash
+hostfn deploy production --dry-run
+```
+
+This shows the deployment plan, including which files would be excluded, without making any changes to the server.

--- a/hostfn/docs/content/docs/documentation/advanced/health-checks.mdx
+++ b/hostfn/docs/content/docs/documentation/advanced/health-checks.mdx
@@ -1,0 +1,174 @@
+---
+title: Health Checks
+description: Configure post-deployment health verification to ensure your application is running correctly.
+---
+
+After every deployment, HostFn verifies that your application is running and responding to requests. If the health check fails, HostFn automatically rolls back to the previous deployment.
+
+## How Health Checks Work
+
+HostFn runs health checks on the server using `curl` against your application's health endpoint:
+
+```bash
+curl -sf http://localhost:{port}{path}
+```
+
+The check runs over SSH on the remote server, hitting `localhost` directly. This means the health check works even before Nginx is configured or DNS is set up.
+
+A health check is considered **passing** when `curl` returns exit code `0` (which requires an HTTP `2xx` response due to the `-f` flag). Any non-2xx response or connection failure is treated as a failure.
+
+HostFn retries the health check multiple times with a configurable interval, giving your application time to start up.
+
+## Configuration
+
+Configure health checks in your `hostfn.config.json`:
+
+```json title="hostfn.config.json"
+{
+  "health": {
+    "path": "/health",
+    "timeout": 60,
+    "retries": 10,
+    "interval": 3
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `path` | `string` | `"/health"` | HTTP path to check on the application |
+| `timeout` | `number` | `60` | Per-attempt curl timeout in seconds |
+| `retries` | `number` | `10` | Number of health check attempts before giving up |
+| `interval` | `number` | `3` | Seconds to wait between retry attempts |
+
+With the default settings, HostFn will attempt the health check up to 10 times, waiting 3 seconds between each attempt, with each curl request capped at 60 seconds.
+
+## Implementing a Health Endpoint
+
+Your application needs to expose an HTTP endpoint that returns a `2xx` status code when healthy. A minimal implementation:
+
+```ts title="src/index.ts"
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+```
+
+### Recommended: Deeper Health Checks
+
+For production applications, consider checking downstream dependencies in your health endpoint:
+
+```ts title="src/index.ts"
+app.get('/health', async (req, res) => {
+  try {
+    // Check database connectivity
+    await db.execute(sql`SELECT 1`);
+
+    // Check Redis if applicable
+    await redis.ping();
+
+    res.json({
+      status: 'ok',
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(503).json({
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+```
+
+This approach ensures that your application is not only running but can actually serve requests.
+
+## Health Check During Deployment
+
+During deployment, the health check runs as **Phase 6**:
+
+```
+  ── Health Check ──
+
+  ⠋ Health check attempt 1/10...
+  ⠋ Health check attempt 2/10...
+  ✔ Health check passed
+```
+
+If all retries are exhausted without a successful response:
+
+```
+  ── Health Check ──
+
+  ⠋ Health check attempt 1/10...
+  ⠋ Health check attempt 2/10...
+  ...
+  ✗ Health check failed
+
+  ── Rolling Back ──
+
+  ✔ Rolled back to previous deployment
+```
+
+## Auto-Rollback on Failure
+
+When a health check fails, HostFn triggers an automatic rollback:
+
+1. The previous `dist/` directory is restored from the backup created earlier in the deployment
+2. PM2 is reloaded with the restored files
+3. The deployment is marked as failed
+
+This ensures your application stays available even when a new deployment has issues.
+
+## Tuning Health Check Settings
+
+### Slow-Starting Applications
+
+If your application takes a long time to start (loading large datasets, warming caches, etc.), increase the retries and interval:
+
+```json title="hostfn.config.json"
+{
+  "health": {
+    "path": "/health",
+    "timeout": 120,
+    "retries": 20,
+    "interval": 5
+  }
+}
+```
+
+This gives your application up to 100 seconds to become healthy.
+
+### Fast-Starting Applications
+
+For lightweight applications that start quickly, you can reduce the wait time:
+
+```json title="hostfn.config.json"
+{
+  "health": {
+    "path": "/health",
+    "timeout": 15,
+    "retries": 5,
+    "interval": 2
+  }
+}
+```
+
+### Custom Health Path
+
+If your application uses a different path for health checks, configure it:
+
+```json title="hostfn.config.json"
+{
+  "health": {
+    "path": "/api/status"
+  }
+}
+```
+
+## Best Practices
+
+1. **Always implement a `/health` endpoint** -- even a simple one that returns `200 OK` is better than none
+2. **Keep health checks fast** -- the endpoint should respond within a few hundred milliseconds
+3. **Check critical dependencies** -- database connections, external services your app cannot function without
+4. **Do not check optional dependencies** -- if your app can work without Redis caching, do not fail the health check when Redis is down
+5. **Return meaningful responses** -- include status information in the JSON body for debugging

--- a/hostfn/docs/content/docs/documentation/advanced/meta.json
+++ b/hostfn/docs/content/docs/documentation/advanced/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Advanced",
+  "pages": ["rollback", "backups", "health-checks", "deployment-locks", "ssh", "file-sync", "troubleshooting"]
+}

--- a/hostfn/docs/content/docs/documentation/advanced/rollback.mdx
+++ b/hostfn/docs/content/docs/documentation/advanced/rollback.mdx
@@ -1,0 +1,125 @@
+---
+title: Rollback
+description: Roll back to a previous deployment version when something goes wrong.
+---
+
+HostFn provides both manual and automatic rollback capabilities. If a deployment fails, HostFn automatically restores the previous version. You can also manually roll back to any saved backup at any time.
+
+## Manual Rollback
+
+Use the `hostfn rollback` command to restore a previous deployment:
+
+```bash
+hostfn rollback <environment>
+```
+
+For example:
+
+```bash
+hostfn rollback production
+```
+
+This will:
+
+1. Connect to the server via SSH
+2. List all available backups (most recent first)
+3. Prompt you to select a backup to restore
+4. Ask for confirmation
+5. Restore the selected backup
+6. Reload the PM2 process
+
+### Interactive Backup Selection
+
+When you run `hostfn rollback` without the `--to` option, HostFn presents an interactive list of up to 10 available backups:
+
+```
+$ hostfn rollback production
+
+  Rollback - production
+
+  ✔ Connected
+  ✔ Found 5 backup(s)
+
+  ── Available Backups ──
+
+  1. 2026-03-11T14-30-00-000Z
+  2. 2026-03-10T09-15-22-000Z
+  3. 2026-03-09T18-45-10-000Z
+  4. 2026-03-08T12-00-05-000Z
+  5. 2026-03-07T08-20-33-000Z
+
+  ? Select backup to restore:
+  > 1. 2026-03-11T14-30-00-000Z (latest)
+    2. 2026-03-10T09-15-22-000Z
+    3. 2026-03-09T18-45-10-000Z
+```
+
+After selecting a backup, HostFn asks for confirmation before proceeding:
+
+```
+  ⚠ This will rollback to: 2026-03-11T14-30-00-000Z
+  ? Are you sure you want to rollback? (y/N)
+```
+
+### Rolling Back to a Specific Backup
+
+Use the `--to` option to skip the interactive prompt and go directly to a specific backup:
+
+```bash
+hostfn rollback production --to 2026-03-10T09-15-22-000Z
+```
+
+This is useful in scripts or when you already know which backup you want to restore.
+
+## Auto-Rollback on Failed Deployments
+
+The `hostfn deploy` command has built-in auto-rollback. If any of the following steps fail during deployment, HostFn automatically restores the previous version:
+
+- **Build failure** -- the build command returns a non-zero exit code
+- **PM2 start/reload failure** -- the process manager fails to start the application
+- **Health check failure** -- the application does not respond with a healthy status
+
+When auto-rollback triggers, HostFn:
+
+1. Restores the backup created at the start of the deployment
+2. Reloads the PM2 process with the previous version
+3. Reports the rollback result
+
+```
+  ✗ Health check failed
+
+  ── Rolling Back ──
+
+  ✔ Rolled back to previous deployment
+  ℹ Previous deployment restored successfully
+```
+
+Auto-rollback only activates when there is a previous deployment to restore. On the first deployment, there is no backup to fall back to.
+
+## After a Rollback
+
+After a successful rollback, verify the service is running correctly:
+
+```bash
+hostfn status production
+```
+
+Check the application logs for any issues:
+
+```bash
+hostfn logs production
+```
+
+## What Gets Rolled Back
+
+A rollback restores:
+
+| Item | Restored |
+|---|---|
+| `dist/` directory | Yes |
+| `package.json` | No |
+| `node_modules/` | No |
+| `.env` file | No |
+| Nginx configuration | No |
+
+The rollback replaces the `dist/` directory with the backup copy and reloads PM2. Environment variables, Nginx configuration, and installed dependencies are not affected.

--- a/hostfn/docs/content/docs/documentation/advanced/ssh.mdx
+++ b/hostfn/docs/content/docs/documentation/advanced/ssh.mdx
@@ -1,0 +1,185 @@
+---
+title: SSH Configuration
+description: How HostFn connects to your server and manages SSH authentication.
+---
+
+HostFn connects to remote servers over SSH for all operations -- file syncing, remote commands, health checks, and process management. Understanding how SSH authentication works in HostFn helps with debugging connection issues and setting up CI/CD pipelines.
+
+## Connection String Format
+
+Server connections are specified in `hostfn.config.json` using the `server` field:
+
+```json title="hostfn.config.json"
+{
+  "environments": {
+    "production": {
+      "server": "ubuntu@prod.example.com",
+      "port": 3000
+    }
+  }
+}
+```
+
+The connection string supports two formats:
+
+| Format | Example | Description |
+|---|---|---|
+| `user@host` | `ubuntu@prod.example.com` | Connect on default port 22 |
+| `user@host:port` | `ubuntu@prod.example.com:2222` | Connect on a custom SSH port |
+
+## SSH Key Lookup Order
+
+HostFn resolves SSH authentication in the following order:
+
+1. **Password authentication** -- if `--password` option or `HOSTFN_SSH_PASSWORD` env var is set
+2. **`HOSTFN_SSH_KEY` environment variable** -- base64-encoded private key (CI/CD mode)
+3. **SSH agent** -- if `SSH_AUTH_SOCK` is set, HostFn uses the SSH agent for authentication
+4. **`~/.ssh/id_rsa`** -- RSA key file
+5. **`~/.ssh/id_ed25519`** -- Ed25519 key file
+6. **`~/.ssh/id_ecdsa`** -- ECDSA key file
+
+HostFn checks these in order and uses the first one it finds. If using an SSH agent alongside a key file, both the agent and the key file are configured so passphrase-protected keys work automatically.
+
+## SSH Agent
+
+If you use passphrase-protected SSH keys, make sure your SSH agent is running and has your key loaded:
+
+```bash
+# Start the agent (if not running)
+eval "$(ssh-agent -s)"
+
+# Add your key
+ssh-add ~/.ssh/id_ed25519
+```
+
+HostFn detects the SSH agent via the `SSH_AUTH_SOCK` environment variable, which is set automatically when the agent is running.
+
+## Keepalive Settings
+
+HostFn configures SSH keepalive to prevent connections from dropping during long operations like `npm install` or large file syncs:
+
+| Setting | Value | Description |
+|---|---|---|
+| `keepaliveInterval` | 30 seconds | How often to send keepalive packets |
+| `keepaliveCountMax` | 10 | Maximum missed keepalives before disconnect |
+
+With these settings, a connection can survive up to 5 minutes of network inactivity before being dropped.
+
+## Password Authentication
+
+For commands that support password authentication, you can provide the password via a CLI flag or the `HOSTFN_SSH_PASSWORD` environment variable. For `hostfn deploy`, use the environment variable:
+
+```bash
+# Using the environment variable with deploy
+HOSTFN_SSH_PASSWORD="your-password" hostfn deploy production
+```
+
+Password authentication is less secure than key-based authentication and is not recommended for production environments. Use it only for initial server setup or testing.
+
+## CI/CD Mode
+
+In CI/CD environments (GitHub Actions, GitLab CI, etc.), SSH keys are typically stored as secrets. HostFn supports loading keys from environment variables.
+
+### Setting Up the SSH Key
+
+Base64-encode your private key and store it as a CI/CD secret:
+
+```bash
+cat ~/.ssh/id_ed25519 | base64
+```
+
+Set this as `HOSTFN_SSH_KEY` in your CI/CD environment.
+
+### GitHub Actions Example
+
+```yaml title=".github/workflows/deploy.yml"
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm install -g hostfn
+
+      - name: Deploy to production
+        run: hostfn deploy production --ci
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.HOSTFN_SSH_KEY }}
+```
+
+### Passphrase-Protected Keys in CI/CD
+
+If your SSH key has a passphrase, set it with the `HOSTFN_SSH_PASSPHRASE` environment variable:
+
+```yaml title=".github/workflows/deploy.yml"
+- name: Deploy to production
+  run: hostfn deploy production --ci
+  env:
+    HOSTFN_SSH_KEY: ${{ secrets.HOSTFN_SSH_KEY }}
+    HOSTFN_SSH_PASSPHRASE: ${{ secrets.HOSTFN_SSH_PASSPHRASE }}
+```
+
+### Overriding the Server Host
+
+In CI/CD, you can override the server from the config file using the `HOSTFN_HOST` environment variable:
+
+```yaml
+env:
+  HOSTFN_HOST: ubuntu@staging-2.example.com
+```
+
+This is useful for deploying the same codebase to different servers without modifying the config file.
+
+## NVM in Non-Interactive SSH Sessions
+
+SSH sessions opened programmatically (as HostFn does) are non-interactive, which means shell profile files like `.bashrc` are not sourced. This can cause `node`, `npm`, and `pm2` to be unavailable.
+
+HostFn handles this automatically by sourcing NVM before every remote command:
+
+```bash
+export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && <your-command>
+```
+
+This ensures that the correct Node.js version is active regardless of the shell's initialization state. You do not need to configure anything for this to work -- it happens transparently.
+
+## Troubleshooting SSH Connections
+
+### Connection Refused
+
+```
+SSH connection failed: connect ECONNREFUSED
+```
+
+- Verify the server IP and port are correct
+- Check that the SSH daemon is running: `systemctl status sshd`
+- Check firewall rules: `ufw status` or `iptables -L`
+
+### Permission Denied
+
+```
+SSH connection failed: All configured authentication methods failed
+```
+
+- Verify your SSH key is in `~/.ssh/authorized_keys` on the server
+- Check key file permissions: `chmod 600 ~/.ssh/id_ed25519`
+- Check `.ssh` directory permissions: `chmod 700 ~/.ssh`
+- Try connecting manually: `ssh ubuntu@your-server.com`
+
+### Key Not Found
+
+```
+Failed to load SSH key from /Users/you/.ssh/id_rsa
+```
+
+- Check which key files exist: `ls -la ~/.ssh/`
+- If using a non-standard key name, start your SSH agent and add the key
+- In CI/CD, set the `HOSTFN_SSH_KEY` environment variable

--- a/hostfn/docs/content/docs/documentation/advanced/troubleshooting.mdx
+++ b/hostfn/docs/content/docs/documentation/advanced/troubleshooting.mdx
@@ -1,0 +1,334 @@
+---
+title: Troubleshooting
+description: Solutions to common issues encountered when deploying with HostFn.
+---
+
+This page covers common problems you might encounter when using HostFn and how to resolve them.
+
+## rsync Not Installed
+
+**Error:**
+
+```
+rsync is not installed on your system.
+```
+
+**Solution:** Install rsync on your local machine:
+
+| Platform | Command |
+|---|---|
+| macOS | `brew install rsync` |
+| Ubuntu / Debian | `sudo apt-get install rsync` |
+| CentOS / RHEL | `sudo yum install rsync` |
+| Windows | Install via [WSL](https://learn.microsoft.com/windows/wsl/install) and use `sudo apt-get install rsync` |
+
+For standard remote deployments, rsync needs to be installed on both your local machine and the remote server. Local mode (`--local`) is the path that avoids needing rsync on the remote host.
+
+## SSH Connection Failed
+
+**Error:**
+
+```
+SSH connection failed: connect ECONNREFUSED
+```
+
+**Possible causes and solutions:**
+
+1. **Wrong host or port** -- double-check the `server` field in your config:
+   ```json
+   "server": "ubuntu@your-server.com"
+   ```
+
+2. **SSH key not found** -- verify your key exists:
+   ```bash
+   ls -la ~/.ssh/id_ed25519 ~/.ssh/id_rsa ~/.ssh/id_ecdsa
+   ```
+
+3. **Key permissions too open** -- SSH keys must have restricted permissions:
+   ```bash
+   chmod 600 ~/.ssh/id_ed25519
+   chmod 700 ~/.ssh
+   ```
+
+4. **SSH agent not running** -- if using passphrase-protected keys:
+   ```bash
+   eval "$(ssh-agent -s)"
+   ssh-add ~/.ssh/id_ed25519
+   ```
+
+5. **Firewall blocking SSH** -- check the server's firewall:
+   ```bash
+   # On the server
+   sudo ufw status
+   sudo ufw allow 22
+   ```
+
+6. **Test the connection manually** -- verify you can connect outside of HostFn:
+   ```bash
+   ssh ubuntu@your-server.com "echo connected"
+   ```
+
+## Health Check Failed
+
+**Error:**
+
+```
+Health check failed after 10 attempts
+Service is not responding to health checks
+```
+
+**Possible causes and solutions:**
+
+1. **No health endpoint** -- make sure your application exposes a health endpoint:
+   ```ts title="src/index.ts"
+   app.get('/health', (req, res) => {
+     res.json({ status: 'ok' });
+   });
+   ```
+
+2. **Wrong port** -- verify the `port` in your config matches the port your application listens on:
+   ```json
+   "port": 3000
+   ```
+
+3. **Wrong health path** -- verify the `health.path` matches your endpoint:
+   ```json
+   "health": {
+     "path": "/health"
+   }
+   ```
+
+4. **Application crashing on startup** -- check the PM2 logs:
+   ```bash
+   hostfn logs production
+   ```
+   Or directly on the server:
+   ```bash
+   ssh ubuntu@your-server.com "pm2 logs my-api-production --lines 50"
+   ```
+
+5. **Application starts slowly** -- increase the retries and interval:
+   ```json title="hostfn.config.json"
+   {
+     "health": {
+       "retries": 20,
+       "interval": 5
+     }
+   }
+   ```
+
+6. **Missing environment variables** -- the app may crash because a required env var is not set:
+   ```bash
+   hostfn env validate production
+   ```
+
+## Deployment Lock
+
+**Error:**
+
+```
+Deployment is already in progress
+Started by: developer
+Started at: 3/11/2026, 2:30:00 PM
+Age: 2 minute(s)
+```
+
+**Solutions:**
+
+1. **Wait for the current deployment to finish** -- another deployment is genuinely in progress
+
+2. **Wait for the lock to expire** -- locks auto-expire after 5 minutes
+
+3. **Remove the lock manually** -- if you are certain no deployment is running:
+   ```bash
+   ssh ubuntu@your-server.com "rm /var/www/my-api-production/.hostfn-deploy.lock"
+   ```
+
+4. **Prevent concurrent deployments in CI/CD** -- use concurrency groups:
+   ```yaml title=".github/workflows/deploy.yml"
+   concurrency:
+     group: deploy-production
+     cancel-in-progress: false
+   ```
+
+## Build Failed
+
+**Error:**
+
+```
+Build failed: <error output>
+```
+
+**Possible causes and solutions:**
+
+1. **Missing dev dependencies** -- if your build requires devDependencies, make sure `build.command` is set in your config. HostFn installs all dependencies (including dev) when a build command is configured:
+   ```json
+   {
+     "build": {
+       "command": "npm run build"
+     }
+   }
+   ```
+
+2. **Wrong Node.js version** -- verify the `version` field matches what your project needs:
+   ```json
+   "version": "20"
+   ```
+
+3. **Build works locally but fails on server** -- platform-specific issues. Check for:
+   - Native binary dependencies (e.g., `sharp`, `better-sqlite3`)
+   - Path case sensitivity (Linux is case-sensitive, macOS is not by default)
+   - Environment variables needed during build
+
+4. **Out of memory** -- the server may not have enough RAM. Check with:
+   ```bash
+   ssh ubuntu@your-server.com "free -h"
+   ```
+
+## PM2 Start Failed
+
+**Error:**
+
+```
+PM2 start failed: <error output>
+```
+
+**Possible causes and solutions:**
+
+1. **Wrong entry point** -- verify `start.entry` points to the correct file:
+   ```json
+   {
+     "start": {
+       "command": "npm start",
+       "entry": "dist/index.js"
+     }
+   }
+   ```
+
+2. **Port already in use** -- another process is using the configured port:
+   ```bash
+   ssh ubuntu@your-server.com "lsof -i :3000"
+   ```
+   Kill the conflicting process or change the port in your config.
+
+3. **PM2 not installed** -- HostFn installs PM2 automatically, but if it fails:
+   ```bash
+   ssh ubuntu@your-server.com "npm install -g pm2"
+   ```
+
+4. **Check PM2 logs for the actual error**:
+   ```bash
+   ssh ubuntu@your-server.com "pm2 logs my-api-production --lines 100"
+   ```
+
+## Nginx Configuration Test Failed
+
+**Error:**
+
+```
+Nginx configuration test failed
+```
+
+**Possible causes and solutions:**
+
+1. **Syntax error in generated config** -- inspect the Nginx config:
+   ```bash
+   ssh ubuntu@your-server.com "cat /etc/nginx/sites-available/my-api-production"
+   ```
+
+2. **Port conflict** -- another Nginx server block is already listening on port 80/443 for the same domain:
+   ```bash
+   ssh ubuntu@your-server.com "nginx -t"
+   ```
+   The output will show the exact error location.
+
+3. **Nginx not installed** -- run server setup first:
+   ```bash
+   hostfn server setup ubuntu@your-server.com
+   ```
+
+4. **Test Nginx manually**:
+   ```bash
+   ssh ubuntu@your-server.com "sudo nginx -t"
+   ```
+
+## SSL Certificate Failed
+
+**Error:**
+
+```
+SSL certificate provisioning failed
+```
+
+**Possible causes and solutions:**
+
+1. **DNS not configured** -- your domain must point to the server's IP address before requesting an SSL certificate. Verify with:
+   ```bash
+   dig +short your-domain.com
+   ```
+   The result should be your server's IP address.
+
+2. **Let's Encrypt rate limits** -- Let's Encrypt limits certificate requests. If you hit the limit, wait and try again later. See [Let's Encrypt rate limits](https://letsencrypt.org/docs/rate-limits/).
+
+3. **Port 80 blocked** -- Let's Encrypt needs port 80 to be accessible for HTTP-01 challenges:
+   ```bash
+   ssh ubuntu@your-server.com "sudo ufw allow 80"
+   ```
+
+4. **Certbot not installed** -- run server setup:
+   ```bash
+   hostfn server setup ubuntu@your-server.com
+   ```
+
+## General Debugging Tips
+
+### Check the deployment from the server
+
+SSH into the server and inspect the deployment directory:
+
+```bash
+ssh ubuntu@your-server.com
+
+# Check the deployment directory
+ls -la /var/www/my-api-production/
+
+# Check PM2 processes
+pm2 list
+
+# Check PM2 logs
+pm2 logs my-api-production
+
+# Check Nginx status
+sudo systemctl status nginx
+
+# Check Nginx error logs
+sudo tail -f /var/log/nginx/error.log
+```
+
+### Test locally first
+
+Before deploying, make sure your application builds and runs locally:
+
+```bash
+npm run build
+npm start
+curl http://localhost:3000/health
+```
+
+### Use dry run mode
+
+Preview what a deployment would do without making changes:
+
+```bash
+hostfn deploy production --dry-run
+```
+
+### Check server resources
+
+Ensure the server has enough resources:
+
+```bash
+ssh ubuntu@your-server.com "df -h"    # Disk space
+ssh ubuntu@your-server.com "free -h"  # Memory
+ssh ubuntu@your-server.com "nproc"    # CPU cores
+```

--- a/hostfn/docs/content/docs/documentation/concepts/configuration.mdx
+++ b/hostfn/docs/content/docs/documentation/concepts/configuration.mdx
@@ -1,0 +1,252 @@
+---
+title: Configuration
+description: Understand the hostfn.config.json file and all available options.
+---
+
+All HostFn behavior is controlled by a single `hostfn.config.json` file in your project root. This file is validated against a Zod schema when loaded, giving you clear error messages for any misconfiguration.
+
+## Full Configuration Example
+
+```json title="hostfn.config.json"
+{
+  "name": "my-api",
+  "runtime": "nodejs",
+  "version": "20",
+  "environments": {
+    "production": {
+      "server": "ubuntu@prod.example.com",
+      "port": 3000,
+      "instances": "max",
+      "domain": "api.example.com",
+      "sslEmail": "admin@example.com"
+    },
+    "staging": {
+      "server": "ubuntu@staging.example.com",
+      "port": 3000,
+      "instances": 2
+    }
+  },
+  "build": {
+    "command": "npm run build",
+    "directory": "dist",
+    "nodeModules": "all"
+  },
+  "start": {
+    "command": "npm start",
+    "entry": "dist/index.js"
+  },
+  "health": {
+    "path": "/health",
+    "timeout": 60,
+    "retries": 10,
+    "interval": 3
+  },
+  "env": {
+    "required": ["DATABASE_URL", "JWT_SECRET"],
+    "optional": ["REDIS_URL", "LOG_LEVEL"]
+  },
+  "sync": {
+    "exclude": [
+      "node_modules", ".git", ".github",
+      "dist", "build", ".env", ".env.*", "*.log",
+      ".turbo", ".wrangler"
+    ]
+  },
+  "backup": {
+    "keep": 5
+  }
+}
+```
+
+## Top-Level Fields
+
+### `name` (required)
+
+The application name. Used to derive the remote directory (`/var/www/{name}-{env}`) and the PM2 service name (`{name}-{env}`).
+
+```json
+"name": "my-api"
+```
+
+### `runtime` (required)
+
+The application runtime. Currently, HostFn executes the `nodejs` runtime. Other values are reserved in the schema for future adapters:
+
+| Value | Description |
+|---|---|
+| `nodejs` | Node.js application |
+| `python` | Planned |
+| `go` | Planned |
+| `ruby` | Planned |
+| `rust` | Planned |
+| `docker` | Planned |
+
+### `version` (required)
+
+The runtime version to use on the server. For Node.js, this is the major version number:
+
+```json
+"version": "20"
+```
+
+HostFn will install this version via nvm on the server and switch to it before each deployment.
+
+## Environment Configuration
+
+The `environments` object maps environment names to their settings. You can define as many environments as you need.
+
+```json
+"environments": {
+  "production": { ... },
+  "staging": { ... },
+  "development": { ... }
+}
+```
+
+### Environment Fields
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `server` | `string` | Yes | — | SSH connection string (`user@host` or `user@host:port`) |
+| `port` | `number` | Yes | — | Port the application listens on |
+| `instances` | `number \| "max"` | No | `1` | PM2 cluster instances. `"max"` uses all CPU cores |
+| `domain` | `string \| string[]` | No | — | Domain name(s) for Nginx/SSL |
+| `sslEmail` | `string` | No | — | Email for Let's Encrypt certificate registration |
+
+### Multiple Domains
+
+You can assign multiple domains to a single environment:
+
+```json
+"domain": ["example.com", "www.example.com"]
+```
+
+## Build Configuration
+
+Controls how your application is built on the server.
+
+```json
+"build": {
+  "command": "npm run build",
+  "directory": "dist",
+  "nodeModules": "all"
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `command` | `string` | — | Build command to run (e.g., `npm run build`) |
+| `directory` | `string` | `"dist"` | Build output directory |
+| `nodeModules` | `"all" \| "production" \| "none"` | `"all"` when `build.command` is set, otherwise `"production"` | Which node_modules to install |
+
+If `build` is omitted, HostFn skips the build step and installs only production dependencies.
+
+When `build.nodeModules` is omitted, HostFn defaults to installing **all** dependencies when `build.command` is present. Set `build.nodeModules` to `"production"` or `"none"` to override that behavior.
+
+## Start Configuration
+
+Defines how the application starts.
+
+```json
+"start": {
+  "command": "npm start",
+  "entry": "dist/index.js"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `command` | `string` | Yes | Start command |
+| `entry` | `string` | No | Entry point file (used in PM2 ecosystem config) |
+
+The `entry` field is the file PM2 will execute. If not specified, it defaults to `dist/index.js`.
+
+## Health Check Configuration
+
+Controls post-deployment health verification.
+
+```json
+"health": {
+  "path": "/health",
+  "timeout": 60,
+  "retries": 10,
+  "interval": 3
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `path` | `string` | `"/health"` | HTTP path to check |
+| `timeout` | `number` | `60` | Per-attempt curl timeout in seconds |
+| `retries` | `number` | `10` | Number of health check attempts |
+| `interval` | `number` | `3` | Seconds between retries |
+
+HostFn uses `curl --max-time {timeout} -sf` on the server to check `http://localhost:{port}{path}`. Success follows curl's `-f` exit-code behavior rather than an explicit `200-299` status check in HostFn itself, so 3xx responses can also count as healthy even though HostFn does not pass `-L` to follow redirects.
+
+## Environment Variables Configuration
+
+Defines which environment variables your application expects.
+
+```json
+"env": {
+  "required": ["DATABASE_URL", "JWT_SECRET"],
+  "optional": ["REDIS_URL", "LOG_LEVEL"]
+}
+```
+
+These are used by `hostfn env validate` to check that all required variables are set on the server before deployment.
+
+## Sync Configuration
+
+Controls which files are synced to the server via rsync.
+
+```json
+"sync": {
+  "exclude": [
+    "node_modules", ".git", ".github",
+    "dist", "build", ".env", ".env.*", "*.log",
+    ".turbo", ".wrangler"
+  ]
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `exclude` | `string[]` | See below | Patterns to exclude from rsync |
+| `include` | `string[]` | — | Patterns to explicitly include |
+
+Default exclude patterns: `node_modules`, `.git`, `.github`, `dist`, `build`, `.env`, `.env.*`, `*.log`, `.turbo`, `.wrangler`
+
+## Backup Configuration
+
+Controls deployment backup retention.
+
+```json
+"backup": {
+  "keep": 5
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `keep` | `number` | `5` | Number of backups to retain |
+
+## Monorepo Services
+
+For monorepo deployments, add a `services` section. See [Monorepo Deployment](/docs/documentation/deployment/monorepo) for details.
+
+```json
+"services": {
+  "api": {
+    "port": 3001,
+    "path": "services/api",
+    "domain": "api.example.com",
+    "instances": "max"
+  },
+  "web": {
+    "port": 3002,
+    "path": "services/web",
+    "domain": "example.com"
+  }
+}
+```

--- a/hostfn/docs/content/docs/documentation/concepts/meta.json
+++ b/hostfn/docs/content/docs/documentation/concepts/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Concepts",
+  "pages": ["overview", "configuration", "runtimes", "workspaces"]
+}

--- a/hostfn/docs/content/docs/documentation/concepts/overview.mdx
+++ b/hostfn/docs/content/docs/documentation/concepts/overview.mdx
@@ -1,0 +1,89 @@
+---
+title: Overview
+description: Core concepts and architecture of HostFn.
+---
+
+HostFn is designed around a few core principles that make it reliable and easy to use.
+
+## Architecture
+
+```mermaid
+graph TD
+    CLI[hostfn CLI] --> Config[Config Loader]
+    CLI --> SSH[SSH Connection]
+    CLI --> Runtime[Runtime Adapter]
+
+    Config --> Schema[Zod Schema Validation]
+
+    SSH --> FileSync[rsync File Sync]
+    SSH --> Remote[Remote Commands]
+
+    Runtime --> Detect[Auto-Detection]
+    Runtime --> PM2[PM2 Process Manager]
+    Runtime --> Setup[Server Setup Script]
+
+    Remote --> Build[npm install + build]
+    Remote --> Health[Health Check]
+    Remote --> Backup[Backup Manager]
+    Remote --> Lock[Lock Manager]
+    Remote --> Nginx[Nginx Config]
+```
+
+## Key Concepts
+
+### Configuration-Driven
+
+Every deployment is defined by a single `hostfn.config.json` file. This file is validated against a Zod schema at load time, catching configuration errors early before any remote commands are executed.
+
+### Environment-Based
+
+HostFn supports multiple environments (production, staging, etc.) in a single configuration file. Each environment can point to a different server, use different ports, and have different scaling settings.
+
+### Runtime Adapters
+
+HostFn uses a pluggable runtime system. Currently, Node.js is the primary supported runtime, but the architecture supports adding Python, Go, Ruby, and Rust adapters.
+
+### SSH-First
+
+All remote operations happen over SSH. HostFn connects once and runs all commands through that connection. File transfers use rsync over SSH for efficient, incremental syncing.
+
+### Fail-Safe Deployments
+
+Every deployment creates a backup of the current state. If any step fails (build, health check, etc.), HostFn automatically rolls back to the previous deployment and reloads PM2.
+
+## Deployment Lifecycle
+
+A typical deployment follows these phases:
+
+| Phase | What Happens |
+|---|---|
+| **1. Pre-flight** | Validate config, check rsync, connect to server, verify Node.js version, acquire deployment lock |
+| **2. Workspace Bundle** | (Monorepos only) Detect workspace dependencies, bundle them into deployment |
+| **3. File Sync** | rsync project files to remote server, excluding configured patterns |
+| **4. Build** | Install npm dependencies, run build command on the server |
+| **5. Backup** | Create timestamped backup of existing deployment |
+| **6. PM2 Deploy** | Generate PM2 ecosystem config, start or reload the service |
+| **7. Health Check** | Poll health endpoint until the service responds or retries are exhausted |
+| **8. Cleanup** | Remove old backups beyond retention limit, release deployment lock |
+
+If anything fails after the backup is created, HostFn restores the backup and reloads PM2 automatically.
+
+## Directory Structure on Server
+
+HostFn uses a standard directory layout on the remote server:
+
+```
+/var/www/
+  my-app-production/        # Application root
+    dist/                    # Build output
+    node_modules/            # Dependencies
+    package.json
+    ecosystem.config.cjs     # PM2 configuration
+    .env                     # Environment variables
+    .hostfn-deploy.lock      # Deployment lock file
+    backups/                 # Timestamped backups
+      2024-01-15T10-30-00-000Z/
+      2024-01-14T15-20-00-000Z/
+```
+
+The remote directory path is derived from your application name and environment: `/var/www/{name}-{environment}`.

--- a/hostfn/docs/content/docs/documentation/concepts/runtimes.mdx
+++ b/hostfn/docs/content/docs/documentation/concepts/runtimes.mdx
@@ -1,0 +1,106 @@
+---
+title: Runtimes
+description: How HostFn detects and manages application runtimes.
+---
+
+HostFn uses a pluggable runtime adapter system. Each runtime adapter handles detection, default configuration, server setup script generation, and process management.
+
+## Runtime Detection
+
+When you run `hostfn init`, HostFn scans your project directory to detect the runtime:
+
+```bash
+$ hostfn init
+✔ Detected nodejs (confidence: 95%)
+```
+
+### Node.js Detection
+
+The Node.js detector checks for:
+
+| Signal | Confidence |
+|---|---|
+| `package.json` exists | +50% |
+| `package.json` has a `start` script | +20% |
+| `package.json` has a `build` script | +15% |
+| `node_modules/` exists | +10% |
+| `tsconfig.json` exists | +5% |
+
+The detector also reads `package.json` to determine:
+
+- **Build command** - From `scripts.build`
+- **Start command** - From `scripts.start`
+- **Entry point** - Inferred from `main` field
+- **Node.js version** - From `engines.node`
+
+## Node.js Runtime
+
+The Node.js adapter is the primary supported runtime. It uses:
+
+- **nvm** for version management
+- **PM2** for process management (cluster mode, auto-restart, log management)
+- **npm** for dependency installation
+
+### Server Setup
+
+When you run `hostfn server setup`, the Node.js adapter generates a setup script that installs:
+
+1. **nvm** and the specified Node.js version
+2. **PM2** globally via npm
+3. **Nginx** web server
+4. **Certbot** for SSL certificates
+5. **rsync** for file transfers
+6. **build-essential** for native npm modules
+7. **UFW firewall** configuration (ports 22, 80, 443)
+
+Optionally:
+- **Redis** (with `--redis` flag)
+
+### PM2 Ecosystem Config
+
+For each deployment, HostFn generates a PM2 ecosystem configuration file:
+
+```js title="ecosystem.config.cjs"
+module.exports = {
+  apps: [{
+    name: 'my-app-production',
+    script: 'dist/index.js',
+    instances: 'max',
+    exec_mode: 'cluster',
+    env: {
+      NODE_ENV: 'production',
+      PORT: 3000,
+      DATABASE_URL: '...',
+    },
+    error_file: './logs/err.log',
+    out_file: './logs/out.log',
+    time: true,
+    autorestart: true,
+    max_restarts: 10,
+    min_uptime: '10s',
+    max_memory_restart: '1G'
+  }]
+};
+```
+
+Key features:
+- **Cluster mode** with configurable instances (defaults to `"max"` for all CPU cores)
+- **Auto-restart** on crashes with max restart limits
+- **Memory limit** restarts (1GB default)
+- **Timestamped logs** in `./logs/` directory
+- **Environment variables** from the server's `.env` file are injected into the config
+
+## Future Runtimes
+
+The runtime adapter interface is designed for extensibility. Planned runtimes include:
+
+| Runtime | Status | Process Manager |
+|---|---|---|
+| Node.js | Supported | PM2 |
+| Python | Planned | systemd / gunicorn |
+| Go | Planned | systemd |
+| Ruby | Planned | puma / systemd |
+| Rust | Planned | systemd |
+| Docker | Planned | docker-compose |
+
+Each runtime adapter implements the same interface, so the deployment workflow remains identical regardless of the runtime.

--- a/hostfn/docs/content/docs/documentation/concepts/workspaces.mdx
+++ b/hostfn/docs/content/docs/documentation/concepts/workspaces.mdx
@@ -1,0 +1,93 @@
+---
+title: Workspaces & Monorepos
+description: How HostFn handles npm workspaces and monorepo deployments.
+---
+
+HostFn has built-in support for npm workspaces (monorepos). When deploying a service that depends on other workspace packages, HostFn automatically bundles those dependencies into the deployment.
+
+## How Workspace Detection Works
+
+During deployment, HostFn walks up the directory tree looking for a `package.json` with a `workspaces` field. If found, it indexes all workspace packages and checks which ones your service depends on.
+
+```
+my-monorepo/
+  package.json          # Has "workspaces": ["packages/*", "services/*"]
+  packages/
+    shared-utils/       # Workspace package (@myorg/shared-utils)
+    email/              # Workspace package (@myorg/email)
+  services/
+    api/                # Your service - depends on @myorg/shared-utils
+    web/
+```
+
+## Workspace Bundling Process
+
+When workspace dependencies are detected, HostFn:
+
+1. **Creates a temporary bundle directory** in your system's temp folder
+2. **Copies your service** to the bundle (excluding `node_modules` and `.git`)
+3. **Copies workspace dependencies** to `__workspace__/{package-name}/` inside the bundle
+4. **Builds each dependency** if it has a `build` script
+5. **Rewrites `package.json`** to use `file:` references instead of `workspace:` references
+6. **Generates a fresh lockfile** so `npm ci` works on the server
+
+### Example
+
+If your service's `package.json` has:
+
+```json
+{
+  "dependencies": {
+    "@myorg/shared-utils": "workspace:*",
+    "express": "^4.18.0"
+  }
+}
+```
+
+HostFn rewrites it to:
+
+```json
+{
+  "dependencies": {
+    "@myorg/shared-utils": "file:./__workspace__/@myorg/shared-utils",
+    "express": "^4.18.0"
+  }
+}
+```
+
+The bundle directory layout:
+
+```
+/tmp/hostfn-bundle-xxxxx/
+  package.json              # Rewritten with file: references
+  package-lock.json         # Freshly generated
+  src/
+  __workspace__/
+    @myorg/
+      shared-utils/         # Copied workspace dependency
+        package.json
+        dist/               # Pre-built
+        src/
+```
+
+## Version Pinning
+
+When generating the lockfile for the bundle, HostFn pins direct dependencies to the exact versions resolved in the root monorepo lockfile. This prevents npm from upgrading dependencies when generating the lockfile, ensuring the deployment uses the same versions as your development environment.
+
+## Sync Behavior
+
+The `__workspace__/` directory is intentionally **not** placed inside `node_modules/`. This ensures:
+
+1. It's included in the rsync transfer (not excluded like `node_modules`)
+2. It's not wiped when `npm ci` cleans `node_modules` on the server
+
+The `dist` exclude pattern is anchored to the root (`/dist`) for workspace bundles so that compiled output inside `__workspace__/` packages (e.g., `__workspace__/@myorg/email/dist`) is preserved.
+
+## Configuration
+
+Workspace support requires no additional configuration. It activates automatically when:
+
+1. A parent `package.json` has a `workspaces` field
+2. Your service has dependencies using `workspace:` version specifiers (for example `workspace:*` or `workspace:^1.0.0`) or `*`
+
+For monorepo-specific deployment configuration (multiple services), see [Monorepo Deployment](/docs/documentation/deployment/monorepo).

--- a/hostfn/docs/content/docs/documentation/deployment/ci-cd.mdx
+++ b/hostfn/docs/content/docs/documentation/deployment/ci-cd.mdx
@@ -1,0 +1,317 @@
+---
+title: CI/CD Integration
+description: Automate HostFn deployments in your CI/CD pipeline with GitHub Actions, environment variables, and non-interactive mode.
+---
+
+HostFn is designed to work seamlessly in CI/CD pipelines. The `--ci` flag enables non-interactive mode, and SSH authentication is handled through environment variables so no interactive prompts are required.
+
+## The `--ci` Flag
+
+When running in a CI/CD environment, pass the `--ci` flag to disable interactive prompts:
+
+```bash
+hostfn deploy production --ci
+```
+
+In CI mode, HostFn:
+
+- Skips all interactive prompts (no confirmation dialogs)
+- Reads SSH credentials from environment variables instead of the local keychain
+- Outputs clean, machine-readable log lines
+
+## Environment Variables
+
+HostFn uses the following environment variables for CI/CD authentication:
+
+| Variable | Required | Description |
+|---|---|---|
+| `HOSTFN_HOST` | No | Override the server from config (format: `user@host`) |
+| `HOSTFN_SSH_KEY` | Yes (if using key auth) | Base64-encoded SSH private key |
+| `HOSTFN_SSH_PASSWORD` | Yes (if using password auth) | SSH password |
+| `HOSTFN_SSH_PASSPHRASE` | No | Passphrase for the SSH key (if encrypted) |
+
+### SSH Key Setup
+
+HostFn expects the SSH private key to be **base64-encoded** in the `HOSTFN_SSH_KEY` environment variable. This avoids issues with newlines and special characters in CI secret stores.
+
+To encode your SSH key:
+
+```bash
+base64 < ~/.ssh/id_rsa | tr -d '\n'
+```
+
+Copy the output and store it as a secret in your CI platform (e.g., GitHub Actions secret named `SSH_PRIVATE_KEY`).
+
+<Callout type="warn">
+Never commit SSH private keys to your repository. Always use your CI platform's secret management to store `HOSTFN_SSH_KEY`.
+</Callout>
+
+At runtime, HostFn decodes the key and uses it for both the SSH connection and rsync file transfers. A temporary key file is created with `0600` permissions during the rsync operation and deleted immediately afterward.
+
+### Password Authentication
+
+If your server uses password-based SSH authentication instead of keys, set `HOSTFN_SSH_PASSWORD`:
+
+```bash
+export HOSTFN_SSH_PASSWORD="your-ssh-password"
+hostfn deploy production --ci
+```
+
+### Host Override
+
+Use `HOSTFN_HOST` to override the server address from your config. This is useful when your CI environment connects to servers via different hostnames or IP addresses than your local development machine:
+
+```bash
+export HOSTFN_HOST="deploy@10.0.0.50"
+hostfn deploy production --ci
+```
+
+## GitHub Actions Workflow
+
+Here is a complete GitHub Actions workflow that deploys on every push to the `main` branch:
+
+```yaml title=".github/workflows/deploy.yml"
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install HostFn
+        run: npm install -g hostfn
+
+      - name: Deploy to production
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci
+```
+
+### Required GitHub Secrets
+
+Add the following secrets in your repository settings (Settings > Secrets and variables > Actions):
+
+| Secret Name | Value |
+|---|---|
+| `SSH_PRIVATE_KEY` | Base64-encoded SSH private key (`base64 < ~/.ssh/id_rsa \| tr -d '\n'`) |
+
+If your key has a passphrase, also add:
+
+| Secret Name | Value |
+|---|---|
+| `SSH_PASSPHRASE` | The passphrase for your SSH key |
+
+And update your workflow to include it:
+
+```yaml
+      - name: Deploy to production
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          HOSTFN_SSH_PASSPHRASE: ${{ secrets.SSH_PASSPHRASE }}
+        run: hostfn deploy production --ci
+```
+
+## Monorepo CI Deployment
+
+For monorepos, use the `--service` flag to deploy individual services. This lets you set up separate deployment jobs or deploy only the services that changed.
+
+### Deploy All Services
+
+```yaml title=".github/workflows/deploy-all.yml"
+name: Deploy All Services
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm install -g hostfn
+      - name: Deploy all services
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci
+```
+
+### Deploy Specific Services
+
+```yaml title=".github/workflows/deploy-services.yml"
+name: Deploy Services
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-account:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm install -g hostfn
+      - name: Deploy account service
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci --service account
+
+  deploy-auth:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm install -g hostfn
+      - name: Deploy auth service
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci --service auth
+```
+
+### Deploy on Changed Paths
+
+To deploy services only when their code changes, use workflow path filters or a changed-files action instead of checking `github.event.head_commit.modified` directly:
+
+```yaml title=".github/workflows/deploy-on-change.yml"
+name: Deploy Changed Services
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      account: ${{ steps.filter.outputs.account }}
+      auth: ${{ steps.filter.outputs.auth }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            account:
+              - 'services/account/**'
+            auth:
+              - 'services/auth/**'
+
+  deploy-account:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.account == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm install -g hostfn
+      - name: Deploy account service
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci --service account
+
+  deploy-auth:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.auth == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm install -g hostfn
+      - name: Deploy auth service
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci --service auth
+```
+
+## Staging and Production Pipeline
+
+A common pattern is to deploy to staging first, then promote to production:
+
+```yaml title=".github/workflows/staged-deploy.yml"
+name: Staged Deployment
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm install -g hostfn
+      - name: Deploy to staging
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy staging --ci
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm install -g hostfn
+      - name: Deploy to production
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci
+```
+
+The `needs: deploy-staging` ensures production only deploys after staging succeeds. The `environment: production` setting enables GitHub's environment protection rules (manual approval, required reviewers, etc.).
+
+## Dry Run in CI
+
+Use `--dry-run` in your CI pipeline to preview deployments without executing them. This is useful for pull request checks:
+
+```yaml
+      - name: Deployment dry run
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: hostfn deploy production --ci --dry-run
+```
+
+## Next Steps
+
+- [Local Deployment Mode](/docs/documentation/deployment/local-mode) -- Deploy from self-hosted runners
+- [Dry Run](/docs/documentation/deployment/dry-run) -- Preview deployments without executing
+- [Deployment Overview](/docs/documentation/deployment/overview) -- Understand the full deployment lifecycle

--- a/hostfn/docs/content/docs/documentation/deployment/dry-run.mdx
+++ b/hostfn/docs/content/docs/documentation/deployment/dry-run.mdx
@@ -1,0 +1,74 @@
+---
+title: Dry Run
+description: Preview a deployment without executing any changes.
+---
+
+The dry run mode shows you exactly what a deployment would do, without making any changes to your server.
+
+## Usage
+
+```bash
+hostfn deploy production --dry-run
+```
+
+## What It Shows
+
+The dry run outputs a complete deployment plan:
+
+```
+  Deploy Application
+
+  Application  my-api
+  Runtime      nodejs
+  Environment  production
+  Server       ubuntu@my-server.com
+  Port         3000
+
+  ⚠ DRY RUN MODE - No changes will be made
+
+  Deployment Plan:
+
+  1. Pre-flight Checks
+     ✓ Check rsync availability
+     ✓ Connect to server
+     ✓ Verify remote directory
+
+  2. File Sync
+     → Sync /Users/you/my-api to /var/www/my-api-production
+     → Exclude: node_modules, .git, dist, .env, *.log
+
+  3. Remote Build
+     → npm ci --production
+     → npm run build
+
+  4. Backup
+     → Create timestamped backup of current deployment
+
+  5. PM2 Deployment
+     → Check if my-api-production exists
+     → Start/Reload PM2 process
+
+  6. Health Check
+     → Poll /health
+     → Retries: 10
+
+  7. Cleanup
+     → Keep last 5 backups
+```
+
+## When to Use
+
+- **Before first deployment** to verify configuration is correct
+- **Before major changes** to review what will happen
+- **In CI/CD pipelines** as a validation step before the actual deploy
+- **When debugging** configuration issues
+
+## Combining with Other Flags
+
+```bash
+# Dry run for a specific monorepo service
+hostfn deploy production --dry-run --service api
+
+# Dry run for staging
+hostfn deploy staging --dry-run
+```

--- a/hostfn/docs/content/docs/documentation/deployment/local-mode.mdx
+++ b/hostfn/docs/content/docs/documentation/deployment/local-mode.mdx
@@ -1,0 +1,63 @@
+---
+title: Local Deployment Mode
+description: Deploy without SSH for self-hosted runners and local servers.
+---
+
+Local deployment mode skips SSH and rsync entirely, copying files directly on the same machine. This is useful for **self-hosted CI/CD runners** that run on the deployment target.
+
+## Usage
+
+```bash
+hostfn deploy production --local
+```
+
+## When to Use Local Mode
+
+- **Self-hosted GitHub Actions runners** running directly on your VPS
+- **Local development servers** where the app runs on the same machine
+- **Testing deployment workflows** without needing a remote server
+
+## How It Differs from Remote Mode
+
+| Aspect | Remote Mode | Local Mode |
+|---|---|---|
+| Connection | SSH over network | Direct local execution |
+| File Transfer | rsync over SSH | Node.js `cpSync` |
+| Commands | Executed via SSH | Executed via `child_process.exec` |
+| rsync Required | Yes | No |
+| SSH Key Required | Yes | No |
+
+## How It Works
+
+1. Instead of establishing an SSH connection, HostFn creates a `LocalExecutor` that runs commands using Node.js `child_process`
+2. Files are copied using `fs.cpSync` instead of rsync, using local filtering based on the configured exclude list
+3. All other phases (build, PM2 deployment, health check) work identically
+
+## Example: Self-Hosted Runner
+
+```yaml title=".github/workflows/deploy.yml"
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm install -g hostfn
+      - run: hostfn deploy production --local --ci
+```
+
+## Combining with CI Mode
+
+You can combine `--local` with `--ci` for non-interactive local deployments:
+
+```bash
+hostfn deploy production --local --ci
+```

--- a/hostfn/docs/content/docs/documentation/deployment/meta.json
+++ b/hostfn/docs/content/docs/documentation/deployment/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Deployment",
+  "pages": ["overview", "single-service", "monorepo", "ci-cd", "local-mode", "dry-run"]
+}

--- a/hostfn/docs/content/docs/documentation/deployment/monorepo.mdx
+++ b/hostfn/docs/content/docs/documentation/deployment/monorepo.mdx
@@ -1,0 +1,359 @@
+---
+title: Monorepo Deployment
+description: Deploy multiple services from a monorepo, with support for per-service servers, Nginx path routing, and selective deployment.
+---
+
+HostFn supports deploying multiple services from a single monorepo. Each service gets its own PM2 process, port, and remote directory. You can deploy all services at once or target a specific service with the `--service` flag.
+
+## Monorepo Configuration
+
+To enable monorepo deployment, add a `services` section to your `hostfn.config.json`. Each key is a service name, and its value describes the service's path within the monorepo, port, and optional settings.
+
+```json title="hostfn.config.json"
+{
+  "name": "myapp",
+  "runtime": "nodejs",
+  "version": "20",
+  "environments": {
+    "production": {
+      "server": "ubuntu@prod.example.com",
+      "port": 3000,
+      "instances": "max"
+    }
+  },
+  "build": {
+    "command": "npm run build",
+    "directory": "dist",
+    "nodeModules": "all"
+  },
+  "start": {
+    "command": "npm start",
+    "entry": "dist/index.js"
+  },
+  "services": {
+    "account": {
+      "port": 3001,
+      "path": "services/account",
+      "domain": "account.example.com",
+      "instances": "max"
+    },
+    "auth": {
+      "port": 3002,
+      "path": "services/auth",
+      "domain": "auth.example.com",
+      "instances": 2
+    },
+    "notification": {
+      "port": 3003,
+      "path": "services/notification",
+      "domain": "notification.example.com"
+    },
+    "analytics": {
+      "port": 3004,
+      "path": "services/analytics"
+    }
+  },
+  "health": {
+    "path": "/health",
+    "timeout": 60,
+    "retries": 10,
+    "interval": 3
+  }
+}
+```
+
+### Service Configuration Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `port` | `number` | Yes | Port this service listens on |
+| `path` | `string` | Yes | Relative path to the service directory within the monorepo |
+| `domain` | `string \| string[]` | No | Domain name(s) for Nginx/SSL |
+| `exposePath` | `string` | No | Nginx path prefix for routing (e.g., `"/api"`) |
+| `server` | `string` | No | Override server for this service (defaults to environment server) |
+| `instances` | `number \| "max"` | No | PM2 instances for this service |
+
+## Deploying All Services
+
+When a `services` section is present in your config, `hostfn deploy` automatically deploys all services in sequence:
+
+```bash
+hostfn deploy production
+```
+
+```
+$ hostfn deploy production
+
+  Deploy Application
+
+  Application          myapp
+  Environment          production
+  Services to deploy   account, auth, notification, analytics
+
+  ── Deploying Service: account ──
+
+  Path       services/account
+  Port       3001
+  Server     ubuntu@prod.example.com
+  Domain     account.example.com
+  Instances  max
+
+  ── Pre-flight Checks ──
+  ✔ rsync available
+  ✔ Connected to server
+  ...
+  ✔ Service 'account' deployed successfully
+
+  ── Deploying Service: auth ──
+
+  Path       services/auth
+  Port       3002
+  Server     ubuntu@prod.example.com
+  Domain     auth.example.com
+  Instances  2
+
+  ...
+  ✔ Service 'auth' deployed successfully
+
+  ── Deploying Service: notification ──
+  ...
+  ✔ Service 'notification' deployed successfully
+
+  ── Deploying Service: analytics ──
+  ...
+  ✔ Service 'analytics' deployed successfully
+
+  ── Deployment Summary ──
+
+  Total services  4
+  Successful      4
+  Failed          0
+  Duration        127s
+
+  All services deployed successfully!
+```
+
+### Partial Failure Behavior
+
+If one service fails to deploy, HostFn continues deploying the remaining services. A summary at the end shows which services succeeded and which failed:
+
+```
+  ── Deployment Summary ──
+
+  Total services  4
+  Successful      3
+  Failed          1
+
+  Successful deployments:
+    ✓ account
+    ✓ auth
+    ✓ notification
+
+  Failed deployments:
+    ✗ analytics: Build failed: ...
+```
+
+HostFn exits with a non-zero code if any service fails.
+
+## Deploying a Specific Service
+
+Use the `--service` flag to deploy only one service:
+
+```bash
+hostfn deploy production --service auth
+```
+
+This is useful when:
+
+- You only changed code in one service
+- You want faster deployments during development
+- A previous multi-service deploy had a partial failure and you want to retry just the failed service
+
+If the specified service name does not exist in your config, HostFn shows the available services:
+
+```
+Error: Service 'payments' not found in configuration
+Available services: account, auth, notification, analytics
+```
+
+## Remote Directory Naming
+
+Each service gets its own remote directory following the pattern `/var/www/{name}-{serviceName}-{env}`:
+
+| Service | Remote Directory |
+|---|---|
+| `account` | `/var/www/myapp-account-production` |
+| `auth` | `/var/www/myapp-auth-production` |
+| `notification` | `/var/www/myapp-notification-production` |
+| `analytics` | `/var/www/myapp-analytics-production` |
+
+Each service also gets its own PM2 process name: `myapp-account-production`, `myapp-auth-production`, etc.
+
+## Multi-Server Configuration
+
+By default, all services deploy to the server defined in the environment config. To deploy specific services to different servers, add a `server` field to individual service configs:
+
+```json title="hostfn.config.json"
+{
+  "name": "myapp",
+  "runtime": "nodejs",
+  "version": "18",
+  "environments": {
+    "production": {
+      "server": "ubuntu@shared.example.com",
+      "port": 3000,
+      "instances": "max"
+    }
+  },
+  "build": {
+    "command": "npm run build",
+    "directory": "dist"
+  },
+  "start": {
+    "command": "npm start",
+    "entry": "dist/index.js"
+  },
+  "services": {
+    "account": {
+      "port": 3001,
+      "path": "services/account",
+      "domain": "account.example.com",
+      "server": "ubuntu@account-server.example.com",
+      "instances": "max"
+    },
+    "auth": {
+      "port": 3002,
+      "path": "services/auth",
+      "domain": "auth.example.com",
+      "server": "ubuntu@auth-server.example.com",
+      "instances": 4
+    },
+    "notification": {
+      "port": 3003,
+      "path": "services/notification",
+      "domain": "notification.example.com"
+    },
+    "analytics": {
+      "port": 3004,
+      "path": "services/analytics",
+      "server": "ubuntu@analytics-server.example.com"
+    }
+  }
+}
+```
+
+In this example:
+
+- **account** deploys to `ubuntu@account-server.example.com`
+- **auth** deploys to `ubuntu@auth-server.example.com`
+- **notification** deploys to `ubuntu@shared.example.com` (inherits the environment default)
+- **analytics** deploys to `ubuntu@analytics-server.example.com`
+
+<Callout type="info">
+Services without a `server` field inherit the server from the environment configuration. This lets you mix shared and dedicated servers in the same config.
+</Callout>
+
+## Nginx Path Prefix Routing with `exposePath`
+
+When multiple services share the same domain, you can route traffic based on URL path prefixes using the `exposePath` field. This configures Nginx to proxy requests to different services based on the path.
+
+```json title="hostfn.config.json"
+{
+  "services": {
+    "web": {
+      "port": 3001,
+      "path": "services/web",
+      "domain": "example.com"
+    },
+    "api": {
+      "port": 3002,
+      "path": "services/api",
+      "domain": "example.com",
+      "exposePath": "/api"
+    },
+    "docs": {
+      "port": 3003,
+      "path": "services/docs",
+      "domain": "example.com",
+      "exposePath": "/docs"
+    }
+  }
+}
+```
+
+When you run `hostfn expose production`, this generates Nginx configuration with location blocks:
+
+- `example.com/api/*` routes to the `api` service on port 3002
+- `example.com/docs/*` routes to the `docs` service on port 3003
+- `example.com/*` (everything else) routes to the `web` service on port 3001
+
+The generated Nginx location block for a path-based service looks like:
+
+```nginx
+# api
+location /api {
+    proxy_pass http://localhost:3002;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_cache_bypass $http_upgrade;
+    proxy_read_timeout 60s;
+    proxy_connect_timeout 60s;
+}
+```
+
+## Workspace Dependencies
+
+If your monorepo uses npm workspaces and services depend on shared packages, HostFn automatically detects and bundles workspace dependencies during deployment. Dependencies specified as `workspace:*` or `*` that match workspace packages are:
+
+1. Built locally (if they have a `build` script)
+2. Copied into a `__workspace__/` directory in the deployment bundle
+3. Referenced via `file:` paths in the rewritten `package.json`
+4. A lockfile is generated locally for deterministic installs on the server
+
+This happens transparently -- no extra configuration is needed.
+
+```
+monorepo/
+  ├── packages/
+  │   ├── shared-utils/     # workspace dependency
+  │   └── email/            # workspace dependency
+  └── services/
+      ├── account/          # depends on shared-utils
+      └── auth/             # depends on shared-utils, email
+```
+
+During deployment of the `auth` service:
+
+```
+  ── Workspace Bundling ──
+
+  Detected 2 workspace dependencies: @myapp/shared-utils, @myapp/email
+
+  → Building @myapp/shared-utils...
+  ✓ Bundled @myapp/shared-utils
+  → Building @myapp/email...
+  ✓ Bundled @myapp/email
+  ✔ Workspace dependencies bundled
+```
+
+## CI/CD with Monorepo
+
+In CI/CD pipelines, use the `--service` flag to deploy individual services. This is particularly useful when combined with change detection to only deploy services that have been modified:
+
+```bash
+# Deploy only the auth service
+hostfn deploy production --ci --service auth
+```
+
+See [CI/CD Integration](/docs/documentation/deployment/ci-cd) for a full GitHub Actions workflow example.
+
+## Next Steps
+
+- [CI/CD Integration](/docs/documentation/deployment/ci-cd) -- Automate monorepo deployments
+- [Configuration Reference](/docs/documentation/concepts/configuration) -- Full details on all configuration options
+- [Deployment Overview](/docs/documentation/deployment/overview) -- Understand the 7-phase lifecycle

--- a/hostfn/docs/content/docs/documentation/deployment/overview.mdx
+++ b/hostfn/docs/content/docs/documentation/deployment/overview.mdx
@@ -1,0 +1,184 @@
+---
+title: Deployment Overview
+description: Understand HostFn's 8-phase deployment lifecycle, from pre-flight checks to cleanup, with automatic rollback on failure.
+---
+
+HostFn deploys your application through a structured 8-phase lifecycle. Each phase has a clear responsibility, and if anything fails after a backup has been created, HostFn automatically rolls back to the previous working deployment.
+
+## The 8-Phase Deployment Lifecycle
+
+Every `hostfn deploy` execution follows this sequence:
+
+```mermaid
+graph TD
+    A["1. Pre-flight Checks"] --> B["2. Workspace Bundle"]
+    B --> C["3. File Sync"]
+    C --> D["4. Build"]
+    D --> E["5. Backup"]
+    E --> F["6. PM2 Deploy"]
+    F --> G["7. Health Check"]
+    G --> H["8. Cleanup"]
+    F -- "failure" --> R["Auto-Rollback"]
+    G -- "failure" --> R
+    R --> H
+```
+
+### Phase 1: Pre-flight Checks
+
+Before anything is transferred or modified, HostFn verifies the deployment environment is ready.
+
+| Check | Description |
+|---|---|
+| rsync availability | Confirms `rsync` is installed locally (skipped in `--local` mode) |
+| SSH connection | Establishes a connection to the server via SSH |
+| Node.js version | Verifies the correct Node.js version is active (installs via nvm if needed) |
+| PM2 availability | Confirms PM2 is installed globally (installs if missing) |
+| Remote directory | Creates `/var/www/{name}-{env}` if it does not exist |
+| Deployment lock | Acquires a lock file to prevent concurrent deployments |
+
+If any pre-flight check fails, the deployment aborts before any files are modified.
+
+### Phase 2: Workspace Bundle
+
+If your project is part of a monorepo with workspace dependencies (e.g., npm workspaces), HostFn detects them automatically and creates a self-contained deployment bundle. Workspace dependencies are copied into a `__workspace__/` directory and `package.json` references are rewritten to use `file:` paths. A lockfile is generated locally to ensure deterministic installs on the server.
+
+This phase is skipped entirely for standalone (non-workspace) projects.
+
+### Phase 3: File Sync
+
+Source files are transferred to the server using `rsync` over SSH. The sync uses archive mode with compression (`-avz`) and deletes files on the server that no longer exist locally (`--delete`).
+
+Files matching the `sync.exclude` patterns in your config are excluded. The defaults are:
+
+```
+node_modules, .git, .github, dist, build, .env, .env.*, *.log, .turbo, .wrangler
+```
+
+In `--local` mode, files are copied directly using the filesystem instead of rsync.
+
+### Phase 4: Build
+
+HostFn installs dependencies and runs your build command on the server.
+
+1. **Dependency installation** -- Uses `npm ci` when a lockfile is present, `npm install` otherwise. If a `build.command` is configured, all dependencies (including devDependencies) are installed; otherwise only production dependencies.
+2. **Build execution** -- Runs your `build.command` (e.g., `npm run build`). Skipped if no build command is configured.
+
+### Phase 5: Backup
+
+Before the PM2 process is modified, HostFn creates a timestamped backup of the current deployment's `dist/` directory and best-effort copies `package.json`. Backups are stored at `/var/www/{name}-{env}/backups/`.
+
+If this is the first deployment (no existing `dist/` directory), the backup step is skipped.
+
+### Phase 6: PM2 Deploy
+
+HostFn generates a PM2 ecosystem configuration file (`ecosystem.config.cjs`) and starts or reloads the process.
+
+- **First deployment**: PM2 starts a new process using the ecosystem config
+- **Subsequent deployments**: PM2 deletes and restarts the process with the updated config
+
+The ecosystem config includes environment variables read from the server's `.env` file, cluster mode settings, log paths, and auto-restart policies.
+
+### Phase 7: Health Check
+
+After the service is started, HostFn polls the health endpoint using `curl` on the server:
+
+```
+curl -sf http://localhost:{port}{healthPath}
+```
+
+The check retries up to `health.retries` times (default: 10) with `health.interval` seconds (default: 3) between attempts. Each curl request also uses `health.timeout` as its per-attempt timeout. Success follows curl's `-f` exit-code behavior.
+
+If all retries are exhausted without a healthy response, the deployment is considered failed and triggers an automatic rollback.
+
+### Phase 8: Cleanup
+
+After a successful deployment, HostFn:
+
+1. Removes old backups beyond the configured retention count (`backup.keep`, default: 5)
+2. Releases the deployment lock
+3. Cleans up any temporary workspace bundle directories
+
+## Automatic Rollback
+
+If the deployment fails **after** a backup has been created (during phases 6 or 7), HostFn automatically:
+
+1. Restores the previous deployment from the backup
+2. Reloads the PM2 process with the old version
+3. Reports the rollback result
+
+```
+  Deployment failed!
+  Service is not responding to health checks
+
+  ── Rolling Back ──
+
+  ✔ Rolled back to previous deployment
+  Previous deployment restored successfully
+```
+
+If the rollback itself fails, HostFn logs a message indicating manual intervention is required.
+
+<Callout type="info">
+Rollback only applies when there is a previous deployment to restore. First-time deployments that fail require manual investigation.
+</Callout>
+
+## Deployment Lock
+
+HostFn uses a lock file on the server to prevent concurrent deployments to the same application and environment. If another deployment is already in progress, the lock acquisition will fail and the deployment will abort. The lock is released in the `finally` block whenever the deploy process can still run cleanup.
+
+## Typical Deployment Output
+
+```
+$ hostfn deploy production
+
+  Deploy Application
+
+  Application       my-api
+  Runtime           nodejs
+  Environment       production
+  Server            ubuntu@my-server.com
+  Port              3000
+  Remote Directory  /var/www/my-api-production
+
+  ── Pre-flight Checks ──
+
+  ✔ rsync available
+  ✔ Connected to server
+  ✔ Node.js v20.11.0 ready
+  ✔ Remote directory created
+  ✔ Deployment lock acquired
+
+  ── Syncing Files ──
+
+  ✔ Files synced successfully
+
+  ── Building Application ──
+
+  ✔ Dependencies installed
+  ✔ Build completed
+
+  ── Creating Backup ──
+
+  ✔ Backup created: 2026-03-11T14-30-00-000Z
+
+  ── Deploying Service ──
+
+  ✔ Service reloaded
+
+  ── Health Check ──
+
+  ✔ Health check passed
+
+  Deployment completed successfully!
+
+  Environment  production
+  Service      my-api-production
+  Duration     42s
+  Health URL   http://my-server.com:3000/health
+```
+
+## Next Steps
+
+- [Single Service Deployment](/docs/documentation/deployment/single-service) -- Deploy a standard Node.js application
+- [Monorepo Deployment](/docs/documentation/deployment/monorepo) -- Deploy multiple services from a monorepo
+- [CI/CD Integration](/docs/documentation/deployment/ci-cd) -- Automate deployments with GitHub Actions

--- a/hostfn/docs/content/docs/documentation/deployment/single-service.mdx
+++ b/hostfn/docs/content/docs/documentation/deployment/single-service.mdx
@@ -1,0 +1,273 @@
+---
+title: Single Service Deployment
+description: Walk through deploying a standard Node.js application to your VPS server with HostFn.
+---
+
+This guide covers deploying a single Node.js application -- the most common deployment scenario. If you have a monorepo with multiple services, see [Monorepo Deployment](/docs/documentation/deployment/monorepo) instead.
+
+## Prerequisites
+
+Before deploying, make sure you have:
+
+1. A `hostfn.config.json` file in your project root (run `hostfn init` to create one)
+2. A server set up with `hostfn server setup`
+3. Environment variables pushed to the server (if needed)
+4. A `/health` endpoint in your application
+
+## The Deploy Command
+
+```bash
+hostfn deploy production
+```
+
+The first argument is the environment name, which must match a key in your `environments` configuration. If omitted, it defaults to `production`.
+
+### Command Options
+
+| Flag | Description |
+|---|---|
+| `--host <host>` | Override the server host from config |
+| `--ci` | CI/CD mode (non-interactive) |
+| `--local` | Local deployment mode (skip SSH) |
+| `--dry-run` | Show deployment plan without executing |
+
+## Configuration
+
+A minimal single-service configuration looks like this:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-api",
+  "runtime": "nodejs",
+  "version": "20",
+  "environments": {
+    "production": {
+      "server": "ubuntu@my-server.com",
+      "port": 3000,
+      "instances": "max",
+      "domain": "api.example.com"
+    }
+  },
+  "build": {
+    "command": "npm run build",
+    "directory": "dist",
+    "nodeModules": "all"
+  },
+  "start": {
+    "command": "npm start",
+    "entry": "dist/index.js"
+  },
+  "health": {
+    "path": "/health",
+    "timeout": 60,
+    "retries": 10,
+    "interval": 3
+  }
+}
+```
+
+## Port Configuration
+
+The `port` field in your environment config determines which port PM2 injects as the `PORT` environment variable. Your application should listen on this port:
+
+```ts title="src/index.ts"
+const port = process.env.PORT || 3000;
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});
+```
+
+HostFn writes the port into the PM2 ecosystem config, but values read from the server's `.env` file are merged afterward. If your remote `.env` also defines `PORT`, it can override the configured port.
+
+<Callout type="warn">
+Make sure no other service on the server is using the same port. Each application and environment should have a unique port number.
+</Callout>
+
+## Remote Directory Structure
+
+HostFn deploys your application to `/var/www/{name}-{env}` on the server. For a config with `"name": "my-api"` deployed to the `production` environment, the directory is:
+
+```
+/var/www/my-api-production/
+```
+
+After deployment, the remote directory contains:
+
+```
+/var/www/my-api-production/
+  ├── dist/                  # Built application output
+  ├── src/                   # Source files (synced from local)
+  ├── node_modules/          # Installed dependencies
+  ├── package.json           # Project manifest
+  ├── package-lock.json      # Lockfile (if present)
+  ├── ecosystem.config.cjs   # PM2 process configuration
+  ├── .env                   # Environment variables (pushed separately)
+  ├── logs/                  # PM2 log files
+  │   ├── out.log
+  │   └── err.log
+  └── backups/               # Timestamped deployment backups
+      ├── 2026-03-10T14-30-00-000Z/
+      └── 2026-03-11T09-15-00-000Z/
+```
+
+## PM2 Ecosystem Config
+
+HostFn generates an `ecosystem.config.cjs` file on the server during each deployment. This file tells PM2 how to run your application.
+
+Here is an example of the generated file:
+
+```js title="ecosystem.config.cjs"
+module.exports = {
+  apps: [{
+    name: 'my-api-production',
+    script: 'dist/index.js',
+    instances: 'max',
+    exec_mode: 'cluster',
+    env: {
+      NODE_ENV: "production",
+      PORT: 3000,
+      DATABASE_URL: "postgresql://...",
+      JWT_SECRET: "..."
+    },
+    error_file: './logs/err.log',
+    out_file: './logs/out.log',
+    time: true,
+    autorestart: true,
+    max_restarts: 10,
+    min_uptime: '10s',
+    max_memory_restart: '1G'
+  }]
+};
+```
+
+Key properties:
+
+| Property | Value | Description |
+|---|---|---|
+| `name` | `{name}-{env}` | Unique PM2 process identifier |
+| `script` | `dist/index.js` | Entry point (from `start.entry` config) |
+| `instances` | `"max"` | Current generated value for single-service PM2 config |
+| `exec_mode` | `"cluster"` | Enables Node.js cluster mode for multi-core usage |
+| `env` | `{ ... }` | Merged environment variables from the `.env` file on the server |
+| `max_memory_restart` | `"1G"` | Restart the process if it exceeds 1 GB of memory |
+| `autorestart` | `true` | Automatically restart the process if it crashes |
+
+### Environment Variables in the Ecosystem Config
+
+HostFn reads the `.env` file from the remote server during deployment and merges those values into the ecosystem config. It also injects `NODE_ENV` (set to the environment name) and `PORT` (set to the configured port). This means your `.env` file on the server is the source of truth for environment variables.
+
+## Full Deployment Example
+
+```
+$ hostfn deploy production
+
+  Deploy Application
+
+  Application       my-api
+  Runtime           nodejs
+  Environment       production
+  Server            ubuntu@my-server.com
+  Port              3000
+  Remote Directory  /var/www/my-api-production
+
+  ── Pre-flight Checks ──
+
+  ✔ rsync available
+  ✔ Connected to server
+  ✔ Node.js v20.11.0 ready
+  ✔ Remote directory created
+  ✔ Deployment lock acquired
+
+  ── Syncing Files ──
+
+  ✔ Files synced successfully
+
+  ── Building Application ──
+
+  ✔ Dependencies installed
+  ✔ Build completed
+
+  ── Creating Backup ──
+
+  ✔ Backup created: 2026-03-11T14-30-00-000Z
+
+  ── Deploying Service ──
+
+  ✔ Service reloaded
+
+  ── Health Check ──
+
+  ✔ Health check passed
+
+  Deployment completed successfully!
+
+  Environment  production
+  Service      my-api-production
+  Duration     38s
+  Health URL   http://my-server.com:3000/health
+
+  Next steps:
+
+  1. Configure domain and SSL (if needed):
+  $ hostfn expose production
+
+  2. View logs:
+  $ hostfn logs production
+```
+
+## Multiple Environments
+
+You can define multiple environments and deploy to any of them:
+
+```json title="hostfn.config.json"
+{
+  "environments": {
+    "production": {
+      "server": "ubuntu@prod.example.com",
+      "port": 3000,
+      "instances": "max",
+      "domain": "api.example.com"
+    },
+    "staging": {
+      "server": "ubuntu@staging.example.com",
+      "port": 3000,
+      "instances": 2
+    }
+  }
+}
+```
+
+```bash
+# Deploy to staging
+hostfn deploy staging
+
+# Deploy to production
+hostfn deploy production
+```
+
+Each environment deploys to its own directory on its own server (`/var/www/my-api-staging` and `/var/www/my-api-production`), with its own PM2 process and environment variables.
+
+## After Deployment
+
+Once deployed, you can manage your application with these commands:
+
+```bash
+# View service status (CPU, memory, uptime)
+hostfn status production
+
+# View application logs
+hostfn logs production
+
+# Configure Nginx reverse proxy and SSL
+hostfn expose production
+
+# Roll back to previous deployment
+hostfn rollback production
+```
+
+## Next Steps
+
+- [Monorepo Deployment](/docs/documentation/deployment/monorepo) -- Deploy multiple services from a single repository
+- [CI/CD Integration](/docs/documentation/deployment/ci-cd) -- Automate deployments with GitHub Actions
+- [Dry Run](/docs/documentation/deployment/dry-run) -- Preview what a deployment will do

--- a/hostfn/docs/content/docs/documentation/environment/meta.json
+++ b/hostfn/docs/content/docs/documentation/environment/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Environment Variables",
+  "pages": ["overview", "push-pull", "validation"]
+}

--- a/hostfn/docs/content/docs/documentation/environment/overview.mdx
+++ b/hostfn/docs/content/docs/documentation/environment/overview.mdx
@@ -1,0 +1,130 @@
+---
+title: Environment Variables
+description: Understand how HostFn manages environment variables across your deployments.
+---
+
+Environment variables store sensitive configuration like database URLs, API keys, and secrets. HostFn provides a set of commands to manage these variables on your servers without exposing them in source control.
+
+## How Environment Variables Work
+
+In HostFn, environment variables are:
+
+1. **Stored as a `.env` file on the server** at `/var/www/{name}-{env}/.env`
+2. **Injected into your application** via the PM2 ecosystem configuration during deployment
+3. **Never included in rsync** -- `.env` files are excluded from file syncing by default
+
+For example, if your app is named `my-api` and you are deploying to the `production` environment, the `.env` file lives at:
+
+```
+/var/www/my-api-production/.env
+```
+
+### How Variables Reach Your Application
+
+During deployment, HostFn generates a PM2 ecosystem configuration that references the `.env` file. PM2 reads this file and injects all variables into the process environment, making them available via `process.env` in Node.js:
+
+```ts title="src/index.ts"
+const dbUrl = process.env.DATABASE_URL;
+const port = process.env.PORT || 3000;
+```
+
+## Available Commands
+
+HostFn provides five commands for managing environment variables:
+
+| Command | Description |
+|---|---|
+| `hostfn env list <env>` | List all variables on the server (values masked) |
+| `hostfn env set <env> <KEY> <VALUE>` | Set a single variable on the server |
+| `hostfn env push <env> <file>` | Upload an entire `.env` file to the server |
+| `hostfn env pull <env> <file>` | Download the `.env` file from the server |
+| `hostfn env validate <env>` | Check that all required variables are set |
+
+See [Push & Pull](/docs/documentation/environment/push-pull) for detailed usage of each command and [Validation](/docs/documentation/environment/validation) for the validation workflow.
+
+## Configuration
+
+In your `hostfn.config.json`, the `env` section defines which variables your application expects:
+
+```json title="hostfn.config.json"
+{
+  "env": {
+    "required": ["DATABASE_URL", "JWT_SECRET"],
+    "optional": ["REDIS_URL", "LOG_LEVEL", "SENTRY_DSN"]
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `required` | `string[]` | Variables that must be present. `hostfn env validate` fails if any are missing. |
+| `optional` | `string[]` | Variables that are recognized but not required. For documentation purposes. |
+
+These lists are used by the `hostfn env validate` command to verify that your server has all necessary variables before you deploy. The `optional` list serves as documentation for your team so everyone knows which variables are available.
+
+## Typical Workflow
+
+A common workflow for managing environment variables:
+
+### Initial Setup
+
+```bash
+# 1. Create a local .env file (never commit this to git)
+echo 'DATABASE_URL=postgresql://user:pass@db.example.com:5432/myapp' > .env.production
+echo 'JWT_SECRET=my-secret-key-here' >> .env.production
+
+# 2. Push it to the server
+hostfn env push production .env.production
+
+# 3. Validate all required variables are present
+hostfn env validate production
+
+# 4. Deploy
+hostfn deploy production
+```
+
+### Updating a Single Variable
+
+```bash
+# Set one variable without touching the rest
+hostfn env set production LOG_LEVEL "debug"
+
+# Redeploy for the change to take effect
+hostfn deploy production
+```
+
+### Pulling for Review
+
+```bash
+# Download current variables to inspect them
+hostfn env pull production .env.production.bak
+
+# Review the file
+cat .env.production.bak
+
+# Clean up (do not commit this file)
+rm .env.production.bak
+```
+
+## Security Best Practices
+
+- **Never commit `.env` files to git.** Add `.env` and `.env.*` to your `.gitignore`.
+- **Use `hostfn env push`** to transfer variables securely over SSH rather than copy-pasting them.
+- **Values are masked when listed.** The `hostfn env list` command shows keys but replaces all values with `***`.
+- **Rotate secrets regularly.** Use `hostfn env set` to update individual secrets without rewriting the entire file.
+- **Use different variables per environment.** Each environment (production, staging, etc.) has its own `.env` file at its own path on the server.
+
+## File Location Reference
+
+| Environment | Server Path |
+|---|---|
+| `production` | `/var/www/{name}-production/.env` |
+| `staging` | `/var/www/{name}-staging/.env` |
+| `development` | `/var/www/{name}-development/.env` |
+
+The `{name}` placeholder is replaced with the `name` field from your `hostfn.config.json`.
+
+## Next Steps
+
+- [Push & Pull](/docs/documentation/environment/push-pull) -- Learn the full details of each env command
+- [Validation](/docs/documentation/environment/validation) -- Set up pre-deployment validation for required variables

--- a/hostfn/docs/content/docs/documentation/environment/push-pull.mdx
+++ b/hostfn/docs/content/docs/documentation/environment/push-pull.mdx
@@ -1,0 +1,228 @@
+---
+title: Push & Pull
+description: Upload, download, list, and set environment variables on your servers.
+---
+
+HostFn provides four commands for transferring and managing environment variables between your local machine and your servers. All communication happens over SSH.
+
+## Push a File
+
+The `hostfn env push` command uploads an entire `.env` file from your local machine to the server.
+
+```bash
+hostfn env push <environment> <file>
+```
+
+### How It Works
+
+1. Reads the local `.env` file and counts the variables
+2. Asks for confirmation before uploading
+3. Creates a backup of the existing `.env` on the server (if one exists)
+4. Uploads the new file to `/var/www/{name}-{env}/.env`
+
+### Example
+
+```bash
+hostfn env push production .env.production
+```
+
+```
+  Push Environment File - production
+
+  Local file  .env.production
+  Variables   5
+
+  ? Push 5 variables to production? Yes
+
+  ✔ Connected
+  ✔ Remote directory ready
+  ✔ Backup created
+  ✔ .env file uploaded
+
+  ✅ Environment file pushed successfully!
+
+  Backup saved at: /var/www/my-api-production/.env.backup
+
+  ⚠ Restart service for changes to take effect:
+  $ hostfn deploy production
+```
+
+### Backup Behavior
+
+Every time you push a new `.env` file, the previous version is saved as `.env.backup` at the same path on the server. This allows you to manually restore the old values if needed:
+
+```bash
+# On the server, restore the backup
+ssh ubuntu@my-server.com 'cp /var/www/my-api-production/.env.backup /var/www/my-api-production/.env'
+```
+
+### Important
+
+After pushing new environment variables, you need to redeploy for the changes to take effect. PM2 reads the `.env` file at startup time, so a running process will not pick up changes until it restarts.
+
+```bash
+hostfn deploy production
+```
+
+## Pull a File
+
+The `hostfn env pull` command downloads the `.env` file from the server to your local machine.
+
+```bash
+hostfn env pull <environment> <file>
+```
+
+### Example
+
+```bash
+hostfn env pull production .env.production.local
+```
+
+```
+  Pull Environment File - production
+
+  ✔ Connected
+  ✔ .env file downloaded
+
+  ✅ Environment file pulled successfully!
+
+  Saved to  .env.production.local
+
+  ⚠ This file contains sensitive data - do not commit to git!
+```
+
+### Security Warning
+
+Pulled `.env` files contain **unmasked secrets**. Take these precautions:
+
+- **Do not commit pulled files to git.** Ensure your `.gitignore` includes `.env` and `.env.*`.
+- **Delete the file when you are done reviewing it.** Do not leave copies of production secrets on your local machine.
+- **Use a descriptive filename** (e.g., `.env.production.local`) to avoid accidentally pushing it or confusing it with a template.
+
+```bash title=".gitignore"
+.env
+.env.*
+```
+
+### When the File Does Not Exist
+
+If no `.env` file exists on the server, the command reports this and exits without creating a local file:
+
+```
+  ⚠ No .env file found on server
+```
+
+## Set a Variable
+
+The `hostfn env set` command sets or updates a single environment variable on the server without modifying other variables.
+
+```bash
+hostfn env set <environment> <KEY> <VALUE>
+```
+
+### Example
+
+```bash
+hostfn env set production LOG_LEVEL "debug"
+```
+
+```
+  Set Environment Variable - production
+
+  Key    LOG_LEVEL
+  Value  ***
+
+  ✔ Connected
+  ✔ Variable updated
+
+  ✅ Environment variable set successfully!
+
+  ⚠ Restart service for changes to take effect:
+  $ hostfn deploy production
+```
+
+### Key Format
+
+Variable names must follow the standard convention: uppercase letters, numbers, and underscores, starting with a letter or underscore.
+
+```
+Valid:   DATABASE_URL, JWT_SECRET, API_KEY_V2, _INTERNAL
+Invalid: database-url, my.key, 2FAST
+```
+
+If the key format is invalid, the command exits with an error:
+
+```
+Error: Invalid key format. Must be uppercase, alphanumeric, and underscores only.
+```
+
+### Adding vs. Updating
+
+- If the key does not exist in the `.env` file, it is **appended** to the end
+- If the key already exists, the old value is **replaced** with the new one
+
+### Requires an Existing `.env` File
+
+The `env set` command requires that a `.env` file already exists on the server. If no file exists, push one first:
+
+```bash
+# Create a minimal .env and push it
+echo 'NODE_ENV=production' > .env.production
+hostfn env push production .env.production
+
+# Now you can set individual variables
+hostfn env set production DATABASE_URL "postgresql://..."
+```
+
+## List Variables
+
+The `hostfn env list` command displays all environment variables on the server with their values masked for security.
+
+```bash
+hostfn env list <environment>
+```
+
+### Example
+
+```bash
+hostfn env list production
+```
+
+```
+  Environment Variables - production
+
+  ✔ Connected
+
+  ── Environment Variables ──
+
+  DATABASE_URL=***
+  JWT_SECRET=***
+  REDIS_URL=***
+  LOG_LEVEL=***
+  NODE_ENV=***
+
+  Total: 5 variable(s)
+```
+
+### Masked Output
+
+Values are always displayed as `***`. This command is safe to run in shared terminals, screen recordings, or CI/CD logs. To see actual values, use `hostfn env pull` to download the file.
+
+## Command Summary
+
+| Command | What It Does | Requires Existing `.env` |
+|---|---|---|
+| `hostfn env push <env> <file>` | Upload entire `.env` file | No (creates one) |
+| `hostfn env pull <env> <file>` | Download `.env` file | Yes |
+| `hostfn env set <env> KEY VALUE` | Set one variable | Yes |
+| `hostfn env list <env>` | List variables (masked) | Yes |
+
+## Applying Changes
+
+Environment variable changes are **not applied to running services immediately**. After modifying variables with `push` or `set`, redeploy your application:
+
+```bash
+hostfn deploy production
+```
+
+During deployment, PM2 restarts the application and reads the updated `.env` file, making the new values available to your code.

--- a/hostfn/docs/content/docs/documentation/environment/validation.mdx
+++ b/hostfn/docs/content/docs/documentation/environment/validation.mdx
@@ -1,0 +1,209 @@
+---
+title: Validation
+description: Validate that all required environment variables are set before deploying.
+---
+
+The `hostfn env validate` command checks your server to ensure all required environment variables are present. This helps catch missing configuration before a deployment fails at runtime.
+
+## Usage
+
+```bash
+hostfn env validate <environment>
+```
+
+### Example
+
+```bash
+hostfn env validate production
+```
+
+## How It Works
+
+1. Reads the `env.required` array from your `hostfn.config.json`
+2. Connects to the server and reads the `.env` file at `/var/www/{name}-{env}/.env`
+3. Parses the file to extract all defined variable names
+4. Compares the required list against the variables found on the server
+5. Reports a pass/fail result for each variable
+
+## Configuration
+
+Define your required variables in `hostfn.config.json`:
+
+```json title="hostfn.config.json"
+{
+  "env": {
+    "required": ["DATABASE_URL", "JWT_SECRET", "REDIS_URL"],
+    "optional": ["LOG_LEVEL", "SENTRY_DSN"]
+  }
+}
+```
+
+Only the `required` array is checked by `hostfn env validate`. The `optional` array is for documentation purposes and is not validated.
+
+## Example Output
+
+### All Variables Present
+
+```
+$ hostfn env validate production
+
+  Validate Environment Variables - production
+
+  Checking 3 required variable(s)...
+
+  ✔ Connected
+
+  ── Validation Results ──
+
+  ✓ DATABASE_URL
+  ✓ JWT_SECRET
+  ✓ REDIS_URL
+
+  ✅ All required environment variables are set!
+```
+
+The command exits with code `0` when all required variables are found.
+
+### Missing Variables
+
+```
+$ hostfn env validate production
+
+  Validate Environment Variables - production
+
+  Checking 3 required variable(s)...
+
+  ✔ Connected
+
+  ── Validation Results ──
+
+  ✓ DATABASE_URL
+  ✗ JWT_SECRET (missing)
+  ✗ REDIS_URL (missing)
+
+  ✗ Missing 2 required variable(s)
+
+  Set missing variables:
+  $ hostfn env set production JWT_SECRET "value"
+  $ hostfn env set production REDIS_URL "value"
+```
+
+The command exits with code `1` when any required variable is missing. This makes it straightforward to use in CI/CD pipelines where a non-zero exit code stops the pipeline.
+
+### No `.env` File Found
+
+If the server has no `.env` file at all, the command reports the error and suggests pushing one:
+
+```
+$ hostfn env validate production
+
+  Validate Environment Variables - production
+
+  Checking 3 required variable(s)...
+
+  ✔ Connected
+
+  ✗ No .env file found on server
+  Push environment variables first:
+  $ hostfn env push production .env
+```
+
+### No Required Variables Defined
+
+If the `env.required` array is empty or not defined in your config, the command warns you:
+
+```
+$ hostfn env validate production
+
+  Validate Environment Variables - production
+
+  ⚠ No required environment variables defined in config
+  Add them to hostfn.config.json under env.required
+```
+
+## Using in CI/CD Pipelines
+
+The `hostfn env validate` command is designed to work well in automated pipelines. Because it exits with code `1` on failure, you can add it as a pre-deployment check:
+
+### GitHub Actions
+
+```yaml title=".github/workflows/deploy.yml"
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install HostFn
+        run: npm install -g hostfn
+
+      - name: Validate environment variables
+        run: hostfn env validate production
+
+      - name: Deploy
+        run: hostfn deploy production --ci
+```
+
+If validation fails, the pipeline stops before the deploy step runs, preventing a deployment with missing configuration.
+
+### GitLab CI
+
+```yaml title=".gitlab-ci.yml"
+deploy:
+  stage: deploy
+  script:
+    - npm install -g hostfn
+    - hostfn env validate production
+    - hostfn deploy production --ci
+```
+
+### Shell Script
+
+```bash title="deploy.sh"
+#!/bin/bash
+set -e
+
+echo "Validating environment..."
+hostfn env validate production
+
+echo "Deploying..."
+hostfn deploy production --ci
+```
+
+The `set -e` flag ensures the script exits on the first error, so a failed validation prevents the deployment.
+
+## Best Practices
+
+### Keep the Required List Up to Date
+
+When you add a new environment variable to your application code, add it to the `env.required` array in your config. This ensures validation catches it before deployment:
+
+```json title="hostfn.config.json"
+{
+  "env": {
+    "required": [
+      "DATABASE_URL",
+      "JWT_SECRET",
+      "REDIS_URL",
+      "STRIPE_SECRET_KEY"
+    ]
+  }
+}
+```
+
+### Validate Before Every Deploy
+
+Make `hostfn env validate` a mandatory step in your deployment process. Whether you deploy manually or through CI/CD, running validation first saves time debugging runtime errors caused by missing configuration.
+
+```bash
+hostfn env validate production && hostfn deploy production
+```
+
+### Use Different Required Lists Per Concern
+
+The `env.required` array applies to all environments. If your staging environment uses different services than production, consider using the same required list and providing stub values for services not in use:
+
+```bash
+# Staging does not use Stripe, but set a placeholder to pass validation
+hostfn env set staging STRIPE_SECRET_KEY "stripe_secret_placeholder"
+```

--- a/hostfn/docs/content/docs/documentation/getting-started/first-deploy.mdx
+++ b/hostfn/docs/content/docs/documentation/getting-started/first-deploy.mdx
@@ -1,0 +1,152 @@
+---
+title: Your First Deploy
+description: Set up your server and deploy your application for the first time.
+---
+
+This guide continues from [Quickstart](/docs/documentation/getting-started/quickstart). You should already have a `hostfn.config.json` file in your project.
+
+## Step 1: Set Up the Server
+
+HostFn can automatically provision your server with everything needed for deployments:
+
+```bash
+hostfn server setup ubuntu@my-server.com
+```
+
+This installs:
+
+- **Node.js** (via nvm) at the version specified in your config
+- **PM2** process manager for running and monitoring your app
+- **Nginx** reverse proxy for handling HTTP traffic
+- **Certbot** for SSL certificates
+- **rsync** for file syncing
+- **UFW firewall** rules (ports 22, 80, 443)
+
+The setup takes 2-5 minutes and streams output to your terminal so you can follow progress.
+
+### Optional: Install Redis
+
+```bash
+hostfn server setup ubuntu@my-server.com --redis
+```
+
+## Step 2: Push Environment Variables
+
+If your app needs environment variables (database URLs, API keys, etc.), push them to the server before deploying:
+
+```bash
+# Push an entire .env file
+hostfn env push production .env.production
+
+# Or set individual variables
+hostfn env set production DATABASE_URL "postgresql://..."
+hostfn env set production JWT_SECRET "my-secret-key"
+```
+
+## Step 3: Deploy
+
+With the server ready and environment variables in place, deploy your application:
+
+```bash
+hostfn deploy production
+```
+
+HostFn executes a 7-phase deployment:
+
+```
+$ hostfn deploy production
+
+  Deploy Application
+
+  Application       my-api
+  Runtime           nodejs
+  Environment       production
+  Server            ubuntu@my-server.com
+  Port              3000
+
+  ── Pre-flight Checks ──
+
+  ✔ rsync available
+  ✔ Connected to server
+  ✔ Node.js v20.11.0 ready
+  ✔ Remote directory created
+  ✔ Deployment lock acquired
+
+  ── Syncing Files ──
+
+  ✔ Files synced successfully
+
+  ── Building Application ──
+
+  ✔ Dependencies installed
+  ✔ Build completed
+
+  ── Creating Backup ──
+
+  ℹ No existing deployment to backup
+
+  ── Deploying Service ──
+
+  ✔ Service started
+
+  ── Health Check ──
+
+  ✔ Health check passed
+
+  ✅ Deployment completed successfully!
+
+  Environment  production
+  Service      my-api-production
+  Duration     34s
+  Health URL   http://my-server.com:3000/health
+
+  Next steps:
+
+  1. Configure domain and SSL (if needed):
+  $ hostfn expose production
+
+  2. View logs:
+  $ hostfn logs production
+```
+
+## Step 4: Configure Domain and SSL
+
+If you have a domain configured, expose your service through Nginx with SSL:
+
+```bash
+hostfn expose production
+```
+
+This will:
+1. Generate an Nginx reverse proxy configuration
+2. Write it to the server
+3. Obtain an SSL certificate from Let's Encrypt
+4. Configure automatic HTTPS redirect
+
+After this, your app will be accessible at `https://api.example.com`.
+
+## Step 5: Verify
+
+Check your deployment status:
+
+```bash
+# View service status (memory, CPU, uptime)
+hostfn status production
+
+# View application logs
+hostfn logs production
+
+# View server information
+hostfn server info ubuntu@my-server.com
+```
+
+## What Happens on Subsequent Deploys
+
+After the first deployment, subsequent deploys are faster because:
+
+- The server is already set up
+- Dependencies are partially cached
+- PM2 performs a **zero-downtime reload** instead of a cold start
+- A backup is created before each deployment in case a rollback is needed
+
+Simply run `hostfn deploy production` again whenever you want to deploy new changes.

--- a/hostfn/docs/content/docs/documentation/getting-started/installation.mdx
+++ b/hostfn/docs/content/docs/documentation/getting-started/installation.mdx
@@ -1,0 +1,77 @@
+---
+title: Installation
+description: Install HostFn and its prerequisites.
+---
+
+## Install HostFn
+
+HostFn is published on npm and can be installed globally:
+
+```bash
+npm install -g hostfn
+```
+
+Verify the installation:
+
+```bash
+hostfn --version
+```
+
+## Prerequisites
+
+Before using HostFn, make sure you have the following:
+
+### Local Machine
+
+| Requirement | Version | Check |
+|---|---|---|
+| Node.js | 18+ | `node --version` |
+| rsync | Any | `rsync --version` |
+| SSH key | — | `ls ~/.ssh/id_*` |
+
+**Installing rsync:**
+
+```bash
+# macOS
+brew install rsync
+
+# Ubuntu/Debian
+sudo apt-get install rsync
+
+# Windows (via WSL)
+sudo apt-get install rsync
+```
+
+### Remote Server
+
+You need a Linux server with:
+
+- **SSH access** configured with key authentication
+- **Root or sudo access** (for the initial server setup)
+- **Ubuntu 20.04+**, Debian 11+, CentOS 8+, or similar Linux distribution
+
+HostFn will install everything else (Node.js, PM2, Nginx) during `hostfn server setup`.
+
+## SSH Key Setup
+
+If you don't already have an SSH key:
+
+```bash
+# Generate a new SSH key
+ssh-keygen -t ed25519 -C "your-email@example.com"
+
+# Copy it to your server
+ssh-copy-id ubuntu@your-server.com
+```
+
+HostFn looks for SSH keys in this order:
+
+1. `HOSTFN_SSH_KEY` environment variable (base64-encoded, for CI/CD)
+2. SSH agent (`SSH_AUTH_SOCK`)
+3. `~/.ssh/id_ed25519`
+4. `~/.ssh/id_ecdsa`
+5. `~/.ssh/id_rsa`
+
+## Next Steps
+
+Once installed, continue to [Quickstart](/docs/documentation/getting-started/quickstart) to initialize your first project.

--- a/hostfn/docs/content/docs/documentation/getting-started/meta.json
+++ b/hostfn/docs/content/docs/documentation/getting-started/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Getting Started",
+  "pages": ["installation", "quickstart", "first-deploy"]
+}

--- a/hostfn/docs/content/docs/documentation/getting-started/quickstart.mdx
+++ b/hostfn/docs/content/docs/documentation/getting-started/quickstart.mdx
@@ -1,0 +1,129 @@
+---
+title: Quickstart
+description: Initialize HostFn in your project in under 5 minutes.
+---
+
+This guide walks you through initializing HostFn in an existing Node.js project.
+
+## Step 1: Initialize Your Project
+
+Navigate to your project directory and run:
+
+```bash
+hostfn init
+```
+
+HostFn will:
+
+1. **Detect your runtime** - Scans for `package.json` and identifies Node.js automatically
+2. **Prompt for configuration** - Asks for your app name, server details, and build/start commands
+3. **Generate `hostfn.config.json`** - Writes the configuration file to your project root
+
+### Example Interactive Session
+
+```
+$ hostfn init
+
+  Initialize hostfn
+
+  ✔ Detected nodejs (confidence: 95%)
+
+  ── Project Configuration ──
+
+  ? Application name: my-api
+  ? nodejs version: 20
+
+  ── Environment Configuration ──
+
+  ? Production server (user@host): ubuntu@my-server.com
+  ? Production port: 3000
+  ? Domain (optional): api.example.com
+
+  ── Build & Start Configuration ──
+
+  ? Build command: npm run build
+  ? Start command: npm start
+
+  ✔ Configuration created
+
+  ✅ hostfn initialized successfully!
+
+  Config file  hostfn.config.json
+  Runtime      nodejs
+  Environment  production
+
+  Next steps:
+  $ hostfn server setup ubuntu@my-server.com
+  $ hostfn deploy production
+```
+
+## Step 2: Review the Configuration
+
+After `hostfn init`, you'll have a `hostfn.config.json` file:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-api",
+  "runtime": "nodejs",
+  "version": "20",
+  "environments": {
+    "production": {
+      "server": "ubuntu@my-server.com",
+      "port": 3000,
+      "instances": "max",
+      "domain": "api.example.com"
+    }
+  },
+  "build": {
+    "command": "npm run build",
+    "directory": "dist",
+    "nodeModules": "all"
+  },
+  "start": {
+    "command": "npm start",
+    "entry": "dist/index.js"
+  },
+  "health": {
+    "path": "/health",
+    "timeout": 60,
+    "retries": 10,
+    "interval": 3
+  },
+  "env": {
+    "required": [],
+    "optional": []
+  },
+  "sync": {
+    "exclude": [
+      "node_modules", ".git", ".github",
+      "dist", "build", ".env", ".env.*", "*.log"
+    ]
+  },
+  "backup": {
+    "keep": 5
+  }
+}
+```
+
+### Important: Health Endpoint
+
+HostFn verifies your app is running after each deployment by hitting a health endpoint. Make sure your application exposes one:
+
+```ts title="src/index.ts"
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+```
+
+## Step 3: Add to `.gitignore`
+
+You may want to keep your config in source control (it doesn't contain secrets), but make sure `.env` files are excluded:
+
+```bash title=".gitignore"
+.env
+.env.*
+```
+
+## Next Steps
+
+Continue to [Your First Deploy](/docs/documentation/getting-started/first-deploy) to set up your server and make your first deployment.

--- a/hostfn/docs/content/docs/documentation/index.mdx
+++ b/hostfn/docs/content/docs/documentation/index.mdx
@@ -1,0 +1,17 @@
+---
+title: Documentation
+description: Comprehensive guides for deploying applications with HostFn.
+---
+
+Welcome to the HostFn documentation. These guides cover everything from initial setup to advanced deployment patterns.
+
+## Sections
+
+<Cards>
+  <Card title="Getting Started" href="/docs/documentation/getting-started/installation" description="Install HostFn, initialize your project, and make your first deployment." />
+  <Card title="Core Concepts" href="/docs/documentation/concepts/overview" description="Understand configuration, runtimes, and workspace support." />
+  <Card title="Deployment" href="/docs/documentation/deployment/overview" description="Single-service, monorepo, CI/CD, and local deployment modes." />
+  <Card title="Server Management" href="/docs/documentation/server-management/setup" description="Provision servers, configure Nginx, and set up SSL." />
+  <Card title="Environment Variables" href="/docs/documentation/environment/overview" description="Manage secrets and configuration across environments." />
+  <Card title="Advanced" href="/docs/documentation/advanced/rollback" description="Rollbacks, backups, health checks, deployment locks, and troubleshooting." />
+</Cards>

--- a/hostfn/docs/content/docs/documentation/meta.json
+++ b/hostfn/docs/content/docs/documentation/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "Documentation",
+  "root": true,
+  "pages": [
+    "index",
+    "getting-started",
+    "concepts",
+    "deployment",
+    "server-management",
+    "environment",
+    "advanced"
+  ]
+}

--- a/hostfn/docs/content/docs/documentation/server-management/domains.mdx
+++ b/hostfn/docs/content/docs/documentation/server-management/domains.mdx
@@ -1,0 +1,230 @@
+---
+title: Domain Configuration
+description: Configure custom domains and DNS for your HostFn deployments.
+---
+
+HostFn supports custom domain names for your deployed services. Domains are configured in your `hostfn.config.json` file and used by the [`hostfn expose`](/docs/documentation/server-management/nginx-ssl) command to generate Nginx configurations and obtain SSL certificates.
+
+## Single Domain
+
+To assign a single domain to an environment, set the `domain` field as a string:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-api",
+  "environments": {
+    "production": {
+      "server": "ubuntu@my-server.com",
+      "port": 3000,
+      "domain": "api.example.com",
+      "sslEmail": "admin@example.com"
+    }
+  }
+}
+```
+
+This configures Nginx with `server_name api.example.com` and obtains an SSL certificate for that domain.
+
+## Multiple Domains
+
+To assign multiple domains to a single environment, set the `domain` field as an array of strings:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-app",
+  "environments": {
+    "production": {
+      "server": "ubuntu@my-server.com",
+      "port": 3000,
+      "domain": ["example.com", "www.example.com"],
+      "sslEmail": "admin@example.com"
+    }
+  }
+}
+```
+
+This configures Nginx with `server_name example.com www.example.com` and obtains a single SSL certificate that covers both domains (a multi-domain or SAN certificate).
+
+A common use case is serving both the bare domain and the `www` subdomain from the same application.
+
+## SSL Email
+
+The `sslEmail` field specifies the email address used when registering with Let's Encrypt. This email receives:
+
+- Expiry warnings if automatic renewal fails
+- Important notices from Let's Encrypt about your certificates
+
+```json
+{
+  "sslEmail": "admin@example.com"
+}
+```
+
+SSL is only set up when **both** `domain` and `sslEmail` are present. If either is missing, `hostfn expose` configures Nginx for HTTP only.
+
+| Configuration | Result |
+|---|---|
+| `domain` + `sslEmail` present | Nginx + SSL (HTTPS) |
+| `domain` present, no `sslEmail` | Nginx HTTP only |
+| No `domain` | Nginx with catch-all `server_name _`, HTTP only |
+
+## Monorepo Routing
+
+In a monorepo configuration, `hostfn expose` applies environment-level domains to a single Nginx `server_name` set, then routes traffic to services by path:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-platform",
+  "environments": {
+    "production": {
+      "server": "ubuntu@my-server.com",
+      "port": 3000,
+      "domain": "example.com",
+      "sslEmail": "admin@example.com"
+    }
+  },
+  "services": {
+    "api": {
+      "port": 3001,
+      "path": "services/api",
+      "exposePath": "/api"
+    },
+    "web": {
+      "port": 3002,
+      "path": "services/web"
+    },
+    "docs": {
+      "port": 3003,
+      "path": "services/docs",
+      "exposePath": "/docs"
+    }
+  }
+}
+```
+
+Services without an `exposePath` become the default `/` route. All routed services share the environment's configured domain set.
+
+## Different Domains per Environment
+
+A common pattern is using different domains for production and staging:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-api",
+  "environments": {
+    "production": {
+      "server": "ubuntu@prod.example.com",
+      "port": 3000,
+      "domain": "api.example.com",
+      "sslEmail": "admin@example.com"
+    },
+    "staging": {
+      "server": "ubuntu@staging.example.com",
+      "port": 3000,
+      "domain": "staging-api.example.com",
+      "sslEmail": "admin@example.com"
+    }
+  }
+}
+```
+
+Then expose each environment separately:
+
+```bash
+hostfn expose production
+hostfn expose staging
+```
+
+## DNS Setup
+
+Before running `hostfn expose`, you need to point your domain to your server's IP address. This is done by creating DNS records with your domain registrar or DNS provider.
+
+### Step 1: Find Your Server IP
+
+```bash
+hostfn server info ubuntu@my-server.com
+```
+
+Or SSH into the server and run:
+
+```bash
+curl -s ifconfig.me
+```
+
+### Step 2: Create an A Record
+
+Log in to your DNS provider and create an **A record** pointing your domain to the server's IP address:
+
+| Type | Name | Value | TTL |
+|---|---|---|---|
+| A | `api.example.com` | `203.0.113.10` | 300 |
+
+For bare domains (e.g., `example.com`) pointing directly to a server IP, use an **A** record. ALIAS or ANAME records are only relevant when your DNS provider asks you to point the apex at another hostname instead of an IP.
+
+### Step 3: Create Records for All Domains
+
+If you configured multiple domains, create an A record for each one:
+
+| Type | Name | Value | TTL |
+|---|---|---|---|
+| A | `example.com` | `203.0.113.10` | 300 |
+| A | `www.example.com` | `203.0.113.10` | 300 |
+
+### Step 4: Wait for Propagation
+
+DNS changes can take anywhere from a few minutes to 48 hours to propagate, although most providers update within 5-15 minutes. You can check propagation status with:
+
+```bash
+dig api.example.com +short
+```
+
+The output should show your server's IP address.
+
+### Step 5: Expose the Service
+
+Once DNS is pointing to your server, run the expose command:
+
+```bash
+hostfn expose production
+```
+
+Certbot validates domain ownership by making an HTTP request to your server. If DNS has not propagated yet, the SSL certificate step will fail. In that case, wait and try again:
+
+```bash
+# Re-run to retry SSL after DNS propagates
+hostfn expose production --force
+```
+
+## No Domain (IP Access)
+
+If you do not set a `domain` in your configuration, your app is still accessible via the server's IP address. HostFn generates an Nginx config with `server_name _` (catch-all), which responds to any hostname.
+
+This is fine for development, internal tools, or testing. For production applications accessed by users, a domain with SSL is strongly recommended.
+
+## Troubleshooting
+
+### SSL certificate fails to obtain
+
+**Cause:** DNS is not pointing to the server yet, or the domain is unreachable.
+
+**Fix:** Verify DNS with `dig your-domain.com +short` and ensure the result matches your server IP. Then re-run with `--force`:
+
+```bash
+hostfn expose production --force
+```
+
+### Certificate does not cover all domains
+
+**Cause:** You added a new domain after the initial certificate was obtained.
+
+**Fix:** Re-run `hostfn expose`. HostFn detects that the existing certificate is missing domains and uses Certbot's `--expand` flag to add them.
+
+### Nginx shows the default page instead of your app
+
+**Cause:** The default Nginx site is still enabled and taking precedence.
+
+**Fix:** HostFn automatically disables the default site when a custom domain is configured. If you still see the default page, re-run with `--force`:
+
+```bash
+hostfn expose production --force
+```

--- a/hostfn/docs/content/docs/documentation/server-management/info.mdx
+++ b/hostfn/docs/content/docs/documentation/server-management/info.mdx
@@ -1,0 +1,136 @@
+---
+title: Server Information
+description: View system details and running services on your server.
+---
+
+The `hostfn server info` command connects to your server over SSH and displays a summary of system resources, installed runtimes, and all running PM2 services.
+
+## Usage
+
+```bash
+hostfn server info <host>
+```
+
+The `<host>` argument is your SSH connection string in `user@host` format:
+
+```bash
+hostfn server info ubuntu@my-server.com
+```
+
+## What It Shows
+
+The command gathers information in three categories:
+
+### System
+
+| Field | Source | Description |
+|---|---|---|
+| OS | `/etc/os-release` | Operating system name and version |
+| Disk | `df -h /` | Disk usage (used / total with percentage) |
+| Memory | `free -h` | RAM usage (used / total) |
+
+### Runtime
+
+| Field | Description |
+|---|---|
+| Node.js | Installed version (via nvm), or "not installed" |
+| PM2 | PM2 process manager version, or "not installed" |
+| Nginx | Service status (`active`, `inactive`, or `not running`) |
+
+### Services
+
+Lists every PM2-managed process with:
+
+| Field | Description |
+|---|---|
+| Name | The PM2 service name (e.g., `my-api-production`) |
+| Status | `online`, `stopped`, `errored`, etc. |
+| Memory | Current memory usage in MB |
+| CPU | Current CPU percentage |
+| Uptime | How long the service has been running (e.g., `3d 12h`, `45m`) |
+
+## Example Output
+
+```
+$ hostfn server info ubuntu@my-server.com
+
+  Server Information
+
+  Host  ubuntu@my-server.com
+
+  ✔ Connected
+
+  ✔ Information gathered
+
+  ── System ──
+
+  OS      Ubuntu 22.04.3 LTS
+  Disk    12G used / 50G total (24% used)
+  Memory  1.8G used / 4.0G total
+
+  ── Runtime ──
+
+  Node.js  v20.11.0
+  PM2      5.3.0
+  Nginx    active
+
+  ── Services ──
+
+  my-api-production
+    Status: online
+    Memory: 87MB  CPU: 0.2%  Uptime: 3d 12h
+
+  my-api-staging
+    Status: online
+    Memory: 64MB  CPU: 0.1%  Uptime: 1d 4h
+```
+
+### When No Services Are Running
+
+If PM2 has no managed processes, the Services section displays:
+
+```
+  ── Services ──
+
+  No PM2 services running
+```
+
+## How It Works
+
+The command connects over SSH and runs several commands in parallel to minimize latency:
+
+1. Reads `/etc/os-release` for the OS name
+2. Runs `node --version` (via nvm) for the Node.js version
+3. Runs `pm2 --version` for the PM2 version
+4. Checks `systemctl is-active nginx` for Nginx status
+5. Runs `df -h /` for disk usage
+6. Runs `free -h` for memory usage
+7. Runs `pm2 jlist` to get a JSON list of all managed services
+
+All queries execute concurrently, so the command typically completes in 1-2 seconds after the SSH connection is established.
+
+## Use Cases
+
+- **Pre-deployment check** -- Verify your server has the expected Node.js version and enough disk space before deploying
+- **Debugging** -- Quickly see if a service has crashed, is consuming too much memory, or has recently restarted
+- **Multi-server overview** -- Run the command against each of your servers to compare resource usage
+
+```bash title="Check multiple servers"
+hostfn server info ubuntu@prod-1.example.com
+hostfn server info ubuntu@prod-2.example.com
+hostfn server info ubuntu@staging.example.com
+```
+
+## Error Handling
+
+If the SSH connection fails, the command reports the error and exits:
+
+```
+✗ Failed to get server information
+Error: Connection refused
+```
+
+Common causes include:
+- Incorrect SSH credentials or key configuration
+- Server firewall blocking port 22
+- Server is offline or unreachable

--- a/hostfn/docs/content/docs/documentation/server-management/meta.json
+++ b/hostfn/docs/content/docs/documentation/server-management/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Server Management",
+  "pages": ["setup", "info", "nginx-ssl", "domains"]
+}

--- a/hostfn/docs/content/docs/documentation/server-management/nginx-ssl.mdx
+++ b/hostfn/docs/content/docs/documentation/server-management/nginx-ssl.mdx
@@ -1,0 +1,298 @@
+---
+title: Nginx & SSL
+description: Configure Nginx reverse proxy and SSL certificates for your deployed services.
+---
+
+The `hostfn expose` command generates an Nginx reverse proxy configuration, writes it to your server, and optionally obtains SSL certificates from Let's Encrypt using Certbot.
+
+## Usage
+
+```bash
+hostfn expose [environment]
+```
+
+The environment defaults to `production` if not specified:
+
+```bash
+# Expose production services
+hostfn expose
+
+# Expose staging services
+hostfn expose staging
+```
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--host <host>` | Config `server` value | Override the SSH connection string |
+| `--skip-ssl` | `false` | Skip SSL certificate setup (HTTP only) |
+| `--force` | `false` | Overwrite an existing Nginx configuration |
+
+### Examples
+
+```bash title="Default: Nginx + SSL"
+hostfn expose production
+```
+
+```bash title="HTTP only, no SSL"
+hostfn expose production --skip-ssl
+```
+
+```bash title="Overwrite existing config"
+hostfn expose production --force
+```
+
+```bash title="Override host"
+hostfn expose production --host ubuntu@different-server.com
+```
+
+## Prerequisites
+
+Before running `hostfn expose`, your server needs Nginx installed. Certbot is only required when SSL setup is enabled (domain + `sslEmail`, without `--skip-ssl`). Both can be installed automatically by [`hostfn server setup`](/docs/documentation/server-management/setup). The command checks for the required tools and shows a clear error if one is missing:
+
+```
+Error: Nginx is not installed on the server.
+Run: hostfn server setup <host> --env production
+```
+
+## How It Works
+
+### 1. Detect Nginx Config System
+
+HostFn auto-detects how your server organizes Nginx configurations:
+
+| System | Used By | Config Path |
+|---|---|---|
+| `sites-available` / `sites-enabled` | Debian, Ubuntu | `/etc/nginx/sites-available/hostfn-{env}` |
+| `conf.d` | RHEL, CentOS, Fedora | `/etc/nginx/conf.d/hostfn-{env}.conf` |
+
+On `sites-available` systems, the config is written to `sites-available` and symlinked into `sites-enabled`.
+
+### 2. Disable Default Site
+
+When using a `sites-available` system with a custom domain configured, HostFn automatically disables the default Nginx site by removing the `/etc/nginx/sites-enabled/default` symlink. This prevents conflicts between the default catch-all server block and your domain-specific configuration.
+
+### 3. Generate Reverse Proxy Config
+
+The generated Nginx configuration includes full WebSocket support and standard proxy headers:
+
+```nginx title="Generated Nginx config (single service)"
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.example.com;
+
+    # my-api-production
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 60s;
+        proxy_connect_timeout 60s;
+    }
+}
+```
+
+### 4. Write and Reload
+
+After generating the configuration, HostFn:
+
+1. Writes the config file to the server
+2. Enables the site (on `sites-available` systems)
+3. Runs `nginx -t` to validate the configuration
+4. Reloads Nginx with `systemctl reload nginx`
+
+If the configuration test fails, the command stops and displays the Nginx error output.
+
+### 5. Obtain SSL Certificate
+
+If a domain and `sslEmail` are configured (and `--skip-ssl` is not set), HostFn runs Certbot to obtain an SSL certificate:
+
+```bash
+# Command executed on server
+sudo certbot --nginx -d api.example.com --email admin@example.com \
+  --non-interactive --agree-tos --redirect
+```
+
+Certbot modifies the Nginx config to add SSL directives and sets up an HTTP-to-HTTPS redirect automatically.
+
+## Single Service Configuration
+
+For a standard (non-monorepo) project, the `expose` command proxies all traffic on `/` to your application port:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-api",
+  "environments": {
+    "production": {
+      "server": "ubuntu@my-server.com",
+      "port": 3000,
+      "domain": "api.example.com",
+      "sslEmail": "admin@example.com"
+    }
+  }
+}
+```
+
+This creates one location block routing `/ -> localhost:3000`.
+
+## Monorepo Configuration
+
+For monorepo projects with multiple services, HostFn generates path-based routing using the `exposePath` field from each service configuration:
+
+```json title="hostfn.config.json"
+{
+  "name": "my-app",
+  "environments": {
+    "production": {
+      "server": "ubuntu@my-server.com",
+      "port": 3000,
+      "domain": "example.com",
+      "sslEmail": "admin@example.com"
+    }
+  },
+  "services": {
+    "api": {
+      "port": 3001,
+      "path": "services/api",
+      "exposePath": "/api"
+    },
+    "web": {
+      "port": 3002,
+      "path": "services/web"
+    }
+  }
+}
+```
+
+This generates:
+
+- `/api` proxied to `localhost:3001`
+- `/` (default) proxied to `localhost:3002`
+
+A service without an `exposePath` is treated as the default service and receives the `/` location block. Services with an `exposePath` get their own path-based location blocks, which take priority over the default.
+
+```nginx title="Generated Nginx config (monorepo)"
+server {
+    listen 80;
+    listen [::]:80;
+    server_name example.com;
+
+    # my-app-api
+    location /api {
+        proxy_pass http://localhost:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 60s;
+        proxy_connect_timeout 60s;
+    }
+
+    # my-app-web
+    location / {
+        proxy_pass http://localhost:3002;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 60s;
+        proxy_connect_timeout 60s;
+    }
+}
+```
+
+## SSL Certificate Handling
+
+### New Certificates
+
+When no certificate exists for the primary domain, Certbot obtains a new one and configures Nginx for HTTPS with an automatic HTTP redirect.
+
+### Existing Certificates
+
+If a certificate already exists for the primary domain, HostFn checks whether it covers all the required domains. If some domains are missing from the certificate, it uses Certbot's `--expand` flag to add them:
+
+```bash
+# Expansion command executed on server
+sudo certbot --nginx -d example.com -d www.example.com \
+  --email admin@example.com --non-interactive --agree-tos \
+  --redirect --expand
+```
+
+If all domains are already covered, HostFn triggers a certificate renewal instead (which is a no-op if the certificate is still valid).
+
+### HTTPS Configuration
+
+After Certbot runs, the final Nginx configuration includes:
+
+- SSL certificate and key paths pointing to `/etc/letsencrypt/live/{domain}/`
+- HTTP/2 support
+- Automatic HTTP-to-HTTPS redirect
+- Certbot-managed SSL parameters
+
+```nginx title="HTTPS server block (managed by Certbot)"
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name api.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/api.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.example.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        ...
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.example.com;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+```
+
+### Auto-Renewal
+
+Certbot automatically sets up a systemd timer (or cron job) for certificate renewal. You do not need to configure this manually. Certificates are renewed approximately 30 days before expiry.
+
+## Updating an Existing Configuration
+
+If you have already run `hostfn expose` and need to update the configuration (for example, after adding a domain), use the `--force` flag:
+
+```bash
+hostfn expose production --force
+```
+
+Without `--force`, the command detects the existing config and skips writing it. However, it will still update the configuration automatically if the `server_name` has changed (for example, from a catch-all `_` to a specific domain).
+
+## Without a Domain
+
+If no `domain` is set in your configuration, `hostfn expose` generates a config with `server_name _` (catch-all) so the server responds to any hostname or IP address. SSL is not configured in this case since Certbot requires a valid domain name.
+
+```bash title="Expose without domain"
+hostfn expose production --skip-ssl
+```
+
+Your app will be accessible at `http://<server-ip>`.

--- a/hostfn/docs/content/docs/documentation/server-management/setup.mdx
+++ b/hostfn/docs/content/docs/documentation/server-management/setup.mdx
@@ -1,0 +1,209 @@
+---
+title: Server Setup
+description: Provision a new server with all dependencies needed for HostFn deployments.
+---
+
+The `hostfn server setup` command automates the full provisioning of a fresh Linux server, installing everything your Node.js application needs to run in production.
+
+## Usage
+
+```bash
+hostfn server setup <host>
+```
+
+The `<host>` argument is your SSH connection string in `user@host` format:
+
+```bash
+hostfn server setup ubuntu@my-server.com
+```
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--env <environment>` | `production` | Environment name (used for directory and service naming) |
+| `--node-version <version>` | `20` | Node.js major version to install via nvm |
+| `--port <port>` | `3000` | Application port (used in the initial Nginx config) |
+| `--redis` | `false` | Also install and configure Redis |
+| `--password <password>` | — | SSH password (if not using key-based authentication) |
+
+### Examples
+
+```bash title="Basic setup"
+hostfn server setup ubuntu@my-server.com
+```
+
+```bash title="Custom Node.js version and port"
+hostfn server setup ubuntu@my-server.com --node-version 22 --port 8080
+```
+
+```bash title="Setup staging environment with Redis"
+hostfn server setup ubuntu@staging.example.com --env staging --redis
+```
+
+```bash title="Password-based SSH authentication"
+hostfn server setup ubuntu@my-server.com --password "my-ssh-password"
+```
+
+## What Gets Installed
+
+The setup script installs and configures the following software on your server:
+
+| Software | Purpose |
+|---|---|
+| **nvm** | Node Version Manager for installing and switching Node.js versions |
+| **Node.js** | JavaScript runtime (version specified via `--node-version`) |
+| **PM2** | Production process manager for running, monitoring, and restarting your app |
+| **Nginx** | Reverse proxy for handling HTTP/HTTPS traffic |
+| **Certbot** | Let's Encrypt client for SSL certificate provisioning |
+| **rsync** | Fast file synchronization used during deployments |
+| **build-essential** | C/C++ compiler toolchain needed by some npm packages |
+| **UFW** | Firewall configured to allow SSH (22), HTTP (80), and HTTPS (443) |
+
+When the `--redis` flag is passed, Redis is also installed and configured to start on boot.
+
+## How It Works
+
+The setup process follows these steps:
+
+1. **Script generation** -- HostFn generates a Bash setup script tailored to your options (Node.js version, port, Redis, etc.)
+2. **Confirmation prompt** -- You are asked whether to execute the script on the server now
+3. **Upload and execute** -- The script is uploaded to `/tmp/hostfn-setup.sh` on the server and executed over SSH
+4. **Streaming output** -- All output is streamed to your terminal in real time so you can follow progress
+
+If your `hostfn.config.json` file exists, the command reads the `runtime` field from it. Otherwise, it defaults to Node.js.
+
+### Declining Execution
+
+If you choose **not** to execute immediately, the script is saved to a local temporary file. HostFn shows you the commands to upload and run it manually:
+
+```
+Setup script saved at: /tmp/hostfn-setup.sh
+
+Run manually with:
+$ scp /tmp/hostfn-setup.sh ubuntu@my-server.com:~/hostfn-setup.sh
+$ ssh ubuntu@my-server.com 'bash ~/hostfn-setup.sh'
+```
+
+This is useful when you want to review the script before running it, or when you need to hand it off to someone with server access.
+
+## Example Output
+
+```
+$ hostfn server setup ubuntu@my-server.com --redis
+
+  Server Setup
+
+  Host         ubuntu@my-server.com
+  Environment  production
+  Port         3000
+  Redis        Yes
+
+  ✔ Setup script generated
+
+  ? Execute setup on server now? Yes
+
+  ── Executing Setup on Server ──
+
+  ✔ Connected to server
+  ✔ Setup script uploaded
+
+  Executing setup (this may take several minutes)...
+
+  ==========================================
+  Node.js Server Setup (hostfn)
+  Environment: production
+  ==========================================
+  Detected OS: Ubuntu 22.04.3 LTS
+
+  [1/8] Installing Node.js v20 via nvm...
+  Node.js v20.11.0 installed
+
+  [2/8] Installing PM2 process manager...
+  5.3.0
+
+  [3/8] Installing system dependencies...
+  nginx certbot rsync build-essential installed
+
+  [4/8] Configuring Nginx...
+  nginx: configuration file /etc/nginx/nginx.conf test is successful
+
+  [5/8] Installing Redis...
+  redis-server installed and running
+
+  [6/8] Creating deployment directories...
+
+  [7/8] Configuring PM2 startup...
+  PM2 startup configured
+
+  [8/8] Configuring firewall...
+  Firewall rules updated
+
+  ==========================================
+  Server setup complete!
+  ==========================================
+  Node.js: v20.11.0
+  npm: 10.2.4
+  PM2: 5.3.0
+  Nginx: Running
+  Port: 3000
+  ==========================================
+
+  ✅ Server setup completed successfully!
+
+  Your server is ready for deployments.
+
+  Next steps:
+
+  1. Set environment variables (if needed):
+  $ hostfn env push production .env
+     Or set individual variables:
+  $ hostfn env set production KEY value
+
+  2. Deploy your application:
+  $ hostfn deploy production
+```
+
+## Setup Script Details
+
+The generated script performs work in numbered phases:
+
+1. **Node.js via nvm** -- Installs nvm if not present, then installs and activates the requested Node.js version. If nvm is already installed, it installs the requested version alongside any existing ones.
+
+2. **PM2** -- Installed globally via npm. PM2 startup is configured so your services restart automatically if the server reboots.
+
+3. **System dependencies** -- Uses the appropriate package manager (`apt-get`, `yum`, or `dnf`) to install Nginx, Certbot, rsync, curl, git, and build tools.
+
+4. **Nginx** -- A default reverse proxy configuration is written that proxies all traffic from port 80 to your application port. The script auto-detects whether the system uses `sites-available/sites-enabled` (Debian/Ubuntu) or `conf.d` (RHEL/CentOS).
+
+5. **Redis** (optional) -- When the `--redis` flag is used, Redis is installed and enabled to start on boot.
+
+6. **Deployment directories** -- Creates `/var/www` (owned by your SSH user) and `/var/log/pm2` for PM2 log files.
+
+7. **PM2 startup** -- Configures PM2 to start on system boot so your services survive server restarts.
+
+8. **Firewall** -- If UFW is available, opens ports 22 (SSH), 80 (HTTP), and 443 (HTTPS), then enables the firewall.
+
+All output is logged to `/tmp/hostfn-setup.log` on the server. If setup fails, HostFn downloads the last 50 lines of this log and displays them in your terminal.
+
+## Error Handling
+
+If the setup fails partway through:
+
+- The exit code and relevant log output are displayed in your terminal
+- The full log remains on the server at `/tmp/hostfn-setup.log`
+- You can inspect it manually:
+
+```bash
+ssh ubuntu@my-server.com 'cat /tmp/hostfn-setup.log'
+```
+
+If the SSH connection itself fails, the script is still saved locally so you can transfer and run it manually.
+
+## Next Steps
+
+Once setup completes:
+
+1. [Push environment variables](/docs/documentation/environment/push-pull) if your app needs them
+2. [Deploy your application](/docs/documentation/getting-started/first-deploy) with `hostfn deploy`
+3. [Configure domain and SSL](/docs/documentation/server-management/nginx-ssl) with `hostfn expose`

--- a/hostfn/docs/content/docs/index.mdx
+++ b/hostfn/docs/content/docs/index.mdx
@@ -1,0 +1,78 @@
+---
+title: HostFn
+description: Universal application deployment CLI for VPS and bare-metal servers.
+---
+
+HostFn is a deployment CLI that makes it simple to deploy Node.js applications to any Linux server over SSH. It handles the entire deployment lifecycle: server provisioning, file syncing, building, process management with PM2, Nginx configuration, SSL certificates, health checks, backups, and rollbacks.
+
+## Why HostFn?
+
+Deploying to a VPS or bare-metal server shouldn't require complex infrastructure. HostFn gives you production-grade deployments with a single command:
+
+```bash
+hostfn deploy production
+```
+
+**No Docker required.** No Kubernetes. No cloud-specific lock-in. Just your code running on your server.
+
+## Key Features
+
+- **Zero-downtime deployments** - PM2 cluster mode with graceful reloads
+- **Automatic server setup** - One command provisions Node.js, PM2, Nginx, and SSL
+- **Monorepo support** - Deploy multiple services from a single codebase with workspace dependency bundling
+- **Environment management** - Push, pull, set, and validate environment variables securely
+- **Automatic rollbacks** - Failed deployments automatically restore the previous version
+- **Nginx and SSL** - Auto-configures reverse proxy and Let's Encrypt certificates
+- **CI/CD ready** - Non-interactive mode with SSH key and host environment variables
+- **Health checks** - Configurable endpoint polling after each deployment
+- **Deployment locks** - Prevents concurrent deployments to the same server
+- **Backup management** - Timestamped backups with configurable retention
+
+## Quick Start
+
+```bash
+# Install
+npm install -g hostfn
+
+# Initialize a project
+hostfn init
+
+# Set up your server
+hostfn server setup ubuntu@your-server.com
+
+# Deploy
+hostfn deploy production
+```
+
+## How It Works
+
+```mermaid
+graph LR
+    A[hostfn deploy] --> B[Pre-flight Checks]
+    B --> C[Sync Files via rsync]
+    C --> D[Install Dependencies]
+    D --> E[Build Application]
+    E --> F[Create Backup]
+    F --> G[Start/Reload PM2]
+    G --> H[Health Check]
+    H --> I[Success]
+    H -->|Failed| J[Auto-Rollback]
+```
+
+HostFn connects to your server via SSH, syncs your project files using rsync, installs dependencies, builds your application, and manages the PM2 process. If anything fails, it automatically rolls back to the previous deployment.
+
+## Requirements
+
+- **Node.js** 18+ (on your local machine)
+- **rsync** installed locally (macOS: `brew install rsync`, Ubuntu: `apt install rsync`)
+- A **Linux server** with SSH access (Ubuntu, Debian, CentOS, or similar)
+- **SSH key** authentication configured
+
+## Next Steps
+
+<Cards>
+  <Card title="Getting Started" href="/docs/documentation/getting-started/installation" description="Install HostFn and set up your first project." />
+  <Card title="Configuration" href="/docs/documentation/concepts/configuration" description="Learn about the hostfn.config.json file." />
+  <Card title="CLI Reference" href="/docs/cli" description="Complete command reference." />
+  <Card title="CI/CD Setup" href="/docs/documentation/deployment/ci-cd" description="Automate deployments with GitHub Actions." />
+</Cards>

--- a/hostfn/docs/content/docs/meta.json
+++ b/hostfn/docs/content/docs/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "HostFn",
+  "pages": ["index", "documentation", "cli", "reference"]
+}

--- a/hostfn/docs/content/docs/reference/config-schema.mdx
+++ b/hostfn/docs/content/docs/reference/config-schema.mdx
@@ -1,0 +1,276 @@
+---
+title: Configuration Schema
+description: Complete reference for every field in the hostfn.config.json configuration file.
+---
+
+HostFn is configured via a `hostfn.config.json` file in your project root. This page documents every available field, organized by section.
+
+## Full Example
+
+```json title="hostfn.config.json"
+{
+  "name": "my-api",
+  "runtime": "nodejs",
+  "version": "20",
+  "environments": {
+    "production": {
+      "server": "ubuntu@prod.example.com",
+      "port": 3000,
+      "instances": "max",
+      "domain": "api.example.com",
+      "sslEmail": "admin@example.com"
+    },
+    "staging": {
+      "server": "ubuntu@staging.example.com",
+      "port": 3000,
+      "instances": 2
+    }
+  },
+  "build": {
+    "command": "npm run build",
+    "directory": "dist",
+    "nodeModules": "all"
+  },
+  "start": {
+    "command": "npm start",
+    "entry": "dist/index.js"
+  },
+  "health": {
+    "path": "/health",
+    "timeout": 60,
+    "retries": 10,
+    "interval": 3
+  },
+  "env": {
+    "required": ["DATABASE_URL", "JWT_SECRET"],
+    "optional": ["REDIS_URL", "LOG_LEVEL"]
+  },
+  "sync": {
+    "exclude": [
+      "node_modules", ".git", ".github",
+      "dist", "build", ".env", ".env.*", "*.log",
+      ".turbo", ".wrangler"
+    ]
+  },
+  "backup": {
+    "keep": 5
+  },
+  "services": {
+    "api": {
+      "port": 3001,
+      "path": "services/api",
+      "domain": "api.example.com",
+      "instances": "max"
+    },
+    "web": {
+      "port": 3002,
+      "path": "services/web",
+      "domain": "example.com"
+    }
+  }
+}
+```
+
+## Top-Level Fields
+
+These are the root-level fields in the configuration file.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | `string` | Yes | -- | Application name. Used for remote directory (`/var/www/{name}-{env}`) and PM2 service name (`{name}-{env}`). |
+| `runtime` | `string` | Yes | -- | Application runtime. See [supported runtimes](#runtime-values) below. |
+| `version` | `string` | Yes | -- | Runtime version (e.g., `"20"` for Node.js 20). Installed via nvm on the server. |
+| `environments` | `object` | Yes | -- | Map of environment names to [environment configurations](#environments). |
+| `build` | `object` | No | -- | [Build configuration](#build). If omitted, no build step runs. |
+| `start` | `object` | Yes | -- | [Start configuration](#start). |
+| `health` | `object` | No | See defaults | [Health check configuration](#health). |
+| `env` | `object` | No | `{ required: [], optional: [] }` | [Environment variables configuration](#env). |
+| `sync` | `object` | No | See defaults | [File sync configuration](#sync). |
+| `backup` | `object` | No | `{ keep: 5 }` | [Backup configuration](#backup). |
+| `services` | `object` | No | -- | [Monorepo service configuration](#services). |
+
+### Runtime Values
+
+| Value | Status | Description |
+|---|---|---|
+| `nodejs` | Supported | Node.js application |
+| `python` | Planned | Python application |
+| `go` | Planned | Go application |
+| `ruby` | Planned | Ruby application |
+| `rust` | Planned | Rust application |
+| `docker` | Planned | Docker container |
+
+## Environments
+
+The `environments` object maps environment names (e.g., `"production"`, `"staging"`) to their configuration. You can define as many environments as you need.
+
+```json
+"environments": {
+  "production": { ... },
+  "staging": { ... },
+  "development": { ... }
+}
+```
+
+### Environment Fields
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `server` | `string` | Yes | -- | SSH connection string. Format: `user@host` or `user@host:port`. |
+| `port` | `number` | Yes | -- | Port the application listens on. Must be a positive integer. |
+| `instances` | `number \| "max"` | No | `1` | Number of PM2 cluster instances. Set to `"max"` to use all available CPU cores. |
+| `domain` | `string \| string[]` | No | -- | Domain name(s) for Nginx reverse proxy and SSL certificates. It can be a single string or an array of strings. |
+| `sslEmail` | `string` | No | -- | Email address for Let's Encrypt certificate registration. Required if using SSL. |
+
+## Build
+
+Controls how the application is built on the remote server. This entire section is optional. If omitted, HostFn skips the build step and only installs production dependencies.
+
+```json
+"build": {
+  "command": "npm run build",
+  "directory": "dist",
+  "nodeModules": "all"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `command` | `string` | Yes | -- | Build command to run on the server (e.g., `"npm run build"`, `"npx tsc"`). |
+| `directory` | `string` | No | `"dist"` | Build output directory. |
+| `nodeModules` | `"all" \| "production" \| "none"` | No | `"all"` when `build.command` is set, otherwise `"production"` | Which dependencies to install. `"all"` includes devDependencies. |
+
+When `build.nodeModules` is omitted, HostFn defaults to installing all dependencies when `build.command` is present. Set `build.nodeModules` to `"production"` or `"none"` to override that behavior.
+
+## Start
+
+Defines how the application starts via PM2.
+
+```json
+"start": {
+  "command": "npm start",
+  "entry": "dist/index.js"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `command` | `string` | Yes | -- | Start command for the application. |
+| `entry` | `string` | No | `"dist/index.js"` | Entry point file. Used in the PM2 ecosystem config to determine which file to execute. |
+
+## Health
+
+Controls post-deployment health check behavior. If omitted, defaults are used.
+
+```json
+"health": {
+  "path": "/health",
+  "timeout": 60,
+  "retries": 10,
+  "interval": 3
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `path` | `string` | No | `"/health"` | HTTP path to check on the application (e.g., `"/health"`, `"/api/status"`). |
+| `timeout` | `number` | No | `60` | Per-attempt curl timeout in seconds. |
+| `retries` | `number` | No | `10` | Number of health check attempts before declaring failure. |
+| `interval` | `number` | No | `3` | Seconds to wait between health check attempts. |
+
+HostFn checks `http://localhost:{port}{path}` on the remote server using `curl -sf`. A successful curl exit code is considered healthy, which normally means a non-4xx/non-5xx response. Because HostFn does not pass `-L`, 3xx responses can count as healthy without curl following the redirect.
+
+## Env
+
+Declares which environment variables the application expects. Used by `hostfn env validate` to verify all required variables are set on the server before deployment.
+
+```json
+"env": {
+  "required": ["DATABASE_URL", "JWT_SECRET"],
+  "optional": ["REDIS_URL", "LOG_LEVEL"]
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `required` | `string[]` | No | `[]` | Environment variables that must be set. `hostfn env validate` exits with an error if any are missing. |
+| `optional` | `string[]` | No | `[]` | Environment variables that may be set. Informational only. |
+
+## Sync
+
+Controls which files are transferred to the server via rsync.
+
+```json
+"sync": {
+  "exclude": [
+    "node_modules", ".git", ".github",
+    "dist", "build", ".env", ".env.*", "*.log",
+    ".turbo", ".wrangler"
+  ],
+  "include": ["dist/static"]
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `exclude` | `string[]` | No | See below | Rsync exclude patterns. Files matching these patterns are not transferred. |
+| `include` | `string[]` | No | -- | Rsync include patterns. Used to override excludes for specific files. |
+
+**Default exclude patterns:**
+
+`node_modules`, `.git`, `.github`, `dist`, `build`, `.env`, `.env.*`, `*.log`, `.turbo`, `.wrangler`
+
+## Backup
+
+Controls deployment backup retention.
+
+```json
+"backup": {
+  "keep": 5
+}
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `keep` | `number` | No | `5` | Number of backups to retain. Older backups are deleted after each deployment. Must be a positive integer. |
+
+Backups are stored at `/var/www/{name}-{env}/backups/{timestamp}/` on the remote server.
+
+## Services
+
+For monorepo deployments, the `services` object defines individual services within the codebase. Each key is the service name, and the value is its configuration.
+
+```json
+"services": {
+  "api": {
+    "port": 3001,
+    "path": "services/api",
+    "domain": "api.example.com",
+    "server": "ubuntu@api-server.example.com",
+    "instances": "max"
+  },
+  "web": {
+    "port": 3002,
+    "path": "services/web",
+    "domain": "example.com",
+    "exposePath": "/app"
+  }
+}
+```
+
+### Service Fields
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `port` | `number` | Yes | -- | Port this service listens on. Must be a positive integer. |
+| `path` | `string` | Yes | -- | Path to the service within the monorepo (relative to project root). |
+| `domain` | `string \| string[]` | No | -- | Domain name(s) for this service. It can be a single string or an array. |
+| `exposePath` | `string` | No | -- | Nginx path prefix for this service (e.g., `"/api"`, `"/docs"`). |
+| `server` | `string` | No | Environment server | Override server for this service. Defaults to the environment's `server` field. |
+| `instances` | `number \| "max"` | No | -- | PM2 cluster instances for this service. |
+
+When `services` is defined, `hostfn deploy` deploys all services by default. Use `--service <name>` to deploy a specific service.
+
+## Schema Validation
+
+The configuration file is validated against a [Zod](https://zod.dev/) schema when loaded. If there are validation errors, HostFn provides clear error messages indicating which fields are invalid and what values are expected.

--- a/hostfn/docs/content/docs/reference/environment-variables.mdx
+++ b/hostfn/docs/content/docs/reference/environment-variables.mdx
@@ -1,0 +1,164 @@
+---
+title: Environment Variables
+description: All environment variables that HostFn reads for SSH, CI/CD, and deployment configuration.
+---
+
+HostFn reads several environment variables to configure SSH connections, enable CI/CD mode, and override deployment settings. This page documents all of them.
+
+## Reference
+
+| Variable | Description | Example |
+|---|---|---|
+| `HOSTFN_HOST` | Override the server host from config | `ubuntu@staging-2.example.com` |
+| `HOSTFN_SSH_KEY` | Base64-encoded SSH private key | `LS0tLS1CRUdJTi...` |
+| `HOSTFN_SSH_PASSWORD` | SSH password for password authentication | `your-password` |
+| `HOSTFN_SSH_PASSPHRASE` | Passphrase for encrypted SSH key | `your-passphrase` |
+| `SSH_AUTH_SOCK` | SSH agent socket path (standard) | `/tmp/ssh-xxxxx/agent.12345` |
+
+## HOSTFN_HOST
+
+Overrides the `server` field from your `hostfn.config.json` for all SSH connections and rsync operations. This lets you deploy the same codebase to a different server without modifying the config file.
+
+```bash
+HOSTFN_HOST="ubuntu@staging-2.example.com" hostfn deploy staging
+```
+
+**Use case:** Deploying to dynamic environments in CI/CD, such as review apps or canary servers.
+
+```yaml title=".github/workflows/deploy.yml"
+- name: Deploy to staging
+  run: hostfn deploy staging --ci
+  env:
+    HOSTFN_HOST: ${{ vars.STAGING_HOST }}
+    HOSTFN_SSH_KEY: ${{ secrets.SSH_KEY }}
+```
+
+## HOSTFN_SSH_KEY
+
+A base64-encoded SSH private key. When set, HostFn uses this key for all SSH connections instead of looking for key files on disk. This is the primary way to provide SSH authentication in CI/CD environments.
+
+### Encoding Your Key
+
+```bash
+cat ~/.ssh/id_ed25519 | base64
+```
+
+Copy the output and store it as a CI/CD secret.
+
+### Usage
+
+```bash
+export HOSTFN_SSH_KEY="$(cat ~/.ssh/id_ed25519 | base64)"
+hostfn deploy production
+```
+
+### How It Works
+
+HostFn decodes the base64 string and uses the resulting key material directly for SSH connections (via the `ssh2` library). For rsync, it writes the decoded key to a temporary file with `0600` permissions, uses it for the sync, and then deletes it.
+
+If the key cannot be decoded, HostFn exits with an error:
+
+```
+Failed to decode HOSTFN_SSH_KEY from environment variable
+Make sure it's base64 encoded: cat ~/.ssh/id_rsa | base64
+```
+
+## HOSTFN_SSH_PASSWORD
+
+SSH password for servers that use password authentication instead of key-based authentication.
+
+```bash
+HOSTFN_SSH_PASSWORD="your-password" hostfn deploy production
+```
+
+This is equivalent to using the `--password` CLI option. Password authentication is less secure than key-based authentication and is not recommended for production use.
+
+**Priority:** If `HOSTFN_SSH_PASSWORD` is set, it takes precedence over key-based authentication methods.
+
+## HOSTFN_SSH_PASSPHRASE
+
+Passphrase for encrypted SSH private keys. Used in combination with `HOSTFN_SSH_KEY` or key files on disk.
+
+```bash
+export HOSTFN_SSH_KEY="$(cat ~/.ssh/id_ed25519 | base64)"
+export HOSTFN_SSH_PASSPHRASE="my-key-passphrase"
+hostfn deploy production
+```
+
+### CI/CD Usage
+
+```yaml title=".github/workflows/deploy.yml"
+- name: Deploy
+  run: hostfn deploy production --ci
+  env:
+    HOSTFN_SSH_KEY: ${{ secrets.HOSTFN_SSH_KEY }}
+    HOSTFN_SSH_PASSPHRASE: ${{ secrets.HOSTFN_SSH_PASSPHRASE }}
+```
+
+## SSH_AUTH_SOCK
+
+This is a standard environment variable set by `ssh-agent`, not specific to HostFn. When present, HostFn uses the SSH agent for authentication, which allows passphrase-protected keys to be used without re-entering the passphrase.
+
+```bash
+# Start the agent and add your key
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+
+# The agent sets SSH_AUTH_SOCK automatically
+echo $SSH_AUTH_SOCK
+# /tmp/ssh-xxxxx/agent.12345
+
+# HostFn detects the agent and uses it
+hostfn deploy production
+```
+
+HostFn passes `SSH_AUTH_SOCK` to the `ssh2` library as the `agent` configuration option. This works alongside key file authentication -- if both are configured, the SSH client tries both methods.
+
+## Environment Variable Priority
+
+When multiple authentication methods are available, HostFn uses the following priority order:
+
+1. **`HOSTFN_SSH_PASSWORD`** (or `--password` option) -- password authentication
+2. **`HOSTFN_SSH_KEY`** -- base64-encoded key from environment
+3. **`SSH_AUTH_SOCK`** + key files -- SSH agent with local key files (`~/.ssh/id_rsa`, `~/.ssh/id_ed25519`, `~/.ssh/id_ecdsa`)
+
+The first available method is used. If no method succeeds, HostFn exits with an error explaining which key paths were tried.
+
+## CI/CD Quick Reference
+
+Here is a minimal GitHub Actions configuration using HostFn environment variables:
+
+```yaml title=".github/workflows/deploy.yml"
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm install -g hostfn
+
+      - name: Deploy to production
+        run: hostfn deploy production --ci
+        env:
+          HOSTFN_SSH_KEY: ${{ secrets.HOSTFN_SSH_KEY }}
+```
+
+For deploying to a dynamic host:
+
+```yaml title=".github/workflows/deploy.yml"
+- name: Deploy to staging
+  run: hostfn deploy staging --ci
+  env:
+    HOSTFN_HOST: ${{ vars.STAGING_HOST }}
+    HOSTFN_SSH_KEY: ${{ secrets.HOSTFN_SSH_KEY }}
+    HOSTFN_SSH_PASSPHRASE: ${{ secrets.HOSTFN_SSH_PASSPHRASE }}
+```

--- a/hostfn/docs/content/docs/reference/index.mdx
+++ b/hostfn/docs/content/docs/reference/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Reference
+description: API and configuration reference for HostFn.
+---
+
+Complete reference documentation for HostFn configuration and environment variables.
+
+<Cards>
+  <Card title="Configuration Schema" href="/docs/reference/config-schema" description="Full reference for every field in hostfn.config.json, organized by section." />
+  <Card title="Environment Variables" href="/docs/reference/environment-variables" description="All environment variables that HostFn reads for SSH, CI/CD, and server configuration." />
+</Cards>

--- a/hostfn/docs/content/docs/reference/meta.json
+++ b/hostfn/docs/content/docs/reference/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Reference",
+  "description": "API & Configuration Reference",
+  "root": true,
+  "pages": [
+    "index",
+    "config-schema",
+    "environment-variables"
+  ]
+}

--- a/hostfn/docs/lib/source.ts
+++ b/hostfn/docs/lib/source.ts
@@ -1,0 +1,13 @@
+import { docs } from "@/.source";
+import { loader } from "fumadocs-core/source";
+
+const fumadocsSource = docs.toFumadocsSource();
+const rawFiles = (fumadocsSource as { files: unknown }).files;
+const files = typeof rawFiles === "function" ? rawFiles() : rawFiles;
+
+export const source = loader({
+  baseUrl: "/docs",
+  source: {
+    files,
+  },
+});

--- a/hostfn/docs/next.config.mjs
+++ b/hostfn/docs/next.config.mjs
@@ -1,0 +1,10 @@
+import { createMDX } from "fumadocs-mdx/next";
+
+const withMDX = createMDX();
+
+/** @type {import('next').NextConfig} */
+const config = {
+  reactStrictMode: true,
+};
+
+export default withMDX(config);

--- a/hostfn/docs/package.json
+++ b/hostfn/docs/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@hostfn/docs",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 6003",
+    "prebuild": "npm --prefix ../../packages/docs-theme run build && node ./scripts/ensure-docs-deps.mjs",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@21n/fonts": "^1.0.1",
+    "@superfunctions/docs-theme": "*",
+    "@tailwindcss/postcss": "^4",
+    "fumadocs-core": "^15",
+    "fumadocs-mdx": "^11",
+    "fumadocs-ui": "^15",
+    "lightningcss": "^1.31.1",
+    "lucide-react": "^0.575.0",
+    "mermaid": "^11.12.3",
+    "next": "15.3.6",
+    "next-themes": "^0.4.6",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "styled-jsx": "5.1.6"
+  },
+  "devDependencies": {
+    "@types/mdx": "^2",
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "autoprefixer": "^10",
+    "postcss": "^8",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}

--- a/hostfn/docs/postcss.config.mjs
+++ b/hostfn/docs/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/hostfn/docs/scripts/ensure-docs-deps.mjs
+++ b/hostfn/docs/scripts/ensure-docs-deps.mjs
@@ -1,0 +1,86 @@
+import { cpSync, existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const docsDir = join(scriptsDir, '..');
+const hostfnDir = join(docsDir, '..');
+const repoRoot = join(hostfnDir, '..');
+const hostfnNodeModules = join(hostfnDir, 'node_modules');
+
+const candidateBases = [
+  repoRoot,
+  join(repoRoot, 'datafn', 'docs'),
+  join(repoRoot, 'datafn'),
+  join(repoRoot, 'searchfn', 'docs'),
+  join(repoRoot, 'searchfn'),
+];
+
+const moduleNames = ['fumadocs-mdx', 'styled-jsx'];
+const entryCandidates = {
+  'fumadocs-mdx': ['fumadocs-mdx/next', 'fumadocs-mdx'],
+  'styled-jsx': ['styled-jsx', 'styled-jsx/index.js'],
+};
+
+const require = createRequire(import.meta.url);
+
+function findPackageRoot(resolvedPath, moduleName) {
+  let current = dirname(resolvedPath);
+
+  while (current !== dirname(current)) {
+    const manifest = join(current, 'package.json');
+    if (!existsSync(manifest)) {
+      current = dirname(current);
+      continue;
+    }
+
+    try {
+      const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (parsed?.name === moduleName) {
+        return current;
+      }
+    } catch {
+      // Ignore invalid JSON and keep walking.
+    }
+
+    current = dirname(current);
+  }
+
+  return null;
+}
+
+function resolveModuleDir(moduleName) {
+  const entries = entryCandidates[moduleName] ?? [moduleName];
+
+  for (const base of candidateBases) {
+    for (const entry of entries) {
+      try {
+        const resolved = require.resolve(entry, { paths: [base] });
+        const packageRoot = findPackageRoot(resolved, moduleName);
+        if (packageRoot) {
+          return packageRoot;
+        }
+      } catch {
+        // Try the next candidate entry or base.
+      }
+    }
+  }
+
+  return null;
+}
+
+for (const moduleName of moduleNames) {
+  const target = join(hostfnNodeModules, moduleName);
+  const needsNestedDeps = moduleName === 'fumadocs-mdx' && !existsSync(join(target, 'node_modules'));
+  if (existsSync(target) && !needsNestedDeps) {
+    continue;
+  }
+
+  const source = resolveModuleDir(moduleName);
+  if (!source || !existsSync(source) || source === target) {
+    continue;
+  }
+
+  cpSync(source, target, { recursive: true });
+}

--- a/hostfn/docs/source.config.ts
+++ b/hostfn/docs/source.config.ts
@@ -1,0 +1,12 @@
+import { defineDocs, defineConfig } from "fumadocs-mdx/config";
+import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";
+
+export const docs = defineDocs({
+  dir: "content/docs",
+});
+
+export default defineConfig({
+  mdxOptions: {
+    remarkPlugins: [remarkMdxMermaid],
+  },
+});

--- a/hostfn/docs/tsconfig.json
+++ b/hostfn/docs/tsconfig.json
@@ -1,0 +1,50 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ],
+      "@superfunctions/docs-theme": [
+        "../../packages/docs-theme/src/index.ts"
+      ],
+      "@superfunctions/docs-theme/tokens.css": [
+        "../../packages/docs-theme/src/tokens.css"
+      ],
+      "fumadocs-mdx:collections/*": [
+        "./.source/*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".source/**/*.ts",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/hostfn/docs/vercel.json
+++ b/hostfn/docs/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm install --prefix=../.. && npx turbo run build --filter=@hostfn/docs",
+  "framework": "nextjs"
+}

--- a/hostfn/examples/monorepo-config.json
+++ b/hostfn/examples/monorepo-config.json
@@ -17,7 +17,7 @@
   "build": {
     "command": "npm run build",
     "directory": "dist",
-    "nodeModules": "production"
+    "nodeModules": "all"
   },
   "start": {
     "command": "npm start",

--- a/hostfn/examples/monorepo-multi-server-config.json
+++ b/hostfn/examples/monorepo-multi-server-config.json
@@ -12,7 +12,7 @@
   "build": {
     "command": "npm run build",
     "directory": "dist",
-    "nodeModules": "production"
+    "nodeModules": "all"
   },
   "start": {
     "command": "npm start",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2611,8 +2611,8 @@
     "hostfn": {},
     "hostfn/cli": {
       "name": "hostfn",
-      "version": "0.1.5",
-      "license": "Apache-2.0",
+      "version": "0.1.7",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^11.1.0",
@@ -2620,6 +2620,7 @@
         "execa": "^8.0.1",
         "inquirer": "^9.2.12",
         "ora": "^7.0.1",
+        "semver": "^7.7.2",
         "ssh2": "^1.15.0",
         "zod": "^3.22.4"
       },
@@ -2638,6 +2639,46 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "hostfn/docs": {
+      "name": "@hostfn/docs",
+      "version": "0.0.1",
+      "dependencies": {
+        "@21n/fonts": "^1.0.1",
+        "@superfunctions/docs-theme": "*",
+        "@tailwindcss/postcss": "^4",
+        "fumadocs-core": "^15",
+        "fumadocs-mdx": "^11",
+        "fumadocs-ui": "^15",
+        "lightningcss": "^1.31.1",
+        "lucide-react": "^0.575.0",
+        "mermaid": "^11.12.3",
+        "next": "15.3.6",
+        "next-themes": "^0.4.6",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "styled-jsx": "5.1.6"
+      },
+      "devDependencies": {
+        "@types/mdx": "^2",
+        "@types/node": "^22",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "autoprefixer": "^10",
+        "postcss": "^8",
+        "tailwindcss": "^4",
+        "typescript": "^5"
+      }
+    },
+    "hostfn/docs/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "hostfn/node_modules/@bcoe/v8-coverage": {
@@ -4175,6 +4216,10 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@hostfn/docs": {
+      "resolved": "hostfn/docs",
+      "link": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",


### PR DESCRIPTION
## Summary
- add a new `hostfn/docs` Next.js + Fumadocs documentation workspace with CLI, deployment, environment, reference, and server-management guides
- improve `hostfn/cli` monorepo deployment bundling by rewriting bundled workspace deps to `file:` references under `__workspace__/`, generating a lockfile for the bundle, and preserving workspace build output during sync
- add SSH keepalives for long-running remote installs and refresh hostfn package metadata/publish config
- update the root `package-lock.json` minimally for the `hostfn/docs` workspace and the `hostfn/cli` metadata change

## Included Areas
- `hostfn/cli`
- `hostfn/docs`
- root `package-lock.json` (hostfn-specific entries only)

## Notes
- `.conduct` is intentionally excluded for `origin/dev`
- `.gitignore` was not changed; generated docs artifacts like `.next`, `.source`, `next-env.d.ts`, `dist`, and `node_modules` were kept out of the PR

## Verification
- `npm --prefix hostfn/cli run build`
- focused `hostfn/cli` Vitest suite via `node ../node_modules/vitest/vitest.mjs run ...` from `hostfn/cli` (`60` tests passed)
- attempted `npm --prefix hostfn/docs run build`, but it is blocked in the clean branch by Next lockfile patching and shared docs-theme workspace resolution in this extracted environment
- attempted `tsc -p hostfn/docs/tsconfig.json --noEmit`, but it is blocked by missing docs-only dependencies in the borrowed workspace install state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `hostfn/docs` Next.js + Fumadocs site and completes monorepo deploy bundling in `hostfn/cli` by moving workspace deps to `__workspace__/`, rewriting to `file:` refs, generating a bundle lockfile, and improving rsync, SSH keepalives, and installs; aligns with SF-17.

- **New Features**
  - New `hostfn/docs` workspace with guides (CLI, deployment, environment, server management, reference); uses `@superfunctions/docs-theme`, Mermaid, adds Vercel config and a helper script to ensure docs deps in monorepo builds.
  - Monorepo deploy: bundle workspace deps under `__workspace__/`, rewrite to `file:` refs, generate a lockfile, and preserve workspace build output; enforce include-before-exclude rsync filters, normalize `--dry-run`, add local sync helper, and enable SSH keepalives. Smarter install plan auto-selects `npm ci` vs `npm install` and `all` vs `production` from lockfile/config; `build.nodeModules` is now optional, and `init` plus examples default to `"all"`. Adds tests for workspace bundling, lockfile generation, and rsync arg ordering.

- **Dependencies**
  - `hostfn/cli`: bump to `0.1.7`, switch license to MIT, set repository `directory`, add `publishConfig`, `superfunctions` metadata, and `semver`. Root `package-lock.json` updated for `hostfn/docs` and CLI metadata.

<sup>Written for commit 4b87978c51ec0928e5cb1c0917a6305b758d4775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full documentation site (MDX pages, docs UI, OpenGraph image) and monorepo workspace bundling with bundled workspace wiring and lockfile generation.

* **Improvements**
  * Local rsync-based sync helper, smarter install planning (skip when configured), health-check timeout/interval tuning, SSH keepalive, init/defaults now target installing all node modules.

* **Tests**
  * Added tests covering workspace bundling and local rsync command generation.

* **Chores**
  * Package metadata updated (version, license, publish config, added semver runtime dependency, new package config).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->