### PR TITLE
SF-34 - apifn init

### DIFF
--- a/apifn/.github/workflows/api-check.yml
+++ b/apifn/.github/workflows/api-check.yml
@@ -1,0 +1,257 @@
+name: ApiFn API Check
+
+on:
+  workflow_call:
+    inputs:
+      spec_path:
+        description: Path to generated OpenAPI spec (repo-relative)
+        required: true
+        type: string
+      collection_dir:
+        description: Path to OpenCollection directory (repo-relative)
+        required: true
+        type: string
+      environment:
+        description: Collection environment name
+        required: false
+        default: development
+        type: string
+      base_branch:
+        description: Base branch for spec diff
+        required: false
+        default: main
+        type: string
+      fail_on_breaking:
+        description: Fail the workflow when breaking changes are found
+        required: false
+        default: true
+        type: boolean
+      post_pr_comment:
+        description: Post/update PR summary comment
+        required: false
+        default: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      spec_path:
+        description: Path to generated OpenAPI spec (repo-relative)
+        required: true
+        type: string
+      collection_dir:
+        description: Path to OpenCollection directory (repo-relative)
+        required: true
+        type: string
+      environment:
+        description: Collection environment name
+        required: false
+        default: development
+        type: string
+      base_branch:
+        description: Base branch for spec diff
+        required: false
+        default: main
+        type: string
+      fail_on_breaking:
+        description: Fail the workflow when breaking changes are found
+        required: false
+        default: true
+        type: boolean
+      post_pr_comment:
+        description: Post/update PR summary comment
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  api-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI package
+        run: npm -w @apifn/cli run build
+
+      - name: Resolve base spec from base branch
+        id: base_spec
+        shell: bash
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          SPEC_PATH: ${{ inputs.spec_path }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_BRANCH" --depth=1
+          if git show "origin/${BASE_BRANCH}:${SPEC_PATH}" > .apifn-base-openapi.yml; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            printf '{"hasBreakingChanges":false,"summary":{"breaking":0,"nonBreaking":0,"added":0,"removed":0,"modified":0},"breaking":[],"nonBreaking":[],"timestamp":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > diff-report.json
+          fi
+
+      - name: Validate OpenAPI
+        id: validate
+        continue-on-error: true
+        shell: bash
+        env:
+          SPEC_PATH: ${{ inputs.spec_path }}
+        run: |
+          set +e
+          npx --yes apifn validate "$SPEC_PATH" --format json > validate-report.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Diff OpenAPI against base branch
+        id: diff
+        if: steps.base_spec.outputs.found == 'true'
+        continue-on-error: true
+        shell: bash
+        env:
+          SPEC_PATH: ${{ inputs.spec_path }}
+          FAIL_ON_BREAKING: ${{ inputs.fail_on_breaking }}
+        run: |
+          set +e
+          DIFF_ARGS=""
+          if [ "$FAIL_ON_BREAKING" != "true" ]; then
+            DIFF_ARGS="--no-fail-on-breaking"
+          fi
+          npx --yes apifn diff .apifn-base-openapi.yml "$SPEC_PATH" --format json $DIFF_ARGS > diff-report.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Run collection tests
+        id: test
+        continue-on-error: true
+        shell: bash
+        env:
+          COLLECTION_DIR: ${{ inputs.collection_dir }}
+          COLLECTION_ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set +e
+          npx --yes apifn test "$COLLECTION_DIR" --env "$COLLECTION_ENVIRONMENT" --reporter json > test-report.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build markdown summary
+        id: summary
+        shell: bash
+        run: |
+          node <<'JS'
+          const fs = require('node:fs');
+
+          function readJson(path, fallback) {
+            try { return JSON.parse(fs.readFileSync(path, 'utf8')); } catch { return fallback; }
+          }
+
+          const validate = readJson('validate-report.json', { ok: false, errors: [{ path: '', message: 'missing validate report' }] });
+          const diff = readJson('diff-report.json', { hasBreakingChanges: false, summary: { breaking: 0, nonBreaking: 0, added: 0, removed: 0, modified: 0 } });
+          const test = readJson('test-report.json', { summary: { total: 0, passed: 0, failed: 0, skipped: 0, errors: 0 } });
+
+          const validateStatus = validate.ok ? 'PASS' : 'FAIL';
+          const diffStatus = diff.hasBreakingChanges ? 'BREAKING' : 'OK';
+          const testStatus = (test.summary.failed || test.summary.errors) ? 'FAIL' : 'PASS';
+
+          const lines = [
+            '<!-- apifn-ci-report -->',
+            '## ApiFn CI Summary',
+            '',
+            `- Validate: **${validateStatus}**`,
+            `- Diff: **${diffStatus}** (breaking=${diff.summary.breaking ?? 0}, non-breaking=${diff.summary.nonBreaking ?? 0})`,
+            `- Tests: **${testStatus}** (passed=${test.summary.passed ?? 0}, failed=${test.summary.failed ?? 0}, errors=${test.summary.errors ?? 0})`,
+            '',
+            '### Diff Summary',
+            '',
+            '| Metric | Value |',
+            '|---|---:|',
+            `| Breaking | ${diff.summary.breaking ?? 0} |`,
+            `| Non-breaking | ${diff.summary.nonBreaking ?? 0} |`,
+            `| Added | ${diff.summary.added ?? 0} |`,
+            `| Removed | ${diff.summary.removed ?? 0} |`,
+            `| Modified | ${diff.summary.modified ?? 0} |`,
+            '',
+            '### Test Summary',
+            '',
+            '| Metric | Value |',
+            '|---|---:|',
+            `| Total | ${test.summary.total ?? 0} |`,
+            `| Passed | ${test.summary.passed ?? 0} |`,
+            `| Failed | ${test.summary.failed ?? 0} |`,
+            `| Skipped | ${test.summary.skipped ?? 0} |`,
+            `| Errors | ${test.summary.errors ?? 0} |`,
+          ];
+
+          const body = `${lines.join('\n')}\n`;
+          fs.writeFileSync('ci-summary.md', body);
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, body);
+          JS
+
+      - name: Post/Update PR comment
+        if: github.event_name == 'pull_request' && inputs.post_pr_comment == true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            const body = fs.readFileSync('ci-summary.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const marker = '<!-- apifn-ci-report -->';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.user?.type === 'Bot' && c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Enforce CI gates
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          validate_code="${{ steps.validate.outputs.exit_code }}"
+          diff_code="${{ steps.diff.outputs.exit_code }}"
+          test_code="${{ steps.test.outputs.exit_code }}"
+
+          if [ -z "$diff_code" ]; then
+            diff_code=0
+          fi
+
+          if [ "$validate_code" != "0" ]; then
+            echo "Validation failed (exit=$validate_code)"
+            exit "$validate_code"
+          fi
+
+          if [ "$diff_code" != "0" ]; then
+            echo "Diff failed (exit=$diff_code)"
+            exit "$diff_code"
+          fi
+
+          if [ "$test_code" != "0" ]; then
+            echo "Collection tests failed (exit=$test_code)"
+            exit "$test_code"
+          fi

--- a/apifn/README.md
+++ b/apifn/README.md
@@ -1,0 +1,39 @@
+# ApiFn
+
+ApiFn is a code-first, self-hosted API development toolkit for OpenAPI generation, diffing, and collection testing.
+
+## CI/CD
+
+ApiFn provides a reusable GitHub Actions workflow at `apifn/.github/workflows/api-check.yml`.
+
+### What it does
+
+- Validates OpenAPI specs via `apifn validate --format json`
+- Diffs current spec against base branch via `apifn diff --format json`
+- Runs collection tests via `apifn test --reporter json`
+- Emits machine-readable JSON artifacts (`validate-report.json`, `diff-report.json`, `test-report.json`)
+- Builds a markdown summary and posts/updates a PR comment (optional)
+- Enforces non-zero exits for validation failures, breaking changes, and test failures
+
+### Inputs
+
+- `spec_path` (required): Repo-relative OpenAPI path (e.g. `.apifn/openapi.yml`)
+- `collection_dir` (required): Repo-relative OpenCollection directory (e.g. `.apifn/collection`)
+- `environment` (optional, default `development`): Collection environment
+- `base_branch` (optional, default `main`): Branch used to fetch baseline spec
+- `fail_on_breaking` (optional, default `true`): Whether breaking diff exits non-zero
+- `post_pr_comment` (optional, default `true`): Whether to post/update PR summary comment
+
+### Example
+
+See [`apifn/examples/ci-cd/github-actions.yml`](./examples/ci-cd/github-actions.yml).
+
+### Non-GitHub CI
+
+For GitLab/Jenkins/Buildkite, run the same CLI commands directly:
+
+```bash
+apifn validate .apifn/openapi.yml --format json
+apifn diff .apifn/base-openapi.yml .apifn/openapi.yml --format json
+apifn test .apifn/collection --env development --reporter json
+```

--- a/apifn/cli/__tests__/cli.test.ts
+++ b/apifn/cli/__tests__/cli.test.ts
@@ -1,0 +1,264 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runCli } from "../src/index.js";
+
+async function createRouterFixture(cwd: string): Promise<string> {
+  const routerPath = path.join(cwd, "router.ts");
+  await writeFile(
+    routerPath,
+    [
+      "export default {",
+      "  getRoutes() {",
+      "    return [",
+      "      {",
+      "        method: 'GET',",
+      "        path: '/users/:id',",
+      "        handler: async () => Response.json({ id: '1' }),",
+      "        meta: {",
+      "          summary: 'Get User',",
+      "          responses: { 200: { description: 'OK' } },",
+      "          tags: ['users'],",
+      "        },",
+      "      },",
+      "    ];",
+      "  },",
+      "};",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  return routerPath;
+}
+
+describe("cli commands", () => {
+  it("apifn --help shows command list", async () => {
+    const code = await runCli(["--help"]);
+    expect(code).toBe(0);
+  });
+
+  it("TV-CLI-001: init --yes scaffolds collection", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-init-"));
+    const target = path.join(cwd, "test-col");
+    const code = await runCli(["init", target, "--yes"], { cwd });
+
+    expect(code).toBe(0);
+    expect(existsSync(path.join(target, "opencollection.yml"))).toBe(true);
+    expect(existsSync(path.join(target, "environments", "development.yml"))).toBe(true);
+  });
+
+  it("TV-CLI-002 + TV-CLI-003: generate and export OpenAPI", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-generate-"));
+    await createRouterFixture(cwd);
+
+    await writeFile(
+      path.join(cwd, "apifn.config.ts"),
+      [
+        "export default {",
+        "  router: './router.ts',",
+        "  output: './.apifn',",
+        "  openapi: { info: { title: 'CLI API', version: '1.0.0' } },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const genCode = await runCli(["generate"], { cwd });
+    expect(genCode).toBe(0);
+    expect(existsSync(path.join(cwd, ".apifn", "openapi.yml"))).toBe(true);
+
+    const jsonOut = path.join(cwd, "api.json");
+    const exportCode = await runCli(["export", "json", jsonOut], { cwd });
+    expect(exportCode).toBe(0);
+
+    const raw = await readFile(jsonOut, "utf8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.openapi).toBe("3.1.0");
+    expect(parsed.info.title).toBe("CLI API");
+  });
+
+  it("TV-CLI-009: validate returns 0 for valid spec and 1 for invalid spec", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-validate-"));
+    const validPath = path.join(cwd, "valid.yml");
+    const invalidPath = path.join(cwd, "invalid.yml");
+
+    await writeFile(
+      validPath,
+      [
+        "openapi: '3.1.0'",
+        "info:",
+        "  title: Valid API",
+        "  version: '1.0.0'",
+        "paths:",
+        "  /health:",
+        "    get:",
+        "      responses:",
+        "        '200':",
+        "          description: OK",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    await writeFile(
+      invalidPath,
+      [
+        "openapi: '3.1.0'",
+        "info:",
+        "  version: '1.0.0'",
+        "paths: {}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const okCode = await runCli(["validate", validPath], { cwd });
+    const failCode = await runCli(["validate", invalidPath], { cwd });
+
+    expect(okCode).toBe(0);
+    expect(failCode).toBe(1);
+  });
+
+  it("CI-003: validate --format json returns parseable machine output", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-validate-json-"));
+    const validPath = path.join(cwd, "valid.yml");
+    const invalidPath = path.join(cwd, "invalid.yml");
+
+    await writeFile(
+      validPath,
+      [
+        "openapi: '3.1.0'",
+        "info:",
+        "  title: Valid API",
+        "  version: '1.0.0'",
+        "paths: {}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(invalidPath, "openapi: '3.1.0'\ninfo: {}\npaths: {}\n", "utf8");
+
+    let validOut = "";
+    const validCode = await runCli(["validate", validPath, "--format", "json"], {
+      cwd,
+      stdout: (t) => { validOut += t; },
+    });
+    expect(validCode).toBe(0);
+    const validJson = JSON.parse(validOut) as { ok: boolean; errors: unknown[] };
+    expect(validJson.ok).toBe(true);
+    expect(Array.isArray(validJson.errors)).toBe(true);
+
+    let invalidOut = "";
+    const invalidCode = await runCli(["validate", invalidPath, "--format", "json"], {
+      cwd,
+      stdout: (t) => { invalidOut += t; },
+    });
+    expect(invalidCode).toBe(1);
+    const invalidJson = JSON.parse(invalidOut) as { ok: boolean; errors: unknown[] };
+    expect(invalidJson.ok).toBe(false);
+    expect(invalidJson.errors.length).toBeGreaterThan(0);
+  });
+
+  it("imports an OpenAPI URL into an OpenCollection", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-import-"));
+    const spec = {
+      openapi: "3.1.0",
+      info: { title: "Import API", version: "1.0.0" },
+      paths: {
+        "/health": {
+          get: {
+            operationId: "getHealth",
+            tags: ["system"],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    };
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(spec));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("server did not bind");
+    }
+
+    try {
+      const outputDir = path.join(cwd, "collection");
+      const code = await runCli([
+        "import",
+        "openapi",
+        `http://127.0.0.1:${address.port}/openapi.json`,
+        "--output",
+        outputDir,
+        "--base-url",
+        "http://127.0.0.1:8787",
+        "--env",
+        "test",
+      ], { cwd });
+
+      expect(code).toBe(0);
+      expect(existsSync(path.join(outputDir, "opencollection.yml"))).toBe(true);
+      expect(existsSync(path.join(outputDir, "system", "gethealth.yml"))).toBe(true);
+      const env = await readFile(path.join(outputDir, "environments", "test.yml"), "utf8");
+      expect(env).toContain("http://127.0.0.1:8787");
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => error ? reject(error) : resolve())
+      );
+    }
+  });
+
+  it("import --force replaces generated collection files without deleting unrelated files", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-import-force-"));
+    const outputDir = path.join(cwd, "collection");
+    const firstSpecPath = path.join(cwd, "first.json");
+    const secondSpecPath = path.join(cwd, "second.json");
+
+    await writeFile(firstSpecPath, JSON.stringify({
+      openapi: "3.1.0",
+      info: { title: "First API", version: "1.0.0" },
+      paths: {
+        "/old": {
+          get: {
+            operationId: "oldHealth",
+            tags: ["system"],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    }), "utf8");
+    await writeFile(secondSpecPath, JSON.stringify({
+      openapi: "3.1.0",
+      info: { title: "Second API", version: "1.0.0" },
+      paths: {
+        "/new": {
+          get: {
+            operationId: "newHealth",
+            tags: ["system"],
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    }), "utf8");
+
+    expect(await runCli(["import", "openapi", firstSpecPath, "--output", outputDir], { cwd })).toBe(0);
+
+    const unrelatedRootFile = path.join(outputDir, "README.md");
+    const unrelatedNestedFile = path.join(outputDir, "system", "notes.txt");
+    await writeFile(unrelatedRootFile, "keep me", "utf8");
+    await writeFile(unrelatedNestedFile, "keep me too", "utf8");
+
+    const code = await runCli(["import", "openapi", secondSpecPath, "--output", outputDir, "--force"], { cwd });
+
+    expect(code).toBe(0);
+    expect(existsSync(path.join(outputDir, "system", "oldhealth.yml"))).toBe(false);
+    expect(existsSync(path.join(outputDir, "system", "newhealth.yml"))).toBe(true);
+    expect(existsSync(unrelatedRootFile)).toBe(true);
+    expect(existsSync(unrelatedNestedFile)).toBe(true);
+  });
+});

--- a/apifn/cli/__tests__/config.test.ts
+++ b/apifn/cli/__tests__/config.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { defineConfig, loadConfig } from "../src/index.js";
+
+describe("config loading", () => {
+  it("TV-CORE-003: loads default apifn.config.ts", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-config-"));
+    await writeFile(
+      path.join(cwd, "apifn.config.ts"),
+      [
+        "export default {",
+        "  openapi: { info: { title: 'Test', version: '1.0.0' } },",
+        "  router: './src/router.ts',",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const { config, path: loadedPath } = await loadConfig({ cwd });
+    expect(loadedPath).toBe(path.join(cwd, "apifn.config.ts"));
+    expect(config.openapi?.info?.title).toBe("Test");
+    expect(config.router).toBe("./src/router.ts");
+  });
+
+  it("TV-CORE-003: config path is overridable", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-config-"));
+    const custom = path.join(cwd, "custom.config.ts");
+
+    await writeFile(
+      custom,
+      [
+        "export default { openapi: { info: { title: 'Custom', version: '2.0.0' } } };",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const { config, path: loadedPath } = await loadConfig({ cwd, configPath: custom });
+    expect(loadedPath).toBe(custom);
+    expect(config.openapi?.info?.title).toBe("Custom");
+  });
+
+  it("NEG-TV-CORE-003: invalid config field type throws clear error", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "apifn-cli-config-"));
+    await writeFile(
+      path.join(cwd, "apifn.config.ts"),
+      [
+        "export default { openapi: { info: { title: 123 } } };",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    await expect(loadConfig({ cwd })).rejects.toThrow("info.title must be a string");
+  });
+
+  it("defineConfig is identity helper", () => {
+    const cfg = defineConfig({ output: ".apifn" });
+    expect(cfg.output).toBe(".apifn");
+  });
+});

--- a/apifn/cli/__tests__/diff-command.test.ts
+++ b/apifn/cli/__tests__/diff-command.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration tests for `apifn diff` command.
+ *
+ * Covers: TV-CLI-005, TV-CI-002, CI-003 (JSON format).
+ */
+
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { runCli } from "../src/index.js";
+
+const FIXTURES = path.join(import.meta.dirname, "fixtures", "diff");
+const BEFORE = path.join(FIXTURES, "before.yml");
+const AFTER_BREAKING = path.join(FIXTURES, "after-breaking.yml");
+const AFTER_NONBREAKING = path.join(FIXTURES, "after-nonbreaking.yml");
+
+describe("apifn diff command — CLI-005, CI-002, CI-003", () => {
+    it("TV-CLI-005: human-readable output contains key sections", async () => {
+        const lines: string[] = [];
+        await runCli(["diff", BEFORE, AFTER_BREAKING], {
+            stdout: (t) => lines.push(t),
+        });
+
+        const output = lines.join("");
+        expect(output).toContain("API Diff Report");
+        expect(output).toContain("Breaking Changes");
+    });
+
+    it("TV-CI-002 + TV-CLI-005: breaking changes → exit 1", async () => {
+        const code = await runCli(["diff", BEFORE, AFTER_BREAKING], {
+            stdout: () => { },
+        });
+
+        expect(code).toBe(1);
+    });
+
+    it("TV-CI-002: non-breaking changes → exit 0", async () => {
+        const code = await runCli(["diff", BEFORE, AFTER_NONBREAKING], {
+            stdout: () => { },
+        });
+
+        expect(code).toBe(0);
+    });
+
+    it("TV-CI-002: identical specs → exit 0 with no changes", async () => {
+        const lines: string[] = [];
+        const code = await runCli(["diff", BEFORE, BEFORE], {
+            stdout: (t) => lines.push(t),
+        });
+
+        expect(code).toBe(0);
+        const output = lines.join("");
+        expect(output).toContain("No changes detected");
+    });
+
+    it("CI-003: --format json → valid JSON on stdout with SPEC 6.5 shape", async () => {
+        let raw = "";
+        const code = await runCli(["diff", BEFORE, AFTER_BREAKING, "--format", "json"], {
+            stdout: (t) => { raw += t; },
+        });
+
+        expect(code).toBe(1);
+        const json = JSON.parse(raw) as {
+            hasBreakingChanges: boolean;
+            summary: { breaking: number; nonBreaking: number; added: number; removed: number; modified: number };
+            breaking: unknown[];
+            nonBreaking: unknown[];
+            timestamp: string;
+        };
+        expect(json.hasBreakingChanges).toBe(true);
+        expect(json.summary.breaking).toBeGreaterThan(0);
+        expect(json.timestamp).toBeTruthy();
+        expect(Array.isArray(json.breaking)).toBe(true);
+        expect(Array.isArray(json.nonBreaking)).toBe(true);
+    });
+
+    it("CI-003: --format json for non-breaking → hasBreakingChanges false", async () => {
+        let raw = "";
+        await runCli(["diff", BEFORE, AFTER_NONBREAKING, "--format", "json"], {
+            stdout: (t) => { raw += t; },
+        });
+
+        const json = JSON.parse(raw) as { hasBreakingChanges: boolean; summary: { breaking: number } };
+        expect(json.hasBreakingChanges).toBe(false);
+        expect(json.summary.breaking).toBe(0);
+    });
+
+    it("TV-CI-002: --fail-on-breaking false → exit 0 even with breaking changes", async () => {
+        const code = await runCli(
+            ["diff", BEFORE, AFTER_BREAKING, "--no-fail-on-breaking"],
+            { stdout: () => { } }
+        );
+
+        // --no-fail-on-breaking sets failOnBreaking=false
+        expect(code).toBe(0);
+    });
+
+    it("TV-CLI-005 + CI-002: missing file → exit 2", async () => {
+        const code = await runCli(["diff", "/tmp/__nonexistent.yml", BEFORE]);
+        expect(code).toBe(2);
+    });
+
+    it("TV-CLI-005: non-breaking output shows added endpoint", async () => {
+        const lines: string[] = [];
+        await runCli(["diff", BEFORE, AFTER_NONBREAKING], {
+            stdout: (t) => lines.push(t),
+        });
+        const output = lines.join("");
+        // Should mention the new /orders endpoint (non-breaking addition)
+        expect(output).toContain("orders");
+        expect(output).toContain("No breaking changes");
+    });
+
+    it("TV-CLI-005: breaking output identifies specific breaking changes", async () => {
+        let raw = "";
+        await runCli(["diff", BEFORE, AFTER_BREAKING, "--format", "json"], {
+            stdout: (t) => { raw += t; },
+        });
+
+        const json = JSON.parse(raw) as { breaking: Array<{ type: string; description: string }> };
+        // Should have: delete endpoint removed, required param added, response field removed
+        const types = json.breaking.map((e) => e.type);
+        expect(types).toContain("removed"); // delete endpoint removed
+        expect(json.breaking.some((e) => e.description.toLowerCase().includes("required"))).toBe(true);
+    });
+});

--- a/apifn/cli/__tests__/fixtures/diff/after-breaking.yml
+++ b/apifn/cli/__tests__/fixtures/diff/after-breaking.yml
@@ -1,0 +1,41 @@
+openapi: '3.1.0'
+info:
+  title: Test API
+  version: '1.1.0'
+paths:
+  /users:
+    get:
+      summary: List users (updated)
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: filter
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+  /users/{id}:
+    get:
+      summary: Get user
+      responses:
+        '200':
+          description: OK
+  /orders:
+    get:
+      summary: List orders
+      responses:
+        '200':
+          description: OK

--- a/apifn/cli/__tests__/fixtures/diff/after-nonbreaking.yml
+++ b/apifn/cli/__tests__/fixtures/diff/after-nonbreaking.yml
@@ -1,0 +1,50 @@
+openapi: '3.1.0'
+info:
+  title: Test API
+  version: '1.1.0'
+paths:
+  /users:
+    get:
+      summary: List users (updated description)
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  email:
+                    type: string
+  /users/{id}:
+    get:
+      summary: Get user
+      responses:
+        '200':
+          description: OK
+    delete:
+      summary: Delete user
+      responses:
+        '204':
+          description: Deleted
+  /orders:
+    get:
+      summary: List orders
+      responses:
+        '200':
+          description: OK

--- a/apifn/cli/__tests__/fixtures/diff/before.yml
+++ b/apifn/cli/__tests__/fixtures/diff/before.yml
@@ -1,0 +1,37 @@
+openapi: '3.1.0'
+info:
+  title: Test API
+  version: '1.0.0'
+paths:
+  /users:
+    get:
+      summary: List users
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+  /users/{id}:
+    get:
+      summary: Get user
+      responses:
+        '200':
+          description: OK
+    delete:
+      summary: Delete user
+      responses:
+        '204':
+          description: Deleted

--- a/apifn/cli/__tests__/fixtures/failing-collection/environments/development.yml
+++ b/apifn/cli/__tests__/fixtures/failing-collection/environments/development.yml
@@ -1,0 +1,3 @@
+name: development
+variables:
+  baseUrl: http://localhost:19998

--- a/apifn/cli/__tests__/fixtures/failing-collection/opencollection.yml
+++ b/apifn/cli/__tests__/fixtures/failing-collection/opencollection.yml
@@ -1,0 +1,2 @@
+name: Failing Collection
+type: collection

--- a/apifn/cli/__tests__/fixtures/passing-collection/environments/development.yml
+++ b/apifn/cli/__tests__/fixtures/passing-collection/environments/development.yml
@@ -1,0 +1,3 @@
+name: development
+variables:
+  baseUrl: http://localhost:19999

--- a/apifn/cli/__tests__/fixtures/passing-collection/opencollection.yml
+++ b/apifn/cli/__tests__/fixtures/passing-collection/opencollection.yml
@@ -1,0 +1,2 @@
+name: Passing Collection
+type: collection

--- a/apifn/cli/__tests__/serve-mock-snippet.test.ts
+++ b/apifn/cli/__tests__/serve-mock-snippet.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for `apifn mock` and `apifn snippet` commands.
+ *
+ * Covers: TV-CLI-007 (mock), TV-CLI-008 (snippet)
+ *
+ * Note: `apifn serve` is long-lived (blocks on SIGINT) so it's
+ * tested via unit-level patterns only. Mock and snippet are testable
+ * without signal handling since we use runMockCommand/runSnippetCommand
+ * directly in tests (not via the CLI wrapper) or stop the server ourselves.
+ */
+
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { runCli } from "../src/index.js";
+import { runSnippetCommand } from "../src/commands/snippet.js";
+import { runMockCommand } from "../src/commands/mock.js";
+import { createOutput } from "../src/utils/output.js";
+
+const FIXTURES = path.join(import.meta.dirname, "fixtures", "diff");
+const BEFORE_SPEC = path.join(FIXTURES, "before.yml");
+
+// Minimal output stub
+function silentOutput() {
+    return createOutput({ quiet: true });
+}
+
+// ─── TV-CLI-008: snippet command ──────────────────────────────────────────────
+
+describe("TV-CLI-008: apifn snippet command", () => {
+    it("generates curl snippet for a specific path via runSnippetCommand", async () => {
+        const lines: string[] = [];
+        const code = await runSnippetCommand({
+            specPath: BEFORE_SPEC,
+            apiPath: "/users",
+            method: "get",
+            target: "curl",
+            baseUrl: "https://api.example.com",
+            output: silentOutput(),
+            writeStdout: (t) => lines.push(t),
+        });
+
+        expect(code).toBe(0);
+        const output = lines.join("");
+        expect(output).toContain("curl -X GET");
+        expect(output).toContain("https://api.example.com/users");
+    });
+
+    it("generates fetch snippet for a specific path", async () => {
+        const lines: string[] = [];
+        await runSnippetCommand({
+            specPath: BEFORE_SPEC,
+            apiPath: "/users",
+            method: "get",
+            target: "fetch",
+            baseUrl: "https://api.example.com",
+            output: silentOutput(),
+            writeStdout: (t) => lines.push(t),
+        });
+
+        const output = lines.join("");
+        expect(output).toContain("await fetch(");
+        expect(output).toContain("https://api.example.com/users");
+    });
+
+    it("--all generates snippets for all operations", async () => {
+        const lines: string[] = [];
+        const code = await runSnippetCommand({
+            specPath: BEFORE_SPEC,
+            target: "curl",
+            baseUrl: "https://api.example.com",
+            all: true,
+            output: silentOutput(),
+            writeStdout: (t) => lines.push(t),
+        });
+
+        expect(code).toBe(0);
+        const output = lines.join("");
+        // before.yml has GET /users, GET /users/{id}, DELETE /users/{id}
+        expect(output).toContain("/users");
+        expect(output).toContain("curl -X GET");
+    });
+
+    it("invalid path returns exit 1", async () => {
+        const code = await runSnippetCommand({
+            specPath: BEFORE_SPEC,
+            apiPath: "/nonexistent",
+            method: "get",
+            target: "curl",
+            output: silentOutput(),
+        });
+
+        expect(code).toBe(1);
+    });
+
+    it("invalid target returns exit 1", async () => {
+        const code = await runSnippetCommand({
+            specPath: BEFORE_SPEC,
+            apiPath: "/users",
+            target: "unknown-lang",
+            output: silentOutput(),
+        });
+
+        expect(code).toBe(1);
+    });
+
+    it("missing spec file returns exit 2", async () => {
+        const code = await runSnippetCommand({
+            specPath: "/tmp/__no_such_spec.yml",
+            apiPath: "/users",
+            target: "curl",
+            output: silentOutput(),
+        });
+
+        expect(code).toBe(2);
+    });
+
+    it("snippet via CLI wrapper produces curl output", async () => {
+        const lines: string[] = [];
+        const code = await runCli(
+            ["snippet", BEFORE_SPEC, "/users", "--target", "curl", "--base-url", "https://api.test"],
+            { stdout: (t) => lines.push(t) }
+        );
+
+        expect(code).toBe(0);
+        const output = lines.join("");
+        expect(output).toContain("curl -X GET");
+        expect(output).toContain("https://api.test/users");
+    });
+
+    it("snippet --all via CLI wrapper generates multiple operations", async () => {
+        const lines: string[] = [];
+        const code = await runCli(
+            ["snippet", BEFORE_SPEC, "--all", "--target", "fetch"],
+            { stdout: (t) => lines.push(t) }
+        );
+
+        expect(code).toBe(0);
+        const output = lines.join("");
+        expect(output).toContain("await fetch(");
+    });
+});
+
+// ─── TV-CLI-007: mock command ─────────────────────────────────────────────────
+
+describe("TV-CLI-007: apifn mock command (runMockCommand unit-level)", () => {
+    it("missing spec file returns exit 2", async () => {
+        const code = await runMockCommand({
+            specPath: "/tmp/__no_spec.yml",
+            output: silentOutput(),
+        });
+        expect(code).toBe(2);
+    });
+
+    it("starts mock server on a port and responds correctly", async () => {
+        // We start from the raw module to control lifecycle; we can't use CLI for long-lived servers
+        const { createMockServer } = await import("@apifn/mock");
+        const { parseOpenAPI } = await import("@apifn/core");
+        const { readFile } = await import("node:fs/promises");
+
+        const raw = await readFile(BEFORE_SPEC, "utf8");
+        const spec = parseOpenAPI(raw);
+        const mock = createMockServer({ spec, port: 0 });
+        await mock.start();
+
+        const res = await fetch(`http://localhost:${mock.port}/users`);
+        expect(res.status).toBe(200);
+
+        await mock.stop();
+    });
+
+    it("mock server with --mode examples returns 200", async () => {
+        const { createMockServer } = await import("@apifn/mock");
+        const { parseOpenAPI } = await import("@apifn/core");
+        const { readFile } = await import("node:fs/promises");
+
+        const raw = await readFile(BEFORE_SPEC, "utf8");
+        const spec = parseOpenAPI(raw);
+        const mock = createMockServer({ spec, port: 0, responseMode: "examples" });
+        await mock.start();
+
+        const res = await fetch(`http://localhost:${mock.port}/users`);
+        expect([200, 204]).toContain(res.status);
+
+        await mock.stop();
+    });
+});

--- a/apifn/cli/__tests__/test-command.test.ts
+++ b/apifn/cli/__tests__/test-command.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Integration tests for `apifn test` command.
+ *
+ * Covers: TV-CLI-004, TV-CLI-011 (test-specific exit codes).
+ */
+
+import { createServer } from "node:http";
+import { mkdtemp, readFile, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runCli } from "../src/index.js";
+
+async function startEchoServer(port: number, handler: (status: number, body: string) => void = () => { }): Promise<{ close: () => Promise<void> }> {
+    const server = createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+
+    return {
+        close: () =>
+            new Promise<void>((resolve, reject) =>
+                server.close((err) => (err ? reject(err) : resolve()))
+            ),
+    };
+}
+
+async function startFailingServer(port: number): Promise<{ close: () => Promise<void> }> {
+    const server = createServer((_req, res) => {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Server error" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+
+    return {
+        close: () =>
+            new Promise<void>((resolve, reject) =>
+                server.close((err) => (err ? reject(err) : resolve()))
+            ),
+    };
+}
+
+/** Create a minimal passing collection in a temp dir */
+async function createPassingCollection(baseUrl: string): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), "apifn-test-pass-"));
+
+    await writeFile(
+        path.join(dir, "opencollection.yml"),
+        "name: Passing Test Collection\ntype: collection\n",
+        "utf8"
+    );
+
+    await mkdir(path.join(dir, "environments"), { recursive: true });
+    await writeFile(
+        path.join(dir, "environments", "development.yml"),
+        `name: development\nvariables:\n  baseUrl: "${baseUrl}"\n`,
+        "utf8"
+    );
+
+    // A request that will succeed (server returns 200 which is < 400 → "passed")
+    await writeFile(
+        path.join(dir, "health.yml"),
+        [
+            "info:",
+            "  name: Health Check",
+            "  type: http",
+            "  seq: 1",
+            "http:",
+            "  method: GET",
+            "  url: '{{baseUrl}}/health'",
+            "",
+        ].join("\n"),
+        "utf8"
+    );
+
+    return dir;
+}
+
+/** Create a minimal failing collection in a temp dir */
+async function createFailingCollection(baseUrl: string): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), "apifn-test-fail-"));
+
+    await writeFile(
+        path.join(dir, "opencollection.yml"),
+        "name: Failing Test Collection\ntype: collection\n",
+        "utf8"
+    );
+
+    await mkdir(path.join(dir, "environments"), { recursive: true });
+    await writeFile(
+        path.join(dir, "environments", "development.yml"),
+        `name: development\nvariables:\n  baseUrl: "${baseUrl}"\n`,
+        "utf8"
+    );
+
+    // A request to a 500-returning server → "failed" status
+    await writeFile(
+        path.join(dir, "fail.yml"),
+        [
+            "info:",
+            "  name: Failing Request",
+            "  type: http",
+            "  seq: 1",
+            "http:",
+            "  method: GET",
+            "  url: '{{baseUrl}}/error'",
+            "",
+        ].join("\n"),
+        "utf8"
+    );
+
+    return dir;
+}
+
+describe("apifn test command — CLI-004, CLI-011, RUN-009", () => {
+    const PASS_PORT = 19977;
+    const FAIL_PORT = 19978;
+    let passServer: { close: () => Promise<void> };
+    let failServer: { close: () => Promise<void> };
+    let passDir: string;
+    let failDir: string;
+
+    beforeAll(async () => {
+        passServer = await startEchoServer(PASS_PORT);
+        failServer = await startFailingServer(FAIL_PORT);
+        passDir = await createPassingCollection(`http://127.0.0.1:${PASS_PORT}`);
+        failDir = await createFailingCollection(`http://127.0.0.1:${FAIL_PORT}`);
+    });
+
+    afterAll(async () => {
+        await passServer.close();
+        await failServer.close();
+    });
+
+    it("TV-CLI-004 + TV-CLI-011: passing collection exits 0 with console reporter", async () => {
+        const lines: string[] = [];
+        const code = await runCli(["test", passDir, "--env", "development"], {
+            stdout: (t) => lines.push(t),
+        });
+
+        expect(code).toBe(0);
+        const output = lines.join("");
+        expect(output).toContain("PASS");
+        expect(output).toContain("Passed:  1");
+    });
+
+    it("TV-CLI-004 + TV-CLI-011: failing collection exits 1 with console reporter", async () => {
+        const lines: string[] = [];
+        const code = await runCli(["test", failDir, "--env", "development"], {
+            stdout: (t) => lines.push(t),
+        });
+
+        expect(code).toBe(1);
+        const output = lines.join("");
+        expect(output).toContain("FAIL");
+        expect(output).toContain("Failed:  1");
+    });
+
+    it("TV-CLI-004 + TV-CLI-011: passing collection exits 0 with json reporter — valid JSON on stdout", async () => {
+        let jsonOutput = "";
+        const code = await runCli(["test", passDir, "--env", "development", "--reporter", "json"], {
+            stdout: (t) => {
+                jsonOutput += t;
+            },
+        });
+
+        expect(code).toBe(0);
+        const report = JSON.parse(jsonOutput) as {
+            collectionName: string;
+            summary: { passed: number; failed: number; total: number };
+        };
+        expect(report.collectionName).toBe("Passing Test Collection");
+        expect(report.summary.passed).toBe(1);
+        expect(report.summary.failed).toBe(0);
+        expect(report.summary.total).toBe(1);
+    });
+
+    it("TV-CLI-011: invalid collection dir exits 2", async () => {
+        const code = await runCli(["test", "/tmp/__nonexistent_apifn_test_dir__", "--env", "development"]);
+        expect(code).toBe(2);
+    });
+
+    it("--silent reporter produces no output", async () => {
+        const lines: string[] = [];
+        const code = await runCli(["test", passDir, "--env", "development", "--reporter", "silent"], {
+            stdout: (t) => lines.push(t),
+        });
+
+        expect(code).toBe(0);
+        expect(lines.length).toBe(0);
+    });
+
+    it("supports include/env-var/output and junit reporter", async () => {
+        const outputPath = path.join(await mkdtemp(path.join(tmpdir(), "apifn-junit-")), "report.xml");
+        const lines: string[] = [];
+        const code = await runCli([
+            "test",
+            passDir,
+            "--env",
+            "development",
+            "--include",
+            "*health*",
+            "--env-var",
+            "EXTRA=value",
+            "--reporter",
+            "junit",
+            "--output",
+            outputPath,
+        ], {
+            stdout: (t) => lines.push(t),
+        });
+
+        expect(code).toBe(0);
+        const stdout = lines.join("");
+        expect(stdout).toContain("<testsuite");
+        const artifact = await readFile(outputPath, "utf8");
+        expect(artifact).toContain("<testcase");
+    });
+
+    it("--bail flag stops on first failure", async () => {
+        // Create a collection with 2 requests in a temp dir (both will fail,
+        // but with --bail only 1 should execute before stopping)
+        const dir = await mkdtemp(path.join(tmpdir(), "apifn-bail-"));
+
+        await writeFile(
+            path.join(dir, "opencollection.yml"),
+            "name: Bail Test\ntype: collection\n",
+            "utf8"
+        );
+        await mkdir(path.join(dir, "environments"), { recursive: true });
+        await writeFile(
+            path.join(dir, "environments", "development.yml"),
+            `name: development\nvariables:\n  baseUrl: "http://127.0.0.1:${FAIL_PORT}"\n`,
+            "utf8"
+        );
+        await writeFile(
+            path.join(dir, "request1.yml"),
+            "info:\n  name: Request 1\n  type: http\n  seq: 1\nhttp:\n  method: GET\n  url: '{{baseUrl}}/one'\n",
+            "utf8"
+        );
+        await writeFile(
+            path.join(dir, "request2.yml"),
+            "info:\n  name: Request 2\n  type: http\n  seq: 2\nhttp:\n  method: GET\n  url: '{{baseUrl}}/two'\n",
+            "utf8"
+        );
+
+        let jsonOutput = "";
+        const code = await runCli(
+            ["test", dir, "--env", "development", "--bail", "--reporter", "json"],
+            { stdout: (t) => { jsonOutput += t; } }
+        );
+
+        expect(code).toBe(1);
+        const report = JSON.parse(jsonOutput) as {
+            results: Array<{ status: string }>;
+            summary: { failed: number; skipped: number };
+        };
+        // With bail: first request fails, second should be skipped
+        expect(report.results[0]?.status).toBe("failed");
+        expect(report.results[1]?.status).toBe("skipped");
+        expect(report.summary.skipped).toBe(1);
+    });
+
+    it("RUN-009: console reporter emits per-request pass/fail and summary", async () => {
+        const lines: string[] = [];
+        await runCli(["test", passDir, "--env", "development"], {
+            stdout: (t) => lines.push(t),
+        });
+
+        const output = lines.join("");
+        // Should have header, request line, dashes, results section
+        expect(output).toContain("apifn test");
+        expect(output).toContain("Health Check");
+        expect(output).toContain("Results");
+        expect(output).toContain("All tests passed!");
+    });
+});

--- a/apifn/cli/package.json
+++ b/apifn/cli/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@apifn/cli",
+  "version": "0.0.1",
+  "description": "CLI tools for ApiFn",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "apifn": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@apifn/collections": "0.0.1",
+    "@apifn/core": "0.0.1",
+    "@apifn/mock": "0.0.1",
+    "@apifn/snippets": "0.0.2",
+    "cac": "^6.7.14",
+    "jiti": "^2.4.2",
+    "picocolors": "^1.1.1",
+    "yaml": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/cli"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/apifn/cli/src/bin.ts
+++ b/apifn/cli/src/bin.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { runCli } from "./index.js";
+
+void (async () => {
+  const code = await runCli(process.argv.slice(2));
+  if (code !== 0) {
+    process.exitCode = code;
+  }
+})();

--- a/apifn/cli/src/commands/diff.ts
+++ b/apifn/cli/src/commands/diff.ts
@@ -1,0 +1,164 @@
+/**
+ * `apifn diff <before> <after>` command implementation.
+ *
+ * Loads two OpenAPI documents (file paths or HTTP URLs), runs diffOpenAPI(),
+ * and prints the result in human-readable or JSON format.
+ *
+ * Exit codes (CLI-005, CI-002, CI-003):
+ *   0 — no breaking changes (or --fail-on-breaking false)
+ *   1 — breaking changes detected
+ *   2 — error (file not found, invalid spec, etc.)
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parseOpenAPI, diffOpenAPI, formatDiffAsJson, formatDiffAsText } from "@apifn/core";
+import type { Output } from "../utils/output.js";
+
+export type DiffFormat = "text" | "json";
+
+export interface DiffCommandOptions {
+    /** Path or URL to the "before" spec */
+    before: string;
+    /** Path or URL to the "after" spec */
+    after: string;
+    /** Output format: "text" (default) or "json" */
+    format?: DiffFormat;
+    /** Whether to exit 1 on breaking changes (default: true) */
+    failOnBreaking?: boolean;
+    /** Current working directory */
+    cwd?: string;
+    /** Output helper for errors */
+    output: Output;
+    /** Custom stdout write function */
+    writeStdout?: (text: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Spec loading — file path or HTTP URL
+// ---------------------------------------------------------------------------
+
+async function loadSpec(specRef: string, cwd: string): Promise<string> {
+    if (/^https?:\/\//i.test(specRef)) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10_000);
+        let res: Response;
+        try {
+            res = await fetch(specRef, { signal: controller.signal });
+        } finally {
+            clearTimeout(timeout);
+        }
+        if (!res.ok) {
+            throw new Error(`HTTP ${res.status} fetching ${specRef}`);
+        }
+        return res.text();
+    }
+
+    const resolved = path.resolve(cwd, specRef);
+    return readFile(resolved, "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Command handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the `apifn diff` command.
+ *
+ * @returns exit code: 0 (no breaking), 1 (breaking), 2 (error)
+ */
+export async function runDiffCommand(options: DiffCommandOptions): Promise<number> {
+    const cwd = options.cwd ?? process.cwd();
+    const failOnBreaking = options.failOnBreaking !== false; // default true
+    const format: DiffFormat = options.format ?? "text";
+    const write = options.writeStdout ?? ((text: string) => process.stdout.write(text));
+
+    // Load both specs
+    let beforeRaw: string;
+    let afterRaw: string;
+
+    try {
+        beforeRaw = await loadSpec(options.before, cwd);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        options.output.error(`Failed to load before-spec '${options.before}': ${message}`);
+        return 2;
+    }
+
+    try {
+        afterRaw = await loadSpec(options.after, cwd);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        options.output.error(`Failed to load after-spec '${options.after}': ${message}`);
+        return 2;
+    }
+
+    // Parse specs
+    let beforeDoc;
+    let afterDoc;
+
+    try {
+        beforeDoc = parseOpenAPI(beforeRaw);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        options.output.error(`Failed to parse before-spec: ${message}`);
+        return 2;
+    }
+
+    try {
+        afterDoc = parseOpenAPI(afterRaw);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        options.output.error(`Failed to parse after-spec: ${message}`);
+        return 2;
+    }
+
+    // Compute diff
+    const result = diffOpenAPI(beforeDoc, afterDoc);
+
+    // Output
+    if (format === "json") {
+        const json = formatDiffAsJson(result, new Date().toISOString());
+        write(JSON.stringify(json, null, 2));
+        write("\n");
+    } else {
+        const useColor = true; // color is handled by the CLI global --no-color
+        let pc: {
+            red: (s: string) => string;
+            green: (s: string) => string;
+            yellow: (s: string) => string;
+            bold: (s: string) => string;
+            dim: (s: string) => string;
+        };
+        try {
+            // Dynamic import so it's testable without color
+            const picocolors = await import("picocolors");
+            const p = picocolors.default ?? picocolors;
+            pc = {
+                red: (s) => (useColor ? p.red(s) : s),
+                green: (s) => (useColor ? p.green(s) : s),
+                yellow: (s) => (useColor ? p.yellow(s) : s),
+                bold: (s) => (useColor ? p.bold(s) : s),
+                dim: (s) => (useColor ? p.dim(s) : s),
+            };
+        } catch {
+            pc = {
+                red: (s) => s,
+                green: (s) => s,
+                yellow: (s) => s,
+                bold: (s) => s,
+                dim: (s) => s,
+            };
+        }
+        const text = formatDiffAsText(result, pc);
+        write(text);
+        write("\n");
+    }
+
+    // Exit code
+    if (result.hasBreakingChanges && failOnBreaking) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/apifn/cli/src/commands/export.ts
+++ b/apifn/cli/src/commands/export.ts
@@ -1,0 +1,35 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { stringify as toYaml } from "yaml";
+import { parseOpenAPI } from "@apifn/core";
+import type { ApifnConfig } from "../config.js";
+import type { Output } from "../utils/output.js";
+
+export async function runExportCommand(options: {
+  format?: "yaml" | "json";
+  outputPath?: string;
+  inputPath?: string;
+  cwd?: string;
+  config: ApifnConfig;
+  output: Output;
+}): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const format = options.format ?? "yaml";
+  const inputPath = options.inputPath
+    ? path.resolve(cwd, options.inputPath)
+    : path.resolve(cwd, options.config.output ?? ".apifn", "openapi.yml");
+
+  const raw = await readFile(inputPath, "utf8");
+  const parsed = parseOpenAPI(raw);
+  const rendered = format === "json" ? JSON.stringify(parsed, null, 2) : toYaml(parsed);
+
+  if (options.outputPath) {
+    const resolvedOutput = path.resolve(cwd, options.outputPath);
+    await mkdir(path.dirname(resolvedOutput), { recursive: true });
+    await writeFile(resolvedOutput, rendered, "utf8");
+    options.output.success(`Exported ${format} spec -> ${resolvedOutput}`);
+    return;
+  }
+
+  options.output.info(rendered);
+}

--- a/apifn/cli/src/commands/generate.ts
+++ b/apifn/cli/src/commands/generate.ts
@@ -1,0 +1,49 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { stringify as toYaml } from "yaml";
+import { fromRouter } from "@apifn/core";
+import type { ApifnConfig } from "../config.js";
+import { loadRouter } from "../utils/router-loader.js";
+import type { Output } from "../utils/output.js";
+
+export async function runGenerateCommand(options: {
+  routerPath?: string;
+  outputPath?: string;
+  cwd?: string;
+  config: ApifnConfig;
+  output: Output;
+}): Promise<{ routeCount: number; outputPath: string }> {
+  const cwd = options.cwd ?? process.cwd();
+  const routerPath = options.routerPath ?? options.config.router;
+
+  if (!routerPath) {
+    throw new Error("Router path is required. Pass [router-path] or set config.router.");
+  }
+
+  const router = await loadRouter(routerPath, cwd);
+  const routes = router.getRoutes();
+
+  const configuredInfo = options.config.openapi?.info;
+  const doc = fromRouter(router, {
+    info: {
+      title: "API",
+      version: "1.0.0",
+      ...configuredInfo,
+    },
+    servers: options.config.openapi?.servers,
+  });
+
+  const outputPath = options.outputPath
+    ? path.resolve(cwd, options.outputPath)
+    : path.resolve(cwd, options.config.output ?? ".apifn", "openapi.yml");
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, toYaml(doc), "utf8");
+
+  options.output.success(`Generated OpenAPI for ${routes.length} routes -> ${outputPath}`);
+
+  return {
+    routeCount: routes.length,
+    outputPath,
+  };
+}

--- a/apifn/cli/src/commands/import.ts
+++ b/apifn/cli/src/commands/import.ts
@@ -1,0 +1,114 @@
+import { existsSync } from "node:fs";
+import { readFile, readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { openAPIToCollection, readCollection, writeCollection } from "@apifn/collections";
+import type { CollectionItem } from "@apifn/collections";
+import { parseOpenAPI } from "@apifn/core";
+import type { Output } from "../utils/output.js";
+
+export interface ImportOpenApiCommandOptions {
+  source: string;
+  outputDir: string;
+  baseUrl?: string;
+  env?: string;
+  groupBy?: "tag" | "path";
+  force?: boolean;
+  fetchTimeoutMs?: number;
+  cwd?: string;
+  output: Output;
+}
+
+export async function runImportOpenApiCommand(options: ImportOpenApiCommandOptions): Promise<number> {
+  const cwd = options.cwd ?? process.cwd();
+  const outputDir = path.resolve(cwd, options.outputDir);
+
+  try {
+    if (existsSync(outputDir)) {
+      const entries = await readdir(outputDir);
+      if (entries.length > 0 && !options.force) {
+          options.output.error(`Output directory '${outputDir}' already exists. Use --force to overwrite collection files.`);
+          return 2;
+      }
+
+      if (entries.length > 0 && options.force) {
+        await cleanExistingCollection(outputDir);
+      }
+    }
+
+    const raw = await readSource(options.source, cwd, options.fetchTimeoutMs);
+    const document = parseOpenAPI(raw);
+    const collection = openAPIToCollection(document, {
+      baseUrl: options.baseUrl,
+      environmentName: options.env ?? "development",
+      groupBy: options.groupBy ?? "tag",
+    });
+    collection.rootDir = outputDir;
+
+    await writeCollection(collection);
+    options.output.success(`Imported OpenAPI collection to ${outputDir}`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options.output.error(`Failed to import OpenAPI collection: ${message}`);
+    return 2;
+  }
+}
+
+async function cleanExistingCollection(outputDir: string): Promise<void> {
+  let existingCollection: Awaited<ReturnType<typeof readCollection>>;
+  try {
+    existingCollection = await readCollection(outputDir);
+  } catch {
+    await rm(path.join(outputDir, "opencollection.yml"), { force: true });
+    return;
+  }
+
+  const pathsToRemove = new Set<string>([
+    "opencollection.yml",
+  ]);
+
+  for (const envName of Object.keys(existingCollection.environments)) {
+    pathsToRemove.add(path.posix.join("environments", `${envName}.yml`));
+  }
+
+  function collectItemPaths(items: CollectionItem[]): void {
+    for (const item of items) {
+      if (item.kind === "folder") {
+        pathsToRemove.add(path.posix.join(item.path, "folder.yml"));
+        for (const child of item.children ?? []) {
+          collectItemPaths([child]);
+        }
+      } else {
+        pathsToRemove.add(item.path);
+      }
+    }
+  }
+
+  collectItemPaths(existingCollection.items);
+
+  for (const relativePath of pathsToRemove) {
+    await rm(path.join(outputDir, relativePath), { recursive: true, force: true });
+  }
+}
+
+async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readSource(source: string, cwd: string, timeoutMs = 10_000): Promise<string> {
+  if (source.startsWith("http://") || source.startsWith("https://")) {
+    const response = await fetchWithTimeout(source, timeoutMs);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} while reading ${source}`);
+    }
+    return response.text();
+  }
+
+  return readFile(path.resolve(cwd, source), "utf8");
+}

--- a/apifn/cli/src/commands/init.ts
+++ b/apifn/cli/src/commands/init.ts
@@ -1,0 +1,83 @@
+import { mkdir, readdir } from "node:fs/promises";
+import path from "node:path";
+import { writeCollection, type Collection } from "@apifn/collections";
+import type { Output } from "../utils/output.js";
+import { createInterface } from "node:readline/promises";
+
+async function promptIfNeeded(
+  label: string,
+  fallback: string,
+  shouldPrompt: boolean
+): Promise<string> {
+  if (!shouldPrompt) {
+    return fallback;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(`${label} (${fallback}): `);
+    return answer.trim() || fallback;
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runInitCommand(options: {
+  dir?: string;
+  yes?: boolean;
+  force?: boolean;
+  cwd?: string;
+  output: Output;
+}): Promise<number> {
+  const cwd = options.cwd ?? process.cwd();
+  const dir = path.resolve(cwd, options.dir ?? ".");
+  const shouldPrompt = !options.yes;
+
+  const collectionName = await promptIfNeeded("Collection name", "API Collection", shouldPrompt);
+  const baseUrl = await promptIfNeeded("Base URL", "http://localhost:3000", shouldPrompt);
+
+  await mkdir(dir, { recursive: true });
+  const entries = await readdir(dir);
+  if (entries.length > 0 && !options.force) {
+    options.output.error(`Directory '${dir}' is not empty. Use --force to initialize anyway.`);
+    return 2;
+  }
+
+  const collection: Collection = {
+    info: { name: collectionName, type: "collection" },
+    rootDir: dir,
+    environments: {
+      development: {
+        name: "development",
+        variables: { baseUrl },
+      },
+    },
+    items: [
+      {
+        kind: "folder",
+        name: "Sample",
+        path: "sample",
+        seq: 1,
+        children: [
+          {
+            kind: "request",
+            name: "Health Check",
+            path: "sample/health-check.yml",
+            seq: 1,
+            request: {
+              info: { name: "Health Check", type: "http", seq: 1 },
+              http: {
+                method: "GET",
+                url: "{{baseUrl}}/health",
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  await writeCollection(collection);
+  options.output.success(`Initialized collection in ${dir}`);
+  return 0;
+}

--- a/apifn/cli/src/commands/mock.ts
+++ b/apifn/cli/src/commands/mock.ts
@@ -1,0 +1,87 @@
+/**
+ * `apifn mock [spec]` — start mock server from an OpenAPI spec (CLI-007)
+ *
+ * Wraps @apifn/mock's createMockServer.
+ * Options: --mode, --port, --validate-requests, --delay
+ */
+
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { parseOpenAPI } from "@apifn/core";
+import { createMockServer } from "@apifn/mock";
+import type { Output } from "../utils/output.js";
+
+export type MockMode = "schema" | "examples" | "random";
+
+export interface MockCommandOptions {
+    /** Path to OpenAPI spec */
+    specPath: string;
+    /** Response mode (default: "schema") */
+    mode?: MockMode;
+    /** Port (default: 4010) */
+    port?: number;
+    /** Enable request validation */
+    validateRequests?: boolean;
+    /** Delay in ms */
+    delay?: number;
+    /** CORS (default: true) */
+    cors?: boolean;
+    cwd?: string;
+    output: Output;
+}
+
+export async function runMockCommand(options: MockCommandOptions): Promise<number> {
+    const cwd = options.cwd ?? process.cwd();
+    const specPath = path.resolve(cwd, options.specPath);
+    const port = options.port ?? 4010;
+
+    let raw: string;
+    try {
+        raw = await readFile(specPath, "utf8");
+    } catch {
+        options.output.error(`Could not read spec: ${specPath}`);
+        return 2;
+    }
+
+    let spec: ReturnType<typeof parseOpenAPI>;
+    try {
+        spec = parseOpenAPI(raw);
+    } catch (err) {
+        options.output.error(`Failed to parse spec: ${err instanceof Error ? err.message : String(err)}`);
+        return 2;
+    }
+
+    const mock = createMockServer({
+        spec,
+        port,
+        responseMode: options.mode ?? "schema",
+        validateRequests: options.validateRequests ?? false,
+        delay: options.delay ?? 0,
+        cors: options.cors !== false,
+    });
+
+    try {
+        await mock.start();
+    } catch (err) {
+        options.output.error(`Failed to start mock server: ${err instanceof Error ? err.message : String(err)}`);
+        return 2;
+    }
+
+    options.output.success(`Mock server running at http://localhost:${mock.port}`);
+    options.output.info(`Spec: ${specPath}`);
+    options.output.info(`Mode: ${options.mode ?? "schema"}`);
+    if (options.validateRequests) options.output.info("Request validation: enabled");
+    if (options.delay) options.output.info(`Delay: ${options.delay}ms`);
+    options.output.info("Press Ctrl+C to stop");
+
+    return new Promise((resolve) => {
+        const cleanup = async () => {
+            process.off("SIGINT", cleanup);
+            process.off("SIGTERM", cleanup);
+            await mock.stop();
+            resolve(0);
+        };
+        process.on("SIGINT", cleanup);
+        process.on("SIGTERM", cleanup);
+    });
+}

--- a/apifn/cli/src/commands/serve.ts
+++ b/apifn/cli/src/commands/serve.ts
@@ -1,0 +1,229 @@
+/**
+ * `apifn serve [router-or-spec]` — interactive API explorer server (CLI-006, SERVE-001, SERVE-002)
+ *
+ * Starts a local HTTP server serving a basic API explorer HTML page.
+ * Hot-reloads via Server-Sent Events when the spec file changes.
+ * --port (default 4100), --open
+ */
+
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { parseOpenAPI } from "@apifn/core";
+import type { Output } from "../utils/output.js";
+
+export interface ServeCommandOptions {
+    /** Path to spec or router file */
+    specPath?: string;
+    /** Port to bind (default: 4100) */
+    port?: number;
+    /** Auto-open browser */
+    open?: boolean;
+    /** Current working directory */
+    cwd?: string;
+    output: Output;
+}
+
+// ---------------------------------------------------------------------------
+// HTML template for the basic explorer page
+// ---------------------------------------------------------------------------
+
+function toSafeScriptJson(value: unknown): string {
+    return JSON.stringify(value, null, 2)
+        .replace(/</g, "\\u003c")
+        .replace(/>/g, "\\u003e")
+        .replace(/\//g, "\\u002f");
+}
+
+function buildHtml(spec: unknown, port: number): string {
+    const specJson = toSafeScriptJson(spec);
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ApiFn Explorer</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0f1117; color: #e2e8f0; }
+    header { background: #1a1d2e; border-bottom: 1px solid #2d3748; padding: 16px 24px; display: flex; align-items: center; gap: 12px; }
+    header h1 { font-size: 18px; font-weight: 700; color: #7c3aed; }
+    header span { font-size: 14px; color: #64748b; }
+    main { padding: 24px; max-width: 1200px; margin: 0 auto; }
+    .endpoint { background: #1a1d2e; border: 1px solid #2d3748; border-radius: 8px; margin-bottom: 12px; overflow: hidden; }
+    .endpoint-header { padding: 12px 16px; display: flex; align-items: center; gap: 12px; cursor: pointer; }
+    .method { font-size: 12px; font-weight: 700; padding: 2px 8px; border-radius: 4px; text-transform: uppercase; min-width: 60px; text-align: center; }
+    .get { background: #065f46; color: #6ee7b7; }
+    .post { background: #1e3a5f; color: #93c5fd; }
+    .put { background: #78350f; color: #fcd34d; }
+    .patch { background: #5b21b6; color: #c4b5fd; }
+    .delete { background: #7f1d1d; color: #fca5a5; }
+    .endpoint-path { font-family: monospace; font-size: 14px; }
+    .endpoint-summary { font-size: 13px; color: #64748b; margin-left: auto; }
+    #reload-indicator { position: fixed; top: 12px; right: 12px; background: #7c3aed; color: white; padding: 6px 12px; border-radius: 20px; font-size: 12px; display: none; }
+    .badge { background: #7c3aed22; border: 1px solid #7c3aed44; color: #a78bfa; padding: 2px 8px; border-radius: 12px; font-size: 11px; }
+  </style>
+</head>
+<body>
+<div id="reload-indicator">🔄 Reloading…</div>
+<header>
+  <h1>ApiFn Explorer</h1>
+  <span id="api-title">Loading…</span>
+  <span class="badge" id="api-version"></span>
+</header>
+<main id="endpoints"></main>
+<script>
+const spec = ${specJson};
+document.getElementById('api-title').textContent = spec.info?.title ?? 'API Explorer';
+document.getElementById('api-version').textContent = 'v' + (spec.info?.version ?? '?');
+
+const main = document.getElementById('endpoints');
+const METHODS = ['get','post','put','patch','delete','head','options'];
+const paths = spec.paths ?? {};
+
+for (const [apiPath, pathItem] of Object.entries(paths)) {
+  for (const method of METHODS) {
+    const op = pathItem[method];
+    if (!op) continue;
+    const el = document.createElement('div');
+    el.className = 'endpoint';
+    el.innerHTML = \`<div class="endpoint-header">
+      <span class="method \${method}">\${method}</span>
+      <span class="endpoint-path">\${apiPath}</span>
+      <span class="endpoint-summary">\${op.summary ?? ''}</span>
+    </div>\`;
+    main.appendChild(el);
+  }
+}
+
+// Hot reload via Server-Sent Events
+const ev = new EventSource('/sse');
+ev.onmessage = (e) => {
+  if (e.data === 'reload') {
+    document.getElementById('reload-indicator').style.display = 'block';
+    setTimeout(() => location.reload(), 300);
+  }
+};
+</script>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// runServeCommand
+// ---------------------------------------------------------------------------
+
+export async function runServeCommand(options: ServeCommandOptions): Promise<number> {
+    const cwd = options.cwd ?? process.cwd();
+    const port = options.port ?? 4100;
+    const specPath = options.specPath
+        ? path.resolve(cwd, options.specPath)
+        : undefined;
+
+    // SSE clients for hot reload
+    const sseClients: http.ServerResponse[] = [];
+
+    function notifyReload(): void {
+        for (const client of sseClients) {
+            client.write("data: reload\n\n");
+        }
+        sseClients.length = 0;
+    }
+
+    // Load spec
+    async function loadSpec(): Promise<unknown> {
+        if (!specPath) return { openapi: "3.1.0", info: { title: "No spec loaded", version: "1.0.0" }, paths: {} };
+        const raw = await readFile(specPath, "utf8");
+        return parseOpenAPI(raw);
+    }
+
+    let currentSpec: unknown = await loadSpec().catch(() => ({
+        openapi: "3.1.0",
+        info: { title: "Error loading spec", version: "1.0.0" },
+        paths: {},
+    }));
+
+    // File watcher for hot reload (SERVE-002)
+    let watcher: fs.FSWatcher | undefined;
+    if (specPath) {
+        watcher = fs.watch(specPath, async () => {
+            try {
+                await new Promise<void>((r) => setTimeout(r, 50)); // debounce
+                currentSpec = await loadSpec();
+                options.output.info(`Spec reloaded: ${specPath}`);
+                notifyReload();
+            } catch (err) {
+                options.output.error(`Failed to reload spec: ${err}`);
+            }
+        });
+    }
+
+    // HTTP server
+    const server = http.createServer((req, res) => {
+        const url = req.url ?? "/";
+
+        // SSE endpoint for live reload
+        if (url === "/sse") {
+            res.writeHead(200, {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "Access-Control-Allow-Origin": "*",
+            });
+            res.write(": connected\n\n");
+            sseClients.push(res);
+            req.on("close", () => {
+                const idx = sseClients.indexOf(res);
+                if (idx !== -1) sseClients.splice(idx, 1);
+            });
+            return;
+        }
+
+        // Serve spec as JSON
+        if (url === "/spec.json") {
+            res.setHeader("Content-Type", "application/json");
+            res.writeHead(200);
+            res.end(JSON.stringify(currentSpec, null, 2));
+            return;
+        }
+
+        // Explorer HTML
+        res.setHeader("Content-Type", "text/html; charset=utf-8");
+        res.writeHead(200);
+        res.end(buildHtml(currentSpec, port));
+    });
+
+    return new Promise((resolve) => {
+        const cleanup = () => {
+            process.off("SIGINT", cleanup);
+            process.off("SIGTERM", cleanup);
+            watcher?.close();
+            for (const client of sseClients) {
+                client.end();
+            }
+            sseClients.length = 0;
+            server.close(() => resolve(0));
+        };
+
+        server.listen(port, () => {
+            const url = `http://localhost:${port}`;
+            options.output.success(`API Explorer running at ${url}`);
+            if (specPath) options.output.info(`Watching: ${specPath}`);
+            options.output.info("Press Ctrl+C to stop");
+
+            // Auto-open browser
+            if (options.open) {
+                import("node:child_process").then(({ exec }) => {
+                    const cmd = process.platform === "darwin" ? `open ${url}`
+                        : process.platform === "win32" ? `start ${url}`
+                            : `xdg-open ${url}`;
+                    exec(cmd);
+                });
+            }
+        });
+
+        process.on("SIGINT", cleanup);
+        process.on("SIGTERM", cleanup);
+    });
+}

--- a/apifn/cli/src/commands/snippet.ts
+++ b/apifn/cli/src/commands/snippet.ts
@@ -1,0 +1,115 @@
+/**
+ * `apifn snippet <spec> <path>` — generate code snippet for an endpoint (CLI-008)
+ *
+ * Wraps @apifn/snippets' generateSnippet / generateAllSnippets.
+ * Options: --target (default: curl), --method (default: get), --all, --base-url
+ */
+
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { parseOpenAPI } from "@apifn/core";
+import type { SnippetTarget, SnippetOptions, OperationObject, OpenAPIDocument } from "@apifn/core";
+import { generateSnippet, generateAllSnippets, SUPPORTED_TARGETS } from "@apifn/snippets";
+import type { Output } from "../utils/output.js";
+
+export interface SnippetCommandOptions {
+    /** Path to OpenAPI spec */
+    specPath: string;
+    /** Endpoint path (e.g. /users) */
+    apiPath?: string;
+    /** HTTP method (default: "get") */
+    method?: string;
+    /** Snippet target (default: "curl") */
+    target?: string;
+    /** Base URL override */
+    baseUrl?: string;
+    /** Generate all snippets for all endpoints */
+    all?: boolean;
+    cwd?: string;
+    output: Output;
+    writeStdout?: (text: string) => void;
+}
+
+export async function runSnippetCommand(options: SnippetCommandOptions): Promise<number> {
+    const cwd = options.cwd ?? process.cwd();
+    const specPath = path.resolve(cwd, options.specPath);
+    const write = options.writeStdout ?? ((t: string) => process.stdout.write(t));
+    const target = (options.target ?? "curl") as SnippetTarget;
+    const method = (options.method ?? "get").toLowerCase();
+
+    // Validate target
+    if (!SUPPORTED_TARGETS.includes(target)) {
+        options.output.error(`Unsupported target '${target}'. Supported: ${SUPPORTED_TARGETS.join(", ")}`);
+        return 1;
+    }
+
+    // Load spec
+    let raw: string;
+    try {
+        raw = await readFile(specPath, "utf8");
+    } catch {
+        options.output.error(`Could not read spec: ${specPath}`);
+        return 2;
+    }
+
+    let spec: ReturnType<typeof parseOpenAPI>;
+    try {
+        spec = parseOpenAPI(raw);
+    } catch (err) {
+        options.output.error(`Failed to parse spec: ${err instanceof Error ? err.message : String(err)}`);
+        return 2;
+    }
+
+    const baseUrl = options.baseUrl
+        ?? (spec as OpenAPIDocument).servers?.[0]?.url
+        ?? "https://api.example.com";
+
+    const snippetOpts: SnippetOptions = {
+        target,
+        baseUrl,
+        indent: 2,
+    };
+
+    // --all: generate snippets for every operation
+    if (options.all) {
+        const result = generateAllSnippets(spec as OpenAPIDocument, snippetOpts);
+        if (result.snippets.length === 0) {
+            options.output.info("No operations found in spec.");
+            return 0;
+        }
+        for (const snippet of result.snippets) {
+            write(`\n# ${snippet.method.toUpperCase()} ${snippet.path}\n`);
+            if (snippet.operationId) write(`# ${snippet.operationId}\n`);
+            write(snippet.code);
+            write("\n");
+        }
+        return 0;
+    }
+
+    // Single operation
+    const apiPath = options.apiPath;
+    if (!apiPath) {
+        options.output.error("Specify a path, e.g. apifn snippet spec.yml /users, or use --all");
+        return 1;
+    }
+
+    const specDoc = spec as OpenAPIDocument;
+    const pathItem = (specDoc.paths ?? {})[apiPath];
+
+    if (!pathItem) {
+        options.output.error(`Path '${apiPath}' not found in spec. Available paths: ${Object.keys(specDoc.paths ?? {}).join(", ")}`);
+        return 1;
+    }
+
+    const operation = (pathItem as Record<string, OperationObject | undefined>)[method];
+    if (!operation) {
+        options.output.error(`Method '${method.toUpperCase()}' not found for path '${apiPath}'`);
+        return 1;
+    }
+
+    const code = generateSnippet(operation, apiPath, method, snippetOpts);
+    write(code);
+    write("\n");
+
+    return 0;
+}

--- a/apifn/cli/src/commands/test.ts
+++ b/apifn/cli/src/commands/test.ts
@@ -1,0 +1,188 @@
+/**
+ * `apifn test` command implementation.
+ *
+ * Loads a collection directory, resolves environment, runs the collection
+ * through runCollection(), and reports results via a configurable reporter.
+ *
+ * Exit codes (CLI-011):
+ *   0 — all tests passed
+ *   1 — one or more test failures
+ *   2 — error (invalid collection, missing env, etc.)
+ */
+
+import path from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import {
+    readCollection,
+    runCollection,
+    createConsoleReporter,
+    createJsonReporter,
+    createJUnitReporter,
+    createSilentReporter,
+    loadDotEnvFile,
+    reportToJUnitXml,
+} from "@apifn/collections";
+import type { RunReporter } from "@apifn/collections";
+import type { Output } from "../utils/output.js";
+
+export type ReporterName = "console" | "json" | "junit" | "silent";
+
+export interface TestCommandOptions {
+    /** Directory containing the OpenCollection (default: cwd) */
+    collectionDir?: string;
+    /** Environment name to use */
+    env?: string;
+    /** Stop on first failure */
+    bail?: boolean;
+    /** Run requests in parallel */
+    parallel?: boolean;
+    /** Max concurrent requests when parallel=true */
+    concurrency?: number;
+    /** Per-request timeout in ms */
+    timeout?: number;
+    /** Only run requests matching these paths/patterns */
+    include?: string[];
+    /** Skip requests matching these paths/patterns */
+    exclude?: string[];
+    /** Retry failed requests */
+    retries?: number;
+    /** Delay between sequential requests in ms */
+    delay?: number;
+    /** Environment variable overrides */
+    envVar?: string[];
+    /** Dotenv file to load as overrides */
+    dotenv?: string;
+    /** Headers to redact */
+    redactHeader?: string[];
+    /** Write machine-readable report to this file */
+    outputPath?: string;
+    /** Reporter type */
+    reporter?: ReporterName;
+    /** Whether color output is enabled */
+    color?: boolean;
+    /** Current working directory */
+    cwd?: string;
+    /** Output helper (used for error messages) */
+    output: Output;
+    /** Custom stdout write function for reporter output (default: process.stdout.write) */
+    writeStdout?: (text: string) => void;
+}
+
+/**
+ * Runs the `apifn test` command.
+ *
+ * @returns exit code: 0 (pass), 1 (failures), 2 (error)
+ */
+export async function runTestCommand(options: TestCommandOptions): Promise<number> {
+    const cwd = options.cwd ?? process.cwd();
+    const collectionDir = options.collectionDir
+        ? path.resolve(cwd, options.collectionDir)
+        : cwd;
+
+    const reporterName: ReporterName = options.reporter ?? "console";
+    const stdoutWrite = options.writeStdout ?? ((text: string) => process.stdout.write(text));
+
+    let reporter: RunReporter;
+    if (reporterName === "json") {
+        reporter = createJsonReporter({ write: stdoutWrite });
+    } else if (reporterName === "junit") {
+        reporter = createJUnitReporter({ write: stdoutWrite });
+    } else if (reporterName === "silent") {
+        reporter = createSilentReporter();
+    } else {
+        reporter = createConsoleReporter({
+            color: options.color ?? true,
+            write: stdoutWrite,
+        });
+    }
+
+    let collection;
+    try {
+        collection = await readCollection(collectionDir);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        options.output.error(`Failed to load collection from '${collectionDir}': ${message}`);
+        return 2;
+    }
+
+    const envName = options.env ?? Object.keys(collection.environments)[0];
+    if (!envName) {
+        options.output.error(
+            "No environment specified and collection has no environments. Use --env <name>."
+        );
+        return 2;
+    }
+
+    let report;
+    try {
+        const overrides = {
+            ...loadDotEnv(options.dotenv, cwd),
+            ...parseEnvVars(options.envVar ?? []),
+        };
+
+        report = await runCollection(collection, {
+            environment: envName,
+            bail: options.bail,
+            parallel: options.parallel,
+            concurrency: options.concurrency,
+            timeout: options.timeout,
+            include: options.include,
+            exclude: options.exclude,
+            retries: options.retries,
+            delay: options.delay,
+            overrides,
+            redactHeaders: options.redactHeader,
+            reporter,
+        });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        options.output.error(`Collection run failed: ${message}`);
+        return 2;
+    }
+
+    if (options.outputPath) {
+        await writeReportFile({
+            outputPath: path.resolve(cwd, options.outputPath),
+            reporterName,
+            report,
+        });
+    }
+
+    const { summary } = report;
+    if (summary.failed > 0 || summary.errors > 0) {
+        return 1;
+    }
+
+    return 0;
+}
+
+function loadDotEnv(dotenvPath: string | undefined, cwd: string): Record<string, string> {
+    if (!dotenvPath) {
+        return {};
+    }
+    return loadDotEnvFile(path.resolve(cwd, dotenvPath));
+}
+
+function parseEnvVars(values: string[]): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const value of values) {
+        const index = value.indexOf("=");
+        if (index <= 0) {
+            throw new Error(`Invalid --env-var value '${value}'. Expected KEY=value.`);
+        }
+        result[value.slice(0, index)] = value.slice(index + 1);
+    }
+    return result;
+}
+
+async function writeReportFile(input: {
+    outputPath: string;
+    reporterName: ReporterName;
+    report: Awaited<ReturnType<typeof runCollection>>;
+}): Promise<void> {
+    await mkdir(path.dirname(input.outputPath), { recursive: true });
+    const body = input.reporterName === "junit"
+        ? reportToJUnitXml(input.report)
+        : `${JSON.stringify(input.report, null, 2)}\n`;
+    await writeFile(input.outputPath, body, "utf8");
+}

--- a/apifn/cli/src/commands/validate.ts
+++ b/apifn/cli/src/commands/validate.ts
@@ -1,0 +1,61 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parseOpenAPI, validateOpenAPI } from "@apifn/core";
+import type { Output } from "../utils/output.js";
+
+export async function runValidateCommand(options: {
+  specPath: string;
+  format?: "text" | "json";
+  cwd?: string;
+  output: Output;
+  writeStdout?: (text: string) => void;
+}): Promise<number> {
+  const cwd = options.cwd ?? process.cwd();
+  const specPath = path.resolve(cwd, options.specPath);
+  const format = options.format ?? "text";
+  const write = options.writeStdout ?? ((text: string) => process.stdout.write(text));
+
+  try {
+    const raw = await readFile(specPath, "utf8");
+    const parsed = parseOpenAPI(raw);
+    const errors = await validateOpenAPI(parsed);
+
+    if (format === "json") {
+      write(
+        `${JSON.stringify(
+          {
+            ok: errors.length === 0,
+            errors,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else if (errors.length === 0) {
+      options.output.success("OpenAPI document is valid.");
+    } else {
+      for (const error of errors) {
+        options.output.error(`${error.path}: ${error.message}`);
+      }
+    }
+
+    return errors.length === 0 ? 0 : 1;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (format === "json") {
+      write(
+        `${JSON.stringify(
+          {
+            ok: false,
+            errors: [{ path: "", message }],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    } else {
+      options.output.error(`Failed to validate spec: ${message}`);
+    }
+    return 2;
+  }
+}

--- a/apifn/cli/src/config.ts
+++ b/apifn/cli/src/config.ts
@@ -1,0 +1,160 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { createJiti } from "jiti";
+
+export interface ApifnConfig {
+  openapi?: {
+    info?: {
+      title?: string;
+      version?: string;
+      description?: string;
+      termsOfService?: string;
+      contact?: { name?: string; url?: string; email?: string };
+      license?: { name: string; url?: string };
+    };
+    servers?: Array<{ url: string; description?: string }>;
+  };
+  router?: string;
+  collection?: string;
+  output?: string;
+  defaultEnvironment?: string;
+  watchfn?: { url?: string };
+  diff?: { failOnBreaking?: boolean; ignoreExtensions?: boolean };
+  snippets?: string[];
+}
+
+const DEFAULT_CONFIG_FILE = "apifn.config.ts";
+
+export function defineConfig(config: ApifnConfig): ApifnConfig {
+  return config;
+}
+
+function ensureString(value: unknown, pathLabel: string): void {
+  if (value !== undefined && typeof value !== "string") {
+    throw new Error(`${pathLabel} must be a string`);
+  }
+}
+
+function ensureBoolean(value: unknown, pathLabel: string): void {
+  if (value !== undefined && typeof value !== "boolean") {
+    throw new Error(`${pathLabel} must be a boolean`);
+  }
+}
+
+function ensureStringArray(value: unknown, pathLabel: string): void {
+  if (value !== undefined && (!Array.isArray(value) || value.some((v) => typeof v !== "string"))) {
+    throw new Error(`${pathLabel} must be a string[]`);
+  }
+}
+
+function validateConfig(raw: unknown): ApifnConfig {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Config must export an object");
+  }
+
+  const config = raw as Record<string, unknown>;
+  const allowed = new Set([
+    "openapi",
+    "router",
+    "collection",
+    "output",
+    "defaultEnvironment",
+    "watchfn",
+    "diff",
+    "snippets",
+  ]);
+
+  for (const key of Object.keys(config)) {
+    if (!allowed.has(key)) {
+      throw new Error(`Unknown config field: ${key}`);
+    }
+  }
+
+  ensureString(config.router, "router");
+  ensureString(config.collection, "collection");
+  ensureString(config.output, "output");
+  ensureString(config.defaultEnvironment, "defaultEnvironment");
+
+  if (config.openapi !== undefined) {
+    if (!config.openapi || typeof config.openapi !== "object" || Array.isArray(config.openapi)) {
+      throw new Error("openapi must be an object");
+    }
+
+    const openapi = config.openapi as Record<string, unknown>;
+    if (openapi.info !== undefined) {
+      if (!openapi.info || typeof openapi.info !== "object" || Array.isArray(openapi.info)) {
+        throw new Error("openapi.info must be an object");
+      }
+      const info = openapi.info as Record<string, unknown>;
+      ensureString(info.title, "info.title");
+      ensureString(info.version, "info.version");
+      ensureString(info.description, "info.description");
+      ensureString(info.termsOfService, "info.termsOfService");
+    }
+
+    if (openapi.servers !== undefined) {
+      if (!Array.isArray(openapi.servers)) {
+        throw new Error("openapi.servers must be an array");
+      }
+      for (const [index, server] of openapi.servers.entries()) {
+        if (!server || typeof server !== "object" || Array.isArray(server)) {
+          throw new Error(`openapi.servers[${index}] must be an object`);
+        }
+        const serverRecord = server as Record<string, unknown>;
+        ensureString(serverRecord.url, `openapi.servers[${index}].url`);
+        ensureString(serverRecord.description, `openapi.servers[${index}].description`);
+      }
+    }
+  }
+
+  if (config.watchfn !== undefined) {
+    if (!config.watchfn || typeof config.watchfn !== "object" || Array.isArray(config.watchfn)) {
+      throw new Error("watchfn must be an object");
+    }
+    ensureString((config.watchfn as Record<string, unknown>).url, "watchfn.url");
+  }
+
+  if (config.diff !== undefined) {
+    if (!config.diff || typeof config.diff !== "object" || Array.isArray(config.diff)) {
+      throw new Error("diff must be an object");
+    }
+    const diff = config.diff as Record<string, unknown>;
+    ensureBoolean(diff.failOnBreaking, "diff.failOnBreaking");
+    ensureBoolean(diff.ignoreExtensions, "diff.ignoreExtensions");
+  }
+
+  ensureStringArray(config.snippets, "snippets");
+
+  return config as ApifnConfig;
+}
+
+export async function loadConfig(options?: {
+  cwd?: string;
+  configPath?: string;
+}): Promise<{ config: ApifnConfig; path?: string }> {
+  const cwd = options?.cwd ?? process.cwd();
+  const configuredPath = options?.configPath;
+  const candidates = configuredPath
+    ? [configuredPath]
+    : ["apifn.config.ts", "apifn.config.js", "apifn.config.mjs"];
+
+  for (const candidate of candidates) {
+    const resolved = path.isAbsolute(candidate) ? candidate : path.resolve(cwd, candidate);
+    if (!existsSync(resolved)) {
+      continue;
+    }
+
+    const jiti = createJiti(process.cwd(), { moduleCache: false });
+    const loaded = (await jiti.import(resolved)) as { default?: unknown };
+    const configValue = loaded?.default ?? loaded;
+    return { config: validateConfig(configValue), path: resolved };
+  }
+
+  if (configuredPath) {
+    throw new Error(`Config file not found: ${configuredPath}`);
+  }
+
+  return { config: {}, path: undefined };
+}
+
+export const DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_FILE;

--- a/apifn/cli/src/index.ts
+++ b/apifn/cli/src/index.ts
@@ -1,0 +1,421 @@
+import { cac } from "cac";
+import { DEFAULT_CONFIG_PATH, defineConfig, loadConfig } from "./config.js";
+import { runInitCommand } from "./commands/init.js";
+import { runGenerateCommand } from "./commands/generate.js";
+import { runExportCommand } from "./commands/export.js";
+import { runValidateCommand } from "./commands/validate.js";
+import { runTestCommand } from "./commands/test.js";
+import { runImportOpenApiCommand } from "./commands/import.js";
+import { runDiffCommand } from "./commands/diff.js";
+import { runServeCommand } from "./commands/serve.js";
+import { runMockCommand } from "./commands/mock.js";
+import { runSnippetCommand } from "./commands/snippet.js";
+import { createOutput } from "./utils/output.js";
+
+export { defineConfig, loadConfig };
+
+export interface CliRunOptions {
+  cwd?: string;
+  stdout?: (text: string) => void;
+  stderr?: (text: string) => void;
+}
+
+function toArray(value: string | string[] | undefined): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+export async function runCli(
+  argv = process.argv.slice(2),
+  runOptions: CliRunOptions = {}
+): Promise<number> {
+  let exitCode = 0;
+
+  const cli = cac("apifn");
+  const getGlobals = () =>
+    (cli.options ?? {}) as {
+      config?: string;
+      verbose?: boolean;
+      quiet?: boolean;
+      color?: boolean;
+    };
+
+  cli
+    .option("--config <path>", `Path to config file (default: ${DEFAULT_CONFIG_PATH})`)
+    .option("--verbose", "Enable verbose output")
+    .option("--quiet", "Suppress non-error output")
+    .option("--no-color", "Disable colored output");
+
+  cli
+    .command("init [dir]", "Initialize a new OpenCollection directory")
+    .option("--yes", "Skip interactive prompts")
+    .option("--force", "Allow initializing into a non-empty directory")
+    .action(async (dir: string | undefined, options: { yes?: boolean; force?: boolean }) => {
+      const globals = getGlobals();
+      const output = createOutput({
+        quiet: globals.quiet,
+        verbose: globals.verbose,
+        color: globals.color !== false,
+        writeStdout: runOptions.stdout,
+        writeStderr: runOptions.stderr,
+      });
+
+      const result = await runInitCommand({
+        dir,
+        yes: options.yes,
+        force: options.force,
+        cwd: runOptions.cwd,
+        output,
+      });
+      if (result !== 0) {
+        exitCode = result;
+      }
+    });
+
+  cli
+    .command("generate [routerPath]", "Generate OpenAPI from router")
+    .option("--output <path>", "Output file path")
+    .action(async (routerPath: string | undefined, options: { output?: string }) => {
+      const globals = getGlobals();
+      const output = createOutput({
+        quiet: globals.quiet,
+        verbose: globals.verbose,
+        color: globals.color !== false,
+        writeStdout: runOptions.stdout,
+        writeStderr: runOptions.stderr,
+      });
+      const { config } = await loadConfig({
+        cwd: runOptions.cwd,
+        configPath: globals.config,
+      });
+
+      await runGenerateCommand({
+        routerPath,
+        outputPath: options.output,
+        cwd: runOptions.cwd,
+        config,
+        output,
+      });
+    });
+
+  cli
+    .command("export [format] [output]", "Export generated OpenAPI as yaml/json")
+    .option("--input <path>", "Input OpenAPI path")
+    .action(async (format: string | undefined, outputPath: string | undefined, options: { input?: string }) => {
+      const globals = getGlobals();
+      const output = createOutput({
+        quiet: globals.quiet,
+        verbose: globals.verbose,
+        color: globals.color !== false,
+        writeStdout: runOptions.stdout,
+        writeStderr: runOptions.stderr,
+      });
+      const { config } = await loadConfig({
+        cwd: runOptions.cwd,
+        configPath: globals.config,
+      });
+
+      const normalized = format === "json" ? "json" : "yaml";
+      await runExportCommand({
+        format: normalized,
+        outputPath,
+        inputPath: options.input,
+        cwd: runOptions.cwd,
+        config,
+        output,
+      });
+    });
+
+  cli
+    .command("import <kind> <source>", "Import an OpenAPI document as an OpenCollection")
+    .option("--output <dir>", "Output collection directory")
+    .option("--base-url <url>", "Base URL for generated environment")
+    .option("--env <name>", "Environment name to create (default: development)")
+    .option("--group-by <mode>", "Group requests by tag | path (default: tag)")
+    .option("--force", "Allow writing into a non-empty output directory")
+    .action(
+      async (
+        kind: string,
+        source: string,
+        options: {
+          output?: string;
+          baseUrl?: string;
+          env?: string;
+          groupBy?: string;
+          force?: boolean;
+        }
+      ) => {
+        const globals = getGlobals();
+        const output = createOutput({
+          quiet: globals.quiet,
+          verbose: globals.verbose,
+          color: globals.color !== false,
+          writeStdout: runOptions.stdout,
+          writeStderr: runOptions.stderr,
+        });
+
+        if (kind !== "openapi") {
+          output.error(`Unsupported import kind '${kind}'. Supported: openapi.`);
+          exitCode = 2;
+          return;
+        }
+
+        const groupBy = options.groupBy === "path" ? "path" : "tag";
+        const result = await runImportOpenApiCommand({
+          source,
+          outputDir: options.output ?? ".",
+          baseUrl: options.baseUrl,
+          env: options.env,
+          groupBy,
+          force: options.force,
+          cwd: runOptions.cwd,
+          output,
+        });
+        if (result !== 0) {
+          exitCode = result;
+        }
+      }
+    );
+
+  cli
+    .command("test [collectionDir]", "Run a collection's tests")
+    .option("--env <name>", "Environment name to use")
+    .option("--bail", "Stop on first failure")
+    .option("--parallel", "Run requests in parallel")
+    .option("--concurrency <n>", "Max concurrent requests (parallel mode)")
+    .option("--timeout <ms>", "Per-request timeout in milliseconds")
+    .option("--include <pattern>", "Only run requests matching path/name pattern")
+    .option("--exclude <pattern>", "Skip requests matching path/name pattern")
+    .option("--retries <n>", "Retry failed requests")
+    .option("--delay <ms>", "Delay between sequential requests in milliseconds")
+    .option("--env-var <keyValue>", "Override an environment variable (KEY=value)")
+    .option("--dotenv <path>", "Load dotenv file as environment overrides")
+    .option("--redact-header <name>", "Additional response/request header to redact")
+    .option("--output <path>", "Write machine-readable report artifact")
+    .option("--reporter <type>", "Reporter type: console | json | junit | silent (default: console)")
+    .action(
+      async (
+        collectionDir: string | undefined,
+        options: {
+          env?: string;
+          bail?: boolean;
+          parallel?: boolean;
+          concurrency?: string;
+          timeout?: string;
+          include?: string | string[];
+          exclude?: string | string[];
+          retries?: string;
+          delay?: string;
+          envVar?: string | string[];
+          dotenv?: string;
+          redactHeader?: string | string[];
+          output?: string;
+          reporter?: string;
+        }
+      ) => {
+        const globals = getGlobals();
+        const output = createOutput({
+          quiet: globals.quiet,
+          verbose: globals.verbose,
+          color: globals.color !== false,
+          writeStdout: runOptions.stdout,
+          writeStderr: runOptions.stderr,
+        });
+
+        const reporterValue = options.reporter;
+        const validReporters = ["console", "json", "junit", "silent"] as const;
+        type R = (typeof validReporters)[number];
+        const reporter: R = validReporters.includes(reporterValue as R)
+          ? (reporterValue as R)
+          : "console";
+
+        const result = await runTestCommand({
+          collectionDir,
+          env: options.env,
+          bail: options.bail,
+          parallel: options.parallel,
+          concurrency: options.concurrency ? Number(options.concurrency) : undefined,
+          timeout: options.timeout ? Number(options.timeout) : undefined,
+          include: toArray(options.include),
+          exclude: toArray(options.exclude),
+          retries: options.retries ? Number(options.retries) : undefined,
+          delay: options.delay ? Number(options.delay) : undefined,
+          envVar: toArray(options.envVar),
+          dotenv: options.dotenv,
+          redactHeader: toArray(options.redactHeader),
+          outputPath: options.output,
+          reporter,
+          color: globals.color !== false,
+          cwd: runOptions.cwd,
+          output,
+          writeStdout: runOptions.stdout,
+        });
+        if (result !== 0) {
+          exitCode = result;
+        }
+      }
+    );
+
+  cli
+    .command("diff <before> <after>", "Compare two OpenAPI specs for breaking changes")
+    .option("--format <type>", "Output format: text | json (default: text)")
+    .option("--fail-on-breaking", "Exit 1 on breaking changes (default: true)", { default: true })
+    .action(
+      async (
+        before: string,
+        after: string,
+        options: { format?: string; failOnBreaking?: boolean }
+      ) => {
+        const globals = getGlobals();
+        const output = createOutput({
+          quiet: globals.quiet,
+          verbose: globals.verbose,
+          color: globals.color !== false,
+          writeStdout: runOptions.stdout,
+          writeStderr: runOptions.stderr,
+        });
+
+        const formatValue = options.format === "json" ? "json" : "text";
+        const result = await runDiffCommand({
+          before,
+          after,
+          format: formatValue,
+          failOnBreaking: options.failOnBreaking !== false,
+          cwd: runOptions.cwd,
+          output,
+          writeStdout: runOptions.stdout,
+        });
+        if (result !== 0) {
+          exitCode = result;
+        }
+      }
+    );
+
+  cli
+    .command("serve [specPath]", "Serve interactive API explorer")
+    .option("--port <port>", "Port to bind (default: 4100)")
+    .option("--open", "Open browser automatically")
+    .action(async (specPath: string | undefined, options: { port?: string; open?: boolean }) => {
+      const globals = getGlobals();
+      const output = createOutput({
+        quiet: globals.quiet,
+        verbose: globals.verbose,
+        color: globals.color !== false,
+        writeStdout: runOptions.stdout,
+        writeStderr: runOptions.stderr,
+      });
+      const result = await runServeCommand({
+        specPath,
+        port: options.port ? parseInt(options.port, 10) : undefined,
+        open: options.open ?? false,
+        cwd: runOptions.cwd,
+        output,
+      });
+      if (result !== 0) exitCode = result;
+    });
+
+  cli
+    .command("mock <specPath>", "Start mock server from OpenAPI spec")
+    .option("--mode <mode>", "Response mode: schema | examples | random (default: schema)")
+    .option("--port <port>", "Port to bind (default: 4010)")
+    .option("--validate-requests", "Validate incoming request bodies")
+    .option("--delay <ms>", "Add delay to responses (ms)")
+    .action(async (specPath: string, options: { mode?: string; port?: string; validateRequests?: boolean; delay?: string }) => {
+      const globals = getGlobals();
+      const output = createOutput({
+        quiet: globals.quiet,
+        verbose: globals.verbose,
+        color: globals.color !== false,
+        writeStdout: runOptions.stdout,
+        writeStderr: runOptions.stderr,
+      });
+      const mode = ["schema", "examples", "random"].includes(options.mode ?? "")
+        ? (options.mode as "schema" | "examples" | "random")
+        : "schema";
+      const result = await runMockCommand({
+        specPath,
+        mode,
+        port: options.port ? parseInt(options.port, 10) : undefined,
+        validateRequests: options.validateRequests ?? false,
+        delay: options.delay ? parseInt(options.delay, 10) : undefined,
+        cwd: runOptions.cwd,
+        output,
+      });
+      if (result !== 0) exitCode = result;
+    });
+
+  cli
+    .command("snippet <specPath> [apiPath]", "Generate code snippet for an endpoint")
+    .option("--target <target>", "Snippet target (curl, fetch, axios, …) (default: curl)")
+    .option("--method <method>", "HTTP method (default: get)")
+    .option("--base-url <url>", "Base URL override")
+    .option("--all", "Generate snippets for all endpoints")
+    .action(async (specPath: string, apiPath: string | undefined, options: { target?: string; method?: string; baseUrl?: string; all?: boolean }) => {
+      const globals = getGlobals();
+      const output = createOutput({
+        quiet: globals.quiet,
+        verbose: globals.verbose,
+        color: globals.color !== false,
+        writeStdout: runOptions.stdout,
+        writeStderr: runOptions.stderr,
+      });
+      const result = await runSnippetCommand({
+        specPath,
+        apiPath,
+        target: options.target,
+        method: options.method,
+        baseUrl: options.baseUrl,
+        all: options.all ?? false,
+        cwd: runOptions.cwd,
+        output,
+        writeStdout: runOptions.stdout,
+      });
+      if (result !== 0) exitCode = result;
+    });
+
+  cli
+    .command("validate <specPath>", "Validate OpenAPI document")
+    .option("--format <type>", "Output format: text | json (default: text)")
+    .action(async (specPath: string, options: { format?: string }) => {
+      const globals = getGlobals();
+      const output = createOutput({
+        quiet: globals.quiet,
+        verbose: globals.verbose,
+        color: globals.color !== false,
+        writeStdout: runOptions.stdout,
+        writeStderr: runOptions.stderr,
+      });
+
+      const result = await runValidateCommand({
+        specPath,
+        format: options.format === "json" ? "json" : "text",
+        cwd: runOptions.cwd,
+        output,
+        writeStdout: runOptions.stdout,
+      });
+      if (result !== 0) {
+        exitCode = result;
+      }
+    });
+
+  cli.help();
+  cli.version("0.0.1");
+
+  try {
+    cli.parse(["node", "apifn", ...argv], { run: false });
+    await cli.runMatchedCommand();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const output = createOutput({
+      writeStdout: runOptions.stdout,
+      writeStderr: runOptions.stderr,
+      color: false,
+    });
+    output.error(message);
+    return 1;
+  }
+
+  return exitCode;
+}

--- a/apifn/cli/src/types.ts
+++ b/apifn/cli/src/types.ts
@@ -1,0 +1,1 @@
+export type {};

--- a/apifn/cli/src/utils/output.ts
+++ b/apifn/cli/src/utils/output.ts
@@ -1,0 +1,58 @@
+import pc from "picocolors";
+
+export interface OutputOptions {
+  quiet?: boolean;
+  verbose?: boolean;
+  color?: boolean;
+  writeStdout?: (text: string) => void;
+  writeStderr?: (text: string) => void;
+}
+
+export interface Output {
+  info: (message: string) => void;
+  success: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+  debug: (message: string) => void;
+}
+
+function withColor(enabled: boolean) {
+  return {
+    green: (value: string) => (enabled ? pc.green(value) : value),
+    yellow: (value: string) => (enabled ? pc.yellow(value) : value),
+    red: (value: string) => (enabled ? pc.red(value) : value),
+    cyan: (value: string) => (enabled ? pc.cyan(value) : value),
+  };
+}
+
+export function createOutput(options: OutputOptions = {}): Output {
+  const out = options.writeStdout ?? ((text: string) => process.stdout.write(text));
+  const err = options.writeStderr ?? ((text: string) => process.stderr.write(text));
+  const colors = withColor(options.color ?? true);
+
+  return {
+    info(message) {
+      if (!options.quiet) {
+        out(`${message}\n`);
+      }
+    },
+    success(message) {
+      if (!options.quiet) {
+        out(`${colors.green(message)}\n`);
+      }
+    },
+    warn(message) {
+      if (!options.quiet) {
+        out(`${colors.yellow(message)}\n`);
+      }
+    },
+    error(message) {
+      err(`${colors.red(message)}\n`);
+    },
+    debug(message) {
+      if (!options.quiet && options.verbose) {
+        out(`${colors.cyan(message)}\n`);
+      }
+    },
+  };
+}

--- a/apifn/cli/src/utils/router-loader.ts
+++ b/apifn/cli/src/utils/router-loader.ts
@@ -1,0 +1,31 @@
+import { createJiti } from "jiti";
+import path from "node:path";
+import type { Router } from "@superfunctions/http";
+
+function isRouter(value: unknown): value is Router<unknown> {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as Router<unknown>).getRoutes === "function"
+  );
+}
+
+export async function loadRouter(
+  routerPath: string,
+  cwd = process.cwd()
+): Promise<Router<unknown>> {
+  const resolved = path.isAbsolute(routerPath) ? routerPath : path.resolve(cwd, routerPath);
+  const jiti = createJiti(cwd, { moduleCache: false });
+  const loaded = await jiti.import(resolved) as Record<string, unknown>;
+
+  const candidates = [loaded?.default, loaded?.router, loaded];
+  const router = candidates.find((candidate) => isRouter(candidate));
+
+  if (!router) {
+    throw new Error(
+      `Router export not found in ${resolved}. Expected default export or named export 'router'.`
+    );
+  }
+
+  return router;
+}

--- a/apifn/cli/tsconfig.json
+++ b/apifn/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apifn/cli/tsup.config.ts
+++ b/apifn/cli/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/bin.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/apifn/cli/vitest.config.ts
+++ b/apifn/cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/apifn/collections/__tests__/assertions.test.ts
+++ b/apifn/collections/__tests__/assertions.test.ts
@@ -1,0 +1,123 @@
+import { createAssertionRuntime } from "../src/runner/assertions.js";
+
+describe("assertion runtime", () => {
+  it("TV-ASSERT-001: status code assertions pass and fail", async () => {
+    const runtime = createAssertionRuntime();
+
+    await runtime.test("status is 200", () => {
+      runtime.expect(200).to.equal(200);
+    });
+    await runtime.test("status is 200 (neg)", () => {
+      runtime.expect(404).to.equal(200);
+    });
+
+    expect(runtime.getResults()).toEqual([
+      { name: "status is 200", passed: true },
+      {
+        name: "status is 200 (neg)",
+        passed: false,
+        expected: 200,
+        actual: 404,
+        error: expect.stringContaining("to equal 200"),
+      },
+    ]);
+  });
+
+  it("TV-ASSERT-002: body property and length assertions", async () => {
+    const runtime = createAssertionRuntime();
+    const body = { id: "1", name: "John", items: [1, 2, 3, 4, 5] };
+
+    await runtime.test("json field equality", () => {
+      runtime.expect(body.name).to.equal("John");
+    });
+    await runtime.test("has id property", () => {
+      runtime.expect(body).to.have.property("id");
+    });
+    await runtime.test("items length", () => {
+      runtime.expect(body.items).to.have.length(5);
+    });
+
+    expect(runtime.getResults().every((result) => result.passed)).toBe(true);
+  });
+
+  it("TV-ASSERT-003: header include assertion", async () => {
+    const runtime = createAssertionRuntime();
+
+    await runtime.test("content-type is json", () => {
+      runtime.expect("application/json; charset=utf-8").to.include("application/json");
+    });
+
+    expect(runtime.getResults()).toEqual([{ name: "content-type is json", passed: true }]);
+  });
+
+  it("TV-ASSERT-004: response time below assertion", async () => {
+    const runtime = createAssertionRuntime();
+
+    await runtime.test("response is fast", () => {
+      runtime.expect(120).to.be.below(500);
+    });
+
+    expect(runtime.getResults()).toEqual([{ name: "response is fast", passed: true }]);
+  });
+
+  it("TV-ASSERT-005: JSON path assertions", async () => {
+    const runtime = createAssertionRuntime();
+    const body = { users: [{ name: "Alice" }] };
+
+    await runtime.test("first user is Alice", () => {
+      runtime.expect(body).to.have.jsonPath("$.users[0].name", "Alice");
+    });
+
+    expect(runtime.getResults()).toEqual([{ name: "first user is Alice", passed: true }]);
+  });
+
+  it("TV-ASSERT-006: schema validation assertions include errors", async () => {
+    const runtime = createAssertionRuntime();
+
+    await runtime.test("schema match", () => {
+      runtime.expect({ id: "1", active: true }).to.matchSchema({
+        type: "object",
+        required: ["id", "active"],
+        properties: {
+          id: { type: "string" },
+          active: { type: "boolean" },
+        },
+      });
+    });
+    await runtime.test("schema mismatch", () => {
+      runtime.expect({ id: 1 }).to.matchSchema({
+        type: "object",
+        required: ["id", "active"],
+        properties: {
+          id: { type: "string" },
+          active: { type: "boolean" },
+        },
+      });
+    });
+
+    const results = runtime.getResults();
+    expect(results[0]).toEqual({ name: "schema match", passed: true });
+    expect(results[1]?.passed).toBe(false);
+    expect(results[1]?.error).toContain("Schema validation failed");
+    expect(results[1]?.error).toContain("$.id should be string");
+  });
+
+  it("TV-ASSERT-007: custom assertion function failures are captured", async () => {
+    const runtime = createAssertionRuntime();
+
+    await runtime.test("custom check", () => {
+      const response = { status: 500 };
+      if (response.status >= 400) {
+        throw new Error("status must be < 400");
+      }
+    });
+
+    expect(runtime.getResults()).toEqual([
+      {
+        name: "custom check",
+        passed: false,
+        error: "status must be < 400",
+      },
+    ]);
+  });
+});

--- a/apifn/collections/__tests__/environment.test.ts
+++ b/apifn/collections/__tests__/environment.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readCollection } from "../src/reader.js";
+import {
+  readEnvironmentFile,
+  readEnvironments,
+  selectEnvironment,
+  writeEnvironmentFile,
+} from "../src/environment.js";
+
+describe("environment file handling", () => {
+  it("TV-ENV-001: reads and writes environment file in OpenCollection format", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "apifn-env-"));
+    const filePath = path.join(dir, "development.yml");
+
+    await writeEnvironmentFile(filePath, {
+      name: "development",
+      variables: {
+        baseUrl: "http://localhost:3000",
+      },
+    });
+
+    const parsed = await readEnvironmentFile(filePath);
+    expect(parsed).toEqual({
+      name: "development",
+      variables: {
+        baseUrl: "http://localhost:3000",
+      },
+    });
+  });
+
+  it("TV-ENV-005: supports multiple environments and discovery", async () => {
+    const fixture = await mkdtemp(path.join(tmpdir(), "apifn-env-coll-"));
+    await writeFile(
+      path.join(fixture, "opencollection.yml"),
+      "name: Env Collection\n",
+      "utf8"
+    );
+
+    const usersDir = path.join(fixture, "users");
+    await mkdir(usersDir, { recursive: true });
+    await writeFile(
+      path.join(usersDir, "list-users.yml"),
+      [
+        "info:",
+        "  name: List Users",
+        "  type: http",
+        "http:",
+        "  method: GET",
+        "  url: '{{baseUrl}}/users'",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const envDir = path.join(fixture, "environments");
+    await mkdir(envDir, { recursive: true });
+
+    await writeEnvironmentFile(path.join(envDir, "development.yml"), {
+      name: "development",
+      variables: { baseUrl: "http://localhost:3000" },
+    });
+
+    await writeEnvironmentFile(path.join(envDir, "staging.yml"), {
+      name: "staging",
+      variables: { baseUrl: "https://staging.example.com" },
+    });
+
+    await writeEnvironmentFile(path.join(envDir, "production.yml"), {
+      name: "production",
+      variables: { baseUrl: "https://api.example.com" },
+    });
+
+    const envs = await readEnvironments(envDir);
+    expect(Object.keys(envs).sort()).toEqual(["development", "production", "staging"]);
+
+    const collection = await readCollection(fixture);
+    expect(collection.environments.staging?.variables.baseUrl).toBe(
+      "https://staging.example.com"
+    );
+    expect(selectEnvironment(collection.environments, "production").variables.baseUrl).toBe(
+      "https://api.example.com"
+    );
+  });
+
+  it("rejects array variables and duplicate environment keys", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "apifn-env-"));
+    await writeFile(
+      path.join(dir, "bad.yml"),
+      ["name: bad", "variables:", "  - nope", ""].join("\n"),
+      "utf8"
+    );
+
+    await expect(readEnvironmentFile(path.join(dir, "bad.yml"))).rejects.toThrow(
+      /Environment variables are required/
+    );
+
+    const envDir = await mkdtemp(path.join(tmpdir(), "apifn-env-dupe-"));
+    await writeFile(path.join(envDir, "dev.yml"), "name: dev\nvariables: {}\n", "utf8");
+    await writeFile(path.join(envDir, "dev.yaml"), "name: dev2\nvariables: {}\n", "utf8");
+
+    await expect(readEnvironments(envDir)).rejects.toThrow(/Duplicate environment key 'dev'/);
+  });
+});

--- a/apifn/collections/__tests__/fixtures/bruno-collection/environments/dev.yml
+++ b/apifn/collections/__tests__/fixtures/bruno-collection/environments/dev.yml
@@ -1,0 +1,2 @@
+variables:
+  baseUrl: http://localhost:3000

--- a/apifn/collections/__tests__/fixtures/bruno-collection/opencollection.yml
+++ b/apifn/collections/__tests__/fixtures/bruno-collection/opencollection.yml
@@ -1,0 +1,1 @@
+name: Bruno Sample

--- a/apifn/collections/__tests__/fixtures/bruno-collection/users/folder.yml
+++ b/apifn/collections/__tests__/fixtures/bruno-collection/users/folder.yml
@@ -1,0 +1,1 @@
+name: Users

--- a/apifn/collections/__tests__/fixtures/bruno-collection/users/get-users.yml
+++ b/apifn/collections/__tests__/fixtures/bruno-collection/users/get-users.yml
@@ -1,0 +1,8 @@
+info:
+  name: Get Users
+  type: http
+http:
+  method: GET
+  url: '{{baseUrl}}/users'
+settings:
+  timeout: 5000

--- a/apifn/collections/__tests__/fixtures/test-collection/admin/audits/folder.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/admin/audits/folder.yml
@@ -1,0 +1,2 @@
+name: Audits
+seq: 1

--- a/apifn/collections/__tests__/fixtures/test-collection/admin/audits/list-audits.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/admin/audits/list-audits.yml
@@ -1,0 +1,7 @@
+info:
+  name: List Audits
+  type: http
+  seq: 1
+http:
+  method: GET
+  url: '{{baseUrl}}/admin/audits'

--- a/apifn/collections/__tests__/fixtures/test-collection/admin/folder.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/admin/folder.yml
@@ -1,0 +1,2 @@
+name: Admin
+seq: 2

--- a/apifn/collections/__tests__/fixtures/test-collection/environments/development.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/environments/development.yml
@@ -1,0 +1,4 @@
+name: development
+variables:
+  baseUrl: http://localhost:3000
+  apiVersion: v1

--- a/apifn/collections/__tests__/fixtures/test-collection/opencollection.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/opencollection.yml
@@ -1,0 +1,3 @@
+name: Test Collection
+version: 1.0.0
+description: Fixture collection

--- a/apifn/collections/__tests__/fixtures/test-collection/users/create-user.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/users/create-user.yml
@@ -1,0 +1,10 @@
+info:
+  name: Create User
+  type: http
+  seq: 2
+http:
+  method: POST
+  url: '{{baseUrl}}/users'
+  body:
+    type: json
+    data: '{"name":"test"}'

--- a/apifn/collections/__tests__/fixtures/test-collection/users/folder.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/users/folder.yml
@@ -1,0 +1,2 @@
+name: Users
+seq: 1

--- a/apifn/collections/__tests__/fixtures/test-collection/users/list-users.yml
+++ b/apifn/collections/__tests__/fixtures/test-collection/users/list-users.yml
@@ -1,0 +1,7 @@
+info:
+  name: List Users
+  type: http
+  seq: 1
+http:
+  method: GET
+  url: '{{baseUrl}}/users'

--- a/apifn/collections/__tests__/generator.test.ts
+++ b/apifn/collections/__tests__/generator.test.ts
@@ -1,0 +1,203 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createRouter } from "@superfunctions/http";
+import { fromRouter } from "@apifn/core";
+import { openAPIToCollection, readCollection, routerToCollection, validateCollection, writeCollection } from "../src/index.js";
+
+function flattenRequests(items: Array<{ kind: string; children?: unknown[]; path: string }>): string[] {
+  const result: string[] = [];
+
+  function walk(nodes: Array<{ kind: string; children?: unknown[]; path: string }>): void {
+    for (const node of nodes) {
+      if (node.kind === "request") {
+        result.push(node.path);
+      }
+      if (node.kind === "folder" && Array.isArray(node.children)) {
+        walk(node.children as Array<{ kind: string; children?: unknown[]; path: string }>);
+      }
+    }
+  }
+
+  walk(items);
+  return result.sort((a, b) => a.localeCompare(b));
+}
+
+describe("collection generator", () => {
+  it("TV-COLL-004: generates collection from OpenAPI with grouping, baseUrl, templated params, and request body", async () => {
+    const doc = {
+      openapi: "3.1.0" as const,
+      info: { title: "Generated API", version: "1.0.0" },
+      servers: [{ url: "https://api.example.com" }],
+      paths: {
+        "/users": {
+          get: {
+            tags: ["users"],
+            summary: "List users",
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+          post: {
+            tags: ["users"],
+            summary: "Create user",
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      name: { type: "string" },
+                      age: { type: "number" },
+                    },
+                    required: ["name", "age"],
+                  },
+                },
+              },
+            },
+            responses: {
+              "201": { description: "Created" },
+            },
+          },
+        },
+        "/users/{id}": {
+          get: {
+            tags: ["users"],
+            summary: "Get user",
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+    };
+
+    const collection = openAPIToCollection(doc, { groupBy: "tag" });
+
+    expect(collection.info.name).toBe("Generated API");
+    expect(collection.environments.development.variables.baseUrl).toBe(
+      "https://api.example.com"
+    );
+
+    const usersFolder = collection.items.find((item) => item.kind === "folder" && item.path === "users");
+    expect(usersFolder).toBeDefined();
+    expect(usersFolder?.children).toHaveLength(3);
+
+    const requests = usersFolder?.children ?? [];
+    const getUserById = requests.find((item) => item.path.includes("get-user.yml"));
+    expect(getUserById?.request?.http.url).toBe("{{baseUrl}}/users/{{id}}");
+
+    const createUser = requests.find((item) => item.name === "Create user");
+    expect(createUser?.request?.http.body?.type).toBe("json");
+    expect(createUser?.request?.http.body?.data).toContain("name");
+    expect(flattenRequests(collection.items)).toEqual([
+      "users/create-user.yml",
+      "users/get-user.yml",
+      "users/list-users.yml",
+    ]);
+
+    expect(validateCollection(collection)).toEqual([]);
+
+    const outDir = await mkdtemp(path.join(tmpdir(), "apifn-gen-"));
+    await writeCollection({ ...collection, rootDir: outDir });
+    const reRead = await readCollection(outDir);
+    expect(flattenRequests(reRead.items)).toHaveLength(3);
+  });
+
+  it("supports path-prefix grouping", () => {
+    const doc = {
+      openapi: "3.1.0" as const,
+      info: { title: "Path Group API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: { responses: { "200": { description: "OK" } } },
+        },
+        "/orders": {
+          get: { responses: { "200": { description: "OK" } } },
+        },
+      },
+    };
+
+    const collection = openAPIToCollection(doc, { groupBy: "path" });
+    const folders = collection.items.filter((item) => item.kind === "folder").map((item) => item.path);
+
+    expect(folders).toEqual(["orders", "users"]);
+  });
+
+  it("unwraps named OpenAPI examples when generating request bodies", () => {
+    const doc = {
+      openapi: "3.1.0" as const,
+      info: { title: "Example API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          post: {
+            tags: ["users"],
+            summary: "Create user",
+            requestBody: {
+              content: {
+                "application/json": {
+                  examples: {
+                    named: {
+                      summary: "Named example",
+                      value: { name: "Alice" },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      },
+    };
+
+    const collection = openAPIToCollection(doc, { groupBy: "tag" });
+    const folder = collection.items.find((item) => item.kind === "folder" && item.path === "users");
+    const request = folder?.children?.find((item) => item.kind === "request");
+
+    expect(request?.request?.http.body?.data).toBe(JSON.stringify({ name: "Alice" }, null, 2));
+    expect(request?.request?.http.body?.data).not.toContain("\"value\"");
+  });
+
+  it("TV-COLL-005: routerToCollection matches fromRouter + openAPIToCollection", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/api/users/:id",
+          handler: async () => Response.json({ id: "1" }),
+          meta: {
+            tags: ["users"],
+            summary: "Get user",
+            responses: {
+              200: { description: "OK" },
+            },
+          },
+        },
+      ],
+    });
+
+    const opts = {
+      info: { title: "Router API", version: "1.0.0" },
+      include: ["/api"],
+      groupBy: "tag" as const,
+      baseUrl: "https://api.example.com",
+    };
+
+    const generated = routerToCollection(router, opts);
+    const manual = openAPIToCollection(
+      fromRouter(router, {
+        info: opts.info,
+        include: opts.include,
+      }),
+      {
+        groupBy: opts.groupBy,
+        baseUrl: opts.baseUrl,
+      }
+    );
+
+    expect(generated).toEqual(manual);
+    expect(validateCollection(generated)).toEqual([]);
+  });
+});

--- a/apifn/collections/__tests__/http-client.test.ts
+++ b/apifn/collections/__tests__/http-client.test.ts
@@ -1,0 +1,204 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createCookieJar, createFetchHttpClient } from "../src/index.js";
+
+async function startServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void
+): Promise<{ baseUrl: string; close(): Promise<void> }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("server did not bind to a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve())
+    ),
+  };
+}
+
+describe("fetch HTTP client", () => {
+  it("persists cookies across requests", async () => {
+    const server = await startServer((req, res) => {
+      if (req.url === "/login") {
+        res.writeHead(200, {
+          "set-cookie": ["session=abc; Path=/; HttpOnly"],
+          "content-type": "application/json",
+        });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
+      res.writeHead(req.headers.cookie === "session=abc" ? 200 : 401);
+      res.end(req.headers.cookie ?? "");
+    });
+
+    try {
+      const client = createFetchHttpClient({ cookieJar: createCookieJar() });
+      await client.send({
+        method: "POST",
+        url: `${server.baseUrl}/login`,
+        headers: {},
+      });
+      const session = await client.send({
+        method: "GET",
+        url: `${server.baseUrl}/session`,
+        headers: {},
+      });
+
+      expect(session.status).toBe(200);
+      expect(session.body).toBe("session=abc");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("ignores cookies for unrelated domains", async () => {
+    const jar = createCookieJar();
+
+    jar.storeFromResponse("http://api.example.com/login", [
+      "session=bad; Domain=evil.example.com; Path=/",
+      "local=ok; Domain=.example.com; Path=/",
+    ]);
+
+    expect(jar.get("session", "http://evil.example.com/")).toBeUndefined();
+    expect(jar.get("local", "http://api.example.com/")).toBe("ok");
+  });
+
+  it("follows redirects and records redirect chain", async () => {
+    const server = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.writeHead(302, { location: "/finish" });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("done");
+    });
+
+    try {
+      const client = createFetchHttpClient();
+      const result = await client.send({
+        method: "GET",
+        url: `${server.baseUrl}/start`,
+        headers: {},
+        followRedirects: true,
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.body).toBe("done");
+      expect(result.redirects).toEqual([
+        expect.objectContaining({
+          status: 302,
+          url: `${server.baseUrl}/start`,
+          location: `${server.baseUrl}/finish`,
+        }),
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("keeps sensitive headers on same-origin redirects", async () => {
+    const seen: Array<Record<string, string | string[] | undefined>> = [];
+    const server = await startServer((req, res) => {
+      seen.push(req.headers);
+      if (req.url === "/start") {
+        res.writeHead(302, { location: "/finish" });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("done");
+    });
+
+    try {
+      const client = createFetchHttpClient();
+      const result = await client.send({
+        method: "GET",
+        url: `${server.baseUrl}/start`,
+        headers: {
+          authorization: "Bearer secret",
+          cookie: "session=abc",
+          "x-api-key": "api-secret",
+          "x-trace-id": "trace-1",
+        },
+        followRedirects: true,
+      });
+
+      expect(result.status).toBe(200);
+      expect(seen[1]).toEqual(expect.objectContaining({
+        authorization: "Bearer secret",
+        cookie: "session=abc",
+        "x-api-key": "api-secret",
+        "x-trace-id": "trace-1",
+      }));
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("strips sensitive headers on cross-origin redirects", async () => {
+    const seen: Array<Record<string, string | string[] | undefined>> = [];
+    const first = await startServer((_req, res) => {
+      res.writeHead(302, { location: `${second.baseUrl}/finish` });
+      res.end();
+    });
+    const second = await startServer((req, res) => {
+      seen.push(req.headers);
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("done");
+    });
+
+    try {
+      const client = createFetchHttpClient();
+      const result = await client.send({
+        method: "GET",
+        url: `${first.baseUrl}/start`,
+        headers: {
+          authorization: "Bearer secret",
+          cookie: "session=abc",
+          "proxy-authorization": "Basic secret",
+          "x-api-key": "api-secret",
+          "x-auth-token": "token-secret",
+          "x-trace-id": "trace-1",
+        },
+        followRedirects: true,
+      });
+
+      expect(result.status).toBe(200);
+      expect(seen[0]).toEqual(expect.objectContaining({
+        "x-trace-id": "trace-1",
+      }));
+      expect(seen[0]?.authorization).toBeUndefined();
+      expect(seen[0]?.cookie).toBeUndefined();
+      expect(seen[0]?.["proxy-authorization"]).toBeUndefined();
+      expect(seen[0]?.["x-api-key"]).toBeUndefined();
+      expect(seen[0]?.["x-auth-token"]).toBeUndefined();
+    } finally {
+      await first.close();
+      await second.close();
+    }
+  });
+
+  it("fails when max redirects is exceeded", async () => {
+    const server = await startServer((_req, res) => {
+      res.writeHead(302, { location: "/loop" });
+      res.end();
+    });
+
+    try {
+      const client = createFetchHttpClient();
+      await expect(client.send({
+        method: "GET",
+        url: `${server.baseUrl}/loop`,
+        headers: {},
+        followRedirects: true,
+        maxRedirects: 1,
+      })).rejects.toThrow("Maximum redirects exceeded");
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/apifn/collections/__tests__/reader.test.ts
+++ b/apifn/collections/__tests__/reader.test.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import { readCollection } from "../src/reader.js";
+
+describe("readCollection", () => {
+  it("TV-COLL-001: reads OpenCollection fixture with folders, requests, and environments", async () => {
+    const fixture = path.resolve(
+      __dirname,
+      "fixtures/test-collection"
+    );
+
+    const collection = await readCollection(fixture);
+
+    expect(collection.info.name).toBe("Test Collection");
+    expect(collection.environments.development).toEqual({
+      name: "development",
+      variables: {
+        baseUrl: "http://localhost:3000",
+        apiVersion: "v1",
+      },
+    });
+
+    expect(collection.items[0]?.kind).toBe("folder");
+    expect(collection.items[0]?.name).toBe("Users");
+    expect(collection.items[0]?.children?.map((x) => x.name)).toEqual([
+      "List Users",
+      "Create User",
+    ]);
+
+    expect(collection.items[1]?.name).toBe("Admin");
+    expect(collection.items[1]?.children?.[0]?.name).toBe("Audits");
+    expect(collection.items[1]?.children?.[0]?.children?.[0]?.name).toBe("List Audits");
+  });
+
+  it("COLL-001 NEG: missing opencollection.yml throws descriptive error", async () => {
+    const missing = path.resolve(__dirname, "fixtures/does-not-exist");
+    await expect(readCollection(missing)).rejects.toThrow(
+      /No opencollection\.yml found/i
+    );
+  });
+
+  it("TV-COLL-006: reads Bruno-compatible fixture", async () => {
+    const fixture = path.resolve(__dirname, "fixtures/bruno-collection");
+    const collection = await readCollection(fixture);
+
+    expect(collection.info.name).toBe("Bruno Sample");
+    expect(collection.items[0]?.name).toBe("Users");
+    expect(collection.items[0]?.children?.[0]?.request?.http.method).toBe("GET");
+  });
+});

--- a/apifn/collections/__tests__/runner.test.ts
+++ b/apifn/collections/__tests__/runner.test.ts
@@ -1,0 +1,497 @@
+import { createCookieJar, runCollection } from "../src/index.js";
+import type { Collection, HttpClient, HttpClientRequest, HttpClientResponse, RunReporter } from "../src/types.js";
+
+function makeCollection(): Collection {
+  return {
+    info: { name: "Runner Test", type: "collection" },
+    rootDir: "/tmp",
+    environments: {
+      development: {
+        name: "development",
+        variables: {
+          baseUrl: "http://localhost:3000",
+          apiVersion: "v1",
+          apiKey: "env-key",
+        },
+      },
+    },
+    items: [
+      {
+        kind: "folder",
+        name: "Root",
+        path: "root",
+        children: [
+          {
+            kind: "request",
+            name: "First",
+            path: "root/first.yml",
+            seq: 1,
+            request: {
+              info: { name: "First", type: "http", seq: 1 },
+              http: { method: "GET", url: "{{baseUrl}}/{{apiVersion}}/first" },
+            },
+          },
+          {
+            kind: "request",
+            name: "Second",
+            path: "root/second.yml",
+            seq: 2,
+            request: {
+              info: { name: "Second", type: "http", seq: 2 },
+              http: {
+                method: "GET",
+                url: "{{baseUrl}}/second",
+                headers: [{ name: "Authorization", value: "Bearer {{apiKey}}" }],
+              },
+            },
+          },
+          {
+            kind: "request",
+            name: "Third",
+            path: "root/third.yml",
+            seq: 3,
+            request: {
+              info: { name: "Third", type: "http", seq: 3 },
+              http: { method: "GET", url: "{{baseUrl}}/third" },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function response(status = 200, body = "{}", duration = 1): HttpClientResponse {
+  return {
+    status,
+    headers: { "content-type": "application/json" },
+    body,
+    size: Buffer.byteLength(body, "utf8"),
+    duration,
+  };
+}
+
+describe("runCollection", () => {
+  it("TV-RUN-001: executes sequentially in seq order", async () => {
+    const collection = makeCollection();
+    const calls: string[] = [];
+
+    const httpClient: HttpClient = {
+      async send(request) {
+        calls.push(request.url);
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      httpClient,
+    });
+
+    expect(calls).toEqual([
+      "http://localhost:3000/v1/first",
+      "http://localhost:3000/second",
+      "http://localhost:3000/third",
+    ]);
+    expect(report.summary.total).toBe(3);
+    expect(report.summary.passed).toBe(3);
+  });
+
+  it("RUN-002: executes in parallel with concurrency", async () => {
+    const collection = makeCollection();
+    let active = 0;
+    let maxActive = 0;
+
+    const httpClient: HttpClient = {
+      async send() {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        active -= 1;
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      parallel: true,
+      concurrency: 2,
+      httpClient,
+    });
+
+    expect(report.summary.passed).toBe(3);
+    expect(maxActive).toBeGreaterThan(1);
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it("parallel mode isolates script-mutated variables per request", async () => {
+    const collection = makeCollection();
+    collection.environments.development.variables.token = "env-token";
+    const first = collection.items[0]!.children![0]!;
+    const second = collection.items[0]!.children![1]!;
+    first.request!.http.url = "{{baseUrl}}/first";
+    second.request!.http.url = "{{baseUrl}}/{{token}}/second";
+    first.request!.runtime = {
+      scripts: [{ type: "pre-request", code: 'env.set("token", "first-token");' }],
+    };
+    second.request!.runtime = {
+      scripts: [{ type: "pre-request", code: 'env.set("token", "second-token");' }],
+    };
+    collection.items[0]!.children = [first, second];
+
+    const calls: string[] = [];
+    const httpClient: HttpClient = {
+      async send(request) {
+        calls.push(request.url);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      parallel: true,
+      concurrency: 1,
+      httpClient,
+    });
+
+    expect(report.summary.passed).toBe(2);
+    expect(calls).toEqual([
+      "http://localhost:3000/first",
+      "http://localhost:3000/env-token/second",
+    ]);
+  });
+
+  it("RUN-003 + TV-RUN-003 + TV-RUN-004: resolves variables with precedence and warnings", async () => {
+    const collection = makeCollection();
+    collection.items[0]!.children![0]!.request!.http.url = "{{baseUrl}}/{{missing}}/first";
+
+    const captured: HttpClientRequest[] = [];
+    const httpClient: HttpClient = {
+      async send(request) {
+        captured.push(request);
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      overrides: { baseUrl: "http://override:3000", apiKey: "override-key" },
+      httpClient,
+    });
+
+    expect(captured[0]?.url).toBe("http://override:3000/{{missing}}/first");
+    expect(captured[1]?.headers.Authorization).toBe("Bearer override-key");
+    expect(report.results[0]?.warnings).toContain("Unresolved variable: missing");
+  });
+
+  it("RUN-004 + RUN-005 + TV-RUN-005: runs pre-request and test scripts", async () => {
+    const collection = makeCollection();
+    const first = collection.items[0]!.children![0]!;
+    first.request!.http.url = "{{baseUrl}}/dynamic";
+    first.request!.runtime = {
+      scripts: [
+        {
+          type: "pre-request",
+          code: `
+            req.url = req.url + "?mode=scripted";
+            req.headers["x-runtime"] = "yes";
+            env.token = "runtime-token";
+          `,
+        },
+        {
+          type: "tests",
+          code: `
+            test("should return 200", function() {
+              expect(res.status).to.equal(200);
+            });
+            test("should have items", function() {
+              expect(res.body.items).to.have.length.above(0);
+            });
+          `,
+        },
+      ],
+    };
+    collection.items[0]!.children = [first];
+
+    const calls: HttpClientRequest[] = [];
+    const httpClient: HttpClient = {
+      async send(request) {
+        calls.push(request);
+        return response(200, JSON.stringify({ items: [{ id: "1" }] }), 20);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      httpClient,
+      bail: true,
+    });
+
+    expect(calls[0]?.url).toContain("mode=scripted");
+    expect(calls[0]?.headers["x-runtime"]).toBe("yes");
+    expect(report.results[0]?.assertions).toEqual([
+      { name: "should return 200", passed: true },
+      { name: "should have items", passed: true },
+    ]);
+  });
+
+  it("caps captured response bodies by UTF-8 byte length", async () => {
+    const collection = makeCollection();
+    collection.items[0]!.children = [collection.items[0]!.children![0]!];
+    const maxCapturedBodyBytes = 10 * 1024 * 1024;
+    const body = "界".repeat(Math.ceil(maxCapturedBodyBytes / 3) + 10);
+
+    const httpClient: HttpClient = {
+      async send() {
+        return response(200, body);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      httpClient,
+    });
+
+    const capturedBody = report.results[0]?.response?.body ?? "";
+    expect(Buffer.byteLength(capturedBody, "utf8")).toBeLessThanOrEqual(maxCapturedBodyBytes);
+    expect(capturedBody).not.toContain("\uFFFD");
+  });
+
+  it("RUN-006: bail stops after first failed request and skips remaining", async () => {
+    const collection = makeCollection();
+
+    const httpClient: HttpClient = {
+      async send(request) {
+        if (request.url.includes("first")) {
+          return response(500, "boom");
+        }
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      bail: true,
+      httpClient,
+    });
+
+    expect(report.results[0]?.status).toBe("failed");
+    expect(report.results[1]?.status).toBe("skipped");
+    expect(report.results[2]?.status).toBe("skipped");
+    expect(report.summary.skipped).toBe(2);
+  });
+
+  it("TV-RUN-007: enforces timeout", async () => {
+    const collection = makeCollection();
+
+    const httpClient: HttpClient = {
+      async send() {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      timeout: 50,
+      httpClient,
+      bail: true,
+    });
+
+    expect(report.results[0]?.status).toBe("error");
+    expect(report.results[0]?.error).toContain("Request timed out after 50ms");
+  });
+
+  it("RUN-008: retries failed requests and records attempts", async () => {
+    const collection = makeCollection();
+    let attemptCount = 0;
+
+    const httpClient: HttpClient = {
+      async send() {
+        attemptCount += 1;
+        if (attemptCount < 3) {
+          throw new Error("Transient error");
+        }
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      retries: 2,
+      httpClient,
+      bail: true,
+    });
+
+    expect(report.results[0]?.status).toBe("passed");
+    expect(report.results[0]?.attempts).toHaveLength(3);
+  });
+
+  it("RUN-010 + RUN-011: report shape and request/response capture with redaction/truncation", async () => {
+    const collection = makeCollection();
+    const largeBody = "x".repeat(11 * 1024 * 1024);
+
+    const httpClient: HttpClient = {
+      async send() {
+        return response(200, largeBody);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      httpClient,
+      bail: true,
+      redactHeaders: ["authorization"],
+    });
+
+    const first = report.results[0]!;
+    expect(report.id).toBeTruthy();
+    expect(report.collectionName).toBe("Runner Test");
+    expect(report.summary.total).toBe(3);
+    expect(first.request.method).toBe("GET");
+    expect(first.response?.status).toBe(200);
+
+    const second = report.results[1]!;
+    expect(second.request.headers.Authorization).toBe("[REDACTED]");
+    expect(first.response?.body.length).toBeLessThanOrEqual(10 * 1024 * 1024);
+  });
+
+  it("RUN-009: reporter callbacks are emitted", async () => {
+    const collection = makeCollection();
+    const events: string[] = [];
+
+    const reporter: RunReporter = {
+      onStart() {
+        events.push("start");
+      },
+      onRequestStart(item) {
+        events.push(`request-start:${item.name}`);
+      },
+      onRequestComplete(result) {
+        events.push(`request-complete:${result.name}`);
+      },
+      onComplete() {
+        events.push("complete");
+      },
+    };
+
+    const httpClient: HttpClient = {
+      async send() {
+        return response(200);
+      },
+    };
+
+    await runCollection(collection, {
+      environment: "development",
+      reporter,
+      httpClient,
+    });
+
+    expect(events[0]).toBe("start");
+    expect(events).toContain("request-start:First");
+    expect(events).toContain("request-complete:Third");
+    expect(events[events.length - 1]).toBe("complete");
+  });
+
+  it("supports include/exclude filters and marks non-matching requests skipped", async () => {
+    const collection = makeCollection();
+    const calls: string[] = [];
+    const httpClient: HttpClient = {
+      async send(request) {
+        calls.push(request.url);
+        return response(200);
+      },
+    };
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      include: ["*second*"],
+      exclude: ["*third*"],
+      httpClient,
+    });
+
+    expect(calls).toEqual(["http://localhost:3000/second"]);
+    expect(report.summary.passed).toBe(1);
+    expect(report.summary.skipped).toBe(2);
+  });
+
+  it("applies sequential delay between requests", async () => {
+    const collection = makeCollection();
+    const started = Date.now();
+
+    await runCollection(collection, {
+      environment: "development",
+      delay: 20,
+      httpClient: {
+        async send() {
+          return response(200);
+        },
+      },
+    });
+
+    expect(Date.now() - started).toBeGreaterThanOrEqual(35);
+  });
+
+  it("redacts sensitive request and response bodies", async () => {
+    const collection = makeCollection();
+    const first = collection.items[0]!.children![0]!;
+    first.request!.http.method = "POST";
+    first.request!.http.body = {
+      type: "json",
+      data: JSON.stringify({ email: "person@example.com", password: "secret", token: "tok" }),
+    };
+    collection.items[0]!.children = [first];
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      httpClient: {
+        async send() {
+          return response(200, JSON.stringify({ token: "secret-token", ok: true }));
+        },
+      },
+    });
+
+    expect(report.results[0]?.request.body).toContain("[REDACTED]");
+    expect(report.results[0]?.request.body).not.toContain("secret");
+    expect(report.results[0]?.response?.body).not.toContain("secret-token");
+  });
+
+  it("passes cookie jar helpers into scripts", async () => {
+    const collection = makeCollection();
+    const first = collection.items[0]!.children![0]!;
+    first.request!.runtime = {
+      scripts: [
+        {
+          type: "pre-request",
+          code: `
+            cookies.set("session", "abc", req.url);
+            req.headers.cookie = "session=" + cookies.get("session", req.url);
+          `,
+        },
+        {
+          type: "tests",
+          code: `
+            test("cookie helper is available", function() {
+              expect(cookies.get("session", req.url)).to.equal("abc");
+            });
+          `,
+        },
+      ],
+    };
+    collection.items[0]!.children = [first];
+
+    const report = await runCollection(collection, {
+      environment: "development",
+      cookieJar: createCookieJar(),
+      httpClient: {
+        async send(request) {
+          expect(request.headers.cookie).toBe("session=abc");
+          return response(200);
+        },
+      },
+    });
+
+    expect(report.summary.passed).toBe(1);
+  });
+});

--- a/apifn/collections/__tests__/script-sandbox.test.ts
+++ b/apifn/collections/__tests__/script-sandbox.test.ts
@@ -1,0 +1,183 @@
+import {
+  executePreRequestScript,
+  executeTestScript,
+} from "../src/runner/script-sandbox.js";
+import type { AssertionResult } from "../src/types.js";
+
+describe("script sandbox", () => {
+  it("RUN-004: pre-request scripts can mutate req and env", async () => {
+    const req = {
+      method: "GET",
+      url: "http://localhost:3000/users",
+      headers: { "x-token": "old" },
+      body: "{\"ok\":true}",
+    };
+    const env = {
+      token: "abc123",
+    };
+
+    const result = await executePreRequestScript({
+      code: `
+        req.url = req.url + "?source=test";
+        req.headers["authorization"] = "Bearer " + env.token;
+        env.requestId = "req-1";
+      `,
+      req,
+      env,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(req.url).toContain("source=test");
+    expect(req.headers.authorization).toBe("Bearer abc123");
+    expect(env.requestId).toBe("req-1");
+  });
+
+  it("RUN-004: pre-request script error aborts with error result", async () => {
+    const result = await executePreRequestScript({
+      code: "throw new Error('bad script');",
+      req: {
+        method: "GET",
+        url: "http://localhost:3000/users",
+        headers: {},
+      },
+      env: {},
+    });
+
+    expect(result.error?.message).toContain("Pre-request script failed");
+    expect(result.error?.message).toContain("bad script");
+  });
+
+  it("enforces timeouts for awaited async scripts", async () => {
+    const result = await executePreRequestScript({
+      code: "await new Promise(() => {});",
+      req: {
+        method: "GET",
+        url: "http://localhost:3000/users",
+        headers: {},
+      },
+      env: {},
+      timeoutMs: 20,
+    });
+
+    expect(result.error?.message).toContain("Script execution timed out after 20ms");
+  });
+
+  it("TV-RUN-005: test script executes and records assertion results", async () => {
+    const assertions: AssertionResult[] = [];
+    const result = await executeTestScript({
+      code: `
+        test("should return 200", function() {
+          expect(res.status).to.equal(200);
+        });
+        test("should have items", function() {
+          expect(res.body.items).to.have.length.above(0);
+        });
+      `,
+      req: {
+        method: "GET",
+        url: "http://localhost:3000/items",
+        headers: {},
+      },
+      res: {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: { items: [{ id: "1" }] },
+        responseTime: 40,
+      },
+      env: {},
+      assertionResults: assertions,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(assertions).toHaveLength(2);
+    expect(assertions[0]).toEqual({ name: "should return 200", passed: true });
+    expect(assertions[1]).toEqual({ name: "should have items", passed: true });
+  });
+
+  it("TV-RUN-005 negative: failed assertion is recorded", async () => {
+    const assertions: AssertionResult[] = [];
+    await executeTestScript({
+      code: `
+        test("should return 200", function() {
+          expect(res.status).to.equal(200);
+        });
+      `,
+      req: {
+        method: "GET",
+        url: "http://localhost:3000/items",
+        headers: {},
+      },
+      res: {
+        status: 404,
+        headers: { "content-type": "application/json" },
+        body: {},
+        responseTime: 50,
+      },
+      env: {},
+      assertionResults: assertions,
+    });
+
+    expect(assertions).toHaveLength(1);
+    expect(assertions[0]).toEqual({
+      name: "should return 200",
+      passed: false,
+      expected: 200,
+      actual: 404,
+      error: expect.stringContaining("to equal 200"),
+    });
+  });
+
+  it("sandbox blocks require('fs')", async () => {
+    const assertions: AssertionResult[] = [];
+    const result = await executeTestScript({
+      code: "require('fs').readFileSync('/etc/passwd')",
+      req: {
+        method: "GET",
+        url: "http://localhost:3000/items",
+        headers: {},
+      },
+      res: {
+        status: 200,
+        headers: {},
+        body: {},
+        responseTime: 10,
+      },
+      env: {},
+      assertionResults: assertions,
+    });
+
+    expect(result.error?.message).toContain("Test script failed");
+    expect(assertions[0]?.passed).toBe(false);
+  });
+
+  it("exposes safe utility globals and response.json helper", async () => {
+    const assertions: AssertionResult[] = [];
+    await executeTestScript({
+      code: `
+        const url = new URL("http://localhost/items?mode=test");
+        const id = crypto.randomUUID();
+        test("safe globals work", function() {
+          expect(url.searchParams.get("mode")).to.equal("test");
+          expect(Boolean(id)).to.equal(true);
+          expect(atob(btoa("hello"))).to.equal("hello");
+          expect(res.json().ok).to.equal(true);
+        });
+      `,
+      req: {
+        method: "GET",
+        url: "http://localhost:3000/items",
+        headers: {},
+      },
+      res: {
+        status: 200,
+        headers: {},
+        body: { ok: true },
+        responseTime: 10,
+      },
+      env: {},
+      assertionResults: assertions,
+    });
+
+    expect(assertions[0]?.passed).toBe(true);
+  });
+});

--- a/apifn/collections/__tests__/variables.test.ts
+++ b/apifn/collections/__tests__/variables.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  interpolateVariables,
+  loadDotEnvFile,
+  resolveVariableContext,
+} from "../src/variables.js";
+
+describe("variable interpolation", () => {
+  it("TV-ENV-002: interpolates variables in templates and warns unresolved", () => {
+    const context = {
+      baseUrl: "http://localhost:3000",
+      apiVersion: "v1",
+    };
+
+    const resolved = interpolateVariables("{{baseUrl}}/{{apiVersion}}/users", context);
+    expect(resolved.value).toBe("http://localhost:3000/v1/users");
+
+    const unresolved = interpolateVariables("{{baseUrl}}/{{missing}}", context);
+    expect(unresolved.value).toBe("http://localhost:3000/{{missing}}");
+    expect(unresolved.warnings).toEqual(["Unresolved variable: missing"]);
+  });
+
+  it("TV-ENV-003: resolves process.env secrets and errors for missing vars", () => {
+    const resolved = interpolateVariables(
+      "Bearer {{process.env.API_KEY}}",
+      {},
+      {
+        processEnv: { API_KEY: "sk-test-123" },
+      }
+    );
+
+    expect(resolved.value).toBe("Bearer sk-test-123");
+
+    expect(() =>
+      interpolateVariables("{{process.env.MISSING_VAR}}", {}, { processEnv: {} })
+    ).toThrow(/Environment variable MISSING_VAR is not set/);
+  });
+
+  it("TV-ENV-004: applies precedence overrides > env > collection without implicit process.env seeding", () => {
+    const context = resolveVariableContext({
+      overrides: { baseUrl: "http://override:3000" },
+      environment: { baseUrl: "http://env:3000", apiKey: "env-key" },
+      collection: { apiKey: "coll-key", timeout: "5000" },
+      processEnv: { baseUrl: "http://proc:3000", timeout: "1000" },
+    });
+
+    expect(context.baseUrl).toBe("http://override:3000");
+    expect(context.apiKey).toBe("env-key");
+    expect(context.timeout).toBe("5000");
+    expect(context).not.toHaveProperty("baseUrl", "http://proc:3000");
+  });
+
+  it("ENV-003: supports loading .env file", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "apifn-dotenv-"));
+    const envPath = path.join(dir, ".env");
+    await writeFile(envPath, "API_KEY=dotenv-secret\nBASE_URL=http://dotenv.local\n", "utf8");
+
+    const parsed = loadDotEnvFile(envPath);
+    expect(parsed).toEqual({
+      API_KEY: "dotenv-secret",
+      BASE_URL: "http://dotenv.local",
+    });
+  });
+});

--- a/apifn/collections/__tests__/writer.test.ts
+++ b/apifn/collections/__tests__/writer.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readCollection } from "../src/reader.js";
+import { validateCollection } from "../src/validator.js";
+import { writeCollection } from "../src/writer.js";
+
+describe("writeCollection + validateCollection", () => {
+  it("TV-COLL-002: round-trip write then read preserves structure", async () => {
+    const fixture = path.resolve(__dirname, "fixtures/test-collection");
+    const source = await readCollection(fixture);
+
+    const outDir = await mkdtemp(path.join(tmpdir(), "apifn-collection-"));
+    const toWrite = { ...source, rootDir: outDir };
+
+    await writeCollection(toWrite);
+    const roundTripped = await readCollection(outDir);
+
+    expect(roundTripped.info).toEqual(source.info);
+    expect(roundTripped.environments).toEqual(source.environments);
+    expect(roundTripped.items).toEqual(source.items);
+  });
+
+  it("TV-COLL-003: valid collection returns empty validation errors", async () => {
+    const fixture = path.resolve(__dirname, "fixtures/test-collection");
+    const collection = await readCollection(fixture);
+
+    expect(validateCollection(collection)).toEqual([]);
+  });
+
+  it("TV-COLL-003: invalid request/env produce validation errors with paths", async () => {
+    const fixture = path.resolve(__dirname, "fixtures/test-collection");
+    const collection = await readCollection(fixture);
+
+    collection.environments.development = {
+      name: "development",
+      variables: undefined as unknown as Record<string, string>,
+    };
+
+    const usersFolder = collection.items.find((item) => item.name === "Users");
+    if (!usersFolder || usersFolder.kind !== "folder" || !usersFolder.children?.[0]) {
+      throw new Error("Fixture structure mismatch");
+    }
+
+    usersFolder.children[0].request = {
+      ...usersFolder.children[0].request!,
+      http: {
+        ...usersFolder.children[0].request!.http,
+        method: "",
+      },
+    };
+
+    const errors = validateCollection(collection);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((error) => error.path.includes("request.http.method"))).toBe(true);
+    expect(errors.some((error) => error.path.includes("environments.development.variables"))).toBe(
+      true
+    );
+  });
+
+  it("rejects request and folder paths that escape the collection root", async () => {
+    const fixture = path.resolve(__dirname, "fixtures/test-collection");
+    const source = await readCollection(fixture);
+    const outDir = await mkdtemp(path.join(tmpdir(), "apifn-collection-"));
+
+    await expect(
+      writeCollection({
+        ...source,
+        rootDir: outDir,
+        items: [
+          {
+            kind: "request",
+            name: "escape",
+            path: "../escape.yml",
+            request: source.items[0]!.children![0]!.request,
+          },
+        ],
+      })
+    ).rejects.toThrow(/unsafe path segment|relative path/);
+  });
+
+  it("rejects environment names that are unsafe path segments", async () => {
+    const fixture = path.resolve(__dirname, "fixtures/test-collection");
+    const source = await readCollection(fixture);
+    const outDir = await mkdtemp(path.join(tmpdir(), "apifn-collection-"));
+
+    await expect(
+      writeCollection({
+        ...source,
+        rootDir: outDir,
+        environments: {
+          "../secrets": {
+            name: "escape",
+            variables: {},
+          },
+        },
+      })
+    ).rejects.toThrow(/Environment name contains unsafe characters/);
+  });
+
+  it("returns validation errors for malformed environments and item lists", () => {
+    const collection = {
+      info: { name: "Broken", type: "collection" },
+      rootDir: "/tmp",
+      environments: [] as unknown,
+      items: {} as unknown,
+    } as Parameters<typeof validateCollection>[0];
+
+    const errors = validateCollection(collection);
+    expect(errors.some((error) => error.path === "environments")).toBe(true);
+    expect(errors.some((error) => error.path === "items")).toBe(true);
+  });
+});

--- a/apifn/collections/package.json
+++ b/apifn/collections/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@apifn/collections",
+  "version": "0.0.1",
+  "description": "OpenCollection YAML read/write/run for ApiFn",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@apifn/core": "0.0.1",
+    "dotenv": "^16.6.1",
+    "glob": "^11.0.3",
+    "yaml": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/collections"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/apifn/collections/src/environment.ts
+++ b/apifn/collections/src/environment.ts
@@ -1,0 +1,90 @@
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parse as parseYaml, stringify as toYaml } from "yaml";
+import type { Environment } from "./types.js";
+
+function isYaml(fileName: string): boolean {
+  return fileName.endsWith(".yml") || fileName.endsWith(".yaml");
+}
+
+export async function readEnvironmentFile(filePath: string): Promise<Environment> {
+  const raw = await readFile(filePath, "utf8");
+  const parsed = parseYaml(raw) as Record<string, unknown> | null;
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`Invalid environment YAML in ${filePath}`);
+  }
+
+  const fileName = path.basename(filePath, path.extname(filePath));
+  const name = typeof parsed.name === "string" ? parsed.name : fileName;
+  const variables = parsed.variables;
+
+  if (!variables || typeof variables !== "object" || Array.isArray(variables)) {
+    throw new Error(`Environment variables are required in ${filePath}`);
+  }
+
+  return {
+    name,
+    variables: Object.fromEntries(
+      Object.entries(variables as Record<string, unknown>).map(([key, value]) => [
+        key,
+        String(value),
+      ])
+    ),
+  };
+}
+
+export async function writeEnvironmentFile(
+  filePath: string,
+  environment: Environment
+): Promise<void> {
+  const payload = {
+    name: environment.name,
+    variables: environment.variables,
+  };
+
+  await writeFile(filePath, toYaml(payload), "utf8");
+}
+
+export async function readEnvironments(envDir: string): Promise<Record<string, Environment>> {
+  const entries = await readdir(envDir, { withFileTypes: true });
+  const result: Record<string, Environment> = {};
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !isYaml(entry.name)) {
+      continue;
+    }
+
+    const filePath = path.join(envDir, entry.name);
+    const environment = await readEnvironmentFile(filePath);
+    const key = path.basename(entry.name, path.extname(entry.name));
+    if (result[key]) {
+      throw new Error(`Duplicate environment key '${key}' in ${envDir}`);
+    }
+    result[key] = environment;
+  }
+
+  return result;
+}
+
+export async function writeEnvironments(
+  envDir: string,
+  environments: Record<string, Environment>
+): Promise<void> {
+  for (const [name, environment] of Object.entries(environments)) {
+    const filePath = path.join(envDir, `${name}.yml`);
+    await writeEnvironmentFile(filePath, environment);
+  }
+}
+
+export function selectEnvironment(
+  environments: Record<string, Environment>,
+  name: string
+): Environment {
+  const environment = environments[name];
+  if (!environment) {
+    throw new Error(`Environment '${name}' not found`);
+  }
+
+  return environment;
+}

--- a/apifn/collections/src/generator.ts
+++ b/apifn/collections/src/generator.ts
@@ -1,0 +1,311 @@
+import { fromRouter, type OpenAPIDocument, type Router } from "@apifn/core";
+import type {
+  Collection,
+  CollectionGenerateOptions,
+  CollectionItem,
+  OpenCollectionRequest,
+  RouterCollectionOptions,
+} from "./types.js";
+
+const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+] as const;
+
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+interface OperationRecord {
+  path: string;
+  method: HttpMethod;
+  operation: NonNullable<OpenAPIDocument["paths"][string][HttpMethod]>;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+function toTitle(value: string): string {
+  return value
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+    .trim();
+}
+
+function pathToTemplate(pathname: string): string {
+  return pathname.replace(/\{([^}]+)\}/g, "{{$1}}");
+}
+
+function defaultFromSchema(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") {
+    return undefined;
+  }
+
+  const record = schema as Record<string, unknown>;
+
+  if (record.example !== undefined) {
+    return record.example;
+  }
+
+  if (Array.isArray(record.enum) && record.enum.length > 0) {
+    return record.enum[0];
+  }
+
+  const typeValue = record.type;
+  const type = Array.isArray(typeValue) ? typeValue.find((t) => t !== "null") : typeValue;
+
+  if (type === "object") {
+    const properties = record.properties as Record<string, unknown> | undefined;
+    if (!properties) {
+      return {};
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, propertySchema] of Object.entries(properties)) {
+      const value = defaultFromSchema(propertySchema);
+      if (value !== undefined) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  if (type === "array") {
+    const itemSchema = record.items;
+    const item = defaultFromSchema(itemSchema);
+    return item === undefined ? [] : [item];
+  }
+
+  if (type === "string") {
+    return "string";
+  }
+
+  if (type === "integer" || type === "number") {
+    return 0;
+  }
+
+  if (type === "boolean") {
+    return true;
+  }
+
+  return undefined;
+}
+
+function explicitExampleValue(example: unknown): unknown {
+  if (!example || typeof example !== "object" || Array.isArray(example)) {
+    return example;
+  }
+
+  if ("value" in example) {
+    return (example as { value: unknown }).value;
+  }
+
+  return undefined;
+}
+
+function inferRequestBody(operation: OperationRecord["operation"]): OpenCollectionRequest["http"]["body"] | undefined {
+  const media = operation.requestBody && "content" in operation.requestBody
+    ? operation.requestBody.content["application/json"]
+    : undefined;
+
+  if (!media) {
+    return undefined;
+  }
+
+  const namedExample = media.examples ? explicitExampleValue(Object.values(media.examples)[0]) : undefined;
+  const explicitExample = media.example ?? namedExample;
+  const payload = explicitExample !== undefined ? explicitExample : defaultFromSchema(media.schema);
+
+  if (payload === undefined) {
+    return undefined;
+  }
+
+  return {
+    type: "json",
+    data: JSON.stringify(payload, null, 2),
+  };
+}
+
+function operationToRequest(
+  operationRecord: OperationRecord,
+  baseUrlVariable = "{{baseUrl}}"
+): OpenCollectionRequest {
+  const requestName = operationRecord.operation.operationId
+    ? operationRecord.operation.operationId
+    : operationRecord.operation.summary
+    ? operationRecord.operation.summary
+    : toTitle(`${operationRecord.method} ${operationRecord.path}`);
+
+  return {
+    info: {
+      name: requestName,
+      type: "http",
+    },
+    http: {
+      method: operationRecord.method.toUpperCase(),
+      url: `${baseUrlVariable}${pathToTemplate(operationRecord.path)}`,
+      ...(inferRequestBody(operationRecord.operation)
+        ? { body: inferRequestBody(operationRecord.operation) }
+        : {}),
+    },
+  };
+}
+
+function collectOperations(document: OpenAPIDocument): OperationRecord[] {
+  const records: OperationRecord[] = [];
+
+  for (const [pathname, pathItem] of Object.entries(document.paths)) {
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (operation && typeof operation === "object") {
+        records.push({
+          path: pathname,
+          method,
+          operation,
+        });
+      }
+    }
+  }
+
+  return records;
+}
+
+function groupKeyByPath(pathname: string): string {
+  const firstSegment = pathname.split("/").filter(Boolean)[0];
+  return firstSegment ? slugify(firstSegment) : "root";
+}
+
+function createRequestItem(
+  groupKey: string,
+  request: OpenCollectionRequest,
+  operationRecord: OperationRecord,
+  seq: number
+): CollectionItem {
+  const nameSlug = slugify(request.info.name);
+  const methodPrefix = operationRecord.method.toLowerCase();
+  const fallbackPathSlug = slugify(operationRecord.path.replace(/[{}]/g, "")) || "root";
+  const fileName = `${nameSlug || `${methodPrefix}-${fallbackPathSlug}`}.yml`;
+
+  return {
+    kind: "request",
+    name: request.info.name,
+    path: `${groupKey}/${fileName}`,
+    request: {
+      ...request,
+      info: {
+        ...request.info,
+        seq,
+      },
+    },
+    seq,
+  };
+}
+
+function toFolderItems(
+  grouped: Map<string, OperationRecord[]>,
+  options: CollectionGenerateOptions
+): CollectionItem[] {
+  const folders: CollectionItem[] = [];
+
+  const sortedGroups = Array.from(grouped.entries()).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+
+  for (let index = 0; index < sortedGroups.length; index += 1) {
+    const [groupKey, operations] = sortedGroups[index];
+    const sortedOperations = [...operations].sort((a, b) => {
+      if (a.path !== b.path) {
+        return a.path.localeCompare(b.path);
+      }
+      return a.method.localeCompare(b.method);
+    });
+
+    const children = sortedOperations.map((operation, seq) => {
+      const request = operationToRequest(operation);
+      return createRequestItem(groupKey, request, operation, seq + 1);
+    });
+
+    folders.push({
+      kind: "folder",
+      name: toTitle(groupKey),
+      path: groupKey,
+      children,
+      seq: index + 1,
+    });
+  }
+
+  return folders;
+}
+
+export function openAPIToCollection(
+  document: OpenAPIDocument,
+  options: CollectionGenerateOptions = {}
+): Collection {
+  const operations = collectOperations(document);
+  const grouped = new Map<string, OperationRecord[]>();
+  const groupBy = options.groupBy ?? "tag";
+
+  for (const operation of operations) {
+    const tag = operation.operation.tags?.[0];
+    const groupKey = groupBy === "tag"
+      ? slugify(tag ?? groupKeyByPath(operation.path))
+      : groupKeyByPath(operation.path);
+
+    const existing = grouped.get(groupKey) ?? [];
+    existing.push(operation);
+    grouped.set(groupKey, existing);
+  }
+
+  const baseUrl = options.baseUrl ?? document.servers?.[0]?.url ?? "http://localhost:3000";
+  const environmentName = options.environmentName ?? "development";
+
+  return {
+    info: {
+      name: document.info.title,
+      version: document.info.version,
+      description: document.info.description,
+      type: "collection",
+    },
+    rootDir: "",
+    environments: {
+      [environmentName]: {
+        name: environmentName,
+        variables: {
+          baseUrl,
+        },
+      },
+    },
+    items: toFolderItems(grouped, options),
+  };
+}
+
+export function routerToCollection(
+  router: Router<unknown>,
+  options: RouterCollectionOptions & {
+    info?: OpenAPIDocument["info"];
+    servers?: OpenAPIDocument["servers"];
+  } = {}
+): Collection {
+  const openApi = fromRouter(router, {
+    info: options.info ?? { title: "API", version: "1.0.0" },
+    servers: options.servers,
+    include: options.include,
+    exclude: options.exclude,
+    basePath: options.basePath,
+  });
+
+  return openAPIToCollection(openApi, {
+    baseUrl: options.baseUrl,
+    groupBy: options.groupBy,
+    includeExamples: options.includeExamples,
+  });
+}

--- a/apifn/collections/src/index.ts
+++ b/apifn/collections/src/index.ts
@@ -1,0 +1,56 @@
+// @apifn/collections — public API
+
+export type {
+  Collection,
+  CollectionInfo,
+  CollectionItem,
+  OpenCollectionRequest,
+  Environment,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  CookieJar,
+  CookieJarCookie,
+  HttpRedirectRecord,
+  RunOptions,
+  RunReport,
+  RequestResult,
+  AssertionResult,
+  RunReporter,
+  CollectionGenerateOptions,
+  RouterCollectionOptions,
+} from "./types.js";
+
+export { readCollection } from "./reader.js";
+export { writeCollection } from "./writer.js";
+export { validateCollection } from "./validator.js";
+export { openAPIToCollection, routerToCollection } from "./generator.js";
+export {
+  readEnvironmentFile,
+  writeEnvironmentFile,
+  readEnvironments,
+  writeEnvironments,
+  selectEnvironment,
+} from "./environment.js";
+export {
+  interpolateVariables,
+  resolveVariableContext,
+  loadDotEnvFile,
+} from "./variables.js";
+export type { InterpolationResult, VariableResolutionInput } from "./variables.js";
+export { createCookieJar, createFetchHttpClient } from "./runner/http-client.js";
+export { runCollection } from "./runner/runner.js";
+export { createAssertionRuntime } from "./runner/assertions.js";
+export {
+  executePreRequestScript,
+  executeTestScript,
+  SCRIPT_TIMEOUT_MS,
+} from "./runner/script-sandbox.js";
+export { buildRunReport } from "./report.js";
+export { createConsoleReporter } from "./runner/reporters/console.js";
+export type { ConsoleReporterOptions } from "./runner/reporters/console.js";
+export { createJsonReporter } from "./runner/reporters/json.js";
+export type { JsonReporterOptions } from "./runner/reporters/json.js";
+export { createJUnitReporter, reportToJUnitXml } from "./runner/reporters/junit.js";
+export type { JUnitReporterOptions } from "./runner/reporters/junit.js";
+export { createSilentReporter } from "./runner/reporters/silent.js";

--- a/apifn/collections/src/reader.ts
+++ b/apifn/collections/src/reader.ts
@@ -1,0 +1,175 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { globSync } from "glob";
+import { parse as parseYaml } from "yaml";
+import type { Collection, CollectionItem, Environment, OpenCollectionRequest } from "./types.js";
+
+interface ReadContext {
+  rootDir: string;
+  requestByPath: Map<string, OpenCollectionRequest>;
+  folderMetaByPath: Map<string, { name?: string; seq?: number }>;
+}
+
+function toPosix(relativePath: string): string {
+  return relativePath.split(path.sep).join("/");
+}
+
+function isYml(filePath: string): boolean {
+  return filePath.endsWith(".yml") || filePath.endsWith(".yaml");
+}
+
+async function readYamlFile(filePath: string): Promise<Record<string, unknown>> {
+  const content = await readFile(filePath, "utf8");
+  const parsed = parseYaml(content);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`Invalid YAML object in ${filePath}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function sortBySeqThenName<T extends { seq?: number; name: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const aSeq = a.seq ?? Number.MAX_SAFE_INTEGER;
+    const bSeq = b.seq ?? Number.MAX_SAFE_INTEGER;
+    if (aSeq !== bSeq) {
+      return aSeq - bSeq;
+    }
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function buildFolderItems(relativeDir: string, context: ReadContext): CollectionItem[] {
+  const prefix = relativeDir ? `${relativeDir}/` : "";
+  const directRequests = Array.from(context.requestByPath.entries())
+    .filter(([requestPath]) => {
+      if (!requestPath.startsWith(prefix)) {
+        return false;
+      }
+      const remaining = requestPath.slice(prefix.length);
+      return !remaining.includes("/");
+    })
+    .map(([requestPath, request]) => ({
+      kind: "request" as const,
+      name: request.info?.name ?? path.basename(requestPath, path.extname(requestPath)),
+      path: requestPath,
+      request,
+      seq: request.info?.seq,
+    }));
+
+  const childFolderNames = new Set<string>();
+
+  for (const requestPath of context.requestByPath.keys()) {
+    if (!requestPath.startsWith(prefix)) {
+      continue;
+    }
+    const remaining = requestPath.slice(prefix.length);
+    const first = remaining.split("/")[0];
+    if (first && remaining.includes("/")) {
+      childFolderNames.add(first);
+    }
+  }
+
+  for (const folderPath of context.folderMetaByPath.keys()) {
+    if (!folderPath.startsWith(prefix)) {
+      continue;
+    }
+    const remaining = folderPath.slice(prefix.length);
+    const first = remaining.split("/")[0];
+    if (first && remaining.includes("/")) {
+      childFolderNames.add(first);
+    }
+    if (first && !remaining.includes("/")) {
+      childFolderNames.add(first);
+    }
+  }
+
+  const folders = Array.from(childFolderNames)
+    .map((folderName) => {
+      const folderPath = prefix ? `${prefix}${folderName}` : folderName;
+      const folderMeta = context.folderMetaByPath.get(folderPath) ?? {};
+      const children = buildFolderItems(folderPath, context);
+      return {
+        kind: "folder" as const,
+        name: folderMeta.name ?? folderName,
+        path: folderPath,
+        children,
+        seq: folderMeta.seq,
+      };
+    })
+    .filter((folder) => folder.children.length > 0 || context.folderMetaByPath.has(folder.path));
+
+  return sortBySeqThenName([...directRequests, ...folders]);
+}
+
+export async function readCollection(rootDir: string): Promise<Collection> {
+  const opencollectionPath = path.join(rootDir, "opencollection.yml");
+  let info: Record<string, unknown>;
+
+  try {
+    info = await readYamlFile(opencollectionPath);
+  } catch {
+    throw new Error(`No opencollection.yml found in ${rootDir}`);
+  }
+
+  const allYamlFiles = globSync("**/*.{yml,yaml}", {
+    cwd: rootDir,
+    nodir: true,
+    dot: false,
+  });
+
+  const requestByPath = new Map<string, OpenCollectionRequest>();
+  const folderMetaByPath = new Map<string, { name?: string; seq?: number }>();
+  const environments: Record<string, Environment> = {};
+
+  for (const relative of allYamlFiles) {
+    const posixPath = toPosix(relative);
+    if (posixPath === "opencollection.yml") {
+      continue;
+    }
+
+    const fullPath = path.join(rootDir, relative);
+    const parsed = await readYamlFile(fullPath);
+
+    if (posixPath.startsWith("environments/") && isYml(posixPath)) {
+      const name = path.basename(posixPath, path.extname(posixPath));
+      environments[name] = {
+        name,
+        variables: (parsed.variables as Record<string, string>) ?? {},
+      };
+      continue;
+    }
+
+    if (path.basename(posixPath) === "folder.yml") {
+      const folderPath = toPosix(path.dirname(posixPath));
+      folderMetaByPath.set(folderPath === "." ? "" : folderPath, {
+        name: typeof parsed.name === "string" ? parsed.name : undefined,
+        seq: typeof parsed.seq === "number" ? parsed.seq : undefined,
+      });
+      continue;
+    }
+
+    if (parsed.info && parsed.http) {
+      requestByPath.set(posixPath, parsed as unknown as OpenCollectionRequest);
+    }
+  }
+
+  const context: ReadContext = {
+    rootDir,
+    requestByPath,
+    folderMetaByPath,
+  };
+
+  const items = buildFolderItems("", context);
+
+  return {
+    info: {
+      name: String(info.name ?? "Collection"),
+      description: typeof info.description === "string" ? info.description : undefined,
+      version: typeof info.version === "string" ? info.version : undefined,
+      type: "collection",
+    },
+    environments,
+    items,
+    rootDir,
+  };
+}

--- a/apifn/collections/src/report.ts
+++ b/apifn/collections/src/report.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from "node:crypto";
+import type { RequestResult, RunReport } from "./types.js";
+
+export function buildRunReport(input: {
+  collectionName: string;
+  environment: string;
+  startedAt: string;
+  completedAt: string;
+  results: RequestResult[];
+}): RunReport {
+  const started = new Date(input.startedAt).getTime();
+  const completed = new Date(input.completedAt).getTime();
+  const duration = Math.max(0, completed - started);
+
+  const summary = {
+    total: input.results.length,
+    passed: input.results.filter((r) => r.status === "passed").length,
+    failed: input.results.filter((r) => r.status === "failed").length,
+    skipped: input.results.filter((r) => r.status === "skipped").length,
+    errors: input.results.filter((r) => r.status === "error").length,
+    duration,
+  };
+
+  return {
+    id: randomUUID(),
+    collectionName: input.collectionName,
+    environment: input.environment,
+    startedAt: input.startedAt,
+    completedAt: input.completedAt,
+    duration,
+    results: input.results,
+    summary,
+  };
+}

--- a/apifn/collections/src/runner/assertions.ts
+++ b/apifn/collections/src/runner/assertions.ts
@@ -1,0 +1,420 @@
+import type { AssertionResult } from "../types.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+class AssertionFailure extends Error {
+  expected?: unknown;
+  actual?: unknown;
+
+  constructor(message: string, expected?: unknown, actual?: unknown) {
+    super(message);
+    this.name = "AssertionFailure";
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+interface AssertionRecorder {
+  currentTestName: string | null;
+  sequence: number;
+  results: AssertionResult[];
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonPath(path: string): Array<string | number> {
+  if (!path.startsWith("$")) {
+    throw new Error("JSONPath must start with '$'");
+  }
+
+  const segments: Array<string | number> = [];
+  let index = 1;
+
+  while (index < path.length) {
+    const char = path[index];
+    if (char === ".") {
+      index += 1;
+      const start = index;
+      while (index < path.length && /[A-Za-z0-9_\-$]/.test(path[index] ?? "")) {
+        index += 1;
+      }
+      const key = path.slice(start, index);
+      if (!key) {
+        throw new Error(`Invalid JSONPath near '${path.slice(start)}'`);
+      }
+      segments.push(key);
+      continue;
+    }
+
+    if (char === "[") {
+      index += 1;
+      const end = path.indexOf("]", index);
+      if (end === -1) {
+        throw new Error("JSONPath bracket is not closed");
+      }
+      const token = path.slice(index, end).trim();
+      if (/^\d+$/.test(token)) {
+        segments.push(Number(token));
+      } else if (
+        (token.startsWith("\"") && token.endsWith("\"")) ||
+        (token.startsWith("'") && token.endsWith("'"))
+      ) {
+        segments.push(token.slice(1, -1));
+      } else {
+        throw new Error(`Unsupported JSONPath segment: [${token}]`);
+      }
+      index = end + 1;
+      continue;
+    }
+
+    throw new Error(`Invalid JSONPath token '${char}' in '${path}'`);
+  }
+
+  return segments;
+}
+
+function resolveJsonPath(value: unknown, path: string): unknown {
+  let cursor = value;
+  for (const segment of parseJsonPath(path)) {
+    if (typeof segment === "number") {
+      if (!Array.isArray(cursor)) {
+        return undefined;
+      }
+      cursor = cursor[segment];
+      continue;
+    }
+
+    if (!isRecord(cursor) && !Array.isArray(cursor)) {
+      return undefined;
+    }
+
+    cursor = (cursor as UnknownRecord)[segment];
+  }
+  return cursor;
+}
+
+function validateAgainstSchema(
+  data: unknown,
+  schema: UnknownRecord,
+  path = "$"
+): string[] {
+  const errors: string[] = [];
+  const type = schema.type;
+
+  if (typeof type === "string") {
+    if (type === "array" && !Array.isArray(data)) {
+      errors.push(`${path} should be array`);
+    } else if (type === "object" && !isRecord(data)) {
+      errors.push(`${path} should be object`);
+    } else if (type === "string" && typeof data !== "string") {
+      errors.push(`${path} should be string`);
+    } else if (type === "number" && typeof data !== "number") {
+      errors.push(`${path} should be number`);
+    } else if (type === "integer" && (!Number.isInteger(data) || typeof data !== "number")) {
+      errors.push(`${path} should be integer`);
+    } else if (type === "boolean" && typeof data !== "boolean") {
+      errors.push(`${path} should be boolean`);
+    }
+  }
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0 && !schema.enum.includes(data)) {
+    errors.push(`${path} should be one of enum values`);
+  }
+
+  if (type === "object" && isRecord(data)) {
+    const required = Array.isArray(schema.required) ? schema.required : [];
+    for (const key of required) {
+      if (typeof key === "string" && !(key in data)) {
+        errors.push(`${path}.${key} is required`);
+      }
+    }
+
+    if (isRecord(schema.properties)) {
+      for (const [key, propertySchema] of Object.entries(schema.properties)) {
+        if (!(key in data) || !isRecord(propertySchema)) {
+          continue;
+        }
+        errors.push(...validateAgainstSchema(data[key], propertySchema, `${path}.${key}`));
+      }
+    }
+  }
+
+  if (type === "array" && Array.isArray(data) && isRecord(schema.items)) {
+    for (let idx = 0; idx < data.length; idx += 1) {
+      errors.push(...validateAgainstSchema(data[idx], schema.items, `${path}[${idx}]`));
+    }
+  }
+
+  return errors;
+}
+
+function normalizeError(error: unknown): {
+  message: string;
+  expected?: unknown;
+  actual?: unknown;
+} {
+  if (error instanceof AssertionFailure) {
+    return {
+      message: error.message,
+      expected: error.expected,
+      actual: error.actual,
+    };
+  }
+
+  if (error instanceof Error) {
+    return { message: error.message };
+  }
+
+  return { message: String(error) };
+}
+
+function assertionName(state: AssertionRecorder): string {
+  if (state.currentTestName) {
+    return state.currentTestName;
+  }
+  state.sequence += 1;
+  return `assertion ${state.sequence}`;
+}
+
+function pushResult(
+  state: AssertionRecorder,
+  payload: {
+    passed: boolean;
+    expected?: unknown;
+    actual?: unknown;
+    error?: string;
+  }
+): void {
+  state.results.push({
+    name: assertionName(state),
+    passed: payload.passed,
+    expected: payload.expected,
+    actual: payload.actual,
+    error: payload.error,
+  });
+}
+
+function runAssertion(
+  state: AssertionRecorder,
+  execute: () => void
+): void {
+  try {
+    execute();
+    pushResult(state, { passed: true });
+  } catch (error) {
+    const normalized = normalizeError(error);
+    pushResult(state, {
+      passed: false,
+      expected: normalized.expected,
+      actual: normalized.actual,
+      error: normalized.message,
+    });
+    throw error;
+  }
+}
+
+function createExpectFn(state: AssertionRecorder) {
+  function expect(actual: unknown) {
+    const to: {
+      equal(expected: unknown): void;
+      include(expected: unknown): void;
+      matchSchema(schema: UnknownRecord): void;
+      have: {
+        property(name: string, expected?: unknown): void;
+        length: ((length: number) => void) & { above(min: number): void };
+        jsonPath(path: string, expected?: unknown): void;
+      };
+      be: {
+        below(expected: number): void;
+      };
+    } = {
+      equal(expected) {
+        runAssertion(state, () => {
+          if (!Object.is(actual, expected)) {
+            throw new AssertionFailure(
+              `Expected ${JSON.stringify(actual)} to equal ${JSON.stringify(expected)}`,
+              expected,
+              actual
+            );
+          }
+        });
+      },
+      include(expected) {
+        runAssertion(state, () => {
+          let passed = false;
+          if (typeof actual === "string" && typeof expected === "string") {
+            passed = actual.includes(expected);
+          } else if (Array.isArray(actual)) {
+            passed = actual.includes(expected);
+          } else if (isRecord(actual) && typeof expected === "string") {
+            passed = expected in actual;
+          }
+
+          if (!passed) {
+            throw new AssertionFailure(
+              `Expected value to include ${JSON.stringify(expected)}`,
+              expected,
+              actual
+            );
+          }
+        });
+      },
+      matchSchema(schema) {
+        runAssertion(state, () => {
+          const errors = validateAgainstSchema(actual, schema);
+          if (errors.length > 0) {
+            throw new AssertionFailure(
+              `Schema validation failed: ${errors.join(", ")}`,
+              schema,
+              actual
+            );
+          }
+        });
+      },
+      have: {
+        property(name, expected) {
+          runAssertion(state, () => {
+            if (!isRecord(actual) && !Array.isArray(actual)) {
+              throw new AssertionFailure(
+                `Expected value to have property '${name}'`,
+                name,
+                actual
+              );
+            }
+
+            const current = (actual as UnknownRecord)[name];
+            if (current === undefined) {
+              throw new AssertionFailure(
+                `Expected value to have property '${name}'`,
+                name,
+                actual
+              );
+            }
+
+            if (arguments.length === 2 && !Object.is(current, expected)) {
+              throw new AssertionFailure(
+                `Expected property '${name}' to equal ${JSON.stringify(expected)}`,
+                expected,
+                current
+              );
+            }
+          });
+        },
+        length: Object.assign(
+          (expectedLength: number) => {
+            runAssertion(state, () => {
+              const candidate = actual as { length?: number };
+              if (candidate?.length !== expectedLength) {
+                throw new AssertionFailure(
+                  `Expected length ${expectedLength} but got ${String(candidate?.length)}`,
+                  expectedLength,
+                  candidate?.length
+                );
+              }
+            });
+          },
+          {
+            above(min: number) {
+              runAssertion(state, () => {
+                const candidate = actual as { length?: number };
+                if (typeof candidate?.length !== "number" || candidate.length <= min) {
+                  throw new AssertionFailure(
+                    `Expected length to be above ${min}`,
+                    `> ${min}`,
+                    candidate?.length
+                  );
+                }
+              });
+            },
+          }
+        ),
+        jsonPath(path, expected) {
+          runAssertion(state, () => {
+            const resolved = resolveJsonPath(actual, path);
+            if (arguments.length === 2) {
+              if (!Object.is(resolved, expected)) {
+                throw new AssertionFailure(
+                  `Expected JSONPath ${path} to equal ${JSON.stringify(expected)}`,
+                  expected,
+                  resolved
+                );
+              }
+            } else if (resolved === undefined) {
+              throw new AssertionFailure(
+                `Expected JSONPath ${path} to exist`,
+                "defined",
+                resolved
+              );
+            }
+          });
+        },
+      },
+      be: {
+        below(expected) {
+          runAssertion(state, () => {
+            if (typeof actual !== "number" || actual >= expected) {
+              throw new AssertionFailure(
+                `Expected ${JSON.stringify(actual)} to be below ${expected}`,
+                `< ${expected}`,
+                actual
+              );
+            }
+          });
+        },
+      },
+    };
+
+    return { to };
+  }
+
+  return expect;
+}
+
+function createTestFn(state: AssertionRecorder) {
+  return async function test(name: string, fn: () => unknown): Promise<void> {
+    const before = state.results.length;
+    state.currentTestName = name;
+    try {
+      await Promise.resolve(fn());
+      if (state.results.length === before) {
+        pushResult(state, { passed: true });
+      }
+    } catch (error) {
+      if (state.results.length === before) {
+        const normalized = normalizeError(error);
+        pushResult(state, {
+          passed: false,
+          expected: normalized.expected,
+          actual: normalized.actual,
+          error: normalized.message,
+        });
+      }
+    } finally {
+      state.currentTestName = null;
+    }
+  };
+}
+
+export interface AssertionRuntime {
+  expect: ReturnType<typeof createExpectFn>;
+  test: ReturnType<typeof createTestFn>;
+  getResults(): AssertionResult[];
+}
+
+export function createAssertionRuntime(): AssertionRuntime {
+  const state: AssertionRecorder = {
+    currentTestName: null,
+    sequence: 0,
+    results: [],
+  };
+
+  return {
+    expect: createExpectFn(state),
+    test: createTestFn(state),
+    getResults() {
+      return [...state.results];
+    },
+  };
+}

--- a/apifn/collections/src/runner/http-client.ts
+++ b/apifn/collections/src/runner/http-client.ts
@@ -1,0 +1,384 @@
+import type {
+  CookieJar,
+  CookieJarCookie,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  HttpRedirectRecord,
+} from "../types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REDIRECTS = 10;
+const CROSS_ORIGIN_REDIRECT_SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "x-api-key",
+  "x-auth-token",
+]);
+
+function toHeadersRecord(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+function getSetCookieHeaders(headers: Headers): string[] {
+  const withGetSetCookie = headers as Headers & {
+    getSetCookie?: () => string[];
+    raw?: () => Record<string, string[]>;
+  };
+
+  if (typeof withGetSetCookie.getSetCookie === "function") {
+    return withGetSetCookie.getSetCookie();
+  }
+
+  if (typeof withGetSetCookie.raw === "function") {
+    return withGetSetCookie.raw()["set-cookie"] ?? [];
+  }
+
+  const combined = headers.get("set-cookie");
+  return combined ? splitCombinedSetCookie(combined) : [];
+}
+
+function splitCombinedSetCookie(value: string): string[] {
+  const result: string[] = [];
+  let start = 0;
+  let inExpires = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const slice = value.slice(index, index + 8).toLowerCase();
+    if (slice === "expires=") {
+      inExpires = true;
+    }
+    if (inExpires && char === ";") {
+      inExpires = false;
+    }
+    if (!inExpires && char === ",") {
+      const next = value.slice(index + 1);
+      if (/^\s*[^=;,]+\s*=/.test(next)) {
+        result.push(value.slice(start, index).trim());
+        start = index + 1;
+      }
+    }
+  }
+
+  result.push(value.slice(start).trim());
+  return result.filter(Boolean);
+}
+
+function normalizeDomain(domain: string): string {
+  return domain.replace(/^\./, "").toLowerCase();
+}
+
+function defaultPath(url: URL): string {
+  if (!url.pathname || url.pathname === "/") {
+    return "/";
+  }
+  const index = url.pathname.lastIndexOf("/");
+  return index <= 0 ? "/" : url.pathname.slice(0, index);
+}
+
+function domainMatches(hostname: string, domain: string): boolean {
+  const host = hostname.toLowerCase();
+  const normalizedDomain = normalizeDomain(domain);
+  return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+}
+
+function pathMatches(pathname: string, cookiePath: string): boolean {
+  if (cookiePath === "/") {
+    return true;
+  }
+  return pathname === cookiePath || pathname.startsWith(`${cookiePath}/`);
+}
+
+function cookieKey(cookie: Pick<CookieJarCookie, "name" | "domain" | "path">): string {
+  return `${cookie.domain}\n${cookie.path}\n${cookie.name}`;
+}
+
+function removeCrossOriginRedirectHeaders(
+  headers: Record<string, string>,
+  fromUrl: string,
+  toUrl: string
+): Record<string, string> {
+  if (new URL(fromUrl).origin === new URL(toUrl).origin) {
+    return headers;
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) =>
+      !CROSS_ORIGIN_REDIRECT_SENSITIVE_HEADERS.has(name.toLowerCase())
+    )
+  );
+}
+
+export function createCookieJar(initialCookies: CookieJarCookie[] = []): CookieJar {
+  const cookies = new Map<string, CookieJarCookie>();
+
+  function pruneExpired(now = Date.now()): void {
+    for (const [key, cookie] of cookies.entries()) {
+      if (cookie.expiresAt !== undefined && cookie.expiresAt <= now) {
+        cookies.delete(key);
+      }
+    }
+  }
+
+  for (const cookie of initialCookies) {
+    cookies.set(cookieKey(cookie), {
+      ...cookie,
+      domain: normalizeDomain(cookie.domain),
+    });
+  }
+
+  return {
+    get(name, url) {
+      pruneExpired();
+      if (url) {
+        const parsed = new URL(url);
+        const matched = Array.from(cookies.values()).find((cookie) =>
+          cookie.name === name &&
+          domainMatches(parsed.hostname, cookie.domain) &&
+          pathMatches(parsed.pathname, cookie.path) &&
+          (!cookie.secure || parsed.protocol === "https:")
+        );
+        return matched?.value;
+      }
+
+      return Array.from(cookies.values()).find((cookie) => cookie.name === name)?.value;
+    },
+    set(name, value, url = "http://localhost/") {
+      const parsed = new URL(url);
+      const cookie: CookieJarCookie = {
+        name,
+        value,
+        domain: normalizeDomain(parsed.hostname),
+        path: defaultPath(parsed),
+      };
+      cookies.set(cookieKey(cookie), cookie);
+    },
+    delete(name, url) {
+      pruneExpired();
+      if (!url) {
+        for (const [key, cookie] of cookies.entries()) {
+          if (cookie.name === name) {
+            cookies.delete(key);
+          }
+        }
+        return;
+      }
+
+      const parsed = new URL(url);
+      for (const [key, cookie] of cookies.entries()) {
+        if (
+          cookie.name === name &&
+          domainMatches(parsed.hostname, cookie.domain) &&
+          pathMatches(parsed.pathname, cookie.path)
+        ) {
+          cookies.delete(key);
+        }
+      }
+    },
+    clear() {
+      cookies.clear();
+    },
+    getCookieHeader(url) {
+      pruneExpired();
+      const parsed = new URL(url);
+      const values = Array.from(cookies.values())
+        .filter((cookie) =>
+          domainMatches(parsed.hostname, cookie.domain) &&
+          pathMatches(parsed.pathname, cookie.path) &&
+          (!cookie.secure || parsed.protocol === "https:")
+        )
+        .sort((a, b) => b.path.length - a.path.length)
+        .map((cookie) => `${cookie.name}=${cookie.value}`);
+
+      return values.length > 0 ? values.join("; ") : undefined;
+    },
+    storeFromResponse(url, setCookieHeaders) {
+      const parsed = new URL(url);
+      for (const header of setCookieHeaders) {
+        const parts = header.split(";").map((part) => part.trim()).filter(Boolean);
+        const [nameValue, ...attributes] = parts;
+        if (!nameValue) {
+          continue;
+        }
+        const separator = nameValue.indexOf("=");
+        if (separator <= 0) {
+          continue;
+        }
+
+        const name = nameValue.slice(0, separator);
+        const value = nameValue.slice(separator + 1);
+        const cookie: CookieJarCookie = {
+          name,
+          value,
+          domain: normalizeDomain(parsed.hostname),
+          path: defaultPath(parsed),
+        };
+
+        for (const attribute of attributes) {
+          const [rawName, ...rawValueParts] = attribute.split("=");
+          const attrName = rawName.toLowerCase();
+          const attrValue = rawValueParts.join("=");
+          if (attrName === "domain" && attrValue) {
+            const domain = normalizeDomain(attrValue);
+            if (!domainMatches(parsed.hostname, domain)) {
+              cookie.domain = "";
+              break;
+            }
+            cookie.domain = domain;
+          } else if (attrName === "path" && attrValue) {
+            cookie.path = attrValue;
+          } else if (attrName === "expires" && attrValue) {
+            const expiresAt = Date.parse(attrValue);
+            if (!Number.isNaN(expiresAt)) {
+              cookie.expiresAt = expiresAt;
+            }
+          } else if (attrName === "max-age" && attrValue) {
+            const maxAge = Number(attrValue);
+            if (Number.isFinite(maxAge)) {
+              cookie.expiresAt = Date.now() + maxAge * 1000;
+            }
+          } else if (attrName === "secure") {
+            cookie.secure = true;
+          } else if (attrName === "httponly") {
+            cookie.httpOnly = true;
+          } else if (attrName === "samesite" && attrValue) {
+            cookie.sameSite = attrValue;
+          }
+        }
+
+        if (!cookie.domain) {
+          continue;
+        }
+
+        const key = cookieKey(cookie);
+        if (cookie.expiresAt !== undefined && cookie.expiresAt <= Date.now()) {
+          cookies.delete(key);
+        } else {
+          cookies.set(key, cookie);
+        }
+      }
+    },
+    toJSON() {
+      pruneExpired();
+      return Array.from(cookies.values()).map((cookie) => ({ ...cookie }));
+    },
+  };
+}
+
+export interface FetchHttpClientOptions {
+  fetchImpl?: typeof fetch;
+  cookieJar?: CookieJar;
+  followRedirects?: boolean;
+  maxRedirects?: number;
+}
+
+export function createFetchHttpClient(
+  fetchImplOrOptions: typeof fetch | FetchHttpClientOptions = fetch
+): HttpClient & { cookieJar: CookieJar } {
+  const options: FetchHttpClientOptions =
+    typeof fetchImplOrOptions === "function"
+      ? { fetchImpl: fetchImplOrOptions }
+      : fetchImplOrOptions;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const cookieJar = options.cookieJar ?? createCookieJar();
+
+  async function sendOnce(
+    request: HttpClientRequest,
+    url: string,
+    redirects: HttpRedirectRecord[],
+    redirectCount: number
+  ): Promise<HttpClientResponse> {
+    const startedAt = Date.now();
+    const controller = new AbortController();
+    const timeout = request.timeout ?? DEFAULT_TIMEOUT_MS;
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const headers = { ...request.headers };
+      const cookieHeader = cookieJar.getCookieHeader(url);
+      if (cookieHeader && !Object.keys(headers).some((name) => name.toLowerCase() === "cookie")) {
+        headers.cookie = cookieHeader;
+      }
+
+      const response = await fetchImpl(url, {
+        method: request.method,
+        headers,
+        body: request.body,
+        signal: controller.signal,
+        redirect: "manual",
+      });
+
+      const setCookieHeaders = getSetCookieHeaders(response.headers);
+      if (setCookieHeaders.length > 0) {
+        cookieJar.storeFromResponse(url, setCookieHeaders);
+      }
+
+      const duration = Date.now() - startedAt;
+      const followRedirects = request.followRedirects ?? options.followRedirects ?? true;
+      const maxRedirects = request.maxRedirects ?? options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+      const location = response.headers.get("location");
+
+      if (
+        followRedirects &&
+        location &&
+        response.status >= 300 &&
+        response.status < 400
+      ) {
+        if (redirectCount >= maxRedirects) {
+          throw new Error(`Maximum redirects exceeded (${maxRedirects})`);
+        }
+
+        const nextUrl = new URL(location, url).toString();
+        redirects.push({
+          status: response.status,
+          url,
+          location: nextUrl,
+          duration,
+        });
+
+        const method = response.status === 303 && request.method.toUpperCase() !== "GET"
+          ? "GET"
+          : request.method;
+        const body = method === "GET" || method === "HEAD" ? undefined : request.body;
+
+        return sendOnce(
+          {
+            ...request,
+            method,
+            body,
+            headers: removeCrossOriginRedirectHeaders(request.headers, url, nextUrl),
+          },
+          nextUrl,
+          redirects,
+          redirectCount + 1
+        );
+      }
+
+      const body = await response.text();
+
+      return {
+        status: response.status,
+        headers: toHeadersRecord(response.headers),
+        body,
+        size: Buffer.byteLength(body, "utf8"),
+        duration: Date.now() - startedAt + redirects.reduce((sum, item) => sum + item.duration, 0),
+        redirects: redirects.length > 0 ? redirects : undefined,
+      };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  return {
+    cookieJar,
+    async send(request: HttpClientRequest): Promise<HttpClientResponse> {
+      return sendOnce(request, request.url, [], 0);
+    },
+  };
+}

--- a/apifn/collections/src/runner/reporters/console.ts
+++ b/apifn/collections/src/runner/reporters/console.ts
@@ -1,0 +1,125 @@
+/**
+ * Console reporter — colored pass/fail output per request with summary at end.
+ */
+
+import pc from "picocolors";
+import type { Collection, CollectionItem, RequestResult, RunOptions, RunReport, RunReporter } from "../../types.js";
+
+export interface ConsoleReporterOptions {
+  /** Whether to use color output (default: true) */
+  color?: boolean;
+  /** Custom write function (default: process.stdout.write) */
+  write?: (text: string) => void;
+}
+
+function badge(status: RequestResult["status"], color: boolean): string {
+  const c = {
+    green: (s: string) => (color ? pc.green(s) : s),
+    red: (s: string) => (color ? pc.red(s) : s),
+    yellow: (s: string) => (color ? pc.yellow(s) : s),
+    gray: (s: string) => (color ? pc.gray(s) : s),
+  };
+  switch (status) {
+    case "passed":
+      return c.green("✓ PASS");
+    case "failed":
+      return c.red("✗ FAIL");
+    case "error":
+      return c.red("✗ ERROR");
+    case "skipped":
+      return c.yellow("– SKIP");
+  }
+}
+
+export function createConsoleReporter(options: ConsoleReporterOptions = {}): RunReporter {
+  const useColor = options.color ?? true;
+  const write = options.write ?? ((text: string) => process.stdout.write(text));
+
+  const c = {
+    bold: (s: string) => (useColor ? pc.bold(s) : s),
+    green: (s: string) => (useColor ? pc.green(s) : s),
+    red: (s: string) => (useColor ? pc.red(s) : s),
+    yellow: (s: string) => (useColor ? pc.yellow(s) : s),
+    cyan: (s: string) => (useColor ? pc.cyan(s) : s),
+    gray: (s: string) => (useColor ? pc.gray(s) : s),
+    dim: (s: string) => (useColor ? pc.dim(s) : s),
+  };
+
+  return {
+    onStart(collection: Collection, _options: RunOptions): void {
+      write(`\n${c.bold("apifn test")} — ${c.cyan(collection.info.name)}\n`);
+      const envName = typeof _options.environment === "string" ? _options.environment : _options.environment.name;
+      write(`${c.dim(`Environment: ${envName}`)}\n\n`);
+    },
+
+    onRequestStart(_item: CollectionItem): void {
+      // No per-request start output; results shown on complete
+    },
+
+    onRequestComplete(result: RequestResult): void {
+      const duration = `${result.duration}ms`;
+      const statusCode = result.statusCode ? ` ${result.statusCode}` : "";
+      write(`  ${badge(result.status, useColor)}  ${result.method}${statusCode}  ${result.name}  ${c.dim(duration)}\n`);
+
+      if (result.status === "failed" || result.status === "error") {
+        if (result.error) {
+          write(`         ${c.red(result.error)}\n`);
+        }
+        for (const assertion of result.assertions) {
+          if (!assertion.passed) {
+            const detail =
+              assertion.expected !== undefined && assertion.actual !== undefined
+                ? ` (expected: ${JSON.stringify(assertion.expected)}, actual: ${JSON.stringify(assertion.actual)})`
+                : assertion.error
+                  ? ` (${assertion.error})`
+                  : "";
+            write(`         ${c.red(`✗ ${assertion.name}${detail}`)}\n`);
+          }
+        }
+      }
+
+      if (result.warnings && result.warnings.length > 0) {
+        for (const warning of result.warnings) {
+          write(`         ${c.yellow(`⚠ ${warning}`)}\n`);
+        }
+      }
+    },
+
+    onComplete(report: RunReport): void {
+      const { summary } = report;
+      write("\n");
+      write(`${"─".repeat(60)}\n`);
+      write(`${c.bold("Results")}\n`);
+      write(`  Total:   ${summary.total}\n`);
+      write(`  ${c.green(`Passed:  ${summary.passed}`)}\n`);
+
+      if (summary.failed > 0) {
+        write(`  ${c.red(`Failed:  ${summary.failed}`)}\n`);
+      } else {
+        write(`  Failed:  ${summary.failed}\n`);
+      }
+
+      if (summary.errors > 0) {
+        write(`  ${c.red(`Errors:  ${summary.errors}`)}\n`);
+      } else {
+        write(`  Errors:  ${summary.errors}\n`);
+      }
+
+      if (summary.skipped > 0) {
+        write(`  ${c.yellow(`Skipped: ${summary.skipped}`)}\n`);
+      } else {
+        write(`  Skipped: ${summary.skipped}\n`);
+      }
+
+      write(`  Duration: ${summary.duration}ms\n`);
+      write(`${"─".repeat(60)}\n`);
+
+      const allPassed = summary.failed === 0 && summary.errors === 0;
+      if (allPassed) {
+        write(`\n${c.green(c.bold("All tests passed!"))}\n\n`);
+      } else {
+        write(`\n${c.red(c.bold(`${summary.failed + summary.errors} test(s) failed.`))}\n\n`);
+      }
+    },
+  };
+}

--- a/apifn/collections/src/runner/reporters/json.ts
+++ b/apifn/collections/src/runner/reporters/json.ts
@@ -1,0 +1,25 @@
+/**
+ * JSON reporter — serializes the full RunReport to stdout as JSON.
+ * Intended for machine-readable / CI integration usage.
+ */
+
+import type { RunReport, RunReporter } from "../../types.js";
+
+export interface JsonReporterOptions {
+    /** Custom write function (default: process.stdout.write) */
+    write?: (text: string) => void;
+    /** JSON indentation spaces (default: 2) */
+    indent?: number;
+}
+
+export function createJsonReporter(options: JsonReporterOptions = {}): RunReporter {
+    const write = options.write ?? ((text: string) => process.stdout.write(text));
+    const indent = options.indent ?? 2;
+
+    return {
+        onComplete(report: RunReport): void {
+            write(JSON.stringify(report, null, indent));
+            write("\n");
+        },
+    };
+}

--- a/apifn/collections/src/runner/reporters/junit.ts
+++ b/apifn/collections/src/runner/reporters/junit.ts
@@ -1,0 +1,64 @@
+import type { RunReport, RunReporter } from "../../types.js";
+
+export interface JUnitReporterOptions {
+  write?: (text: string) => void;
+}
+
+function escapeXml(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+export function reportToJUnitXml(report: RunReport): string {
+  const failures = report.summary.failed;
+  const errors = report.summary.errors;
+  const cases = report.results.map((result) => {
+    const time = (result.duration / 1000).toFixed(3);
+    const name = escapeXml(result.name);
+    const classname = escapeXml(result.path);
+
+    if (result.status === "skipped") {
+      return `    <testcase classname="${classname}" name="${name}" time="${time}"><skipped /></testcase>`;
+    }
+
+    if (result.status === "failed" || result.status === "error") {
+      const message = escapeXml(result.error ?? `${result.method} ${result.statusCode ?? ""}`);
+      const details = escapeXml(JSON.stringify({
+        request: result.request,
+        response: result.response,
+        assertions: result.assertions,
+        attempts: result.attempts,
+      }, null, 2));
+      const tag = result.status === "error" ? "error" : "failure";
+      return [
+        `    <testcase classname="${classname}" name="${name}" time="${time}">`,
+        `      <${tag} message="${message}">${details}</${tag}>`,
+        "    </testcase>",
+      ].join("\n");
+    }
+
+    return `    <testcase classname="${classname}" name="${name}" time="${time}" />`;
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuite name="${escapeXml(report.collectionName)}" tests="${report.summary.total}" failures="${failures}" errors="${errors}" skipped="${report.summary.skipped}" time="${(report.summary.duration / 1000).toFixed(3)}">`,
+    ...cases,
+    "</testsuite>",
+    "",
+  ].join("\n");
+}
+
+export function createJUnitReporter(options: JUnitReporterOptions = {}): RunReporter {
+  const write = options.write ?? ((text: string) => process.stdout.write(text));
+
+  return {
+    onComplete(report): void {
+      write(reportToJUnitXml(report));
+    },
+  };
+}

--- a/apifn/collections/src/runner/reporters/silent.ts
+++ b/apifn/collections/src/runner/reporters/silent.ts
@@ -1,0 +1,13 @@
+/**
+ * Silent reporter — no output (for programmatic/embedded use).
+ */
+
+import type { RunReporter } from "../../types.js";
+
+/**
+ * Returns a RunReporter that produces no output whatsoever.
+ * Useful when consuming apifn programmatically and handling output manually.
+ */
+export function createSilentReporter(): RunReporter {
+    return {};
+}

--- a/apifn/collections/src/runner/runner.ts
+++ b/apifn/collections/src/runner/runner.ts
@@ -1,0 +1,626 @@
+import type {
+  Collection,
+  CollectionItem,
+  CookieJar,
+  Environment,
+  HttpClient,
+  OpenCollectionRequest,
+  RequestResult,
+  RunOptions,
+  RunReporter,
+  RunReport,
+} from "../types.js";
+import { buildRunReport } from "../report.js";
+import { createCookieJar, createFetchHttpClient } from "./http-client.js";
+import { interpolateVariables, resolveVariableContext } from "../variables.js";
+import {
+  executePreRequestScript,
+  executeTestScript,
+  type ScriptRequestContext,
+  type ScriptResponseContext,
+} from "./script-sandbox.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_CAPTURED_BODY_BYTES = 10 * 1024 * 1024;
+const DEFAULT_REDACT_HEADERS = [
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "x-auth-token",
+];
+const DEFAULT_REDACT_BODY_KEYS = [
+  "apiKey",
+  "api_key",
+  "authorization",
+  "bearer",
+  "code",
+  "handoffCode",
+  "otp",
+  "password",
+  "refreshToken",
+  "sessionToken",
+  "token",
+];
+
+interface RequestEntry {
+  item: CollectionItem;
+  request: OpenCollectionRequest;
+}
+
+function sortItems(items: CollectionItem[]): CollectionItem[] {
+  return [...items].sort((a, b) => {
+    const aSeq = a.seq ?? Number.MAX_SAFE_INTEGER;
+    const bSeq = b.seq ?? Number.MAX_SAFE_INTEGER;
+    if (aSeq !== bSeq) {
+      return aSeq - bSeq;
+    }
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function flattenRequestItems(items: CollectionItem[]): RequestEntry[] {
+  const output: RequestEntry[] = [];
+
+  function walk(nodes: CollectionItem[]): void {
+    for (const node of sortItems(nodes)) {
+      if (node.kind === "request" && node.request) {
+        output.push({ item: node, request: node.request });
+      }
+
+      if (node.kind === "folder" && node.children) {
+        walk(node.children);
+      }
+    }
+  }
+
+  walk(items);
+  return output;
+}
+
+function getEnvironment(collection: Collection, env: string | Environment): Environment {
+  if (typeof env !== "string") {
+    return env;
+  }
+
+  const matched = collection.environments[env];
+  if (!matched) {
+    throw new Error(`Environment '${env}' not found`);
+  }
+  return matched;
+}
+
+function redactHeaders(headers: Record<string, string>, redactList: string[]): Record<string, string> {
+  const redactSet = new Set(redactList.map((header) => header.toLowerCase()));
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    result[key] = redactSet.has(key.toLowerCase()) ? "[REDACTED]" : value;
+  }
+  return result;
+}
+
+function redactBody(body: string | undefined): string | undefined {
+  if (body === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.stringify(redactJsonValue(JSON.parse(body) as unknown), null, 2);
+  } catch {
+    return DEFAULT_REDACT_BODY_KEYS.reduce((value, key) => {
+      const pattern = new RegExp(`(${key}=)([^&\\s]+)`, "gi");
+      return value.replace(pattern, `$1[REDACTED]`);
+    }, body);
+  }
+}
+
+function redactJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactJsonValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (DEFAULT_REDACT_BODY_KEYS.some((name) => name.toLowerCase() === key.toLowerCase())) {
+      result[key] = "[REDACTED]";
+    } else {
+      result[key] = redactJsonValue(item);
+    }
+  }
+  return result;
+}
+
+function interpolateRequest(
+  request: OpenCollectionRequest,
+  context: Record<string, string>,
+  processEnv: NodeJS.ProcessEnv
+): {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+
+  const urlInterpolated = interpolateVariables(request.http.url, context, { processEnv });
+  warnings.push(...urlInterpolated.warnings);
+
+  const headers: Record<string, string> = {};
+  for (const header of request.http.headers ?? []) {
+    const interpolated = interpolateVariables(header.value, context, { processEnv });
+    warnings.push(...interpolated.warnings);
+    headers[header.name] = interpolated.value;
+  }
+
+  let body: string | undefined;
+  if (request.http.body?.data !== undefined) {
+    const bodyInterpolated = interpolateVariables(request.http.body.data, context, {
+      processEnv,
+    });
+    warnings.push(...bodyInterpolated.warnings);
+    body = bodyInterpolated.value;
+  }
+
+  let url = urlInterpolated.value;
+  const queryParams = request.http.params?.query ?? [];
+  if (queryParams.length > 0) {
+    const parsedUrl = new URL(urlInterpolated.value);
+    for (const query of queryParams) {
+      if (query.enabled === false) {
+        continue;
+      }
+      const interpolated = interpolateVariables(query.value, context, { processEnv });
+      warnings.push(...interpolated.warnings);
+      parsedUrl.searchParams.set(query.name, interpolated.value);
+    }
+    url = parsedUrl.toString();
+  }
+
+  return {
+    method: request.http.method,
+    url,
+    headers,
+    body,
+    warnings,
+  };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+
+  return new Promise<T>((resolve, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`Request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise
+      .then((value) => resolve(value))
+      .catch((error) => reject(error))
+      .finally(() => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      });
+  });
+}
+
+function truncateBody(body: string): string {
+  const size = Buffer.byteLength(body, "utf8");
+  if (size <= MAX_CAPTURED_BODY_BYTES) {
+    return body;
+  }
+
+  let low = 0;
+  let high = body.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(body.slice(0, mid), "utf8") <= MAX_CAPTURED_BODY_BYTES) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return body.slice(0, low);
+}
+
+async function executeRequest(
+  entry: RequestEntry,
+  options: {
+    collection: Collection;
+    context: Record<string, string>;
+    processEnv: NodeJS.ProcessEnv;
+    timeout: number;
+    retries: number;
+    httpClient: HttpClient;
+    cookieJar?: CookieJar;
+    redactHeaders: string[];
+    reporter?: RunReporter;
+    isolateContext?: boolean;
+  }
+): Promise<RequestResult> {
+  options.reporter?.onRequestStart?.(entry.item);
+
+  const requestContext = options.isolateContext ? { ...options.context } : options.context;
+  const interpolated = interpolateRequest(entry.request, requestContext, options.processEnv);
+  const mutableRequest: ScriptRequestContext = {
+    method: interpolated.method,
+    url: interpolated.url,
+    headers: { ...interpolated.headers },
+    body: interpolated.body,
+  };
+  const assertionResults: RequestResult["assertions"] = [];
+  const scripts = entry.request.runtime?.scripts ?? [];
+
+  for (const script of scripts) {
+    if (script.type !== "pre-request") {
+      continue;
+    }
+
+    const preRequestResult = await executePreRequestScript({
+      code: script.code,
+      req: mutableRequest,
+      env: requestContext,
+      cookies: options.cookieJar,
+    });
+
+    if (preRequestResult.error) {
+      const result: RequestResult = {
+        name: entry.request.info.name,
+        path: entry.item.path,
+        method: mutableRequest.method,
+        url: mutableRequest.url,
+        status: "error",
+        duration: 0,
+        assertions: [],
+        warnings: interpolated.warnings.length ? interpolated.warnings : undefined,
+        error: preRequestResult.error.message,
+        request: {
+          method: mutableRequest.method,
+          url: mutableRequest.url,
+          headers: redactHeaders(mutableRequest.headers, options.redactHeaders),
+          body: redactBody(mutableRequest.body),
+        },
+      };
+      options.reporter?.onRequestComplete?.(result);
+      return result;
+    }
+  }
+
+  const attempts: NonNullable<RequestResult["attempts"]> = [];
+  let lastError: string | undefined;
+
+  for (let attempt = 0; attempt <= options.retries; attempt += 1) {
+    const attemptNumber = attempt + 1;
+    const startedAt = Date.now();
+
+    try {
+      const response = await withTimeout(
+        options.httpClient.send({
+          method: mutableRequest.method,
+          url: mutableRequest.url,
+          headers: mutableRequest.headers,
+          body: mutableRequest.body,
+          timeout: options.timeout,
+          followRedirects: entry.request.settings?.followRedirects,
+          maxRedirects: entry.request.settings?.maxRedirects,
+        }),
+        options.timeout
+      );
+
+      attempts.push({
+        attempt: attemptNumber,
+        statusCode: response.status,
+        duration: response.duration,
+      });
+
+      if (response.status >= 500 && attempt < options.retries) {
+        continue;
+      }
+
+      const parsedResponseBody = (() => {
+        try {
+          return JSON.parse(response.body);
+        } catch {
+          return response.body;
+        }
+      })();
+      const responseForScripts: ScriptResponseContext = {
+        status: response.status,
+        headers: response.headers,
+        body: parsedResponseBody,
+        responseTime: response.duration,
+      };
+
+      for (const script of scripts) {
+        if (script.type !== "tests" && script.type !== "post-response") {
+          continue;
+        }
+
+        const testResult = await executeTestScript({
+          code: script.code,
+          req: mutableRequest,
+          res: responseForScripts,
+          env: requestContext,
+          cookies: options.cookieJar,
+          assertionResults,
+        });
+
+        if (testResult.error) {
+          break;
+        }
+      }
+
+      const hasFailedAssertions = assertionResults.some((assertion) => !assertion.passed);
+      const hasExpectedStatus = statusMatchesExpected(response.status, entry.request.settings?.expectedStatus);
+      const status: RequestResult["status"] =
+        !hasExpectedStatus || hasFailedAssertions ? "failed" : "passed";
+      const result: RequestResult = {
+        name: entry.request.info.name,
+        path: entry.item.path,
+        method: mutableRequest.method,
+        url: mutableRequest.url,
+        status,
+        statusCode: response.status,
+        duration: Date.now() - startedAt,
+        assertions: assertionResults,
+        warnings: interpolated.warnings.length ? interpolated.warnings : undefined,
+        attempts,
+        request: {
+          method: mutableRequest.method,
+          url: mutableRequest.url,
+          headers: redactHeaders(mutableRequest.headers, options.redactHeaders),
+          body: redactBody(mutableRequest.body),
+        },
+        response: {
+          status: response.status,
+          headers: redactHeaders(response.headers, options.redactHeaders),
+          body: redactBody(truncateBody(response.body)) ?? "",
+          size: response.size,
+          redirects: response.redirects,
+        },
+      };
+
+      options.reporter?.onRequestComplete?.(result);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      lastError = message;
+      attempts.push({
+        attempt: attemptNumber,
+        duration: Date.now() - startedAt,
+        error: message,
+      });
+
+      if (attempt < options.retries) {
+        continue;
+      }
+    }
+  }
+
+  const result: RequestResult = {
+    name: entry.request.info.name,
+    path: entry.item.path,
+    method: mutableRequest.method,
+    url: mutableRequest.url,
+    status: "error",
+    duration: attempts[attempts.length - 1]?.duration ?? 0,
+    assertions: assertionResults,
+    warnings: interpolated.warnings.length ? interpolated.warnings : undefined,
+    attempts,
+    error: lastError ?? "Request failed",
+    request: {
+      method: mutableRequest.method,
+      url: mutableRequest.url,
+      headers: redactHeaders(mutableRequest.headers, options.redactHeaders),
+      body: redactBody(mutableRequest.body),
+    },
+  };
+
+  options.reporter?.onRequestComplete?.(result);
+  return result;
+}
+
+function skippedResult(entry: RequestEntry): RequestResult {
+  return {
+    name: entry.request.info.name,
+    path: entry.item.path,
+    method: entry.request.http.method,
+    url: entry.request.http.url,
+    status: "skipped",
+    duration: 0,
+    assertions: [],
+    request: {
+      method: entry.request.http.method,
+      url: entry.request.http.url,
+      headers: {},
+    },
+  };
+}
+
+function patternMatches(value: string, pattern: string): boolean {
+  if (pattern === value) {
+    return true;
+  }
+
+  const escaped = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`, "i").test(value);
+}
+
+function shouldRunEntry(entry: RequestEntry, options: Pick<RunOptions, "include" | "exclude">): boolean {
+  const candidates = [
+    entry.item.path,
+    entry.item.name,
+    entry.request.info.name,
+    `${entry.request.http.method.toUpperCase()} ${entry.request.http.url}`,
+  ];
+
+  const included =
+    !options.include ||
+    options.include.length === 0 ||
+    options.include.some((pattern) =>
+      candidates.some((candidate) => patternMatches(candidate, pattern))
+    );
+  if (!included) {
+    return false;
+  }
+
+  return !(options.exclude ?? []).some((pattern) =>
+    candidates.some((candidate) => patternMatches(candidate, pattern))
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function statusMatchesExpected(status: number, expected: number | number[] | undefined): boolean {
+  if (expected === undefined) {
+    return status < 400;
+  }
+  return Array.isArray(expected) ? expected.includes(status) : status === expected;
+}
+
+export async function runCollection(
+  collection: Collection,
+  options: RunOptions
+): Promise<RunReport> {
+  const startedAt = new Date();
+  const environment = getEnvironment(collection, options.environment);
+  const processEnv = process.env;
+  const collectionVariables =
+    (collection as unknown as { variables?: Record<string, string> }).variables ?? {};
+  const context = resolveVariableContext({
+    overrides: options.overrides,
+    environment: environment.variables,
+    collection: collectionVariables,
+    processEnv,
+  });
+
+  const entries = flattenRequestItems(collection.items);
+  const reporter = options.reporter;
+  reporter?.onStart?.(collection, options);
+
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+  const retries = options.retries ?? 0;
+  const cookieJar = options.cookieJar ?? createCookieJar();
+  const httpClient = options.httpClient ?? createFetchHttpClient({ cookieJar });
+  const redactList = [...DEFAULT_REDACT_HEADERS, ...(options.redactHeaders ?? [])];
+
+  const results: Array<RequestResult | undefined> = new Array(entries.length);
+  let bailTriggered = false;
+
+  if (options.parallel) {
+    const concurrency = Math.max(1, options.concurrency ?? 4);
+    let pointer = 0;
+
+    async function worker(): Promise<void> {
+      while (pointer < entries.length) {
+        const index = pointer;
+        pointer += 1;
+
+        if (options.bail && bailTriggered) {
+          continue;
+        }
+
+        const entry = entries[index];
+        if (!shouldRunEntry(entry, options)) {
+          const skipped = skippedResult(entry);
+          results[index] = skipped;
+          reporter?.onRequestComplete?.(skipped);
+          continue;
+        }
+
+        const result = await executeRequest(entry, {
+          collection,
+          context,
+          processEnv,
+          timeout: entry.request.settings?.timeout ?? timeout,
+          retries,
+          httpClient,
+          cookieJar,
+          redactHeaders: redactList,
+          reporter,
+          isolateContext: true,
+        });
+
+        results[index] = result;
+        if (options.bail && (result.status === "failed" || result.status === "error")) {
+          bailTriggered = true;
+        }
+      }
+    }
+
+    await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  } else {
+    for (let index = 0; index < entries.length; index += 1) {
+      const entry = entries[index];
+
+      if (options.bail && bailTriggered) {
+        results[index] = skippedResult(entry);
+        continue;
+      }
+
+      if (!shouldRunEntry(entry, options)) {
+        const skipped = skippedResult(entry);
+        results[index] = skipped;
+        reporter?.onRequestComplete?.(skipped);
+        continue;
+      }
+
+      const result = await executeRequest(entry, {
+        collection,
+        context,
+        processEnv,
+        timeout: entry.request.settings?.timeout ?? timeout,
+        retries,
+        httpClient,
+        cookieJar,
+        redactHeaders: redactList,
+        reporter,
+      });
+
+      results[index] = result;
+
+      if (options.bail && (result.status === "failed" || result.status === "error")) {
+        bailTriggered = true;
+      }
+
+      if (options.delay && index < entries.length - 1) {
+        await sleep(options.delay);
+      }
+    }
+  }
+
+  for (let index = 0; index < entries.length; index += 1) {
+    if (!results[index]) {
+      const skipped = skippedResult(entries[index]);
+      results[index] = skipped;
+      reporter?.onRequestComplete?.(skipped);
+    }
+  }
+
+  const completedAt = new Date();
+  const report = buildRunReport({
+    collectionName: collection.info.name,
+    environment: environment.name,
+    startedAt: startedAt.toISOString(),
+    completedAt: completedAt.toISOString(),
+    results: results as RequestResult[],
+  });
+
+  reporter?.onComplete?.(report);
+  return report;
+}

--- a/apifn/collections/src/runner/script-sandbox.ts
+++ b/apifn/collections/src/runner/script-sandbox.ts
@@ -1,0 +1,252 @@
+import vm from "node:vm";
+import { randomUUID } from "node:crypto";
+import type { AssertionResult, CookieJar } from "../types.js";
+import { createAssertionRuntime } from "./assertions.js";
+
+export const SCRIPT_TIMEOUT_MS = 10_000;
+
+type EnvStore = Record<string, string>;
+
+export interface ScriptRequestContext {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface ScriptResponseContext {
+  status: number;
+  headers: Record<string, string>;
+  body: unknown;
+  responseTime: number;
+}
+
+interface BaseScriptOptions {
+  code: string;
+  env: EnvStore;
+  req: ScriptRequestContext;
+  cookies?: CookieJar;
+  timeoutMs?: number;
+}
+
+export interface ExecutePreRequestScriptOptions extends BaseScriptOptions {}
+
+export interface ExecuteTestScriptOptions extends BaseScriptOptions {
+  res: ScriptResponseContext;
+  assertionResults: AssertionResult[];
+}
+
+export interface ScriptExecutionError {
+  message: string;
+}
+
+function createEnvProxy(env: EnvStore): EnvStore & {
+  get(name: string): string | undefined;
+  set(name: string, value: unknown): void;
+  unset(name: string): void;
+  delete(name: string): void;
+  all(): EnvStore;
+} {
+  const helper = {
+    get(name: string): string | undefined {
+      return env[name];
+    },
+    set(name: string, value: unknown): void {
+      env[name] = String(value);
+    },
+    unset(name: string): void {
+      delete env[name];
+    },
+    delete(name: string): void {
+      delete env[name];
+    },
+    all(): EnvStore {
+      return { ...env };
+    },
+  };
+
+  return new Proxy(helper as EnvStore & typeof helper, {
+    get(target, prop, receiver) {
+      if (typeof prop === "string" && prop in env) {
+        return env[prop];
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+    set(target, prop, value, receiver) {
+      if (typeof prop === "string" && !(prop in target)) {
+        env[prop] = String(value);
+        return true;
+      }
+      return Reflect.set(target, prop, value, receiver);
+    },
+    ownKeys(target) {
+      return [...new Set([...Reflect.ownKeys(target), ...Object.keys(env)])];
+    },
+    has(target, prop) {
+      if (typeof prop === "string" && prop in env) {
+        return true;
+      }
+      return Reflect.has(target, prop);
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (typeof prop === "string" && prop in env) {
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: env[prop],
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+}
+
+function sanitizeError(error: unknown): ScriptExecutionError {
+  if (error instanceof Error) {
+    return { message: error.message };
+  }
+  return { message: String(error) };
+}
+
+async function runInSandbox(
+  code: string,
+  contextValues: Record<string, unknown>,
+  timeoutMs: number
+): Promise<void> {
+  const context = vm.createContext(
+    {
+      ...contextValues,
+      console: {
+        debug: console.debug.bind(console),
+        error: console.error.bind(console),
+        info: console.info.bind(console),
+        log: console.log.bind(console),
+        warn: console.warn.bind(console),
+      },
+      URL,
+      URLSearchParams,
+      crypto: {
+        randomUUID,
+      },
+      btoa(value: string): string {
+        return Buffer.from(value, "utf8").toString("base64");
+      },
+      atob(value: string): string {
+        return Buffer.from(value, "base64").toString("utf8");
+      },
+      process: undefined,
+      require: undefined,
+      module: undefined,
+      global: undefined,
+      globalThis: undefined,
+      fetch: undefined,
+      Function: undefined,
+      eval: undefined,
+      setTimeout: undefined,
+      setInterval: undefined,
+      setImmediate: undefined,
+      clearTimeout: undefined,
+      clearInterval: undefined,
+      clearImmediate: undefined,
+    },
+    {
+      codeGeneration: {
+        strings: false,
+        wasm: false,
+      },
+    }
+  );
+
+  const wrappedCode = `"use strict"; (async () => { ${code}\n })()`;
+  const script = new vm.Script(wrappedCode, {
+    filename: "collection-script.js",
+  });
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      script.runInContext(context, { timeout: timeoutMs }) as Promise<unknown>,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Script execution timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function normalizeScriptError(error: ScriptExecutionError, kind: "pre-request" | "tests"): ScriptExecutionError {
+  return {
+    message: kind === "pre-request"
+      ? `Pre-request script failed: ${error.message}`
+      : `Test script failed: ${error.message}`,
+  };
+}
+
+export async function executePreRequestScript(
+  options: ExecutePreRequestScriptOptions
+): Promise<{ error?: ScriptExecutionError }> {
+  const env = createEnvProxy(options.env);
+
+  try {
+    await runInSandbox(
+      options.code,
+      {
+        req: options.req,
+        env,
+        cookies: options.cookies,
+      },
+      options.timeoutMs ?? SCRIPT_TIMEOUT_MS
+    );
+    return {};
+  } catch (error) {
+    return {
+      error: normalizeScriptError(sanitizeError(error), "pre-request"),
+    };
+  }
+}
+
+export async function executeTestScript(
+  options: ExecuteTestScriptOptions
+): Promise<{ error?: ScriptExecutionError }> {
+  const env = createEnvProxy(options.env);
+  const assertionRuntime = createAssertionRuntime();
+  const res = {
+    ...options.res,
+    json() {
+      return options.res.body;
+    },
+  };
+
+  try {
+    await runInSandbox(
+      options.code,
+      {
+        req: options.req,
+        res,
+        env,
+        cookies: options.cookies,
+        expect: assertionRuntime.expect,
+        test: assertionRuntime.test,
+      },
+      options.timeoutMs ?? SCRIPT_TIMEOUT_MS
+    );
+  } catch (error) {
+    options.assertionResults.push({
+      name: "script execution",
+      passed: false,
+      error: normalizeScriptError(sanitizeError(error), "tests").message,
+    });
+    return {
+      error: normalizeScriptError(sanitizeError(error), "tests"),
+    };
+  }
+
+  options.assertionResults.push(...assertionRuntime.getResults());
+  return {};
+}

--- a/apifn/collections/src/types.ts
+++ b/apifn/collections/src/types.ts
@@ -1,0 +1,248 @@
+/**
+ * @apifn/collections — Collection types
+ *
+ * Types for OpenCollection YAML read/write, environment management,
+ * and collection runner.
+ */
+
+import type {
+  AuthConfig,
+  IntrospectOptions,
+} from "@apifn/core";
+
+// ============================================================================
+// Collection Types
+// ============================================================================
+
+export interface Collection {
+  /** Collection metadata from opencollection.yml */
+  info: CollectionInfo;
+  /** Environments */
+  environments: Record<string, Environment>;
+  /** Request items organized by folder */
+  items: CollectionItem[];
+  /** Root directory path */
+  rootDir: string;
+}
+
+export interface CollectionInfo {
+  name: string;
+  version?: string;
+  description?: string;
+  type?: "collection";
+}
+
+export interface CollectionItem {
+  kind: "request" | "folder";
+  name: string;
+  /** Relative path within the collection */
+  path: string;
+  /** For kind: "request" — the parsed OpenCollection request YAML */
+  request?: OpenCollectionRequest;
+  /** For kind: "folder" — child items */
+  children?: CollectionItem[];
+  /** Sequence number for ordering */
+  seq?: number;
+}
+
+export interface OpenCollectionRequest {
+  info: { name: string; type: "http"; seq?: number };
+  http: {
+    method: string;
+    url: string;
+    headers?: Array<{ name: string; value: string; enabled?: boolean }>;
+    body?: { type: string; data: string };
+    auth?: "inherit" | "none" | AuthConfig;
+    params?: {
+      path?: Array<{ name: string; value: string }>;
+      query?: Array<{ name: string; value: string; enabled?: boolean }>;
+    };
+  };
+  runtime?: {
+    scripts?: Array<{
+      type: "pre-request" | "tests" | "post-response";
+      code: string;
+    }>;
+  };
+  settings?: {
+    encodeUrl?: boolean;
+    timeout?: number;
+    followRedirects?: boolean;
+    maxRedirects?: number;
+    expectedStatus?: number | number[];
+  };
+}
+
+// ============================================================================
+// Environment Types
+// ============================================================================
+
+export interface Environment {
+  name: string;
+  variables: Record<string, string>;
+}
+
+// ============================================================================
+// Collection Runner Types
+// ============================================================================
+
+export interface HttpClient {
+  send(request: HttpClientRequest): Promise<HttpClientResponse>;
+}
+
+export interface CookieJarCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expiresAt?: number;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: string;
+}
+
+export interface CookieJar {
+  get(name: string, url?: string): string | undefined;
+  set(name: string, value: string, url?: string): void;
+  delete(name: string, url?: string): void;
+  clear(): void;
+  getCookieHeader(url: string): string | undefined;
+  storeFromResponse(url: string, setCookieHeaders: string[]): void;
+  toJSON(): CookieJarCookie[];
+}
+
+export interface HttpClientRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  timeout?: number;
+  followRedirects?: boolean;
+  maxRedirects?: number;
+}
+
+export interface HttpRedirectRecord {
+  status: number;
+  url: string;
+  location: string;
+  duration: number;
+}
+
+export interface HttpClientResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  size: number;
+  duration: number;
+  redirects?: HttpRedirectRecord[];
+}
+
+export interface RunOptions {
+  /** Environment to use */
+  environment: string | Environment;
+  /** Only run requests matching these paths/patterns */
+  include?: string[];
+  /** Skip requests matching these paths/patterns */
+  exclude?: string[];
+  /** Run requests in parallel (default: sequential) */
+  parallel?: boolean;
+  /** Max concurrent requests when parallel=true */
+  concurrency?: number;
+  /** Global timeout per request in ms (default: 30000) */
+  timeout?: number;
+  /** Abort on first failure */
+  bail?: boolean;
+  /** Number of retries for failed requests */
+  retries?: number;
+  /** Delay between sequential requests in ms */
+  delay?: number;
+  /** Custom HTTP client (default: built-in fetch-based) */
+  httpClient?: HttpClient;
+  /** Cookie jar shared across requests and collection scripts */
+  cookieJar?: CookieJar;
+  /** Reporter for progress updates */
+  reporter?: RunReporter;
+  /** Variables that override environment variables */
+  overrides?: Record<string, string>;
+  /** Headers to redact in captured request/response details */
+  redactHeaders?: string[];
+}
+
+export interface RunReport {
+  id: string;
+  collectionName: string;
+  environment: string;
+  startedAt: string;
+  completedAt: string;
+  duration: number;
+  results: RequestResult[];
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    errors: number;
+    duration: number;
+  };
+}
+
+export interface RequestResult {
+  name: string;
+  path: string;
+  method: string;
+  url: string;
+  status: "passed" | "failed" | "skipped" | "error";
+  statusCode?: number;
+  duration: number;
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body?: string;
+  };
+  response?: {
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+    size: number;
+    redirects?: HttpRedirectRecord[];
+  };
+  assertions: AssertionResult[];
+  warnings?: string[];
+  attempts?: Array<{
+    attempt: number;
+    statusCode?: number;
+    duration: number;
+    error?: string;
+  }>;
+  error?: string;
+}
+
+export interface AssertionResult {
+  name: string;
+  passed: boolean;
+  expected?: unknown;
+  actual?: unknown;
+  error?: string;
+}
+
+export interface RunReporter {
+  onStart?(collection: Collection, options: RunOptions): void;
+  onRequestStart?(item: CollectionItem): void;
+  onRequestComplete?(result: RequestResult): void;
+  onComplete?(report: RunReport): void;
+}
+
+// ============================================================================
+// Collection Generation Options
+// ============================================================================
+
+export interface CollectionGenerateOptions {
+  baseUrl?: string;
+  environmentName?: string;
+  groupBy?: "tag" | "path";
+  includeExamples?: boolean;
+}
+
+export type RouterCollectionOptions = CollectionGenerateOptions &
+  IntrospectOptions;

--- a/apifn/collections/src/validator.ts
+++ b/apifn/collections/src/validator.ts
@@ -1,0 +1,84 @@
+import type { ValidationError } from "@apifn/core";
+import type { Collection } from "./types.js";
+
+export function validateCollection(collection: Collection): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!collection.info?.name || typeof collection.info.name !== "string") {
+    errors.push({
+      path: "info.name",
+      message: "Collection info.name is required and must be a string",
+      severity: "error",
+    });
+  }
+
+  if (!collection.environments || typeof collection.environments !== "object" || Array.isArray(collection.environments)) {
+    errors.push({
+      path: "environments",
+      message: "Collection environments must be an object",
+      severity: "error",
+    });
+  } else {
+    for (const [envName, env] of Object.entries(collection.environments)) {
+      if (!env || typeof env !== "object" || Array.isArray(env)) {
+        errors.push({
+          path: `environments.${envName}`,
+          message: "Environment must be an object",
+          severity: "error",
+        });
+        continue;
+      }
+
+      if (!env.variables || typeof env.variables !== "object" || Array.isArray(env.variables)) {
+        errors.push({
+          path: `environments.${envName}.variables`,
+          message: "Environment variables are required",
+          severity: "error",
+        });
+      }
+    }
+  }
+
+  function validateItems(items: unknown, parentPath: string): void {
+    if (!Array.isArray(items)) {
+      errors.push({
+        path: parentPath,
+        message: "Collection items must be an array",
+        severity: "error",
+      });
+      return;
+    }
+
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index] as Partial<Collection["items"][number]> | null;
+      const itemPath = `${parentPath}[${index}]`;
+
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        errors.push({
+          path: itemPath,
+          message: "Collection item must be an object",
+          severity: "error",
+        });
+        continue;
+      }
+
+      if (item.kind === "request") {
+        const method = item.request?.http?.method;
+        if (!method || typeof method !== "string") {
+          errors.push({
+            path: `${itemPath}.request.http.method`,
+            message: "Request http.method is required",
+            severity: "error",
+          });
+        }
+      }
+
+      if (item.kind === "folder" && item.children) {
+        validateItems(item.children, `${itemPath}.children`);
+      }
+    }
+  }
+
+  validateItems(collection.items, "items");
+  return errors;
+}

--- a/apifn/collections/src/variables.ts
+++ b/apifn/collections/src/variables.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from "node:fs";
+import { parse as parseDotEnv } from "dotenv";
+
+export interface VariableResolutionInput {
+  overrides?: Record<string, string>;
+  environment?: Record<string, string>;
+  collection?: Record<string, string>;
+  processEnv?: NodeJS.ProcessEnv;
+}
+
+export interface InterpolationResult {
+  value: string;
+  warnings: string[];
+}
+
+export function loadDotEnvFile(dotEnvPath = ".env"): Record<string, string> {
+  if (!existsSync(dotEnvPath)) {
+    return {};
+  }
+
+  const raw = readFileSync(dotEnvPath, "utf8");
+  return parseDotEnv(raw);
+}
+
+export function resolveVariableContext(input: VariableResolutionInput): Record<string, string> {
+  const resolved: Record<string, string> = {};
+
+  Object.assign(resolved, input.collection ?? {});
+  Object.assign(resolved, input.environment ?? {});
+  Object.assign(resolved, input.overrides ?? {});
+
+  return resolved;
+}
+
+export function interpolateVariables(
+  template: string,
+  context: Record<string, string>,
+  options?: {
+    processEnv?: NodeJS.ProcessEnv;
+  }
+): InterpolationResult {
+  const warnings: string[] = [];
+  const processEnv = options?.processEnv ?? process.env;
+  let value = "";
+  let cursor = 0;
+
+  while (cursor < template.length) {
+    const start = template.indexOf("{{", cursor);
+    if (start === -1) {
+      value += template.slice(cursor);
+      break;
+    }
+
+    const end = template.indexOf("}}", start + 2);
+    if (end === -1) {
+      value += template.slice(cursor);
+      break;
+    }
+
+    value += template.slice(cursor, start);
+    const fullMatch = template.slice(start, end + 2);
+    const key = template.slice(start + 2, end).trim();
+
+    if (key.startsWith("process.env.")) {
+      const envVar = key.slice("process.env.".length);
+      const resolved = processEnv[envVar];
+      if (typeof resolved === "string") {
+        value += resolved;
+        cursor = end + 2;
+        continue;
+      }
+      throw new Error(`Environment variable ${envVar} is not set`);
+    }
+
+    const resolved = context[key];
+    if (resolved !== undefined) {
+      value += resolved;
+      cursor = end + 2;
+      continue;
+    }
+
+    warnings.push(`Unresolved variable: ${key}`);
+    value += fullMatch;
+    cursor = end + 2;
+  }
+
+  return { value, warnings };
+}

--- a/apifn/collections/src/writer.ts
+++ b/apifn/collections/src/writer.ts
@@ -1,0 +1,92 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { stringify as toYaml } from "yaml";
+import type { Collection, CollectionItem } from "./types.js";
+
+function ensureSafeRelativePath(rootDir: string, relativePath: string, label: string): string {
+  if (!relativePath || path.isAbsolute(relativePath)) {
+    throw new Error(`${label} must be a relative path within the collection`);
+  }
+
+  const parts = relativePath.split(/[\\/]+/);
+  if (parts.some((part) => part === "" || part === "." || part === "..")) {
+    throw new Error(`${label} contains an unsafe path segment: ${relativePath}`);
+  }
+
+  const root = path.resolve(rootDir);
+  const resolved = path.resolve(root, ...parts);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes the collection root: ${relativePath}`);
+  }
+
+  return resolved;
+}
+
+function ensureSafeFileStem(name: string, label: string): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(name) || name === "." || name === "..") {
+    throw new Error(`${label} contains unsafe characters: ${name}`);
+  }
+  return name;
+}
+
+async function ensureDir(dirPath: string): Promise<void> {
+  await mkdir(dirPath, { recursive: true });
+}
+
+async function writeYaml(filePath: string, value: unknown): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  await writeFile(filePath, toYaml(value), "utf8");
+}
+
+async function writeItem(rootDir: string, item: CollectionItem): Promise<void> {
+  if (item.kind === "folder") {
+    const folderDir = ensureSafeRelativePath(rootDir, item.path, "Collection folder path");
+    await ensureDir(folderDir);
+    await writeYaml(path.join(folderDir, "folder.yml"), {
+      name: item.name,
+      ...(item.seq !== undefined ? { seq: item.seq } : {}),
+    });
+
+    for (const child of item.children ?? []) {
+      await writeItem(rootDir, child);
+    }
+
+    return;
+  }
+
+  if (!item.request) {
+    throw new Error(`Request item missing request payload: ${item.path}`);
+  }
+
+  await writeYaml(ensureSafeRelativePath(rootDir, item.path, "Collection request path"), item.request);
+}
+
+export async function writeCollection(collection: Collection): Promise<void> {
+  if (!collection.rootDir) {
+    throw new Error("Collection rootDir is required for writeCollection");
+  }
+
+  await ensureDir(collection.rootDir);
+
+  await writeYaml(path.join(collection.rootDir, "opencollection.yml"), {
+    name: collection.info.name,
+    ...(collection.info.description ? { description: collection.info.description } : {}),
+    ...(collection.info.version ? { version: collection.info.version } : {}),
+  });
+
+  const envDir = path.join(collection.rootDir, "environments");
+  await ensureDir(envDir);
+
+  for (const [name, env] of Object.entries(collection.environments)) {
+    const safeName = ensureSafeFileStem(name, "Environment name");
+    await writeYaml(path.join(envDir, `${safeName}.yml`), {
+      name: env.name,
+      variables: env.variables,
+    });
+  }
+
+  for (const item of collection.items) {
+    await writeItem(collection.rootDir, item);
+  }
+}

--- a/apifn/collections/tsconfig.json
+++ b/apifn/collections/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apifn/collections/tsup.config.ts
+++ b/apifn/collections/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/apifn/collections/vitest.config.ts
+++ b/apifn/collections/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/apifn/core/__tests__/diff.test.ts
+++ b/apifn/core/__tests__/diff.test.ts
@@ -1,0 +1,702 @@
+/**
+ * Tests for diffOpenAPI() — Phase 13 deliverable.
+ *
+ * Covers TV-DIFF-001 through TV-DIFF-009.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { OpenAPIDocument } from "../src/types.js";
+import { diffOpenAPI } from "../src/diff/diff.js";
+import { formatDiffAsJson, formatDiffAsText } from "../src/diff/format.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function blankDoc(title = "Test API"): OpenAPIDocument {
+    return {
+        openapi: "3.1.0",
+        info: { title, version: "1.0.0" },
+        paths: {},
+    };
+}
+
+function withPaths(doc: OpenAPIDocument, paths: OpenAPIDocument["paths"]): OpenAPIDocument {
+    return { ...doc, paths: { ...doc.paths, ...paths } };
+}
+
+// ─── TV-DIFF-001: Endpoint removal is breaking ────────────────────────────────
+
+describe("TV-DIFF-001: endpoint removal", () => {
+    it("detects removed endpoint as breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users/{id}": {
+                delete: { responses: { "204": { description: "Deleted" } } },
+                get: { responses: { "200": { description: "OK" } } },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users/{id}": {
+                get: { responses: { "200": { description: "OK" } } },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.path.includes("delete"));
+        expect(entry).toBeDefined();
+        expect(entry?.type).toBe("removed");
+        expect(entry?.breaking).toBe(true);
+        expect(entry?.description).toContain("DELETE");
+        expect(entry?.description).toContain("/users/{id}");
+    });
+
+    it("detects entire path removal as breaking for each method", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": { get: { responses: { "200": { description: "OK" } } } },
+        });
+        const after = blankDoc();
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        expect(result.breaking.length).toBeGreaterThan(0);
+        expect(result.breaking[0]?.description).toContain("removed");
+    });
+});
+
+// ─── TV-DIFF-002: Required param addition is breaking ────────────────────────
+
+describe("TV-DIFF-002: required parameter addition", () => {
+    it("required param added → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "filter", in: "query", required: true, schema: { type: "string" } }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.path.includes("filter"));
+        expect(entry).toBeDefined();
+        expect(entry?.breaking).toBe(true);
+        expect(entry?.description).toContain("Required");
+    });
+
+    it("optional param added → non-breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "sort", in: "query", required: false, schema: { type: "string" } }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(false);
+        const entry = result.nonBreaking.find((e) => e.path.includes("sort"));
+        expect(entry).toBeDefined();
+        expect(entry?.breaking).toBe(false);
+    });
+
+    it("param changed from optional to required → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "limit", in: "query", required: false, schema: { type: "integer" } }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "limit", in: "query", required: true, schema: { type: "integer" } }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.description.includes("required"));
+        expect(entry).toBeDefined();
+    });
+
+    it("unresolved parameter $ref is reported as breaking instead of being dropped", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ $ref: "#/components/parameters/Limit" } as never],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        const entry = result.breaking.find((e) => e.description.includes("#/components/parameters/Limit"));
+        expect(entry).toBeDefined();
+        expect(entry?.breaking).toBe(true);
+    });
+});
+
+// ─── TV-DIFF-003: Type narrowing is breaking ─────────────────────────────────
+
+describe("TV-DIFF-003: type narrowing", () => {
+    it("parameter type narrowed (string|number → string) → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [
+                        { name: "id", in: "query", schema: { type: ["string", "number"] } },
+                    ],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "id", in: "query", schema: { type: "string" } }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.description.toLowerCase().includes("narrow"));
+        expect(entry).toBeDefined();
+    });
+
+    it("existing optional request body field becoming required is breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                post: {
+                    requestBody: {
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    type: "object",
+                                    properties: {
+                                        name: { type: "string" },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    responses: { "201": { description: "Created" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                post: {
+                    requestBody: {
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    type: "object",
+                                    required: ["name"],
+                                    properties: {
+                                        name: { type: "string" },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    responses: { "201": { description: "Created" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        const entry = result.breaking.find((e) => e.description.includes("became required"));
+        expect(entry).toBeDefined();
+        expect(entry?.path).toContain("requestBody");
+    });
+
+    it("existing request body becoming required is breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                post: {
+                    requestBody: {
+                        required: false,
+                        content: {
+                            "application/json": {
+                                schema: { type: "object" },
+                            },
+                        },
+                    },
+                    responses: { "201": { description: "Created" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                post: {
+                    requestBody: {
+                        required: true,
+                        content: {
+                            "application/json": {
+                                schema: { type: "object" },
+                            },
+                        },
+                    },
+                    responses: { "201": { description: "Created" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        const entry = result.breaking.find((e) => e.path === "paths./users.post.requestBody.required");
+        expect(entry).toBeDefined();
+        expect(entry?.breaking).toBe(true);
+    });
+});
+
+// ─── TV-DIFF-004: Response field removal is breaking ─────────────────────────
+
+describe("TV-DIFF-004: response field removal", () => {
+    it("response field removed → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    responses: {
+                        "200": {
+                            description: "OK",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        type: "object",
+                                        properties: { id: { type: "string" }, name: { type: "string" } },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    responses: {
+                        "200": {
+                            description: "OK",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        type: "object",
+                                        properties: { id: { type: "string" } },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.path.includes("name"));
+        expect(entry).toBeDefined();
+        expect(entry?.type).toBe("removed");
+        expect(entry?.description).toContain("name");
+    });
+
+    it("response field added → non-breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    responses: {
+                        "200": {
+                            description: "OK",
+                            content: {
+                                "application/json": {
+                                    schema: { type: "object", properties: { id: { type: "string" } } },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    responses: {
+                        "200": {
+                            description: "OK",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        type: "object",
+                                        properties: { id: { type: "string" }, email: { type: "string" } },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(false);
+        const entry = result.nonBreaking.find((e) => e.path.includes("email"));
+        expect(entry).toBeDefined();
+        expect(entry?.breaking).toBe(false);
+    });
+
+    it("status code removed from responses → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    responses: {
+                        "200": { description: "OK" },
+                        "404": { description: "Not Found" },
+                    },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: { responses: { "200": { description: "OK" } } },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.path.includes("404"));
+        expect(entry).toBeDefined();
+    });
+});
+
+// ─── TV-DIFF-005: Security requirement changes ────────────────────────────────
+
+describe("TV-DIFF-005: security requirement changes", () => {
+    it("security requirement added → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/admin": {
+                get: {
+                    security: [],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/admin": {
+                get: {
+                    security: [{ bearerAuth: [] }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.path.includes("security"));
+        expect(entry).toBeDefined();
+        expect(entry?.type).toBe("added");
+    });
+
+    it("security requirement removed → non-breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/admin": {
+                get: {
+                    security: [{ bearerAuth: [] }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/admin": {
+                get: {
+                    security: [],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(false);
+        const entry = result.nonBreaking.find((e) => e.path.includes("security"));
+        expect(entry).toBeDefined();
+        expect(entry?.type).toBe("removed");
+    });
+
+    it("security alternative removed while auth remains → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/admin": {
+                get: {
+                    security: [{ apiKeyAuth: [] }, { bearerAuth: [] }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/admin": {
+                get: {
+                    security: [{ bearerAuth: [] }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.path.includes("security"));
+        expect(entry).toBeDefined();
+        expect(entry?.type).toBe("removed");
+    });
+});
+
+// ─── TV-DIFF-006: Non-breaking additions ─────────────────────────────────────
+
+describe("TV-DIFF-006: non-breaking additions", () => {
+    it("new endpoint added → non-breaking", () => {
+        const before = blankDoc();
+        const after = withPaths(blankDoc(), {
+            "/orders": {
+                get: { responses: { "200": { description: "OK" } } },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(false);
+        expect(result.nonBreaking.length).toBe(1);
+        expect(result.nonBreaking[0]?.type).toBe("added");
+        expect(result.nonBreaking[0]?.description).toContain("GET /orders");
+    });
+
+    it("description change → non-breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    description: "Get all users",
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    description: "Get all users (updated)",
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(false);
+        const entry = result.nonBreaking.find((e) => e.path.includes("description"));
+        expect(entry).toBeDefined();
+        expect(entry?.breaking).toBe(false);
+    });
+
+    it("deprecated flag added → non-breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: { deprecated: false, responses: { "200": { description: "OK" } } },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: { deprecated: true, responses: { "200": { description: "OK" } } },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(false);
+        const entry = result.nonBreaking.find((e) => e.path.includes("deprecated"));
+        expect(entry).toBeDefined();
+    });
+});
+
+// ─── TV-DIFF-007: Summary generation ─────────────────────────────────────────
+
+describe("TV-DIFF-007: summary generation", () => {
+    it("summary counts are accurate", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: { responses: { "200": { description: "OK" } } },
+                delete: { responses: { "204": { description: "Deleted" } } },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    description: "Updated", // non-breaking modification
+                    responses: {
+                        "200": { description: "OK" },
+                        "400": { description: "Bad Request" }, // added response status (non-breaking)
+                    },
+                },
+                // delete removed → breaking
+            },
+            "/orders": {
+                get: { responses: { "200": { description: "OK" } } }, // added endpoint (non-breaking)
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.summary.breaking).toBe(result.breaking.length);
+        expect(result.summary.nonBreaking).toBe(result.nonBreaking.length);
+        expect(result.summary.added).toBeGreaterThan(0); // /orders + response 400
+        expect(result.summary.removed).toBeGreaterThan(0); // delete removed
+        expect(typeof result.summary.modified).toBe("number");
+    });
+});
+
+// ─── TV-DIFF-008: Deterministic results ─────────────────────────────────────
+
+describe("TV-DIFF-008: deterministic results", () => {
+    it("same inputs produce structurally equal output", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "limit", in: "query" }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+            "/orders": { get: { responses: { "200": { description: "OK" } } } },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "limit", in: "query" }, { name: "filter", in: "query", required: true }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+            // /orders removed
+        });
+
+        const result1 = diffOpenAPI(before, after);
+        const result2 = diffOpenAPI(before, after);
+
+        expect(JSON.stringify(result1)).toBe(JSON.stringify(result2));
+        // Entries should be sorted by path
+        const paths1 = result1.breaking.map((e) => e.path);
+        const paths2 = result2.breaking.map((e) => e.path);
+        expect(paths1).toEqual([...paths1].sort());
+        expect(paths1).toEqual(paths2);
+    });
+});
+
+// ─── TV-DIFF-009: JSON and human-readable output ─────────────────────────────
+
+describe("TV-DIFF-009: formatters", () => {
+    it("formatDiffAsJson produces SPEC 6.5 format", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": { delete: { responses: { "204": { description: "Deleted" } } } },
+        });
+        const after = blankDoc();
+
+        const result = diffOpenAPI(before, after);
+        const json = formatDiffAsJson(result, "2026-03-05T22:00:00Z");
+
+        expect(json.timestamp).toBe("2026-03-05T22:00:00Z");
+        expect(json.hasBreakingChanges).toBe(true);
+        expect(json.summary).toBeDefined();
+        expect(json.breaking).toBeInstanceOf(Array);
+        expect(json.nonBreaking).toBeInstanceOf(Array);
+        // Should be JSON-serializable
+        expect(() => JSON.stringify(json)).not.toThrow();
+    });
+
+    it("formatDiffAsText produces human-readable output with key sections", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": { delete: { responses: { "204": { description: "Deleted" } } } },
+        });
+        const after = blankDoc();
+
+        const result = diffOpenAPI(before, after);
+        const text = formatDiffAsText(result);
+
+        expect(text).toContain("API Diff Report");
+        expect(text).toContain("Breaking Changes");
+        expect(text).toContain("breaking change");
+    });
+
+    it("formatDiffAsText shows 'No changes' when diff is empty", () => {
+        const doc = withPaths(blankDoc(), {
+            "/health": { get: { responses: { "200": { description: "OK" } } } },
+        });
+        const result = diffOpenAPI(doc, doc);
+        const text = formatDiffAsText(result);
+        expect(text).toContain("No changes detected");
+        expect(text).toContain("No breaking changes");
+    });
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("Edge cases", () => {
+    it("identical docs → no changes", () => {
+        const doc = withPaths(blankDoc(), {
+            "/users": { get: { responses: { "200": { description: "OK" } } } },
+        });
+        const result = diffOpenAPI(doc, doc);
+        expect(result.hasBreakingChanges).toBe(false);
+        expect(result.breaking.length).toBe(0);
+        expect(result.nonBreaking.length).toBe(0);
+    });
+
+    it("empty → empty → no changes", () => {
+        const result = diffOpenAPI(blankDoc(), blankDoc());
+        expect(result.breaking.length).toBe(0);
+        expect(result.nonBreaking.length).toBe(0);
+    });
+
+    it("parameter removed → breaking", () => {
+        const before = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [{ name: "limit", in: "query", required: false }],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+        const after = withPaths(blankDoc(), {
+            "/users": {
+                get: {
+                    parameters: [],
+                    responses: { "200": { description: "OK" } },
+                },
+            },
+        });
+
+        const result = diffOpenAPI(before, after);
+        expect(result.hasBreakingChanges).toBe(true);
+        const entry = result.breaking.find((e) => e.path.includes("limit"));
+        expect(entry).toBeDefined();
+        expect(entry?.type).toBe("removed");
+    });
+});

--- a/apifn/core/__tests__/introspect.test.ts
+++ b/apifn/core/__tests__/introspect.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { createRouter } from "@superfunctions/http";
+import { apiSchema, introspectRouter } from "../src/index.js";
+
+describe("introspectRouter", () => {
+  it("TV-INTRO-001 + TV-INTRO-002: extracts all routes with method/path and preserves ordering", () => {
+    const router = createRouter({
+      routes: [
+        { method: "GET", path: "/users", handler: async () => Response.json([]) },
+        {
+          method: "POST",
+          path: "/users",
+          handler: async () => Response.json({}, { status: 201 }),
+        },
+      ],
+    });
+
+    const result = introspectRouter(router);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      method: "GET",
+      path: "/users",
+      parameters: [],
+      responses: { "200": { description: "Success" } },
+      meta: {},
+    });
+    expect(result[1]).toMatchObject({
+      method: "POST",
+      path: "/users",
+      parameters: [],
+      responses: { "200": { description: "Success" } },
+      meta: {},
+    });
+  });
+
+  it("TV-INTRO-003: parses descriptor fields and preserves zod-like schema references", () => {
+    const zodBody = { _def: { typeName: "ZodObject" } } as const;
+    const zodResponse = { _def: { typeName: "ZodObject" } } as const;
+
+    const router = createRouter({
+      routes: [
+        {
+          method: "POST",
+          path: "/users",
+          handler: async () => Response.json({}),
+          meta: apiSchema({
+            summary: "Create user",
+            operationId: "createUser",
+            tags: ["users"],
+            body: zodBody,
+            responses: {
+              201: { description: "Created", schema: zodResponse },
+              400: { description: "Validation error" },
+            },
+          }),
+        },
+      ],
+    });
+
+    const [route] = introspectRouter(router);
+
+    expect(route.summary).toBe("Create user");
+    expect(route.operationId).toBe("createUser");
+    expect(route.tags).toEqual(["users"]);
+    expect(route.requestBody?.content["application/json"]?.schema).toBe(zodBody);
+    expect(route.responses["201"]?.content?.["application/json"]?.schema).toBe(zodResponse);
+    expect(route.responses["400"]).toEqual({ description: "Validation error" });
+  });
+
+  it("TV-INTRO-004: parses TypeBox-like query and response schema descriptors", () => {
+    const typeBoxQuery = {
+      [Symbol.for("TypeBox.Kind")]: "Number",
+      type: "number",
+      minimum: 1,
+      maximum: 100,
+    };
+    const typeBoxResponse = {
+      [Symbol.for("TypeBox.Kind")]: "Array",
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+        },
+      },
+    };
+
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/items",
+          handler: async () => Response.json([]),
+          meta: apiSchema({
+            summary: "List items",
+            query: { limit: typeBoxQuery },
+            responses: {
+              200: {
+                description: "Item list",
+                schema: typeBoxResponse,
+              },
+            },
+          }),
+        },
+      ],
+    });
+
+    const [route] = introspectRouter(router);
+
+    expect(route.parameters).toContainEqual({
+      name: "limit",
+      in: "query",
+      required: false,
+      schema: typeBoxQuery,
+    });
+    expect(route.responses["200"]?.content?.["application/json"]?.schema).toBe(typeBoxResponse);
+  });
+
+  it("TV-INTRO-005: converts path parameters and emits path parameter descriptors", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/orders/:orderId/items/:itemId",
+          handler: async () => Response.json([]),
+        },
+      ],
+    });
+
+    const [route] = introspectRouter(router);
+
+    expect(route.path).toBe("/orders/{orderId}/items/{itemId}");
+    expect(route.parameters).toContainEqual({
+      name: "orderId",
+      in: "path",
+      required: true,
+      schema: { type: "string" },
+    });
+    expect(route.parameters).toContainEqual({
+      name: "itemId",
+      in: "path",
+      required: true,
+      schema: { type: "string" },
+    });
+  });
+
+  it("TV-INTRO-006: applies include/exclude filtering by prefix", () => {
+    const router = createRouter({
+      routes: [
+        { method: "GET", path: "/api/v1/users", handler: async () => Response.json([]) },
+        { method: "GET", path: "/api/v1/orders", handler: async () => Response.json([]) },
+        { method: "GET", path: "/internal/health", handler: async () => Response.json({}) },
+        { method: "GET", path: "/internal/metrics", handler: async () => Response.json({}) },
+      ],
+    });
+
+    expect(introspectRouter(router, { include: ["/api"] })).toHaveLength(2);
+    expect(introspectRouter(router, { exclude: ["/internal"] })).toHaveLength(2);
+    expect(
+      introspectRouter(router, {
+        include: ["/api"],
+        exclude: ["/api/v1/orders"],
+      })
+    ).toHaveLength(1);
+  });
+
+  it("TV-INTRO-007: handles routes with undefined or empty meta using defaults", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/health",
+          handler: async () => Response.json({ ok: true }),
+          meta: undefined,
+        },
+        {
+          method: "GET",
+          path: "/ready",
+          handler: async () => Response.json({ ok: true }),
+          meta: {},
+        },
+      ],
+    });
+
+    const [health, ready] = introspectRouter(router);
+
+    expect(health).toMatchObject({
+      method: "GET",
+      path: "/health",
+      parameters: [],
+      responses: { "200": { description: "Success" } },
+      meta: {},
+    });
+    expect(ready).toMatchObject({
+      method: "GET",
+      path: "/ready",
+      parameters: [],
+      responses: { "200": { description: "Success" } },
+      meta: {},
+    });
+  });
+
+  it("applies basePath before conversion and filtering", () => {
+    const router = createRouter({
+      routes: [{ method: "GET", path: "/users/:id", handler: async () => Response.json({}) }],
+    });
+
+    const [route] = introspectRouter(router, { basePath: "/api/v1", include: ["/api"] });
+
+    expect(route.path).toBe("/api/v1/users/{id}");
+    expect(route.parameters).toContainEqual({
+      name: "id",
+      in: "path",
+      required: true,
+      schema: { type: "string" },
+    });
+  });
+});

--- a/apifn/core/__tests__/openapi-generate.test.ts
+++ b/apifn/core/__tests__/openapi-generate.test.ts
@@ -1,0 +1,327 @@
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { Type } from "@sinclair/typebox";
+import { createRouter } from "@superfunctions/http";
+import { z } from "zod";
+import {
+  apiSchema,
+  fromRouter,
+  generateOpenAPI,
+  introspectRouter,
+  type IntrospectedRoute,
+} from "../src/index.js";
+
+describe("OpenAPI generation", () => {
+  it("TV-OPENAPI-001: generates a valid OpenAPI 3.1 document", async () => {
+    const routes: IntrospectedRoute[] = [
+      {
+        method: "GET",
+        path: "/users",
+        parameters: [],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: z.array(z.object({ id: z.string() })),
+              },
+            },
+          },
+        },
+        meta: {},
+      },
+    ];
+
+    const doc = generateOpenAPI(routes, {
+      info: { title: "Test API", version: "1.0.0" },
+    });
+
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.info.title).toBe("Test API");
+    expect(doc.paths["/users"]?.get).toBeDefined();
+    await expect(SwaggerParser.validate(doc as object)).resolves.toBeDefined();
+  });
+
+  it("TV-OPENAPI-002: creates one operation per method/path and auto operationId", () => {
+    const routes: IntrospectedRoute[] = [
+      {
+        method: "GET",
+        path: "/users",
+        operationId: "getUsers",
+        parameters: [],
+        responses: { "200": { description: "Success" } },
+        meta: {},
+      },
+      {
+        method: "POST",
+        path: "/users",
+        operationId: "createUser",
+        parameters: [],
+        responses: { "201": { description: "Created" } },
+        meta: {},
+      },
+      {
+        method: "GET",
+        path: "/users/{id}",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: { "200": { description: "Success" } },
+        meta: {},
+      },
+    ];
+
+    const doc = generateOpenAPI(routes, {
+      info: { title: "Test API", version: "1.0.0" },
+    });
+
+    expect(doc.paths["/users"]?.get?.operationId).toBe("getUsers");
+    expect(doc.paths["/users"]?.post?.operationId).toBe("createUser");
+    expect(doc.paths["/users/{id}"]?.get?.operationId).toBe("getUsersId");
+  });
+
+  it("TV-OPENAPI-003: maps path/query/header parameters", () => {
+    const route: IntrospectedRoute = {
+      method: "GET",
+      path: "/users/{id}",
+      parameters: [
+        { name: "id", in: "path", required: true, schema: { type: "string" } },
+        { name: "fields", in: "query", required: false, schema: z.string().optional() },
+        { name: "x-trace-id", in: "header", required: false, schema: Type.String() },
+      ],
+      responses: { "200": { description: "Success" } },
+      meta: {},
+    };
+
+    const doc = generateOpenAPI([route], {
+      info: { title: "Test API", version: "1.0.0" },
+    });
+
+    expect(doc.paths["/users/{id}"]?.get?.parameters).toEqual(
+      expect.arrayContaining([
+        {
+          in: "path",
+          name: "id",
+          required: true,
+          schema: { type: "string" },
+        },
+        {
+          in: "query",
+          name: "fields",
+          required: false,
+          schema: { type: "string" },
+        },
+        {
+          in: "header",
+          name: "x-trace-id",
+          required: false,
+          schema: { type: "string" },
+        },
+      ])
+    );
+  });
+
+  it("OPENAPI-004 + OPENAPI-005: generates requestBody, responses, defaults and headers", () => {
+    const routes: IntrospectedRoute[] = [
+      {
+        method: "POST",
+        path: "/users",
+        parameters: [],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: z.object({ name: z.string() }),
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Created",
+            content: {
+              "application/json": {
+                schema: Type.Object({ id: Type.String() }),
+              },
+            },
+            headers: {
+              "x-request-id": {
+                schema: { type: "string" },
+                description: "Request id",
+              },
+            },
+          },
+        },
+        meta: {},
+      },
+      {
+        method: "GET",
+        path: "/health",
+        parameters: [],
+        responses: {},
+        meta: {},
+      },
+    ];
+
+    const doc = generateOpenAPI(routes, {
+      info: { title: "Test API", version: "1.0.0" },
+    });
+
+    expect(
+      doc.paths["/users"]?.post?.requestBody?.content["application/json"]?.schema
+    ).toMatchObject({
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+    expect(doc.paths["/users"]?.post?.requestBody?.required).toBe(true);
+    expect(doc.paths["/users"]?.post?.responses?.["201"]).toMatchObject({
+      description: "Created",
+      headers: {
+        "x-request-id": {
+          description: "Request id",
+          schema: { type: "string" },
+        },
+      },
+    });
+    expect(doc.paths["/health"]?.get?.responses?.["200"]).toEqual({
+      description: "Success",
+    });
+  });
+
+  it("OPENAPI-006 + OPENAPI-007 + OPENAPI-008: tags, security schemes, operation security and servers", () => {
+    const routes: IntrospectedRoute[] = [
+      {
+        method: "GET",
+        path: "/users",
+        tags: ["users", "public"],
+        security: [{ bearerAuth: [] }],
+        parameters: [],
+        responses: { "200": { description: "Success" } },
+        meta: {},
+      },
+      {
+        method: "GET",
+        path: "/orders",
+        tags: ["orders", "public"],
+        parameters: [],
+        responses: { "200": { description: "Success" } },
+        meta: {},
+      },
+    ];
+
+    const withServers = generateOpenAPI(routes, {
+      info: { title: "Test API", version: "1.0.0" },
+      servers: [
+        { url: "https://api.example.com", description: "prod" },
+        { url: "https://staging.example.com", description: "staging" },
+      ],
+      securitySchemes: {
+        apiKeyAuth: { type: "apiKey", in: "header", name: "x-api-key" },
+        bearerAuth: { type: "http", scheme: "bearer" },
+        oauth2Auth: {
+          type: "oauth2",
+          flows: {
+            authorizationCode: {
+              authorizationUrl: "https://example.com/auth",
+              tokenUrl: "https://example.com/token",
+              scopes: { "read:users": "Read users" },
+            },
+          },
+        },
+        openIdAuth: { type: "openIdConnect", openIdConnectUrl: "https://example.com/.well-known/openid-configuration" },
+      },
+    });
+
+    expect(withServers.tags?.map((tag) => tag.name)).toEqual([
+      "orders",
+      "public",
+      "users",
+    ]);
+    expect(withServers.components?.securitySchemes?.apiKeyAuth).toBeDefined();
+    expect(withServers.components?.securitySchemes?.bearerAuth).toBeDefined();
+    expect(withServers.components?.securitySchemes?.oauth2Auth).toBeDefined();
+    expect(withServers.components?.securitySchemes?.openIdAuth).toBeDefined();
+    expect(withServers.paths["/users"]?.get?.security).toEqual([{ bearerAuth: [] }]);
+    expect(withServers.servers).toEqual([
+      { description: "prod", url: "https://api.example.com" },
+      { description: "staging", url: "https://staging.example.com" },
+    ]);
+
+    const withoutServers = generateOpenAPI(routes, {
+      info: { title: "Test API", version: "1.0.0" },
+    });
+
+    expect(withoutServers.servers).toBeUndefined();
+  });
+
+  it("TV-OPENAPI-009: output is deterministic", () => {
+    const routes: IntrospectedRoute[] = [
+      {
+        method: "GET",
+        path: "/users/{id}",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: z.object({ id: z.string(), name: z.string() }),
+              },
+            },
+          },
+        },
+        tags: ["users"],
+        meta: {},
+      },
+    ];
+
+    const options = {
+      info: { title: "Deterministic API", version: "1.0.0" },
+      extensions: { generatedBy: "apifn" },
+    };
+
+    const first = generateOpenAPI(routes, options);
+    const second = generateOpenAPI(routes, options);
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it("TV-OPENAPI-010: fromRouter matches introspect+generate", () => {
+    const router = createRouter({
+      routes: [
+        {
+          method: "GET",
+          path: "/api/users/:id",
+          handler: async () => Response.json({}),
+          meta: apiSchema({
+            operationId: "getUserById",
+            summary: "Get user",
+            query: { fields: z.string().optional() },
+            responses: {
+              200: {
+                description: "OK",
+                schema: z.object({ id: z.string() }),
+              },
+            },
+          }),
+        },
+      ],
+    });
+
+    const options = {
+      info: { title: "Router API", version: "1.0.0" },
+      include: ["/api"],
+      servers: [{ url: "https://api.example.com" }],
+    };
+
+    const direct = fromRouter(router, options);
+    const manual = generateOpenAPI(
+      introspectRouter(router, {
+        include: options.include,
+      }),
+      {
+        info: options.info,
+        servers: options.servers,
+      }
+    );
+
+    expect(direct).toEqual(manual);
+  });
+});

--- a/apifn/core/__tests__/openapi-parse.test.ts
+++ b/apifn/core/__tests__/openapi-parse.test.ts
@@ -1,0 +1,126 @@
+import { parseOpenAPI, validateOpenAPI } from "../src/index.js";
+
+describe("parseOpenAPI", () => {
+  it("TV-OPENAPI-011: parses JSON string", () => {
+    const jsonInput = JSON.stringify({
+      openapi: "3.1.0",
+      info: { title: "External API", version: "2.0.0" },
+      paths: {
+        "/items": {
+          get: {
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+    });
+
+    const parsed = parseOpenAPI(jsonInput);
+    expect(parsed.openapi).toBe("3.1.0");
+    expect(parsed.info.title).toBe("External API");
+  });
+
+  it("TV-OPENAPI-011: parses YAML string", () => {
+    const yamlInput = `
+openapi: "3.1.0"
+info:
+  title: External API
+  version: "2.0.0"
+paths:
+  /items:
+    get:
+      summary: List items
+      responses:
+        "200":
+          description: OK
+`;
+
+    const parsed = parseOpenAPI(yamlInput);
+    expect(parsed.openapi).toBe("3.1.0");
+    expect(parsed.info.title).toBe("External API");
+    expect(parsed.paths["/items"]?.get).toBeDefined();
+  });
+
+  it("TV-OPENAPI-011: parses object input", () => {
+    const input = {
+      openapi: "3.1.0",
+      info: { title: "Object API", version: "1.0.0" },
+      paths: {},
+    };
+
+    const parsed = parseOpenAPI(input);
+    expect(parsed).toBe(input);
+  });
+
+  it("TV-OPENAPI-011 NEG: throws descriptive error for invalid input", () => {
+    expect(() => parseOpenAPI("openapi: : : invalid")).toThrow(/failed to parse/i);
+  });
+
+  it("TV-OPENAPI-013: upconverts 3.0.x nullable schema to 3.1.0", async () => {
+    const input = {
+      openapi: "3.0.3",
+      info: { title: "Old API", version: "1.0.0" },
+      paths: {
+        "/items": {
+          get: {
+            responses: {
+              "200": {
+                description: "OK",
+                content: {
+                  "application/json": {
+                    schema: { type: "string", nullable: true, example: "x" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const parsed = parseOpenAPI(input);
+
+    expect(parsed.openapi).toBe("3.1.0");
+    const schema = parsed.paths["/items"]?.get?.responses?.["200"]?.content?.[
+      "application/json"
+    ]?.schema as { type?: unknown; nullable?: unknown; example?: unknown };
+    expect(schema.type).toEqual(["string", "null"]);
+    expect(schema.nullable).toBeUndefined();
+    expect(schema.example).toBe("x");
+
+    await expect(validateOpenAPI(parsed)).resolves.toEqual([]);
+  });
+
+  it("does not invent a null-only type for nullable schemas without explicit type", () => {
+    const input = {
+      openapi: "3.0.3",
+      info: { title: "Old API", version: "1.0.0" },
+      paths: {
+        "/items": {
+          get: {
+            responses: {
+              "200": {
+                description: "OK",
+                content: {
+                  "application/json": {
+                    schema: { nullable: true, description: "Untyped nullable schema" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const parsed = parseOpenAPI(input);
+    const schema = parsed.paths["/items"]?.get?.responses?.["200"]?.content?.[
+      "application/json"
+    ]?.schema as { type?: unknown; nullable?: unknown; description?: unknown };
+
+    expect(schema.type).toBeUndefined();
+    expect(schema.nullable).toBeUndefined();
+    expect(schema.description).toBe("Untyped nullable schema");
+  });
+});

--- a/apifn/core/__tests__/openapi-validate.test.ts
+++ b/apifn/core/__tests__/openapi-validate.test.ts
@@ -1,0 +1,36 @@
+import { validateOpenAPI } from "../src/index.js";
+
+describe("validateOpenAPI", () => {
+  it("TV-OPENAPI-012: valid document returns empty errors", async () => {
+    const doc = {
+      openapi: "3.1.0" as const,
+      info: { title: "Valid API", version: "1.0.0" },
+      paths: {
+        "/health": {
+          get: {
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+    };
+
+    await expect(validateOpenAPI(doc)).resolves.toEqual([]);
+  });
+
+  it("TV-OPENAPI-012: invalid document returns errors with path/message", async () => {
+    const invalidDoc = {
+      openapi: "3.1.0" as const,
+      info: { version: "1.0.0" },
+      paths: {},
+    } as unknown as Parameters<typeof validateOpenAPI>[0];
+
+    const errors = await validateOpenAPI(invalidDoc);
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.path).toBeTruthy();
+    expect(errors[0]?.message).toBeTruthy();
+    expect(errors[0]?.severity).toBe("error");
+  });
+});

--- a/apifn/core/__tests__/schema.test.ts
+++ b/apifn/core/__tests__/schema.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { Type } from "@sinclair/typebox";
+import {
+  convertSchema,
+  convertTypeBoxSchema,
+  convertZodSchema,
+  deduplicateSchemas,
+  detectSchemaType,
+} from "../src/index.js";
+
+describe("schema conversion", () => {
+  it("TV-SCHEMA-001: converts zod objects with optional fields", () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number().optional(),
+      nested: z.object({ active: z.boolean() }),
+      tags: z.array(z.string()),
+    });
+
+    const converted = convertZodSchema(schema);
+
+    expect(converted.type).toBe("object");
+    expect(converted.properties).toMatchObject({
+      name: { type: "string" },
+      age: { type: "number" },
+      nested: {
+        type: "object",
+        properties: {
+          active: { type: "boolean" },
+        },
+        required: ["active"],
+      },
+      tags: {
+        type: "array",
+        items: { type: "string" },
+      },
+    });
+    expect(converted.required).toEqual(expect.arrayContaining(["name", "nested", "tags"]));
+    expect(converted.required).not.toContain("age");
+  });
+
+  it("TV-SCHEMA-002: converts zod enum", () => {
+    const converted = convertZodSchema(z.enum(["active", "inactive", "pending"]));
+
+    expect(converted).toMatchObject({
+      type: "string",
+      enum: ["active", "inactive", "pending"],
+    });
+  });
+
+  it("TV-SCHEMA-003: passes through TypeBox schema and strips symbol metadata", () => {
+    const schema = Type.Object({
+      id: Type.String(),
+      count: Type.Integer({ minimum: 0 }),
+    });
+
+    const converted = convertTypeBoxSchema(schema);
+
+    expect(converted).toMatchObject({
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        count: { type: "integer", minimum: 0 },
+      },
+      required: ["id", "count"],
+    });
+    expect(Object.getOwnPropertySymbols(converted)).toHaveLength(0);
+  });
+
+  it("TV-SCHEMA-004: passes through plain JSON Schema unchanged", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: {
+        id: { type: "string", format: "uuid" },
+      },
+      required: ["id"],
+    } as const;
+
+    expect(convertSchema(jsonSchema)).toBe(jsonSchema);
+  });
+
+  it("TV-SCHEMA-005: detects schema type correctly and errors for unsupported inputs", () => {
+    expect(detectSchemaType(z.string())).toBe("zod");
+    expect(detectSchemaType(Type.String())).toBe("typebox");
+    expect(detectSchemaType({ type: "string" })).toBe("jsonschema");
+    expect(() => detectSchemaType(42 as never)).toThrow(/Unsupported schema type/i);
+  });
+
+  it("TV-SCHEMA-006: deduplicates repeated schemas into single component ref", () => {
+    const userZod = z.object({ id: z.string(), name: z.string() });
+    const userA = convertZodSchema(userZod);
+    const userB = convertZodSchema(userZod);
+
+    const deduped = deduplicateSchemas([
+      { name: "User", schema: userA },
+      { name: "User", schema: userB },
+    ]);
+
+    expect(Object.keys(deduped.components)).toHaveLength(1);
+    expect(deduped.components.User).toMatchObject({
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        name: { type: "string" },
+      },
+    });
+    expect(deduped.refs).toEqual([
+      "#/components/schemas/User",
+      "#/components/schemas/User",
+    ]);
+  });
+
+  it("deduplicates unnamed structurally equal schemas", () => {
+    const deduped = deduplicateSchemas([
+      { schema: { type: "object", properties: { id: { type: "string" } } } },
+      { schema: { type: "object", properties: { id: { type: "string" } } } },
+    ]);
+
+    expect(Object.keys(deduped.components)).toHaveLength(1);
+    expect(deduped.refs[0]).toBe(deduped.refs[1]);
+  });
+});

--- a/apifn/core/__tests__/testfn-adapter.test.ts
+++ b/apifn/core/__tests__/testfn-adapter.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TestCase } from "@testfn/core";
+import { ApifnTestAdapter } from "../src/integrations/testfn.js";
+
+const mocks = vi.hoisted(() => {
+  return {
+    fastGlob: vi.fn(),
+    readCollection: vi.fn(),
+    runCollection: vi.fn(),
+  };
+});
+
+vi.mock("fast-glob", () => ({
+  default: mocks.fastGlob,
+}));
+
+vi.mock("@apifn/collections", () => ({
+  readCollection: mocks.readCollection,
+  runCollection: mocks.runCollection,
+}));
+
+describe("ApifnTestAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("TV-TESTFN-001: exposes apifn adapter identity", () => {
+    const adapter = new ApifnTestAdapter();
+
+    expect(adapter.name).toBe("apifn");
+    expect(adapter.supports("apifn")).toBe(true);
+    expect(adapter.supports("APIFN")).toBe(true);
+    expect(adapter.supports("vitest")).toBe(false);
+  });
+
+  it("TV-TESTFN-002: discovers request-level test cases from opencollection directories", async () => {
+    const adapter = new ApifnTestAdapter();
+    mocks.fastGlob.mockResolvedValue(["/tmp/work/orders/opencollection.yml"]);
+    mocks.readCollection.mockResolvedValue({
+      info: { name: "Orders API" },
+      environments: {},
+      items: [
+        { kind: "request", name: "List Orders" },
+        {
+          kind: "folder",
+          name: "Auth",
+          children: [{ kind: "request", name: "Login" }],
+        },
+      ],
+    });
+
+    const tests = await adapter.discover(["/tmp/work/orders"]);
+
+    expect(mocks.fastGlob).toHaveBeenCalledWith(
+      "/tmp/work/orders/**/opencollection.yml",
+      { absolute: true },
+    );
+    expect(mocks.readCollection).toHaveBeenCalledWith("/tmp/work/orders");
+    expect(tests).toHaveLength(2);
+    expect(tests.map((t: TestCase) => t.name)).toEqual(["List Orders", "Login"]);
+    expect(tests[0]?.suite).toBe("Orders API");
+    expect(tests[1]?.suite).toBe("Auth");
+  });
+
+  it("TV-TESTFN-003: maps collection request results to testfn result format", async () => {
+    const adapter = new ApifnTestAdapter();
+    mocks.readCollection.mockResolvedValue({
+      info: { name: "Orders API" },
+      environments: { default: {} },
+      items: [],
+    });
+    mocks.runCollection.mockResolvedValue({
+      results: [
+        { name: "List Orders", status: "passed", duration: 11, assertions: [] },
+        {
+          name: "Create Order",
+          status: "failed",
+          duration: 22,
+          assertions: [{ name: "status is 201", passed: false }],
+        },
+        { name: "Sync Orders", status: "error", duration: 33, assertions: [], error: "socket hang up", statusCode: 500 },
+        { name: "Archive Order", status: "skipped", duration: 0, assertions: [] },
+      ],
+    });
+
+    const tests: TestCase[] = [
+      { id: "t1", file: "/tmp/work/orders", name: "List Orders", suite: "Orders API" },
+      { id: "t2", file: "/tmp/work/orders", name: "Create Order", suite: "Orders API" },
+      { id: "t3", file: "/tmp/work/orders", name: "Sync Orders", suite: "Orders API" },
+      { id: "t4", file: "/tmp/work/orders", name: "Archive Order", suite: "Orders API" },
+    ];
+
+    const results = await adapter.run(tests, {});
+
+    expect(results).toHaveLength(4);
+    expect(results[0]).toMatchObject({ id: "t1", status: "passed", duration: 11 });
+    expect(results[1]).toMatchObject({ id: "t2", status: "failed", duration: 22 });
+    expect(results[1]?.error?.message).toContain("status is 201");
+    expect(results[2]).toMatchObject({ id: "t3", status: "failed", duration: 33 });
+    expect(results[2]?.error?.message).toContain("socket hang up");
+    expect(results[3]).toMatchObject({ id: "t4", status: "skipped", duration: 0 });
+  });
+});

--- a/apifn/core/__tests__/watchfn-integration.test.ts
+++ b/apifn/core/__tests__/watchfn-integration.test.ts
@@ -1,0 +1,252 @@
+/**
+ * watchfn integration tests (TV-WATCH-001 through TV-WATCH-004).
+ *
+ * All tests use vi.stubGlobal("fetch", ...) to mock HTTP without a real server.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+    fetchEndpointMetrics,
+    createWatchFnClient,
+    apifnWatchMiddleware,
+} from "../src/integrations/watchfn.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const BASE_URL = "http://watchfn.local:7100";
+
+/** Minimal valid watchfn API metric shape. */
+function mockMetric(overrides: Record<string, unknown> = {}) {
+    return {
+        method: "GET",
+        path: "/users",
+        latency_p50: 45,
+        latency_p95: 120,
+        latency_p99: 250,
+        latency_avg: 60,
+        rpm: 100,
+        total_requests: 5000,
+        error_rate: 0.01,
+        error_count: 50,
+        last_error: undefined,
+        availability: 99.9,
+        last_updated: "2026-03-06T06:00:00Z",
+        ...overrides,
+    };
+}
+
+function mockFetch(body: unknown, status = 200) {
+    return vi.fn().mockResolvedValue({
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+    });
+}
+
+// ─── TV-WATCH-001: fetchEndpointMetrics ───────────────────────────────────────
+
+describe("TV-WATCH-001: fetchEndpointMetrics", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", mockFetch([mockMetric(), mockMetric({ method: "POST", path: "/orders" })]));
+    });
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    it("returns EndpointMetrics[] on success", async () => {
+        const metrics = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(metrics).toHaveLength(2);
+    });
+
+    it("parses latency percentiles correctly", async () => {
+        const [m] = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(m.latency.p50).toBe(45);
+        expect(m.latency.p95).toBe(120);
+        expect(m.latency.p99).toBe(250);
+        expect(m.latency.avg).toBe(60);
+    });
+
+    it("parses throughput (rpm + total)", async () => {
+        const [m] = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(m.throughput.rpm).toBe(100);
+        expect(m.throughput.total).toBe(5000);
+    });
+
+    it("parses error rate and count", async () => {
+        const [m] = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(m.errors.rate).toBe(0.01);
+        expect(m.errors.count).toBe(50);
+    });
+
+    it("parses availability and lastUpdated", async () => {
+        const [m] = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(m.availability).toBe(99.9);
+        expect(m.lastUpdated).toBe("2026-03-06T06:00:00Z");
+    });
+
+    it("appends timeRange query param", async () => {
+        await fetchEndpointMetrics({ baseUrl: BASE_URL, timeRange: "PT1H" });
+        const calledUrl: string = vi.mocked(fetch).mock.calls[0][0] as string;
+        expect(calledUrl).toContain("timeRange=PT1H");
+    });
+
+    it("appends endpoint filter query params", async () => {
+        await fetchEndpointMetrics({ baseUrl: BASE_URL, endpoints: ["GET /users", "POST /orders"] });
+        const calledUrl: string = vi.mocked(fetch).mock.calls[0][0] as string;
+        expect(calledUrl).toContain("endpoint=GET+%2Fusers");
+    });
+
+    it("sends Authorization header when apiKey provided", async () => {
+        await fetchEndpointMetrics({ baseUrl: BASE_URL, apiKey: "test-key" });
+        const calledInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+        expect((calledInit.headers as Record<string, string>)["Authorization"]).toBe("Bearer test-key");
+    });
+
+    it("handles data-wrapped response { data: [...] }", async () => {
+        vi.stubGlobal("fetch", mockFetch({ data: [mockMetric()] }));
+        const metrics = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(metrics).toHaveLength(1);
+    });
+});
+
+// ─── TV-WATCH-001 (graceful degradation) ─────────────────────────────────────
+
+describe("TV-WATCH-001: graceful degradation", () => {
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    it("returns [] and warns on network error", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+        const metrics = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(metrics).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Could not reach watchfn"));
+        warnSpy.mockRestore();
+    });
+
+    it("returns [] and warns on non-2xx response", async () => {
+        vi.stubGlobal("fetch", mockFetch(null, 503));
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+        const metrics = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(metrics).toEqual([]);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("HTTP 503"));
+        warnSpy.mockRestore();
+    });
+
+    it("returns [] on invalid JSON response", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true, status: 200,
+            json: () => Promise.reject(new SyntaxError("Unexpected token")),
+        }));
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+        const metrics = await fetchEndpointMetrics({ baseUrl: BASE_URL });
+        expect(metrics).toEqual([]);
+        warnSpy.mockRestore();
+    });
+});
+
+// ─── createWatchFnClient ──────────────────────────────────────────────────────
+
+describe("createWatchFnClient", () => {
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    it("returns a WatchFnClient with fetchMetrics()", () => {
+        const client = createWatchFnClient({ baseUrl: BASE_URL });
+        expect(typeof client.fetchMetrics).toBe("function");
+    });
+
+    it("fetchMetrics delegates to fetchEndpointMetrics", async () => {
+        vi.stubGlobal("fetch", mockFetch([mockMetric()]));
+        const client = createWatchFnClient({ baseUrl: BASE_URL });
+        const metrics = await client.fetchMetrics({ timeRange: "PT1H" });
+        expect(metrics).toHaveLength(1);
+        const calledUrl: string = vi.mocked(fetch).mock.calls[0][0] as string;
+        expect(calledUrl).toContain("timeRange=PT1H");
+    });
+});
+
+// ─── TV-WATCH-004: apifnWatchMiddleware ──────────────────────────────────────
+
+describe("TV-WATCH-004: apifnWatchMiddleware", () => {
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    it("calls next() and then POSTs an event to watchfn", async () => {
+        const postFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        vi.stubGlobal("fetch", postFetch);
+
+        const middleware = apifnWatchMiddleware({ baseUrl: BASE_URL, fireAndForget: false });
+        const req = { method: "GET", path: "/users" };
+        const res = { statusCode: 200 };
+        let nextCalled = false;
+        const next = async () => { nextCalled = true; };
+
+        await middleware(req, res, next);
+
+        expect(nextCalled).toBe(true);
+        expect(postFetch).toHaveBeenCalledWith(
+            expect.stringContaining("/api/events"),
+            expect.objectContaining({ method: "POST" })
+        );
+    });
+
+    it("event body contains method, path, status_code, duration_ms, timestamp", async () => {
+        const postFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        vi.stubGlobal("fetch", postFetch);
+
+        const middleware = apifnWatchMiddleware({ baseUrl: BASE_URL, fireAndForget: false });
+        await middleware({ method: "POST", path: "/orders" }, { statusCode: 201 }, async () => { });
+
+        const body = JSON.parse(postFetch.mock.calls[0][1].body as string);
+        expect(body.method).toBe("POST");
+        expect(body.path).toBe("/orders");
+        expect(body.status_code).toBe(201);
+        expect(typeof body.duration_ms).toBe("number");
+        expect(typeof body.timestamp).toBe("string");
+    });
+
+    it("does not crash when watchfn is unavailable (fire-and-forget)", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+
+        const middleware = apifnWatchMiddleware({ baseUrl: BASE_URL, fireAndForget: true });
+        // Should not throw
+        await middleware({ method: "GET", path: "/ping" }, { statusCode: 200 }, async () => { });
+        // Give microtasks time to resolve
+        await new Promise((r) => setTimeout(r, 10));
+
+        warnSpy.mockRestore();
+    });
+
+    it("silent mode suppresses warnings", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
+
+        const middleware = apifnWatchMiddleware({ baseUrl: BASE_URL, fireAndForget: false, silent: true });
+        await middleware({ method: "GET", path: "/x" }, { statusCode: 200 }, async () => { });
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    it("sends Authorization header when apiKey provided", async () => {
+        const postFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        vi.stubGlobal("fetch", postFetch);
+
+        const middleware = apifnWatchMiddleware({ baseUrl: BASE_URL, apiKey: "watch-key", fireAndForget: false });
+        await middleware({ method: "GET", path: "/" }, { statusCode: 200 }, async () => { });
+
+        const headers = postFetch.mock.calls[0][1].headers as Record<string, string>;
+        expect(headers["Authorization"]).toBe("Bearer watch-key");
+    });
+
+    it("middleware uses req.url.pathname as fallback when req.path not set", async () => {
+        const postFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        vi.stubGlobal("fetch", postFetch);
+
+        const middleware = apifnWatchMiddleware({ baseUrl: BASE_URL, fireAndForget: false });
+        await middleware(
+            { method: "GET", url: "http://localhost/api/items?q=test" },
+            { statusCode: 200 },
+            async () => { }
+        );
+
+        const body = JSON.parse(postFetch.mock.calls[0][1].body as string);
+        expect(body.path).toBe("/api/items");
+    });
+});

--- a/apifn/core/package.json
+++ b/apifn/core/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@apifn/core",
+  "version": "0.0.1",
+  "description": "Core library for ApiFn — route introspection, schema conversion, OpenAPI generation, and diff",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
+      "require": "./dist/types.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
+    "@testfn/core": "0.0.2",
+    "yaml": "^2.8.1",
+    "zod": "^3.25.28",
+    "zod-to-json-schema": "^3.24.6"
+  },
+  "peerDependencies": {
+    "@sinclair/typebox": "*",
+    "@superfunctions/http": "0.1.3"
+  },
+  "peerDependenciesMeta": {
+    "@sinclair/typebox": {
+      "optional": true
+    },
+    "@superfunctions/http": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.41",
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^3.2.4"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/core"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/apifn/core/src/__tests__/types.test.ts
+++ b/apifn/core/src/__tests__/types.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import type {
+  HttpMethod,
+  IntrospectOptions,
+  IntrospectedRoute,
+  ParameterDescriptor,
+  RequestBodyDescriptor,
+  ResponseDescriptor,
+  SecurityRequirement,
+  SchemaDescriptor,
+  SchemaDescriptorResponse,
+  OpenAPIGenerateOptions,
+  OpenAPIDocument,
+  OpenAPIInfoObject,
+  ServerObject,
+  ExternalDocsObject,
+  TagObject,
+  PathsObject,
+  PathItemObject,
+  OperationObject,
+  ParameterObject,
+  RequestBodyObject,
+  ResponseObject,
+  MediaTypeObject,
+  SchemaObject,
+  ComponentsObject,
+  SecuritySchemeObject,
+  HeaderObject,
+  LinkObject,
+  ExampleObject,
+  ReferenceObject,
+  EncodingObject,
+  OAuthFlowsObject,
+  OAuthFlowObject,
+  DiffResult,
+  DiffEntry,
+  ValidationError,
+  AuthConfig,
+  EndpointMetrics,
+  WatchFnClient,
+  RateLimitInfo,
+  SnippetTarget,
+  SnippetOptions,
+  MockServerOptions,
+  CorsOptions,
+  SchemaInput,
+  JsonSchema,
+  Router,
+  Route,
+  Middleware,
+} from "../index.js";
+
+describe("Core types", () => {
+  it("exports all introspection types", () => {
+    const options: IntrospectOptions = { include: ["/api"] };
+    expect(options.include).toEqual(["/api"]);
+
+    const param: ParameterDescriptor = {
+      name: "id",
+      in: "path",
+      required: true,
+      schema: { type: "string" },
+    };
+    expect(param.name).toBe("id");
+
+    const route: IntrospectedRoute = {
+      method: "GET",
+      path: "/users",
+      parameters: [param],
+      responses: { "200": { description: "Success" } },
+      meta: {},
+    };
+    expect(route.method).toBe("GET");
+  });
+
+  it("exports schema descriptor types", () => {
+    const desc: SchemaDescriptor = {
+      summary: "Create user",
+      operationId: "createUser",
+      tags: ["users"],
+      responses: {
+        201: { description: "Created" },
+      },
+    };
+    expect(desc.operationId).toBe("createUser");
+  });
+
+  it("exports OpenAPI document types", () => {
+    const doc: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {},
+    };
+    expect(doc.openapi).toBe("3.1.0");
+
+    const opts: OpenAPIGenerateOptions = {
+      info: { title: "Test", version: "1.0.0" },
+    };
+    expect(opts.info.title).toBe("Test");
+  });
+
+  it("exports diff types", () => {
+    const entry: DiffEntry = {
+      type: "removed",
+      breaking: true,
+      path: "paths./users.delete",
+      description: "Endpoint removed",
+    };
+    expect(entry.breaking).toBe(true);
+
+    const result: DiffResult = {
+      breaking: [entry],
+      nonBreaking: [],
+      hasBreakingChanges: true,
+      summary: {
+        added: 0,
+        removed: 1,
+        modified: 0,
+        breaking: 1,
+        nonBreaking: 0,
+      },
+    };
+    expect(result.hasBreakingChanges).toBe(true);
+  });
+
+  it("exports validation error type", () => {
+    const err: ValidationError = {
+      path: "info.title",
+      message: "Required",
+      severity: "error",
+    };
+    expect(err.severity).toBe("error");
+  });
+
+  it("exports integration types", () => {
+    const metrics: EndpointMetrics = {
+      method: "GET",
+      path: "/users",
+      latency: { p50: 10, p95: 50, p99: 100, avg: 20 },
+      throughput: { rpm: 100, total: 5000 },
+      errors: { rate: 0.01, count: 50 },
+      availability: 0.99,
+      lastUpdated: "2026-03-05T00:00:00Z",
+    };
+    expect(metrics.method).toBe("GET");
+
+    const rateLimit: RateLimitInfo = {
+      endpoint: "/users",
+      method: "GET",
+      remaining: 90,
+      limit: 100,
+      resetAt: Date.now() + 60000,
+      blocked: false,
+    };
+    expect(rateLimit.blocked).toBe(false);
+  });
+
+  it("exports snippet types", () => {
+    const target: SnippetTarget = "curl";
+    expect(target).toBe("curl");
+
+    const opts: SnippetOptions = {
+      target: "fetch",
+      baseUrl: "http://localhost:3000",
+    };
+    expect(opts.target).toBe("fetch");
+  });
+
+  it("exports auth config type", () => {
+    const auth: AuthConfig = {
+      type: "bearer",
+      token: "test-token",
+    };
+    expect(auth.type).toBe("bearer");
+  });
+
+  it("exports mock server types", () => {
+    const doc: OpenAPIDocument = {
+      openapi: "3.1.0",
+      info: { title: "Test", version: "1.0.0" },
+      paths: {},
+    };
+    const opts: MockServerOptions = {
+      spec: doc,
+      port: 4010,
+      responseMode: "schema",
+    };
+    expect(opts.port).toBe(4010);
+  });
+});

--- a/apifn/core/src/api-schema.ts
+++ b/apifn/core/src/api-schema.ts
@@ -1,0 +1,5 @@
+import type { SchemaDescriptor } from "./types.js";
+
+export function apiSchema(descriptor: SchemaDescriptor): SchemaDescriptor {
+  return descriptor;
+}

--- a/apifn/core/src/diff/diff.ts
+++ b/apifn/core/src/diff/diff.ts
@@ -1,0 +1,155 @@
+/**
+ * `diffOpenAPI(before, after)` — full breaking/non-breaking diff engine.
+ *
+ * Implements DIFF-001 through DIFF-009, Section 7.5 rules.
+ *
+ * The result is deterministic: given the same two documents, the output
+ * is structurally identical (entries sorted by path). (DIFF-008)
+ */
+
+import type {
+    DiffEntry,
+    DiffResult,
+    OpenAPIDocument,
+    PathItemObject,
+    OperationObject,
+} from "../types.js";
+import {
+    HTTP_METHODS,
+    diffParameters,
+    diffRequestBody,
+    diffResponses,
+    diffSecurity,
+    diffMetadata,
+} from "./rules.js";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute breaking vs. non-breaking differences between two OpenAPI documents.
+ *
+ * @returns DiffResult with entries sorted deterministically by `path`.
+ */
+export function diffOpenAPI(before: OpenAPIDocument, after: OpenAPIDocument): DiffResult {
+    const allEntries: DiffEntry[] = [];
+    const emit = (entry: DiffEntry) => allEntries.push(entry);
+
+    const beforePaths = before.paths ?? {};
+    const afterPaths = after.paths ?? {};
+
+    const allPaths = new Set([...Object.keys(beforePaths), ...Object.keys(afterPaths)]);
+
+    for (const apiPath of [...allPaths].sort()) {
+        const beforeItem = beforePaths[apiPath];
+        const afterItem = afterPaths[apiPath];
+
+        if (!beforeItem && afterItem) {
+            // Entire path added (DIFF-006: non-breaking)
+            for (const method of HTTP_METHODS) {
+                const op = afterItem[method];
+                if (op) {
+                    emit({
+                        type: "added",
+                        breaking: false,
+                        path: `paths.${apiPath}.${method}`,
+                        description: `New endpoint ${method.toUpperCase()} ${apiPath} added`,
+                    });
+                }
+            }
+            continue;
+        }
+
+        if (beforeItem && !afterItem) {
+            // Entire path removed — all methods are breaking (DIFF-001)
+            for (const method of HTTP_METHODS) {
+                const op = beforeItem[method];
+                if (op) {
+                    emit({
+                        type: "removed",
+                        breaking: true,
+                        path: `paths.${apiPath}.${method}`,
+                        description: `Endpoint ${method.toUpperCase()} ${apiPath} was removed`,
+                    });
+                }
+            }
+            continue;
+        }
+
+        if (!beforeItem || !afterItem) continue;
+
+        // Both sides have the path — diff individual methods
+        diffPathItem(apiPath, beforeItem, afterItem, emit);
+    }
+
+    // Sort deterministically by path (DIFF-008)
+    allEntries.sort((a, b) => a.path.localeCompare(b.path));
+
+    const breaking = allEntries.filter((e) => e.breaking);
+    const nonBreaking = allEntries.filter((e) => !e.breaking);
+
+    const added = allEntries.filter((e) => e.type === "added").length;
+    const removed = allEntries.filter((e) => e.type === "removed").length;
+    const modified = allEntries.filter((e) => e.type === "modified").length;
+
+    return {
+        breaking,
+        nonBreaking,
+        hasBreakingChanges: breaking.length > 0,
+        summary: {
+            added,
+            removed,
+            modified,
+            breaking: breaking.length,
+            nonBreaking: nonBreaking.length,
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Path-level diff
+// ---------------------------------------------------------------------------
+
+function diffPathItem(
+    apiPath: string,
+    before: PathItemObject,
+    after: PathItemObject,
+    emit: (entry: DiffEntry) => void
+): void {
+    for (const method of HTTP_METHODS) {
+        const beforeOp = before[method] as OperationObject | undefined;
+        const afterOp = after[method] as OperationObject | undefined;
+
+        if (!beforeOp && afterOp) {
+            // Method added on existing path (non-breaking, DIFF-006)
+            emit({
+                type: "added",
+                breaking: false,
+                path: `paths.${apiPath}.${method}`,
+                description: `New endpoint ${method.toUpperCase()} ${apiPath} added`,
+            });
+            continue;
+        }
+
+        if (beforeOp && !afterOp) {
+            // Method removed from existing path (breaking, DIFF-001)
+            emit({
+                type: "removed",
+                breaking: true,
+                path: `paths.${apiPath}.${method}`,
+                description: `Endpoint ${method.toUpperCase()} ${apiPath} was removed`,
+            });
+            continue;
+        }
+
+        if (!beforeOp || !afterOp) continue;
+
+        const opPath = `paths.${apiPath}.${method}`;
+        diffParameters(opPath, beforeOp, afterOp, emit);
+        diffRequestBody(opPath, beforeOp, afterOp, emit);
+        diffResponses(opPath, beforeOp, afterOp, emit);
+        diffSecurity(opPath, beforeOp, afterOp, emit);
+        diffMetadata(opPath, beforeOp, afterOp, emit);
+    }
+}

--- a/apifn/core/src/diff/format.ts
+++ b/apifn/core/src/diff/format.ts
@@ -1,0 +1,106 @@
+/**
+ * Human-readable and JSON formatters for DiffResult.
+ *
+ * Implements DIFF-009.
+ */
+
+import type { DiffResult, DiffEntry } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// JSON format (DIFF-009, SPEC Section 6.5)
+// ---------------------------------------------------------------------------
+
+export interface DiffReportJson {
+    timestamp: string;
+    hasBreakingChanges: boolean;
+    summary: DiffResult["summary"];
+    breaking: DiffEntry[];
+    nonBreaking: DiffEntry[];
+}
+
+/**
+ * Serialize a DiffResult to the SPEC 6.5 JSON format.
+ */
+export function formatDiffAsJson(result: DiffResult, timestamp?: string): DiffReportJson {
+    return {
+        timestamp: timestamp ?? new Date().toISOString(),
+        hasBreakingChanges: result.hasBreakingChanges,
+        summary: result.summary,
+        breaking: result.breaking,
+        nonBreaking: result.nonBreaking,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable text format (DIFF-009)
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a DiffResult as a human-readable text table.
+ * Caller can pass a `color` function map for terminal styling.
+ */
+export function formatDiffAsText(
+    result: DiffResult,
+    colors?: {
+        red?: (s: string) => string;
+        green?: (s: string) => string;
+        yellow?: (s: string) => string;
+        bold?: (s: string) => string;
+        dim?: (s: string) => string;
+    }
+): string {
+    const c = {
+        red: colors?.red ?? ((s: string) => s),
+        green: colors?.green ?? ((s: string) => s),
+        yellow: colors?.yellow ?? ((s: string) => s),
+        bold: colors?.bold ?? ((s: string) => s),
+        dim: colors?.dim ?? ((s: string) => s),
+    };
+
+    const lines: string[] = [];
+
+    lines.push(c.bold("API Diff Report"));
+    lines.push("─".repeat(60));
+
+    // Summary
+    const s = result.summary;
+    lines.push(`Added:       ${c.green(String(s.added))}`);
+    lines.push(`Removed:     ${s.removed > 0 ? c.red(String(s.removed)) : String(s.removed)}`);
+    lines.push(`Modified:    ${String(s.modified)}`);
+    lines.push(`Breaking:    ${s.breaking > 0 ? c.red(String(s.breaking)) : String(s.breaking)}`);
+    lines.push(`Non-breaking:${String(s.nonBreaking)}`);
+    lines.push("─".repeat(60));
+
+    if (result.breaking.length > 0) {
+        lines.push(c.bold(c.red("Breaking Changes:")));
+        for (const entry of result.breaking) {
+            const icon = entry.type === "removed" ? "–" : entry.type === "added" ? "+" : "~";
+            lines.push(`  ${c.red(icon)} ${entry.description}`);
+            lines.push(`    ${c.dim(`path: ${entry.path}`)}`);
+        }
+        lines.push("");
+    }
+
+    if (result.nonBreaking.length > 0) {
+        lines.push(c.bold("Non-Breaking Changes:"));
+        for (const entry of result.nonBreaking) {
+            const icon = entry.type === "removed" ? "–" : entry.type === "added" ? "+" : "~";
+            lines.push(`  ${icon} ${entry.description}`);
+            lines.push(`    ${c.dim(`path: ${entry.path}`)}`);
+        }
+        lines.push("");
+    }
+
+    if (result.breaking.length === 0 && result.nonBreaking.length === 0) {
+        lines.push(c.green("No changes detected."));
+    }
+
+    lines.push("─".repeat(60));
+    if (result.hasBreakingChanges) {
+        lines.push(c.red(c.bold(`⚠ ${result.summary.breaking} breaking change(s) detected!`)));
+    } else {
+        lines.push(c.green("✓ No breaking changes."));
+    }
+
+    return lines.join("\n");
+}

--- a/apifn/core/src/diff/rules.ts
+++ b/apifn/core/src/diff/rules.ts
@@ -1,0 +1,445 @@
+/**
+ * Breaking/non-breaking change classification rules.
+ *
+ * Each rule function inspects specific aspects of two OpenAPI operations
+ * and emits DiffEntry objects via the provided collector.
+ */
+
+import type { DiffEntry, OperationObject, ParameterObject } from "../types.js";
+
+type Emit = (entry: DiffEntry) => void;
+
+/** HTTP methods recognized as operation keys on a PathItem */
+export const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isRef(obj: unknown): obj is { $ref: string } {
+    return typeof obj === "object" && obj !== null && "$ref" in obj;
+}
+
+function emitUnresolvedRef(opPath: string, location: string, ref: string, emit: Emit): void {
+    emit({
+        type: "modified",
+        breaking: true,
+        path: `${opPath}.${location}`,
+        description: `Parameter reference '${ref}' in ${opPath} could not be resolved; diff coverage is incomplete`,
+    });
+}
+
+function resolveParam(p: unknown, opPath: string, location: string, emit: Emit): ParameterObject | null {
+    if (isRef(p)) {
+        emitUnresolvedRef(opPath, location, p.$ref, emit);
+        return null;
+    }
+    if (typeof p === "object" && p !== null && "name" in p && "in" in p) {
+        return p as ParameterObject;
+    }
+    return null;
+}
+
+/** Get the type or types from a JSON Schema object */
+function schemaTypes(schema: Record<string, unknown> | null | undefined): string[] {
+    if (!schema) return [];
+    const t = schema.type;
+    if (Array.isArray(t)) return t.map(String);
+    if (typeof t === "string") return [t];
+    return [];
+}
+
+/** Determine whether moving from beforeTypes to afterTypes is a narrowing */
+function isTypeNarrowing(before: Record<string, unknown> | null, after: Record<string, unknown> | null): boolean {
+    if (!before || !after) return false;
+    const bt = schemaTypes(before);
+    const at = schemaTypes(after);
+    if (bt.length === 0 || at.length === 0) return false;
+    // Narrowing: after has fewer types than before (subset)
+    if (at.length < bt.length) {
+        return at.every((t) => bt.includes(t));
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Parameter rules (DIFF-002, DIFF-003, DIFF-006)
+// ---------------------------------------------------------------------------
+
+export function diffParameters(
+    opPath: string,
+    before: OperationObject,
+    after: OperationObject,
+    emit: Emit
+): void {
+    const beforeParams = (before.parameters ?? [])
+        .map((param, index) => resolveParam(param, opPath, `parameters[${index}]`, emit))
+        .filter((p): p is ParameterObject => p !== null);
+    const afterParams = (after.parameters ?? [])
+        .map((param, index) => resolveParam(param, opPath, `parameters[${index}]`, emit))
+        .filter((p): p is ParameterObject => p !== null);
+
+    const beforeMap = new Map<string, ParameterObject>();
+    for (const p of beforeParams) {
+        beforeMap.set(`${p.in}:${p.name}`, p);
+    }
+
+    const afterMap = new Map<string, ParameterObject>();
+    for (const p of afterParams) {
+        afterMap.set(`${p.in}:${p.name}`, p);
+    }
+
+    // Added parameters
+    for (const [key, afterParam] of afterMap) {
+        if (!beforeMap.has(key)) {
+            const required = afterParam.required === true;
+            emit({
+                type: "added",
+                breaking: required,
+                path: `${opPath}.parameters.${afterParam.name}`,
+                description: required
+                    ? `Required parameter '${afterParam.name}' (${afterParam.in}) added to ${opPath} — breaking`
+                    : `Optional parameter '${afterParam.name}' (${afterParam.in}) added to ${opPath}`,
+            });
+        }
+    }
+
+    // Removed parameters
+    for (const [key, beforeParam] of beforeMap) {
+        if (!afterMap.has(key)) {
+            emit({
+                type: "removed",
+                breaking: true,
+                path: `${opPath}.parameters.${beforeParam.name}`,
+                description: `Parameter '${beforeParam.name}' (${beforeParam.in}) removed from ${opPath}`,
+            });
+        }
+    }
+
+    // Modified parameters — type narrowing (DIFF-003)
+    for (const [key, beforeParam] of beforeMap) {
+        const afterParam = afterMap.get(key);
+        if (!afterParam) continue;
+
+        const bs = beforeParam.schema as Record<string, unknown> | null;
+        const as = afterParam.schema as Record<string, unknown> | null;
+        if (isTypeNarrowing(bs, as)) {
+            emit({
+                type: "modified",
+                breaking: true,
+                path: `${opPath}.parameters.${beforeParam.name}.schema.type`,
+                description: `Parameter '${beforeParam.name}' type narrowed in ${opPath}`,
+                before: bs?.type,
+                after: as?.type,
+            });
+        }
+
+        // required changed from non-required to required
+        if (!beforeParam.required && afterParam.required) {
+            emit({
+                type: "modified",
+                breaking: true,
+                path: `${opPath}.parameters.${beforeParam.name}.required`,
+                description: `Parameter '${beforeParam.name}' became required in ${opPath}`,
+                before: false,
+                after: true,
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request body rules (DIFF-003)
+// ---------------------------------------------------------------------------
+
+export function diffRequestBody(
+    opPath: string,
+    before: OperationObject,
+    after: OperationObject,
+    emit: Emit
+): void {
+    const beforeBody = isRef(before.requestBody) ? null : before.requestBody;
+    const afterBody = isRef(after.requestBody) ? null : after.requestBody;
+
+    if (beforeBody && !afterBody) {
+        emit({
+            type: "removed",
+            breaking: true,
+            path: `${opPath}.requestBody`,
+            description: `Request body removed from ${opPath}`,
+        });
+        return;
+    }
+
+    if (!beforeBody && afterBody) {
+        const required = afterBody.required === true;
+        emit({
+            type: "added",
+            breaking: required,
+            path: `${opPath}.requestBody`,
+            description: required
+                ? `Required request body added to ${opPath} — breaking`
+                : `Optional request body added to ${opPath}`,
+        });
+        return;
+    }
+
+    if (!beforeBody || !afterBody) return;
+
+    if (!beforeBody.required && afterBody.required) {
+        emit({
+            type: "modified",
+            breaking: true,
+            path: `${opPath}.requestBody.required`,
+            description: `Request body became required in ${opPath}`,
+            before: false,
+            after: true,
+        });
+    }
+
+    // Compare JSON schemas from application/json content
+    const beforeSchema = (beforeBody.content?.["application/json"]?.schema ?? null) as Record<string, unknown> | null;
+    const afterSchema = (afterBody.content?.["application/json"]?.schema ?? null) as Record<string, unknown> | null;
+
+    if (!beforeSchema || !afterSchema) return;
+
+    // Detect type narrowing at top level
+    if (isTypeNarrowing(beforeSchema, afterSchema)) {
+        emit({
+            type: "modified",
+            breaking: true,
+            path: `${opPath}.requestBody.content.application/json.schema.type`,
+            description: `Request body type narrowed in ${opPath}`,
+            before: beforeSchema.type,
+            after: afterSchema.type,
+        });
+    }
+
+    // Detect new required fields in body schema (DIFF-002 for body)
+    diffObjectSchemaRequiredFields(opPath, "requestBody.content.application/json.schema", beforeSchema, afterSchema, emit);
+}
+
+function diffObjectSchemaRequiredFields(
+    opPath: string,
+    schemaPath: string,
+    before: Record<string, unknown>,
+    after: Record<string, unknown>,
+    emit: Emit
+): void {
+    const beforeRequired = new Set<string>(Array.isArray(before.required) ? before.required : []);
+    const afterRequired = new Set<string>(Array.isArray(after.required) ? after.required : []);
+
+    const afterProps = (after.properties ?? {}) as Record<string, unknown>;
+    const beforeProps = (before.properties ?? {}) as Record<string, unknown>;
+
+    // Required fields newly introduced or existing optional fields made required.
+    for (const field of afterRequired) {
+        if (!beforeRequired.has(field)) {
+            emit({
+                type: "modified",
+                breaking: true,
+                path: `${opPath}.${schemaPath}.required`,
+                description: beforeProps[field]
+                    ? `Existing request body field '${field}' became required in ${opPath}`
+                    : `New required field '${field}' added to request body in ${opPath}`,
+            });
+        }
+    }
+
+    // Removed properties from body
+    for (const prop of Object.keys(beforeProps)) {
+        if (!(prop in afterProps)) {
+            // Removing a field from the response object is breaking per DIFF-004 semantics but
+            // from a request body perspective it could be considered non-breaking. However, SPEC
+            // Section 7.5 only lists "response field removed" as breaking; skip here.
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response rules (DIFF-004, DIFF-006)
+// ---------------------------------------------------------------------------
+
+export function diffResponses(
+    opPath: string,
+    before: OperationObject,
+    after: OperationObject,
+    emit: Emit
+): void {
+    const beforeResponses = before.responses ?? {};
+    const afterResponses = after.responses ?? {};
+
+    // Removed response status codes
+    for (const statusCode of Object.keys(beforeResponses).sort()) {
+        if (!(statusCode in afterResponses)) {
+            emit({
+                type: "removed",
+                breaking: true,
+                path: `${opPath}.responses.${statusCode}`,
+                description: `Response status ${statusCode} removed from ${opPath}`,
+            });
+        }
+    }
+
+    // Added response status codes (non-breaking)
+    for (const statusCode of Object.keys(afterResponses).sort()) {
+        if (!(statusCode in beforeResponses)) {
+            emit({
+                type: "added",
+                breaking: false,
+                path: `${opPath}.responses.${statusCode}`,
+                description: `Response status ${statusCode} added to ${opPath}`,
+            });
+        }
+    }
+
+    // For existing status codes, diff the schema fields
+    for (const statusCode of Object.keys(beforeResponses).sort()) {
+        if (!(statusCode in afterResponses)) continue;
+        const beforeResp = beforeResponses[statusCode];
+        const afterResp = afterResponses[statusCode];
+        if (isRef(beforeResp) || isRef(afterResp)) continue;
+
+        const beforeSchema = (beforeResp?.content?.["application/json"]?.schema ?? null) as Record<string, unknown> | null;
+        const afterSchema = (afterResp?.content?.["application/json"]?.schema ?? null) as Record<string, unknown> | null;
+
+        if (!beforeSchema || !afterSchema) continue;
+
+        const schemaBasePath = `${opPath}.responses.${statusCode}.content.application/json.schema`;
+
+        // Check for removed properties (DIFF-004: response field removal is breaking)
+        if (typeof beforeSchema.properties === "object" && typeof afterSchema.properties === "object") {
+            const beforeProps = (beforeSchema.properties ?? {}) as Record<string, unknown>;
+            const afterProps = (afterSchema.properties ?? {}) as Record<string, unknown>;
+
+            for (const prop of Object.keys(beforeProps).sort()) {
+                if (!(prop in afterProps)) {
+                    emit({
+                        type: "removed",
+                        breaking: true,
+                        path: `${schemaBasePath}.properties.${prop}`,
+                        description: `Response field '${prop}' removed from ${opPath} (status ${statusCode})`,
+                    });
+                }
+            }
+
+            // Added response fields (non-breaking, DIFF-006)
+            for (const prop of Object.keys(afterProps).sort()) {
+                if (!(prop in beforeProps)) {
+                    emit({
+                        type: "added",
+                        breaking: false,
+                        path: `${schemaBasePath}.properties.${prop}`,
+                        description: `Response field '${prop}' added to ${opPath} (status ${statusCode})`,
+                    });
+                }
+            }
+        }
+
+        // Response type narrowing (DIFF-003 for responses)
+        if (isTypeNarrowing(beforeSchema, afterSchema)) {
+            emit({
+                type: "modified",
+                breaking: true,
+                path: `${schemaBasePath}.type`,
+                description: `Response type narrowed in ${opPath} (status ${statusCode})`,
+                before: beforeSchema.type,
+                after: afterSchema.type,
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Security rules (DIFF-005)
+// ---------------------------------------------------------------------------
+
+export function diffSecurity(
+    opPath: string,
+    before: OperationObject,
+    after: OperationObject,
+    emit: Emit
+): void {
+    const beforeSec = before.security ?? [];
+    const afterSec = after.security ?? [];
+
+    const secKey = (req: Record<string, string[]>) => JSON.stringify(Object.keys(req).sort());
+
+    const beforeKeys = new Set(beforeSec.map(secKey));
+    const afterKeys = new Set(afterSec.map(secKey));
+
+    for (const key of afterKeys) {
+        if (!beforeKeys.has(key)) {
+            emit({
+                type: "added",
+                breaking: true,
+                path: `${opPath}.security`,
+                description: `Security requirement added to ${opPath} — breaking`,
+                before: beforeSec,
+                after: afterSec,
+            });
+            return; // one entry per operation
+        }
+    }
+
+    for (const key of beforeKeys) {
+        if (!afterKeys.has(key)) {
+            const removedAlternative = afterSec.length > 0;
+            emit({
+                type: "removed",
+                breaking: removedAlternative,
+                path: `${opPath}.security`,
+                description: removedAlternative
+                    ? `Security requirement alternative removed from ${opPath} — breaking`
+                    : `Security requirement removed from ${opPath}`,
+                before: beforeSec,
+                after: afterSec,
+            });
+            return;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Description / summary changes (non-breaking, DIFF-006)
+// ---------------------------------------------------------------------------
+
+export function diffMetadata(
+    opPath: string,
+    before: OperationObject,
+    after: OperationObject,
+    emit: Emit
+): void {
+    if (before.description !== after.description && (before.description || after.description)) {
+        emit({
+            type: "modified",
+            breaking: false,
+            path: `${opPath}.description`,
+            description: `Description changed for ${opPath}`,
+            before: before.description,
+            after: after.description,
+        });
+    }
+
+    if (before.summary !== after.summary && (before.summary || after.summary)) {
+        emit({
+            type: "modified",
+            breaking: false,
+            path: `${opPath}.summary`,
+            description: `Summary changed for ${opPath}`,
+            before: before.summary,
+            after: after.summary,
+        });
+    }
+
+    if (before.deprecated !== after.deprecated && after.deprecated) {
+        emit({
+            type: "modified",
+            breaking: false,
+            path: `${opPath}.deprecated`,
+            description: `Endpoint ${opPath} marked as deprecated`,
+            before: false,
+            after: true,
+        });
+    }
+}

--- a/apifn/core/src/index.ts
+++ b/apifn/core/src/index.ts
@@ -1,0 +1,115 @@
+// @apifn/core — public API
+
+// Types
+export type {
+  // HTTP
+  HttpMethod,
+  SchemaInput,
+  JsonSchema,
+
+  // Route Introspection
+  IntrospectOptions,
+  IntrospectedRoute,
+  ParameterDescriptor,
+  RequestBodyDescriptor,
+  ResponseDescriptor,
+  SecurityRequirement,
+
+  // Schema Descriptors
+  SchemaDescriptor,
+  SchemaDescriptorResponse,
+
+  // OpenAPI Document Types
+  OpenAPIDocument,
+  OpenAPIInfoObject,
+  OpenAPIGenerateOptions,
+  ServerObject,
+  ExternalDocsObject,
+  TagObject,
+  PathsObject,
+  PathItemObject,
+  OperationObject,
+  ParameterObject,
+  RequestBodyObject,
+  ResponseObject,
+  MediaTypeObject,
+  SchemaObject,
+  ComponentsObject,
+  SecuritySchemeObject,
+  OAuthFlowsObject,
+  OAuthFlowObject,
+  HeaderObject,
+  LinkObject,
+  ExampleObject,
+  ReferenceObject,
+  EncodingObject,
+
+  // Diff
+  DiffResult,
+  DiffEntry,
+
+  // Validation
+  ValidationError,
+
+  // Auth
+  AuthConfig,
+
+  // Integrations
+  EndpointMetrics,
+  WatchFnClient,
+  RateLimitInfo,
+
+  // Snippets
+  SnippetTarget,
+  SnippetOptions,
+
+  // Mock
+  MockServerOptions,
+  CorsOptions,
+
+  // Re-exports from @superfunctions/http
+  Router,
+  Route,
+  Middleware,
+} from "./types.js";
+
+export { introspectRouter } from "./introspect.js";
+export { apiSchema } from "./api-schema.js";
+export { detectSchemaType } from "./schema/detect.js";
+export { convertZodSchema } from "./schema/zod.js";
+export { convertTypeBoxSchema } from "./schema/typebox.js";
+export { convertSchema } from "./schema/convert.js";
+export { deduplicateSchemas } from "./schema/dedup.js";
+export type { SchemaType } from "./schema/detect.js";
+export type { DeduplicateSchemaInput, DeduplicateSchemasResult } from "./schema/dedup.js";
+export { generateOpenAPI } from "./openapi/generate.js";
+export { fromRouter } from "./openapi/from-router.js";
+export type { FromRouterOptions } from "./openapi/from-router.js";
+export { parseOpenAPI } from "./openapi/parse.js";
+export { validateOpenAPI } from "./openapi/validate.js";
+export { upconvertFrom3_0 } from "./openapi/upconvert.js";
+export { diffOpenAPI } from "./diff/diff.js";
+export { formatDiffAsJson, formatDiffAsText } from "./diff/format.js";
+export type { DiffReportJson } from "./diff/format.js";
+export {
+  fetchEndpointMetrics,
+  createWatchFnClient,
+  apifnWatchMiddleware,
+} from "./integrations/watchfn.js";
+export type {
+  FetchEndpointMetricsOptions,
+  CreateWatchFnClientOptions,
+  WatchFnMiddlewareOptions,
+} from "./integrations/watchfn.js";
+export {
+  mintTestToken,
+  createAuthfnCollectionMiddleware,
+} from "./integrations/authfn.js";
+export type {
+  MintTestTokenOptions,
+  MintTestTokenResponse,
+} from "./integrations/authfn.js";
+export { fetchRateLimits } from "./integrations/secfn.js";
+export { logfnReporter, createCliLogger } from "./integrations/logfn.js";
+export { ApifnTestAdapter } from "./integrations/testfn.js";
+export type { CliLoggerOptions } from "./integrations/logfn.js";

--- a/apifn/core/src/integrations/__tests__/integrations.test.ts
+++ b/apifn/core/src/integrations/__tests__/integrations.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import {
+    mintTestToken,
+    createAuthfnCollectionMiddleware,
+} from "../authfn.js";
+import { fetchRateLimits } from "../secfn.js";
+import { logfnReporter, createCliLogger } from "../logfn.js";
+import type { LogFnClient, SecFnRateLimiter, RateLimitInfo } from "../../types.js";
+import type { AuthfnHttpClientRequest } from "../authfn.js";
+
+describe("PHASE_22 Integrations", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    // =========================================================================
+    // TV-AUTH-001 / NEG-TV-AUTH-001: authfn integration
+    // =========================================================================
+    describe("authfn integration", () => {
+        it("mints a test token with valid TTL (TV-AUTH-001)", async () => {
+            const fetchMock = vi.fn().mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ token: "tk_123", expiresAt: "2026-03-06T19:00:00Z" }),
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const res = await mintTestToken(
+                { baseUrl: "https://auth.api.example.com", adminKey: "admin_secret" },
+                { ttl: 3600, scopes: ["read", "write"] }
+            );
+
+            expect(res.token).toBe("tk_123");
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            const callArgs = fetchMock.mock.calls[0];
+            expect(callArgs[0]).toBe("https://auth.api.example.com/admin/keys/test");
+            expect(callArgs[1].headers).toMatchObject({
+                Authorization: "Bearer admin_secret",
+            });
+            expect(JSON.parse(callArgs[1].body)).toMatchObject({
+                ttl: 3600,
+                scopes: ["read", "write"],
+            });
+        });
+
+        it("rejects test tokens with TTL > 3600 (NEG-TV-AUTH-001)", async () => {
+            await expect(
+                mintTestToken(
+                    { baseUrl: "http://localhost" },
+                    { ttl: 3601 }
+                )
+            ).rejects.toThrow(/TTL cannot exceed 3600 seconds/);
+        });
+
+        it("injects token into collection requests via middleware", async () => {
+            const mockBaseClient = {
+                send: vi.fn().mockResolvedValue({ status: 200 }),
+            };
+            const client = createAuthfnCollectionMiddleware(mockBaseClient, "tk_injected");
+
+            await client.send({
+                method: "GET",
+                url: "http://example.com/api",
+                headers: { Accept: "application/json" },
+            });
+
+            expect(mockBaseClient.send).toHaveBeenCalledTimes(1);
+            const req = mockBaseClient.send.mock.calls[0][0] as AuthfnHttpClientRequest;
+            expect(req.headers["Authorization"]).toBe("Bearer tk_injected");
+            expect(req.headers["Accept"]).toBe("application/json");
+        });
+    });
+
+    // =========================================================================
+    // TV-SEC-001: secfn integration
+    // =========================================================================
+    describe("secfn integration", () => {
+        it("fetches rate limits for multiple endpoints (TV-SEC-001)", async () => {
+            const mockRateLimiter: SecFnRateLimiter = {
+                peek: vi.fn(async (endpoint: string) => {
+                    if (endpoint === "GET /users") {
+                        return { endpoint, method: "GET", remaining: 90, limit: 100, resetAt: 12345, blocked: false };
+                    }
+                    if (endpoint === "POST /orders") {
+                        return { endpoint, method: "POST", remaining: 0, limit: 10, resetAt: 12345, blocked: true };
+                    }
+                    return null; // Endpoint not limited
+                }),
+            };
+
+            const results = await fetchRateLimits(mockRateLimiter, [
+                "GET /users",
+                "POST /orders",
+                "GET /health",
+            ]);
+
+            expect(results).toHaveLength(2);
+            expect(results[0].remaining).toBe(90);
+            expect(results[1].blocked).toBe(true);
+            expect(mockRateLimiter.peek).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    // =========================================================================
+    // TV-LOG-001: logfn integration
+    // =========================================================================
+    describe("logfn integration", () => {
+        function createMockLogFn(): LogFnClient {
+            return {
+                info: vi.fn(),
+                error: vi.fn(),
+                warn: vi.fn(),
+                debug: vi.fn(),
+                child: vi.fn().mockReturnThis(),
+            };
+        }
+
+        it("reports collection runs to logfn (TV-LOG-001)", () => {
+            const logfn = createMockLogFn();
+            const reporter = logfnReporter(logfn);
+
+            // onStart
+            reporter.onStart?.(
+                { info: { name: "Test Collection" } } as any,
+                { environment: "staging" } as any
+            );
+            expect(logfn.info).toHaveBeenCalledWith("collection_run_start", {
+                collection: "Test Collection",
+                environment: "staging",
+            });
+
+            // onRequestComplete
+            reporter.onRequestComplete?.({
+                name: "Get User",
+                method: "GET",
+                url: "http://test",
+                duration: 150,
+                status: "passed",
+            } as any);
+
+            expect(logfn.child).toHaveBeenCalledWith({
+                request_name: "Get User",
+                method: "GET",
+                url: "http://test",
+                duration_ms: 150,
+            });
+            // The child logger is essentially `logfn` configured to `mockReturnThis`
+            expect(logfn.info).toHaveBeenCalledWith("collection_request_complete", { status: "passed" });
+
+            // onComplete
+            reporter.onComplete?.({
+                duration: 2000,
+                summary: { total: 1, passed: 1 },
+            } as any);
+
+            expect(logfn.info).toHaveBeenCalledWith("collection_run_complete", {
+                duration_ms: 2000,
+                summary: { total: 1, passed: 1 },
+            });
+        });
+
+        it("provides fallback CLI logger when logfn is not configured", () => {
+            const consoleLogSpy = vi.spyOn(console, "info").mockImplementation(() => { });
+            const consoleDebugSpy = vi.spyOn(console, "debug").mockImplementation(() => { });
+
+            const logger = createCliLogger({ level: "info" });
+            logger.info("sys_ready", { pid: 1 });
+            logger.debug("tracing", "hidden");
+
+            expect(consoleLogSpy).toHaveBeenCalledWith("[INFO] sys_ready", { pid: 1 });
+            expect(consoleDebugSpy).not.toHaveBeenCalled(); // level is info
+        });
+    });
+});

--- a/apifn/core/src/integrations/authfn.ts
+++ b/apifn/core/src/integrations/authfn.ts
@@ -1,0 +1,94 @@
+import type { AuthFnClient } from "../types.js";
+
+export interface AuthfnHttpClientRequest {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    [key: string]: any;
+}
+
+export interface AuthfnHttpClientResponse {
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+    [key: string]: any;
+}
+
+export interface AuthfnHttpClient {
+    send(request: AuthfnHttpClientRequest): Promise<AuthfnHttpClientResponse>;
+}
+
+export interface MintTestTokenOptions {
+    ttl: number; // in seconds
+    scopes?: string[];
+    resourceIds?: string[];
+}
+
+export interface MintTestTokenResponse {
+    token: string;
+    expiresAt: string;
+}
+
+/**
+ * Mints a short-lived test API key using authfn's admin API (AUTH-001, AUTH-002).
+ * Validates that TTL does not exceed 3600 seconds.
+ */
+export async function mintTestToken(
+    client: AuthFnClient,
+    options: MintTestTokenOptions
+): Promise<MintTestTokenResponse> {
+    if (options.ttl > 3600) {
+        throw new Error("TTL cannot exceed 3600 seconds for test tokens");
+    }
+
+    const url = new URL("/admin/keys/test", client.baseUrl.replace(/\/$/, ""));
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+    };
+    if (client.adminKey) {
+        headers["Authorization"] = `Bearer ${client.adminKey}`;
+    }
+
+    const res = await fetch(url.toString(), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+            ttl: options.ttl,
+            scopes: options.scopes ?? [],
+            resourceIds: options.resourceIds ?? [],
+        }),
+    });
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Failed to mint test token: HTTP ${res.status} ${text}`);
+    }
+
+    const data = (await res.json()) as MintTestTokenResponse;
+    return data;
+}
+
+/**
+ * A higher-order HttpClient wrapper that injects an Authorization header
+ * into all requests (AUTH-003). Useful for collection runner integration.
+ */
+export function createAuthfnCollectionMiddleware(
+    baseClient: AuthfnHttpClient,
+    token: string
+): AuthfnHttpClient {
+    return {
+        async send(req: AuthfnHttpClientRequest): Promise<AuthfnHttpClientResponse> {
+            const headers = { ...req.headers };
+            // Inject Authorization unless already present
+            const hasAuth = Object.keys(headers).some(
+                (k) => k.toLowerCase() === "authorization"
+            );
+            if (!hasAuth) {
+                headers["Authorization"] = `Bearer ${token}`;
+            }
+
+            return baseClient.send({ ...req, headers });
+        },
+    };
+}

--- a/apifn/core/src/integrations/logfn.ts
+++ b/apifn/core/src/integrations/logfn.ts
@@ -1,0 +1,151 @@
+import type { LogFnClient } from "../types.js";
+
+// Duck-typed interfaces to avoid circular dependency with @apifn/collections
+export interface LogfnCollectionItem {
+    name: string;
+    path: string;
+    [key: string]: any;
+}
+
+export interface LogfnCollection {
+    info: { name: string;[key: string]: any };
+    [key: string]: any;
+}
+
+export interface LogfnRunOptions {
+    environment: string | { name: string;[key: string]: any };
+    [key: string]: any;
+}
+
+export interface LogfnRequestResult {
+    name: string;
+    method: string;
+    url: string;
+    status: "passed" | "failed" | "skipped" | "error";
+    duration: number;
+    assertions: Array<{ passed: boolean;[key: string]: any }>;
+    error?: string;
+    [key: string]: any;
+}
+
+export interface LogfnRunReport {
+    duration: number;
+    summary: { total: number; passed: number;[key: string]: any };
+    [key: string]: any;
+}
+
+export interface LogfnRunReporter {
+    onStart?(collection: LogfnCollection, options: LogfnRunOptions): void;
+    onRequestStart?(item: LogfnCollectionItem): void;
+    onRequestComplete?(result: LogfnRequestResult): void;
+    onComplete?(report: LogfnRunReport): void;
+}
+
+
+/**
+ * Creates a RunReporter that logs collection run events via logfn (LOG-001).
+ *
+ * @param logfn The configured logfn client
+ */
+export function logfnReporter(logfn: LogFnClient): LogfnRunReporter {
+    return {
+        onStart(collection: LogfnCollection, options: LogfnRunOptions) {
+            logfn.info("collection_run_start", {
+                collection: collection.info.name,
+                environment:
+                    typeof options.environment === "string"
+                        ? options.environment
+                        : options.environment.name,
+            });
+        },
+        onRequestStart(item: LogfnCollectionItem) {
+            logfn.debug("collection_request_start", {
+                name: item.name,
+                path: item.path,
+            });
+        },
+        onRequestComplete(result: LogfnRequestResult) {
+            // Use child() for per-request context
+            const ctx = logfn.child({
+                request_name: result.name,
+                method: result.method,
+                url: result.url,
+                duration_ms: result.duration,
+            });
+
+            if (result.status === "passed") {
+                ctx.info("collection_request_complete", { status: "passed" });
+            } else if (result.status === "failed") {
+                ctx.error("collection_request_complete", "Request failed assertions", {
+                    status: "failed",
+                    failed_assertions: result.assertions.filter((a: any) => !a.passed),
+                });
+            } else if (result.status === "error") {
+                ctx.error("collection_request_complete", result.error ?? "Unknown error", {
+                    status: "error",
+                });
+            } else {
+                ctx.info("collection_request_complete", { status: result.status });
+            }
+        },
+        onComplete(report: LogfnRunReport) {
+            logfn.info("collection_run_complete", {
+                duration_ms: report.duration,
+                summary: report.summary,
+            });
+        },
+    };
+}
+
+export interface CliLoggerOptions {
+    level?: "debug" | "info" | "warn" | "error";
+    logfn?: LogFnClient;
+}
+
+/**
+ * CLI logging integration (LOG-002)
+ *
+ * Provides structured logging using logfn when available, falling back
+ * to a simple console logger that respects the chosen log level.
+ */
+export function createCliLogger(options: CliLoggerOptions = {}): LogFnClient {
+    const { level = "info", logfn } = options;
+
+    if (logfn) {
+        return logfn;
+    }
+
+    // Fallback console logger
+    const levels = { debug: 0, info: 1, warn: 2, error: 3 };
+    const currentLevel = levels[level] ?? 1;
+
+    function shouldLog(l: keyof typeof levels) {
+        return levels[l] >= currentLevel;
+    }
+
+    return {
+        info(eventType: string, payload?: unknown) {
+            if (shouldLog("info")) console.info(`[INFO] ${eventType}`, payload ?? "");
+        },
+        warn(eventType: string, payload?: unknown) {
+            if (shouldLog("warn")) console.warn(`[WARN] ${eventType}`, payload ?? "");
+        },
+        error(eventType: string, err: Error | string, payload?: unknown) {
+            if (shouldLog("error")) console.error(`[ERROR] ${eventType}`, err, payload ?? "");
+        },
+        debug(eventType: string, payload?: unknown) {
+            if (shouldLog("debug")) console.debug(`[DEBUG] ${eventType}`, payload ?? "");
+        },
+        child(context: Record<string, unknown>) {
+            // Very basic child support for the fallback
+            return {
+                ...this,
+                info: (e: string, p?: any) => this.info(e, { ...context, ...p }),
+                warn: (e: string, p?: any) => this.warn(e, { ...context, ...p }),
+                error: (event: string, err: Error | string, p?: any) =>
+                    this.error(event, err, { ...context, ...p }),
+                debug: (e: string, p?: any) => this.debug(e, { ...context, ...p }),
+            };
+        },
+    };
+}

--- a/apifn/core/src/integrations/secfn.ts
+++ b/apifn/core/src/integrations/secfn.ts
@@ -1,0 +1,31 @@
+import type { RateLimitInfo, SecFnRateLimiter } from "../types.js";
+
+/**
+ * Fetches rate limit headroom for a given list of endpoints (SEC-001).
+ * Uses the provided SecFnRateLimiter's `peek()` method which does not consume tokens.
+ *
+ * @param rateLimiter The secfn rate limiter instance
+ * @param endpoints Array of endpoints, e.g. ["GET /users", "POST /orders"]
+ * @param context Optional context variables to resolve rate limit keys
+ * @returns Array of RateLimitInfo objects detailing remaining limits and reset times
+ */
+export async function fetchRateLimits(
+    rateLimiter: SecFnRateLimiter,
+    endpoints: string[],
+    context?: Record<string, string>
+): Promise<RateLimitInfo[]> {
+    const results: RateLimitInfo[] = [];
+
+    for (const endpoint of endpoints) {
+        try {
+            const info = await rateLimiter.peek(endpoint, context);
+            if (info) {
+                results.push(info);
+            }
+        } catch (err) {
+            console.warn(`[apifn/secfn] Failed to peek rate limit for ${endpoint}:`, err);
+        }
+    }
+
+    return results;
+}

--- a/apifn/core/src/integrations/testfn.ts
+++ b/apifn/core/src/integrations/testfn.ts
@@ -1,0 +1,217 @@
+import * as path from "path";
+import * as fs from "fs";
+import type {
+    TestCase,
+    TestResult,
+    RunOptions,
+    TestStatus,
+    TestError,
+    TestProgress,
+} from "@testfn/core";
+import { BaseAdapter } from "@testfn/core";
+
+// Duck-typing collection types to avoid circular dependency
+interface CollectionItem { kind: string; name: string; children?: CollectionItem[];[key: string]: any; }
+interface CollectionInfo { name: string;[key: string]: any; }
+interface Collection { info: CollectionInfo; items: CollectionItem[]; environments: Record<string, any>;[key: string]: any; }
+interface AssertionResult { passed: boolean; name: string;[key: string]: any; }
+interface RequestResult { name: string; status: "passed" | "failed" | "error" | "skipped"; duration: number; assertions: AssertionResult[]; error?: string; statusCode?: number;[key: string]: any; }
+interface RunReport { results: RequestResult[];[key: string]: any; }
+
+export class ApifnTestAdapter extends BaseAdapter {
+    name = "apifn";
+
+    supports(framework: string): boolean {
+        return framework.toLowerCase() === "apifn";
+    }
+
+    async discover(patterns: string[]): Promise<TestCase[]> {
+        // Dynamic import to avoid circular dependency
+        let glob: ((pattern: string | string[], options?: { absolute?: boolean }) => Promise<string[]>) | undefined;
+        try {
+            // @testfn/core depends on fast-glob, so reuse it when available.
+            const fg = await import("fast-glob");
+            glob = (fg as any).default ?? (fg as any);
+        } catch {
+            console.warn("[apifn/testfn] fast-glob not found, using basic fs discovery");
+        }
+
+        // @ts-ignore
+        const { readCollection } = await import("@apifn/collections");
+        const testCases: TestCase[] = [];
+        const discoveredDirs = new Set<string>();
+
+        for (const pattern of patterns) {
+            if (glob) {
+                // Find opencollection.yml files matching the pattern
+                const files: string[] = await glob(
+                    pattern.endsWith(".yml") || pattern.endsWith(".yaml")
+                        ? pattern
+                        : `${pattern}/**/opencollection.yml`,
+                    { absolute: true }
+                );
+                for (const f of files) {
+                    discoveredDirs.add(path.dirname(f));
+                }
+            } else {
+                // Fallback if no glob (unlikely since testfn has it)
+                try {
+                    if (fs.existsSync(pattern)) {
+                        const stat = fs.statSync(pattern);
+                        if (stat.isDirectory()) {
+                            if (fs.existsSync(path.join(pattern, "opencollection.yml"))) {
+                                discoveredDirs.add(pattern);
+                            }
+                        } else if (pattern.endsWith("opencollection.yml")) {
+                            discoveredDirs.add(path.dirname(pattern));
+                        }
+                    }
+                } catch {
+                    // ignore
+                }
+            }
+        }
+
+        for (const dir of discoveredDirs) {
+            try {
+                const collection: Collection = await readCollection(dir);
+
+                // Walk collection to emit test cases
+                const walk = (items: CollectionItem[], suitePath: string[]) => {
+                    for (const item of items) {
+                        if (item.kind === "request") {
+                            const suiteName = suitePath.length > 0 ? suitePath.join(" > ") : collection.info.name;
+                            testCases.push({
+                                id: this.generateTestId(dir, item.name, suiteName),
+                                file: dir,
+                                name: item.name,
+                                suite: suiteName,
+                                tags: ["api"],
+                            });
+                        } else if (item.kind === "folder" && item.children) {
+                            walk(item.children, [...suitePath, item.name]);
+                        }
+                    }
+                };
+
+                walk(collection.items, []);
+            } catch (err) {
+                console.warn(`[apifn/testfn] Failed to read collection at ${dir}:`, err);
+            }
+        }
+
+        return testCases;
+    }
+
+    async run(tests: TestCase[], options: RunOptions): Promise<TestResult[]> {
+        // @ts-ignore
+        const { runCollection, readCollection } = await import("@apifn/collections");
+        const results: TestResult[] = [];
+
+        // Group tests by collection file/directory
+        const collectionsToRun = new Map<string, TestCase[]>();
+        for (const t of tests) {
+            const list = collectionsToRun.get(t.file) || [];
+            list.push(t);
+            collectionsToRun.set(t.file, list);
+        }
+
+        let completedCount = 0;
+        const updateProgress = (tc: TestCase) => {
+            completedCount++;
+            options.onProgress?.({
+                completed: completedCount,
+                total: tests.length,
+                current: tc,
+            });
+        };
+
+        for (const [dir, testsInCollection] of collectionsToRun.entries()) {
+            try {
+                const collection = await readCollection(dir);
+
+                // We need to run the collection, but ideally only the mapped tests.
+                // For simplicity, we run the collection with 'include' filter based on matched paths.
+                // Since testfn focuses on names, we map names back to items.
+                // Or we just run the whole collection and filter the output (if it's fast enough).
+                // Best approach: Use `include` with the paths of the requests.
+                const report: RunReport = await runCollection(collection, {
+                    // Default to the first environment or a dummy one if none exists
+                    environment: Object.keys(collection.environments)[0] ?? "default",
+                    parallel: options.parallel !== undefined && options.parallel > 1,
+                    concurrency: typeof options.parallel === "number" ? options.parallel : undefined,
+                    timeout: options.timeout,
+                    retries: options.retries,
+                    overrides: options.env,
+                });
+
+                // Map collection results to testfn TestResults
+                for (const reqRes of report.results) {
+                    // Match by request name (testfn test case granularity is per request name).
+                    const matchedTests = testsInCollection.filter((t) => t.name === reqRes.name);
+                    for (const tc of matchedTests) {
+                        let status: TestStatus = "passed";
+                        let testError: TestError | undefined;
+
+                        if (reqRes.status === "failed" || reqRes.status === "error") {
+                            status = "failed";
+
+                            if (reqRes.status === "failed") {
+                                const failedAsserts = reqRes.assertions.filter((a: any) => !a.passed);
+                                const msg = failedAsserts.map((a: any) => `- ${a.name}`).join("\n");
+                                testError = {
+                                    message: `Assertions failed:\n${msg}`,
+                                };
+                            } else if (reqRes.status === "error") {
+                                testError = {
+                                    message: reqRes.error || "Unknown Request Error",
+                                    actual: reqRes.statusCode,
+                                };
+                            }
+                        } else if (reqRes.status === "skipped") {
+                            status = "skipped";
+                        }
+
+                        results.push({
+                            id: tc.id,
+                            status,
+                            duration: reqRes.duration,
+                            error: testError,
+                        });
+                        updateProgress(tc);
+                    }
+                }
+
+                // Handle skipped/omitted tests from collection that were requested
+                const runTestNames = new Set(report.results.map((r: RequestResult) => r.name));
+                for (const tc of testsInCollection) {
+                    if (!runTestNames.has(tc.name)) {
+                        results.push({
+                            id: tc.id,
+                            status: "skipped",
+                            duration: 0,
+                            error: { message: "Test not found or excluded in collection run" },
+                        });
+                        updateProgress(tc);
+                    }
+                }
+            } catch (err) {
+                // Collection load or execution failure applies error to all tests in it
+                for (const tc of testsInCollection) {
+                    results.push({
+                        id: tc.id,
+                        status: "failed",
+                        duration: 0,
+                        error: {
+                            message: err instanceof Error ? err.message : String(err),
+                            stack: err instanceof Error ? err.stack : undefined,
+                        },
+                    });
+                    updateProgress(tc);
+                }
+            }
+        }
+
+        return results;
+    }
+}

--- a/apifn/core/src/integrations/watchfn.ts
+++ b/apifn/core/src/integrations/watchfn.ts
@@ -1,0 +1,284 @@
+/**
+ * watchfn integration for @apifn/core (WATCH-001 through WATCH-004).
+ *
+ * Provides:
+ *  - `fetchEndpointMetrics()` — fetch performance metrics from a watchfn HTTP API
+ *  - `createWatchFnClient()` — factory that returns a WatchFnClient
+ *  - `apifnWatchMiddleware()` — @superfunctions/http middleware that reports per-route
+ *    metrics to watchfn via its event API
+ */
+
+import type { EndpointMetrics, WatchFnClient } from "../types.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface FetchEndpointMetricsOptions {
+    /** watchfn query API base URL (e.g. "http://localhost:7100") */
+    baseUrl: string;
+    /** ISO 8601 duration string, e.g. "PT1H" for last 1 hour */
+    timeRange?: string;
+    /** Filter to specific endpoint keys in the form "METHOD /path" */
+    endpoints?: string[];
+    /** Request timeout in ms (default: 5000) */
+    timeoutMs?: number;
+    /** Optional API key for watchfn */
+    apiKey?: string;
+}
+
+/** Shape of a single metric entry returned by the watchfn query API. */
+interface WatchFnApiMetric {
+    method: string;
+    path: string;
+    latency_p50: number;
+    latency_p95: number;
+    latency_p99: number;
+    latency_avg: number;
+    rpm: number;
+    total_requests: number;
+    error_rate: number;
+    error_count: number;
+    last_error?: string;
+    availability: number;
+    last_updated: string;
+}
+
+/** Watchfn event API request body. */
+interface WatchFnEvent {
+    method: string;
+    path: string;
+    status_code: number;
+    duration_ms: number;
+    timestamp: string;
+}
+
+export interface CreateWatchFnClientOptions extends Omit<FetchEndpointMetricsOptions, "endpoints" | "timeRange"> { }
+
+export interface WatchFnMiddlewareOptions {
+    /** watchfn event API base URL (e.g. "http://localhost:7100") */
+    baseUrl: string;
+    /** Optional API key */
+    apiKey?: string;
+    /** Fire-and-forget: do not await event POST (default: true) */
+    fireAndForget?: boolean;
+    /** Suppress console warnings on errors (default: false) */
+    silent?: boolean;
+    /** Event POST timeout in ms (default: 2000) */
+    timeoutMs?: number;
+}
+
+// ─── Response parsing ─────────────────────────────────────────────────────────
+
+function parseMetric(raw: WatchFnApiMetric): EndpointMetrics {
+    return {
+        method: raw.method,
+        path: raw.path,
+        latency: {
+            p50: raw.latency_p50,
+            p95: raw.latency_p95,
+            p99: raw.latency_p99,
+            avg: raw.latency_avg,
+        },
+        throughput: {
+            rpm: raw.rpm,
+            total: raw.total_requests,
+        },
+        errors: {
+            rate: raw.error_rate,
+            count: raw.error_count,
+            lastError: raw.last_error,
+        },
+        availability: raw.availability,
+        lastUpdated: raw.last_updated,
+    };
+}
+
+// ─── fetchEndpointMetrics ─────────────────────────────────────────────────────
+
+/**
+ * Fetch endpoint metrics from a watchfn query API endpoint.
+ *
+ * On network failure or non-2xx response, returns [] with a console.warn
+ * (graceful degradation — WATCH-001, WATCH-002).
+ *
+ * @example
+ * const metrics = await fetchEndpointMetrics({
+ *   baseUrl: "http://localhost:7100",
+ *   timeRange: "PT1H",
+ *   endpoints: ["GET /users", "POST /orders"],
+ * });
+ */
+export async function fetchEndpointMetrics(
+    options: FetchEndpointMetricsOptions
+): Promise<EndpointMetrics[]> {
+    const {
+        baseUrl,
+        timeRange,
+        endpoints,
+        timeoutMs = 5000,
+        apiKey,
+    } = options;
+
+    const url = new URL("/api/metrics", baseUrl.replace(/\/$/, ""));
+
+    if (timeRange) url.searchParams.set("timeRange", timeRange);
+    if (endpoints?.length) {
+        for (const ep of endpoints) url.searchParams.append("endpoint", ep);
+    }
+
+    const headers: Record<string, string> = {
+        Accept: "application/json",
+    };
+    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+    let res: Response;
+    try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            res = await fetch(url.toString(), { headers, signal: controller.signal });
+        } finally {
+            clearTimeout(timer);
+        }
+    } catch (err) {
+        // Network error or abort — graceful degradation
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[apifn/watchfn] Could not reach watchfn at ${baseUrl}: ${msg}`);
+        return [];
+    }
+
+    if (!res.ok) {
+        console.warn(
+            `[apifn/watchfn] watchfn returned HTTP ${res.status} from ${url.toString()}`
+        );
+        return [];
+    }
+
+    let body: unknown;
+    try {
+        body = await res.json();
+    } catch {
+        console.warn("[apifn/watchfn] Failed to parse watchfn response as JSON");
+        return [];
+    }
+
+    const rawList = Array.isArray(body)
+        ? body
+        : Array.isArray((body as { data?: unknown }).data)
+            ? (body as { data: unknown[] }).data
+            : [];
+
+    return (rawList as WatchFnApiMetric[]).map(parseMetric);
+}
+
+// ─── createWatchFnClient ──────────────────────────────────────────────────────
+
+/**
+ * Creates a `WatchFnClient` object compatible with the UI components.
+ *
+ * @example
+ * const client = createWatchFnClient({ baseUrl: "http://localhost:7100" });
+ * const metrics = await client.fetchMetrics({ timeRange: "PT1H" });
+ */
+export function createWatchFnClient(
+    options: CreateWatchFnClientOptions
+): WatchFnClient {
+    return {
+        fetchMetrics: (opts) =>
+            fetchEndpointMetrics({
+                ...options,
+                timeRange: opts?.timeRange,
+                endpoints: opts?.endpoints,
+            }),
+    };
+}
+
+// ─── apifnWatchMiddleware ─────────────────────────────────────────────────────
+
+/**
+ * @superfunctions/http middleware that captures route metrics and ships them
+ * to a watchfn event API endpoint (WATCH-004).
+ *
+ * @example
+ * router.use(apifnWatchMiddleware({ baseUrl: "http://localhost:7100" }));
+ */
+export function apifnWatchMiddleware(
+    options: WatchFnMiddlewareOptions
+): (req: unknown, res: unknown, next: (...args: unknown[]) => unknown) => Promise<void> {
+    const {
+        baseUrl,
+        apiKey,
+        fireAndForget = true,
+        silent = false,
+        timeoutMs = 2000,
+    } = options;
+
+    const eventUrl = `${baseUrl.replace(/\/$/, "")}/api/events`;
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+    };
+    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+    async function sendEvent(event: WatchFnEvent): Promise<void> {
+        try {
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), timeoutMs);
+            let res: Response;
+            try {
+                res = await fetch(eventUrl, {
+                    method: "POST",
+                    headers,
+                    body: JSON.stringify(event),
+                    signal: controller.signal,
+                });
+            } finally {
+                clearTimeout(timer);
+            }
+            if (!res.ok && !silent) {
+                console.warn(`[apifn/watchfn] Event POST returned HTTP ${res.status}`);
+            }
+        } catch (err) {
+            if (!silent) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`[apifn/watchfn] Failed to send event to watchfn: ${msg}`);
+            }
+        }
+    }
+
+    /**
+     * The actual middleware function.
+     * Compatible with @superfunctions/http Middleware signature:
+     *   (req, res, next) => void | Promise<void>
+     */
+    return async function watchMiddleware(req: unknown, res: unknown, next: (...args: unknown[]) => unknown): Promise<void> {
+        const start = Date.now();
+
+        await next();
+
+        const durationMs = Date.now() - start;
+
+        // Extract method/path/status from request/response objects
+        // @superfunctions/http uses req.method, req.path (or req.url), res.statusCode
+        const r = req as { method?: string; path?: string; url?: string };
+        const s = res as { statusCode?: number };
+
+        const method = r.method ?? "UNKNOWN";
+        const path = r.path ?? (r.url ? new URL(r.url, "http://localhost").pathname : "/unknown");
+        const statusCode = s.statusCode ?? 200;
+
+        const event: WatchFnEvent = {
+            method,
+            path,
+            status_code: statusCode,
+            duration_ms: durationMs,
+            timestamp: new Date().toISOString(),
+        };
+
+        if (fireAndForget) {
+            // Non-blocking — don't hold up the response
+            sendEvent(event).catch(() => {/* already warned inside sendEvent */ });
+        } else {
+            await sendEvent(event);
+        }
+    };
+}

--- a/apifn/core/src/introspect.ts
+++ b/apifn/core/src/introspect.ts
@@ -1,0 +1,271 @@
+import type {
+  IntrospectOptions,
+  IntrospectedRoute,
+  JsonSchema,
+  ParameterDescriptor,
+  RequestBodyDescriptor,
+  ResponseDescriptor,
+  Route,
+  Router,
+  SchemaDescriptor,
+  SchemaDescriptorResponse,
+} from "./types.js";
+
+const KNOWN_DESCRIPTOR_KEYS = [
+  "body",
+  "query",
+  "params",
+  "responses",
+  "summary",
+  "operationId",
+  "tags",
+  "description",
+  "deprecated",
+  "headers",
+  "security",
+] as const;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasSchemaDescriptor(meta: unknown): meta is SchemaDescriptor {
+  if (!isObject(meta)) {
+    return false;
+  }
+
+  return KNOWN_DESCRIPTOR_KEYS.some((key) => key in meta);
+}
+
+function normalizePathSegment(path: string): string {
+  if (!path.startsWith("/")) {
+    return `/${path}`;
+  }
+
+  return path;
+}
+
+function withBasePath(path: string, basePath?: string): string {
+  const routePath = normalizePathSegment(path);
+
+  if (!basePath) {
+    return routePath;
+  }
+
+  const normalizedBasePath = normalizePathSegment(basePath).replace(/\/+$/, "");
+  const normalizedRoutePath = routePath.replace(/^\/+/, "");
+
+  if (!normalizedRoutePath) {
+    return normalizedBasePath || "/";
+  }
+
+  if (normalizedBasePath === "/") {
+    return `/${normalizedRoutePath}`;
+  }
+
+  return `${normalizedBasePath}/${normalizedRoutePath}`;
+}
+
+function toOpenApiPath(path: string): { path: string; pathParams: string[] } {
+  const params: string[] = [];
+  let openApiPath = "";
+  let index = 0;
+
+  while (index < path.length) {
+    const char = path[index];
+    if (char !== ":") {
+      openApiPath += char;
+      index += 1;
+      continue;
+    }
+
+    let end = index + 1;
+    while (end < path.length && /[A-Za-z0-9_]/.test(path[end])) {
+      end += 1;
+    }
+
+    if (end === index + 1) {
+      openApiPath += char;
+      index += 1;
+      continue;
+    }
+
+    const param = path.slice(index + 1, end);
+    params.push(param);
+    openApiPath += `{${param}}`;
+    index = end;
+  }
+
+  return { path: openApiPath, pathParams: params };
+}
+
+function pathParamsToDescriptors(pathParams: string[]): ParameterDescriptor[] {
+  return pathParams.map((name) => ({
+    name,
+    in: "path",
+    required: true,
+    schema: { type: "string" },
+  }));
+}
+
+function applyParameterRecord(
+  parameters: ParameterDescriptor[],
+  source: Record<string, unknown> | undefined,
+  location: ParameterDescriptor["in"],
+  required: boolean
+): void {
+  if (!source) {
+    return;
+  }
+
+  for (const [name, schema] of Object.entries(source)) {
+    const existingIndex = parameters.findIndex(
+      (parameter) => parameter.in === location && parameter.name === name
+    );
+    const descriptor: ParameterDescriptor = {
+      name,
+      in: location,
+      required,
+      schema: schema as JsonSchema,
+    };
+
+    if (existingIndex >= 0) {
+      parameters[existingIndex] = descriptor;
+    } else {
+      parameters.push(descriptor);
+    }
+  }
+}
+
+function toRequestBody(descriptor: SchemaDescriptor): RequestBodyDescriptor | undefined {
+  if (descriptor.body === undefined) {
+    return undefined;
+  }
+
+  return {
+    required: true,
+    content: {
+      "application/json": {
+        schema: descriptor.body as JsonSchema,
+      },
+    },
+  };
+}
+
+function toResponse(response: SchemaDescriptorResponse): ResponseDescriptor {
+  const normalized: ResponseDescriptor = {
+    description: response.description || "Success",
+  };
+
+  if (response.schema !== undefined) {
+    normalized.content = {
+      "application/json": {
+        schema: response.schema as JsonSchema,
+      },
+    };
+  }
+
+  if (response.headers && isObject(response.headers)) {
+    normalized.headers = Object.fromEntries(
+      Object.entries(response.headers).map(([name, schema]) => [
+        name,
+        {
+          schema: schema as JsonSchema,
+        },
+      ])
+    );
+  }
+
+  return normalized;
+}
+
+function toResponses(descriptor?: SchemaDescriptor): Record<string, ResponseDescriptor> {
+  if (!descriptor?.responses || Object.keys(descriptor.responses).length === 0) {
+    return { "200": { description: "Success" } };
+  }
+
+  const responses: Record<string, ResponseDescriptor> = {};
+
+  for (const [status, response] of Object.entries(descriptor.responses)) {
+    responses[String(status)] = toResponse(response);
+  }
+
+  return responses;
+}
+
+function shouldIncludePath(path: string, prefixes?: string[]): boolean {
+  if (!prefixes || prefixes.length === 0) {
+    return true;
+  }
+
+  return prefixes.some((prefix) => path.startsWith(prefix));
+}
+
+function shouldExcludePath(path: string, prefixes?: string[]): boolean {
+  if (!prefixes || prefixes.length === 0) {
+    return false;
+  }
+
+  return prefixes.some((prefix) => path.startsWith(prefix));
+}
+
+function toIntrospectedRoute(
+  route: Route<unknown>,
+  options: IntrospectOptions
+): IntrospectedRoute | null {
+  const fullPath = withBasePath(route.path, options.basePath);
+
+  if (!shouldIncludePath(fullPath, options.include)) {
+    return null;
+  }
+
+  if (shouldExcludePath(fullPath, options.exclude)) {
+    return null;
+  }
+
+  const { path, pathParams } = toOpenApiPath(fullPath);
+  const rawMeta = route.meta;
+  const meta = isObject(rawMeta) ? rawMeta : {};
+  const descriptor: SchemaDescriptor | undefined = hasSchemaDescriptor(rawMeta)
+    ? rawMeta
+    : undefined;
+  const parameters = pathParamsToDescriptors(pathParams);
+
+  if (descriptor) {
+    applyParameterRecord(parameters, descriptor.params, "path", true);
+    applyParameterRecord(parameters, descriptor.query, "query", false);
+    applyParameterRecord(parameters, descriptor.headers, "header", false);
+  }
+
+  return {
+    method: route.method,
+    path,
+    operationId: descriptor?.operationId,
+    summary: descriptor?.summary,
+    description: descriptor?.description,
+    tags: descriptor?.tags,
+    deprecated: descriptor?.deprecated,
+    parameters,
+    requestBody: descriptor ? toRequestBody(descriptor) : undefined,
+    responses: toResponses(descriptor),
+    security: descriptor?.security,
+    meta,
+  };
+}
+
+export function introspectRouter(
+  router: Router<unknown>,
+  options: IntrospectOptions = {}
+): IntrospectedRoute[] {
+  const routes = router.getRoutes();
+  const introspected: IntrospectedRoute[] = [];
+
+  for (const route of routes) {
+    const item = toIntrospectedRoute(route, options);
+    if (item) {
+      introspected.push(item);
+    }
+  }
+
+  return introspected;
+}

--- a/apifn/core/src/openapi/from-router.ts
+++ b/apifn/core/src/openapi/from-router.ts
@@ -1,0 +1,18 @@
+import { introspectRouter } from "../introspect.js";
+import type { IntrospectOptions, OpenAPIDocument, OpenAPIGenerateOptions, Router } from "../types.js";
+import { generateOpenAPI } from "./generate.js";
+
+export type FromRouterOptions = OpenAPIGenerateOptions & IntrospectOptions;
+
+export function fromRouter(
+  router: Router<unknown>,
+  options: FromRouterOptions
+): OpenAPIDocument {
+  const routes = introspectRouter(router, {
+    include: options.include,
+    exclude: options.exclude,
+    basePath: options.basePath,
+  });
+
+  return generateOpenAPI(routes, options);
+}

--- a/apifn/core/src/openapi/generate.ts
+++ b/apifn/core/src/openapi/generate.ts
@@ -1,0 +1,318 @@
+import { convertSchema } from "../schema/convert.js";
+import type {
+  IntrospectedRoute,
+  JsonSchema,
+  OpenAPIDocument,
+  OpenAPIGenerateOptions,
+  OperationObject,
+  ParameterObject,
+  PathItemObject,
+  PathsObject,
+  ResponseDescriptor,
+  ResponseObject,
+  SecurityRequirement,
+  TagObject,
+} from "../types.js";
+
+const METHOD_ORDER = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+] as const;
+
+type HttpMethodKey = (typeof METHOD_ORDER)[number];
+
+function methodKey(method: string): HttpMethodKey {
+  return method.toLowerCase() as HttpMethodKey;
+}
+
+function toOperationId(route: IntrospectedRoute): string {
+  if (route.operationId) {
+    return route.operationId;
+  }
+
+  const method = route.method.toLowerCase();
+  const pathToken = route.path
+    .replace(/[{}]/g, "")
+    .replace(/[^A-Za-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .map((segment, index) =>
+      index === 0
+        ? segment.toLowerCase()
+        : segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase()
+    )
+    .join("");
+
+  return `${method}${pathToken.charAt(0).toUpperCase()}${pathToken.slice(1)}`;
+}
+
+function sortedUnique(values: string[]): string[] {
+  return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeOptionalSchema(schema: JsonSchema): JsonSchema {
+  if (!isObject(schema)) {
+    return schema;
+  }
+
+  const anyOf = schema.anyOf;
+  if (!Array.isArray(anyOf) || anyOf.length !== 2) {
+    return schema;
+  }
+
+  const first = anyOf[0];
+  const second = anyOf[1];
+  if (isObject(first) && "not" in first && isObject(second)) {
+    return second as JsonSchema;
+  }
+
+  return schema;
+}
+
+function toParameters(route: IntrospectedRoute): ParameterObject[] | undefined {
+  if (!route.parameters.length) {
+    return undefined;
+  }
+
+  const parameters = route.parameters.map((parameter) => ({
+    name: parameter.name,
+    in: parameter.in,
+    required: parameter.required,
+    description: parameter.description,
+    deprecated: parameter.deprecated,
+    schema: normalizeOptionalSchema(convertSchema(parameter.schema)),
+  }));
+
+  return parameters.sort((a, b) => {
+    if (a.in !== b.in) {
+      return a.in.localeCompare(b.in);
+    }
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function toResponses(route: IntrospectedRoute): Record<string, ResponseObject> {
+  const entries = Object.entries(route.responses) as Array<
+    [string, ResponseDescriptor]
+  >;
+  const withFallback: Array<[string, ResponseDescriptor]> = entries.length
+    ? entries
+    : [["200", { description: "Success" }]];
+
+  const sorted = withFallback.sort(([a], [b]) => {
+    const aNum = Number(a);
+    const bNum = Number(b);
+
+    if (Number.isNaN(aNum) || Number.isNaN(bNum)) {
+      return a.localeCompare(b);
+    }
+
+    return aNum - bNum;
+  });
+
+  return Object.fromEntries(
+    sorted.map(([status, response]) => {
+      const normalized: ResponseObject = {
+        description: response.description || "Success",
+      };
+
+      if (response.content?.["application/json"]?.schema) {
+        normalized.content = {
+          "application/json": {
+                schema: normalizeOptionalSchema(
+                  convertSchema(response.content["application/json"].schema)
+                ),
+          },
+        };
+      }
+
+      if (response.headers) {
+        normalized.headers = Object.fromEntries(
+          Object.entries(response.headers)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([header, headerValue]) => [
+              header,
+              {
+                description: headerValue.description,
+                schema: normalizeOptionalSchema(convertSchema(headerValue.schema)),
+              },
+            ])
+        );
+      }
+
+      return [status, normalized];
+    })
+  );
+}
+
+function toOperation(route: IntrospectedRoute): OperationObject {
+  const operation: OperationObject = {
+    operationId: toOperationId(route),
+    responses: toResponses(route),
+  };
+
+  if (route.summary) {
+    operation.summary = route.summary;
+  }
+
+  if (route.description) {
+    operation.description = route.description;
+  }
+
+  if (route.deprecated !== undefined) {
+    operation.deprecated = route.deprecated;
+  }
+
+  if (route.tags?.length) {
+    operation.tags = sortedUnique(route.tags);
+  }
+
+  const parameters = toParameters(route);
+  if (parameters?.length) {
+    operation.parameters = parameters;
+  }
+
+  if (route.requestBody?.content?.["application/json"]?.schema) {
+    operation.requestBody = {
+      required: route.requestBody.required ?? true,
+      description: route.requestBody.description,
+      content: {
+        "application/json": {
+          schema: normalizeOptionalSchema(
+            convertSchema(route.requestBody.content["application/json"].schema)
+          ),
+        },
+      },
+    };
+  }
+
+  if (route.security?.length) {
+    operation.security = route.security as SecurityRequirement[];
+  }
+
+  return operation;
+}
+
+function toPaths(routes: IntrospectedRoute[]): PathsObject {
+  const grouped = new Map<string, IntrospectedRoute[]>();
+
+  for (const route of routes) {
+    const existing = grouped.get(route.path) ?? [];
+    existing.push(route);
+    grouped.set(route.path, existing);
+  }
+
+  const sortedPaths = Array.from(grouped.entries()).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+
+  const paths: PathsObject = {};
+
+  for (const [path, pathRoutes] of sortedPaths) {
+    const item: PathItemObject = {};
+    const sortedRoutes = [...pathRoutes].sort(
+      (a, b) =>
+        METHOD_ORDER.indexOf(methodKey(a.method)) -
+        METHOD_ORDER.indexOf(methodKey(b.method))
+    );
+
+    for (const route of sortedRoutes) {
+      const key = methodKey(route.method);
+      (item as Record<HttpMethodKey, OperationObject>)[key] = toOperation(route);
+    }
+
+    paths[path] = item;
+  }
+
+  return paths;
+}
+
+function collectTags(routes: IntrospectedRoute[]): TagObject[] | undefined {
+  const tags = sortedUnique(
+    routes.flatMap((route) => route.tags ?? []).filter((tag) => Boolean(tag))
+  );
+
+  if (!tags.length) {
+    return undefined;
+  }
+
+  return tags.map((name) => ({ name }));
+}
+
+function sortObjectDeep<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortObjectDeep(item)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    const sorted = Object.keys(object)
+      .sort((a, b) => a.localeCompare(b))
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortObjectDeep(object[key]);
+        return acc;
+      }, {});
+
+    return sorted as T;
+  }
+
+  return value;
+}
+
+export function generateOpenAPI(
+  routes: IntrospectedRoute[],
+  options: OpenAPIGenerateOptions
+): OpenAPIDocument {
+  const paths = toPaths(routes);
+  const tags = collectTags(routes);
+
+  const document: OpenAPIDocument = {
+    openapi: "3.1.0",
+    info: options.info,
+    paths,
+  };
+
+  if (options.servers?.length) {
+    document.servers = [...options.servers].sort((a, b) => a.url.localeCompare(b.url));
+  }
+
+  if (options.security?.length) {
+    document.security = options.security;
+  }
+
+  if (options.externalDocs) {
+    document.externalDocs = options.externalDocs;
+  }
+
+  if (tags?.length) {
+    document.tags = tags;
+  }
+
+  if (options.securitySchemes && Object.keys(options.securitySchemes).length > 0) {
+    document.components = {
+      ...(document.components ?? {}),
+      securitySchemes: Object.fromEntries(
+        Object.entries(options.securitySchemes).sort(([a], [b]) => a.localeCompare(b))
+      ),
+    };
+  }
+
+  if (options.extensions) {
+    for (const [key, value] of Object.entries(options.extensions)) {
+      const extensionKey = key.startsWith("x-") ? key : `x-${key}`;
+      document[extensionKey as `x-${string}`] = value;
+    }
+  }
+
+  return sortObjectDeep(document);
+}

--- a/apifn/core/src/openapi/parse.ts
+++ b/apifn/core/src/openapi/parse.ts
@@ -1,0 +1,55 @@
+import { parse as parseYaml } from "yaml";
+import type { OpenAPIDocument } from "../types.js";
+import { upconvertFrom3_0 } from "./upconvert.js";
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStringInput(input: string): unknown {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Invalid OpenAPI input: empty string");
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    try {
+      return parseYaml(trimmed);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid OpenAPI input: failed to parse JSON or YAML (${message})`);
+    }
+  }
+}
+
+function normalizeDocument(raw: unknown): OpenAPIDocument {
+  if (!isObject(raw)) {
+    throw new Error("Invalid OpenAPI document: expected object");
+  }
+
+  const version = raw.openapi;
+  if (typeof version !== "string") {
+    throw new Error("Invalid OpenAPI document: missing openapi version");
+  }
+
+  if (version.startsWith("3.0.")) {
+    return upconvertFrom3_0(raw);
+  }
+
+  if (version !== "3.1.0") {
+    throw new Error(`Unsupported OpenAPI version: ${version}`);
+  }
+
+  return raw as unknown as OpenAPIDocument;
+}
+
+export function parseOpenAPI(input: string | Record<string, unknown>): OpenAPIDocument {
+  if (typeof input === "string") {
+    const parsed = parseStringInput(input);
+    return normalizeDocument(parsed);
+  }
+
+  return normalizeDocument(input);
+}

--- a/apifn/core/src/openapi/upconvert.ts
+++ b/apifn/core/src/openapi/upconvert.ts
@@ -1,0 +1,50 @@
+import type { OpenAPIDocument } from "../types.js";
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function upconvertNode(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => upconvertNode(item));
+  }
+
+  if (!isObject(value)) {
+    return value;
+  }
+
+  const output: Record<string, unknown> = {};
+
+  for (const [key, nodeValue] of Object.entries(value)) {
+    if (key === "nullable" && nodeValue === true) {
+      continue;
+    }
+
+    output[key] = upconvertNode(nodeValue);
+  }
+
+  if (value.nullable === true) {
+    const currentType = output.type;
+
+    if (typeof currentType === "string") {
+      output.type = [currentType, "null"];
+    } else if (Array.isArray(currentType)) {
+      const merged = new Set(currentType as unknown[]);
+      merged.add("null");
+      output.type = Array.from(merged);
+    }
+  }
+
+  return output;
+}
+
+export function upconvertFrom3_0(document: unknown): OpenAPIDocument {
+  if (!isObject(document)) {
+    throw new Error("Invalid OpenAPI document: expected object");
+  }
+
+  const converted = upconvertNode(document) as Record<string, unknown>;
+  converted.openapi = "3.1.0";
+
+  return converted as unknown as OpenAPIDocument;
+}

--- a/apifn/core/src/openapi/validate.ts
+++ b/apifn/core/src/openapi/validate.ts
@@ -1,0 +1,37 @@
+import SwaggerParser from "@apidevtools/swagger-parser";
+import type { OpenAPIDocument, ValidationError } from "../types.js";
+
+function toValidationErrors(error: unknown): ValidationError[] {
+  const details = (error as { details?: Array<{ path?: string | string[]; message?: string }> })
+    ?.details;
+
+  if (Array.isArray(details) && details.length > 0) {
+    return details.map((detail) => ({
+      path: Array.isArray(detail.path)
+        ? detail.path.join(".")
+        : detail.path || "openapi",
+      message: detail.message || "Validation error",
+      severity: "error",
+    }));
+  }
+
+  const message = error instanceof Error ? error.message : "Validation error";
+  return [
+    {
+      path: "openapi",
+      message,
+      severity: "error",
+    },
+  ];
+}
+
+export async function validateOpenAPI(
+  document: OpenAPIDocument
+): Promise<ValidationError[]> {
+  try {
+    await SwaggerParser.validate(document as never);
+    return [];
+  } catch (error) {
+    return toValidationErrors(error);
+  }
+}

--- a/apifn/core/src/schema/convert.ts
+++ b/apifn/core/src/schema/convert.ts
@@ -1,0 +1,18 @@
+import type { JsonSchema, SchemaInput } from "../types.js";
+import { assertJsonSchema, detectSchemaType } from "./detect.js";
+import { convertTypeBoxSchema } from "./typebox.js";
+import { convertZodSchema } from "./zod.js";
+
+export function convertSchema(schema: SchemaInput): JsonSchema {
+  const schemaType = detectSchemaType(schema);
+
+  if (schemaType === "zod") {
+    return convertZodSchema(schema);
+  }
+
+  if (schemaType === "typebox") {
+    return convertTypeBoxSchema(schema);
+  }
+
+  return assertJsonSchema(schema);
+}

--- a/apifn/core/src/schema/dedup.ts
+++ b/apifn/core/src/schema/dedup.ts
@@ -1,0 +1,87 @@
+import type { JsonSchema } from "../types.js";
+
+export interface DeduplicateSchemaInput {
+  schema: JsonSchema;
+  name?: string;
+}
+
+export interface DeduplicateSchemasResult {
+  refs: string[];
+  components: Record<string, JsonSchema>;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+    return `{${entries
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function toComponentName(rawName: string, usedNames: Set<string>): string {
+  const cleaned = rawName.replace(/[^A-Za-z0-9_]/g, "");
+  const baseName = cleaned.length > 0 ? cleaned : "Schema";
+
+  if (!usedNames.has(baseName)) {
+    usedNames.add(baseName);
+    return baseName;
+  }
+
+  let index = 2;
+  while (usedNames.has(`${baseName}${index}`)) {
+    index += 1;
+  }
+
+  const candidate = `${baseName}${index}`;
+  usedNames.add(candidate);
+  return candidate;
+}
+
+export function deduplicateSchemas(
+  schemas: DeduplicateSchemaInput[]
+): DeduplicateSchemasResult {
+  const refs: string[] = [];
+  const components: Record<string, JsonSchema> = {};
+  const byIdentity = new Map<JsonSchema, string>();
+  const byStructure = new Map<string, string>();
+  const usedNames = new Set<string>();
+
+  for (let index = 0; index < schemas.length; index += 1) {
+    const input = schemas[index];
+    const schema = input.schema;
+
+    const identityHit = byIdentity.get(schema);
+    if (identityHit) {
+      refs.push(`#/components/schemas/${identityHit}`);
+      continue;
+    }
+
+    const structureKey = stableStringify(schema);
+    const structureHit = byStructure.get(structureKey);
+    if (structureHit) {
+      byIdentity.set(schema, structureHit);
+      refs.push(`#/components/schemas/${structureHit}`);
+      continue;
+    }
+
+    const explicitName = input.name || (typeof schema.title === "string" ? schema.title : undefined);
+    const fallbackName = `Schema${index + 1}`;
+    const componentName = toComponentName(explicitName ?? fallbackName, usedNames);
+
+    components[componentName] = schema;
+    byIdentity.set(schema, componentName);
+    byStructure.set(structureKey, componentName);
+    refs.push(`#/components/schemas/${componentName}`);
+  }
+
+  return { refs, components };
+}

--- a/apifn/core/src/schema/detect.ts
+++ b/apifn/core/src/schema/detect.ts
@@ -1,0 +1,31 @@
+import type { JsonSchema, SchemaInput } from "../types.js";
+
+export type SchemaType = "zod" | "typebox" | "jsonschema";
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function detectSchemaType(schema: SchemaInput): SchemaType {
+  if (!isObject(schema)) {
+    throw new Error("Unsupported schema type: expected object-like schema");
+  }
+
+  if ("_def" in schema) {
+    return "zod";
+  }
+
+  if (Symbol.for("TypeBox.Kind") in schema) {
+    return "typebox";
+  }
+
+  return "jsonschema";
+}
+
+export function assertJsonSchema(schema: SchemaInput): JsonSchema {
+  if (!isObject(schema)) {
+    throw new Error("Unsupported schema type: expected object-like schema");
+  }
+
+  return schema as JsonSchema;
+}

--- a/apifn/core/src/schema/typebox.ts
+++ b/apifn/core/src/schema/typebox.ts
@@ -1,0 +1,24 @@
+import type { JsonSchema, SchemaInput } from "../types.js";
+
+function stripTypeBoxMetadata(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripTypeBoxMetadata(item));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+
+  for (const key of Object.keys(input)) {
+    output[key] = stripTypeBoxMetadata(input[key]);
+  }
+
+  return output;
+}
+
+export function convertTypeBoxSchema(schema: SchemaInput): JsonSchema {
+  return stripTypeBoxMetadata(schema) as JsonSchema;
+}

--- a/apifn/core/src/schema/zod.ts
+++ b/apifn/core/src/schema/zod.ts
@@ -1,0 +1,33 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { JsonSchema, SchemaInput } from "../types.js";
+
+function cleanupZodSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map((item) => cleanupZodSchema(item));
+  }
+
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+
+  const input = schema as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(input)) {
+    if (key === "$schema") {
+      continue;
+    }
+    output[key] = cleanupZodSchema(value);
+  }
+
+  return output;
+}
+
+export function convertZodSchema(schema: SchemaInput): JsonSchema {
+  const converted = zodToJsonSchema(schema as never, {
+    $refStrategy: "none",
+    target: "jsonSchema2019-09",
+  });
+
+  return cleanupZodSchema(converted) as JsonSchema;
+}

--- a/apifn/core/src/types.ts
+++ b/apifn/core/src/types.ts
@@ -1,0 +1,532 @@
+/**
+ * @apifn/core — Core types and interfaces
+ *
+ * All shared types for route introspection, schema descriptors,
+ * OpenAPI generation, diff detection, and ecosystem integrations.
+ */
+
+import type { Router, Route, Middleware } from "@superfunctions/http";
+
+// Re-export for convenience
+export type { Router, Route, Middleware };
+
+// ============================================================================
+// HTTP Method
+// ============================================================================
+
+export type HttpMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "OPTIONS"
+  | "HEAD";
+
+// ============================================================================
+// Schema Type Aliases
+// ============================================================================
+
+/** Represents any schema type: zod, TypeBox, or plain JSON Schema */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SchemaInput = any;
+
+/** JSON Schema object */
+export type JsonSchema = Record<string, unknown>;
+
+// ============================================================================
+// Route Introspection
+// ============================================================================
+
+export interface IntrospectOptions {
+  /** Include routes matching these path prefixes only */
+  include?: string[];
+  /** Exclude routes matching these path prefixes */
+  exclude?: string[];
+  /** Base path to prepend to all route paths */
+  basePath?: string;
+}
+
+export interface ParameterDescriptor {
+  name: string;
+  in: "path" | "query" | "header" | "cookie";
+  required: boolean;
+  description?: string;
+  deprecated?: boolean;
+  schema: JsonSchema;
+}
+
+export interface RequestBodyDescriptor {
+  required?: boolean;
+  description?: string;
+  content: Record<
+    string,
+    {
+      schema: JsonSchema;
+      examples?: Record<string, unknown>;
+    }
+  >;
+}
+
+export interface ResponseDescriptor {
+  description: string;
+  content?: Record<
+    string,
+    {
+      schema: JsonSchema;
+      examples?: Record<string, unknown>;
+    }
+  >;
+  headers?: Record<string, { schema: JsonSchema; description?: string }>;
+}
+
+export type SecurityRequirement = Record<string, string[]>;
+
+export interface IntrospectedRoute {
+  method: HttpMethod;
+  path: string;
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  deprecated?: boolean;
+  parameters: ParameterDescriptor[];
+  requestBody?: RequestBodyDescriptor;
+  responses: Record<string, ResponseDescriptor>;
+  security?: SecurityRequirement[];
+  meta: Record<string, unknown>;
+}
+
+// ============================================================================
+// Schema Descriptors
+// ============================================================================
+
+export interface SchemaDescriptorResponse {
+  description: string;
+  schema?: SchemaInput;
+  headers?: Record<string, SchemaInput>;
+}
+
+export interface SchemaDescriptor {
+  /** Human-readable summary */
+  summary?: string;
+  /** Detailed description */
+  description?: string;
+  /** Unique operation identifier */
+  operationId?: string;
+  /** Tags for grouping */
+  tags?: string[];
+  /** Whether this endpoint is deprecated */
+  deprecated?: boolean;
+  /** Request body schema (zod, TypeBox, or JSON Schema) */
+  body?: SchemaInput;
+  /** Query parameter schemas */
+  query?: Record<string, SchemaInput>;
+  /** Path parameter schemas */
+  params?: Record<string, SchemaInput>;
+  /** Header parameter schemas */
+  headers?: Record<string, SchemaInput>;
+  /** Response schemas keyed by status code */
+  responses?: Record<string | number, SchemaDescriptorResponse>;
+  /** Security requirements */
+  security?: SecurityRequirement[];
+}
+
+// ============================================================================
+// OpenAPI Types
+// ============================================================================
+
+export interface OpenAPIInfoObject {
+  title: string;
+  version: string;
+  description?: string;
+  termsOfService?: string;
+  contact?: { name?: string; url?: string; email?: string };
+  license?: { name: string; url?: string; identifier?: string };
+  summary?: string;
+}
+
+export interface ServerObject {
+  url: string;
+  description?: string;
+  variables?: Record<
+    string,
+    {
+      default: string;
+      enum?: string[];
+      description?: string;
+    }
+  >;
+}
+
+export interface ExternalDocsObject {
+  url: string;
+  description?: string;
+}
+
+export interface TagObject {
+  name: string;
+  description?: string;
+  externalDocs?: ExternalDocsObject;
+}
+
+export interface SchemaObject extends JsonSchema {
+  [key: string]: unknown;
+}
+
+export interface MediaTypeObject {
+  schema?: SchemaObject;
+  example?: unknown;
+  examples?: Record<string, ExampleObject | ReferenceObject>;
+  encoding?: Record<string, EncodingObject>;
+}
+
+export interface ExampleObject {
+  summary?: string;
+  description?: string;
+  value?: unknown;
+  externalValue?: string;
+}
+
+export interface ReferenceObject {
+  $ref: string;
+  summary?: string;
+  description?: string;
+}
+
+export interface EncodingObject {
+  contentType?: string;
+  headers?: Record<string, HeaderObject | ReferenceObject>;
+  style?: string;
+  explode?: boolean;
+  allowReserved?: boolean;
+}
+
+export interface HeaderObject {
+  description?: string;
+  required?: boolean;
+  deprecated?: boolean;
+  schema?: SchemaObject;
+}
+
+export interface ParameterObject {
+  name: string;
+  in: "path" | "query" | "header" | "cookie";
+  description?: string;
+  required?: boolean;
+  deprecated?: boolean;
+  allowEmptyValue?: boolean;
+  style?: string;
+  explode?: boolean;
+  allowReserved?: boolean;
+  schema?: SchemaObject;
+  example?: unknown;
+  examples?: Record<string, ExampleObject | ReferenceObject>;
+  content?: Record<string, MediaTypeObject>;
+}
+
+export interface RequestBodyObject {
+  description?: string;
+  content: Record<string, MediaTypeObject>;
+  required?: boolean;
+}
+
+export interface ResponseObject {
+  description: string;
+  headers?: Record<string, HeaderObject | ReferenceObject>;
+  content?: Record<string, MediaTypeObject>;
+  links?: Record<string, LinkObject | ReferenceObject>;
+}
+
+export interface LinkObject {
+  operationRef?: string;
+  operationId?: string;
+  parameters?: Record<string, unknown>;
+  requestBody?: unknown;
+  description?: string;
+  server?: ServerObject;
+}
+
+export interface OperationObject {
+  tags?: string[];
+  summary?: string;
+  description?: string;
+  externalDocs?: ExternalDocsObject;
+  operationId?: string;
+  parameters?: Array<ParameterObject | ReferenceObject>;
+  requestBody?: RequestBodyObject | ReferenceObject;
+  responses?: Record<string, ResponseObject | ReferenceObject>;
+  callbacks?: Record<
+    string,
+    Record<string, PathItemObject> | ReferenceObject
+  >;
+  deprecated?: boolean;
+  security?: SecurityRequirement[];
+  servers?: ServerObject[];
+}
+
+export interface PathItemObject {
+  summary?: string;
+  description?: string;
+  get?: OperationObject;
+  put?: OperationObject;
+  post?: OperationObject;
+  delete?: OperationObject;
+  options?: OperationObject;
+  head?: OperationObject;
+  patch?: OperationObject;
+  trace?: OperationObject;
+  servers?: ServerObject[];
+  parameters?: Array<ParameterObject | ReferenceObject>;
+}
+
+export type PathsObject = Record<string, PathItemObject>;
+
+export interface SecuritySchemeObject {
+  type: "apiKey" | "http" | "mutualTLS" | "oauth2" | "openIdConnect";
+  description?: string;
+  name?: string;
+  in?: "query" | "header" | "cookie";
+  scheme?: string;
+  bearerFormat?: string;
+  flows?: OAuthFlowsObject;
+  openIdConnectUrl?: string;
+}
+
+export interface OAuthFlowsObject {
+  implicit?: OAuthFlowObject;
+  password?: OAuthFlowObject;
+  clientCredentials?: OAuthFlowObject;
+  authorizationCode?: OAuthFlowObject;
+}
+
+export interface OAuthFlowObject {
+  authorizationUrl?: string;
+  tokenUrl?: string;
+  refreshUrl?: string;
+  scopes: Record<string, string>;
+}
+
+export interface ComponentsObject {
+  schemas?: Record<string, SchemaObject | ReferenceObject>;
+  responses?: Record<string, ResponseObject | ReferenceObject>;
+  parameters?: Record<string, ParameterObject | ReferenceObject>;
+  examples?: Record<string, ExampleObject | ReferenceObject>;
+  requestBodies?: Record<string, RequestBodyObject | ReferenceObject>;
+  headers?: Record<string, HeaderObject | ReferenceObject>;
+  securitySchemes?: Record<string, SecuritySchemeObject | ReferenceObject>;
+  links?: Record<string, LinkObject | ReferenceObject>;
+  callbacks?: Record<
+    string,
+    Record<string, PathItemObject> | ReferenceObject
+  >;
+  pathItems?: Record<string, PathItemObject | ReferenceObject>;
+}
+
+export interface OpenAPIDocument {
+  openapi: "3.1.0";
+  info: OpenAPIInfoObject;
+  servers?: ServerObject[];
+  paths: PathsObject;
+  components?: ComponentsObject;
+  security?: SecurityRequirement[];
+  tags?: TagObject[];
+  externalDocs?: ExternalDocsObject;
+  jsonSchemaDialect?: string;
+  webhooks?: Record<string, PathItemObject | ReferenceObject>;
+  [key: `x-${string}`]: unknown;
+}
+
+// ============================================================================
+// OpenAPI Generation Options
+// ============================================================================
+
+export interface OpenAPIGenerateOptions {
+  /** OpenAPI info object */
+  info: {
+    title: string;
+    version: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: { name?: string; url?: string; email?: string };
+    license?: { name: string; url?: string };
+  };
+  /** Server URLs */
+  servers?: Array<{ url: string; description?: string }>;
+  /** Global security schemes */
+  securitySchemes?: Record<string, SecuritySchemeObject>;
+  /** Global security requirements */
+  security?: SecurityRequirement[];
+  /** External docs */
+  externalDocs?: { url: string; description?: string };
+  /** Custom x- extensions on the root document */
+  extensions?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Diff Types
+// ============================================================================
+
+export interface DiffEntry {
+  type: "added" | "removed" | "modified";
+  breaking: boolean;
+  path: string;
+  description: string;
+  before?: unknown;
+  after?: unknown;
+}
+
+export interface DiffResult {
+  breaking: DiffEntry[];
+  nonBreaking: DiffEntry[];
+  /** Overall: true if any breaking changes exist */
+  hasBreakingChanges: boolean;
+  summary: {
+    added: number;
+    removed: number;
+    modified: number;
+    breaking: number;
+    nonBreaking: number;
+  };
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+export interface ValidationError {
+  path: string;
+  message: string;
+  severity: "error" | "warning";
+}
+
+// ============================================================================
+// Auth Config (used by UI, collections, snippets)
+// ============================================================================
+
+export interface AuthConfig {
+  type: "bearer" | "basic" | "apikey" | "oauth2";
+  token?: string;
+  username?: string;
+  password?: string;
+  key?: string;
+  keyName?: string;
+  keyIn?: "header" | "query";
+}
+
+// ============================================================================
+// watchfn Integration Types
+// ============================================================================
+
+export interface EndpointMetrics {
+  method: string;
+  path: string;
+  latency: { p50: number; p95: number; p99: number; avg: number };
+  throughput: { rpm: number; total: number };
+  errors: { rate: number; count: number; lastError?: string };
+  availability: number;
+  lastUpdated: string;
+}
+
+export interface WatchFnClient {
+  fetchMetrics(options?: {
+    timeRange?: string;
+    endpoints?: string[];
+  }): Promise<EndpointMetrics[]>;
+}
+
+// ============================================================================
+// secfn Integration Types
+// ============================================================================
+
+export interface RateLimitInfo {
+  endpoint: string;
+  method: string;
+  remaining: number;
+  limit: number;
+  resetAt: number;
+  blocked: boolean;
+}
+
+export interface SecFnRateLimiter {
+  peek(endpoint: string, context?: Record<string, string>): Promise<RateLimitInfo | null>;
+}
+
+// ============================================================================
+// authfn Integration Types
+// ============================================================================
+
+export interface AuthFnClient {
+  baseUrl: string;
+  adminKey?: string;
+}
+
+// ============================================================================
+// logfn Integration Types
+// ============================================================================
+
+export interface LogFnClient {
+  info(eventType: string, payload?: unknown): void;
+  error(eventType: string, error: Error | string, payload?: unknown): void;
+  warn(eventType: string, payload?: unknown): void;
+  debug(eventType: string, payload?: unknown): void;
+  child(context: Record<string, unknown>): LogFnClient;
+}
+
+// ============================================================================
+// Code Snippet Types
+// ============================================================================
+
+export type SnippetTarget =
+  | "curl"
+  | "fetch"
+  | "axios"
+  | "node-fetch"
+  | "python-requests"
+  | "python-httpx"
+  | "go-http"
+  | "ruby-net-http"
+  | "php-curl"
+  | "csharp-httpclient"
+  | "java-okhttp";
+
+export interface SnippetOptions {
+  /** Target language/library */
+  target: SnippetTarget;
+  /** Include auth headers */
+  auth?: { type: string; token?: string; key?: string };
+  /** Base URL */
+  baseUrl: string;
+  /** Indentation (default: 2 spaces) */
+  indent?: number;
+}
+
+// ============================================================================
+// Mock Server Types
+// ============================================================================
+
+export interface MockServerOptions {
+  /** OpenAPI document */
+  spec: OpenAPIDocument;
+  /** Port (default: 4010) */
+  port?: number;
+  /** Generate responses from examples or schema (default: "schema") */
+  responseMode?: "examples" | "schema" | "random";
+  /** Validate incoming requests against schemas */
+  validateRequests?: boolean;
+  /** Delay responses by ms (simulates latency) */
+  delay?: number;
+  /** Maximum accepted request body size in bytes (default: 10 MiB) */
+  maxRequestBodyBytes?: number;
+  /** CORS configuration */
+  cors?: boolean | CorsOptions;
+}
+
+export interface CorsOptions {
+  origin?: string | string[] | ((origin: string) => boolean);
+  methods?: HttpMethod[];
+  allowedHeaders?: string[];
+  exposedHeaders?: string[];
+  credentials?: boolean;
+  maxAge?: number;
+}

--- a/apifn/core/tsconfig.json
+++ b/apifn/core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apifn/core/tsup.config.ts
+++ b/apifn/core/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  external: ["@apifn/collections"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/apifn/core/vitest.config.ts
+++ b/apifn/core/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/apifn/docsfn/__tests__/provider.test.ts
+++ b/apifn/docsfn/__tests__/provider.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Provider tests for @apifn/docsfn (TV-DOCS-001, TV-DOCS-004, TV-DOCS-006).
+ */
+
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { createApifnProvider } from "../src/provider.js";
+import type { OpenAPIDocument } from "../src/types.js";
+
+// Minimal OpenAPI spec fixture with two tags
+const TAGGED_SPEC: OpenAPIDocument = {
+    openapi: "3.0.0",
+    info: { title: "Test API", version: "1.0.0" },
+    paths: {
+        "/users": {
+            get: { tags: ["users"], summary: "List users", responses: { "200": { description: "ok" } } },
+            post: { tags: ["users"], summary: "Create user", responses: { "201": { description: "created" } } },
+        },
+        "/users/{id}": {
+            get: { tags: ["users"], summary: "Get user", parameters: [{ name: "id", in: "path", required: true }], responses: { "200": { description: "ok" } } },
+            delete: { tags: ["users"], summary: "Delete user", responses: { "204": { description: "no content" } } },
+        },
+        "/orders": {
+            get: { tags: ["orders"], summary: "List orders", responses: { "200": { description: "ok" } } },
+            post: { tags: ["orders"], summary: "Create order", responses: { "201": { description: "created" } } },
+        },
+        "/health": {
+            get: { tags: ["system"], summary: "Health check", responses: { "200": { description: "ok" } } },
+        },
+    },
+} as unknown as OpenAPIDocument;
+
+const UNTAGGED_SPEC: OpenAPIDocument = {
+    openapi: "3.0.0",
+    info: { title: "Untagged API", version: "2.0.0" },
+    paths: {
+        "/ping": {
+            get: { summary: "Ping", responses: { "200": { description: "pong" } } },
+        },
+        "/status": {
+            get: { summary: "Status", responses: { "200": { description: "ok" } } },
+        },
+    },
+} as unknown as OpenAPIDocument;
+
+// ─── TV-DOCS-001: splitByTag=true ────────────────────────────────────────────
+
+describe("TV-DOCS-001: createApifnProvider — split by tag", () => {
+    it("returns one entry per tag", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: true });
+        const entries = await provider();
+        const tags = entries.map((e) => e.tag).sort();
+        expect(tags).toEqual(["orders", "system", "users"]);
+    });
+
+    it("all entries have kind: 'api'", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: true });
+        const entries = await provider();
+        for (const e of entries) expect(e.kind).toBe("api");
+    });
+
+    it("each entry slug is derived from the tag", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: true, basePath: "/api" });
+        const entries = await provider();
+        const slugs = entries.map((e) => e.slug).sort();
+        expect(slugs).toEqual(["/api/orders", "/api/system", "/api/users"]);
+    });
+
+    it("users tag has 4 endpoints", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: true });
+        const entries = await provider();
+        const users = entries.find((e) => e.tag === "users")!;
+        expect(users.endpoints).toHaveLength(4);
+    });
+
+    it("endpoints have correct method and path", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: true });
+        const entries = await provider();
+        const users = entries.find((e) => e.tag === "users")!;
+        const methods = users.endpoints.map((e) => e.method).sort();
+        expect(methods).toContain("get");
+        expect(methods).toContain("post");
+        expect(methods).toContain("delete");
+    });
+
+    it("merges path-level parameters into endpoint operations", async () => {
+        const provider = createApifnProvider({
+            spec: {
+                openapi: "3.0.0",
+                info: { title: "Path Params API", version: "1.0.0" },
+                paths: {
+                    "/users/{id}": {
+                        parameters: [{ name: "id", in: "path", required: true }],
+                        get: {
+                            tags: ["users"],
+                            summary: "Get user",
+                            parameters: [{ name: "verbose", in: "query" }],
+                            responses: { "200": { description: "ok" } },
+                        },
+                    },
+                },
+            } as unknown as OpenAPIDocument,
+            splitByTag: false,
+        });
+
+        const entries = await provider();
+        const parameters = entries[0].endpoints[0].operation.parameters ?? [];
+        expect(parameters).toEqual([
+            { name: "id", in: "path", required: true },
+            { name: "verbose", in: "query" },
+        ]);
+    });
+
+    it("operation-level parameters override matching path-level parameters", async () => {
+        const provider = createApifnProvider({
+            spec: {
+                openapi: "3.0.0",
+                info: { title: "Path Params API", version: "1.0.0" },
+                paths: {
+                    "/users/{id}": {
+                        parameters: [{ name: "id", in: "path", required: true, description: "path" }],
+                        get: {
+                            tags: ["users"],
+                            summary: "Get user",
+                            parameters: [{ name: "id", in: "path", required: true, description: "operation" }],
+                            responses: { "200": { description: "ok" } },
+                        },
+                    },
+                },
+            } as unknown as OpenAPIDocument,
+            splitByTag: false,
+        });
+
+        const entries = await provider();
+        expect(entries[0].endpoints[0].operation.parameters).toEqual([
+            { name: "id", in: "path", required: true, description: "operation" },
+        ]);
+    });
+
+    it("deduplicates matching path-level and operation-level parameter references", async () => {
+        const provider = createApifnProvider({
+            spec: {
+                openapi: "3.0.0",
+                info: { title: "Path Params API", version: "1.0.0" },
+                paths: {
+                    "/users/{id}": {
+                        parameters: [{ $ref: "#/components/parameters/UserId" }],
+                        get: {
+                            tags: ["users"],
+                            summary: "Get user",
+                            parameters: [
+                                { $ref: "#/components/parameters/UserId" },
+                                { name: "verbose", in: "query" },
+                            ],
+                            responses: { "200": { description: "ok" } },
+                        },
+                    },
+                },
+            } as unknown as OpenAPIDocument,
+            splitByTag: false,
+        });
+
+        const entries = await provider();
+        expect(entries[0].endpoints[0].operation.parameters).toEqual([
+            { $ref: "#/components/parameters/UserId" },
+            { name: "verbose", in: "query" },
+        ]);
+    });
+
+    it("results are cached (same array reference on second call)", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC });
+        const first = await provider();
+        const second = await provider();
+        expect(first).toBe(second);
+    });
+
+    it("provider.entries is populated after first call", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC });
+        expect(provider.entries).toHaveLength(0);
+        await provider();
+        expect(provider.entries.length).toBeGreaterThan(0);
+    });
+});
+
+// ─── TV-DOCS-001: splitByTag=false ───────────────────────────────────────────
+
+describe("TV-DOCS-001: createApifnProvider — full spec (splitByTag: false)", () => {
+    it("returns a single entry", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: false });
+        const entries = await provider();
+        expect(entries).toHaveLength(1);
+    });
+
+    it("single entry has all endpoints", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: false });
+        const entries = await provider();
+        expect(entries[0].endpoints.length).toBe(7);
+    });
+
+    it("single entry slug is the basePath", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: false, basePath: "/reference" });
+        const entries = await provider();
+        expect(entries[0].slug).toBe("/reference");
+    });
+
+    it("title comes from spec.info.title", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: false });
+        const entries = await provider();
+        expect(entries[0].title).toBe("Test API");
+    });
+});
+
+// ─── TV-DOCS-004: sidebar generation ─────────────────────────────────────────
+
+describe("TV-DOCS-004: sidebar generation", () => {
+    it("each entry has a sidebar group with links", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: true });
+        const entries = await provider();
+        for (const entry of entries) {
+            expect(entry.sidebar.type).toBe("group");
+            expect(entry.sidebar.items.length).toBeGreaterThan(0);
+            for (const item of entry.sidebar.items) {
+                expect(item.type).toBe("link");
+                if (item.type === "link") {
+                    expect(item.label).toBeTruthy();
+                    expect(item.href).toContain(entry.slug);
+                }
+            }
+        }
+    });
+
+    it("sidebar link labels include HTTP method", async () => {
+        const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: true });
+        const entries = await provider();
+        const users = entries.find((e) => e.tag === "users")!;
+        const labels = users.sidebar.items.map((i) => i.type === "link" ? i.label : "").filter(Boolean);
+        expect(labels.some((l) => l.includes("GET"))).toBe(true);
+        expect(labels.some((l) => l.includes("POST"))).toBe(true);
+    });
+});
+
+// ─── TV-DOCS-006: split by tag (multi-page slugs) ────────────────────────────
+
+describe("TV-DOCS-006: split by tag produces correct slugs", () => {
+    it("tag names are slugified (lowercase, hyphens)", async () => {
+        const spec = {
+            ...TAGGED_SPEC,
+            paths: {
+                "/foo": { get: { tags: ["My Tag Group"], responses: { "200": { description: "ok" } } } },
+            },
+        } as unknown as OpenAPIDocument;
+        const provider = createApifnProvider({ spec, splitByTag: true, basePath: "/docs" });
+        const entries = await provider();
+        expect(entries[0].slug).toBe("/docs/my-tag-group");
+    });
+
+    it("endpoints without tags use 'default' tag", async () => {
+        const provider = createApifnProvider({ spec: UNTAGGED_SPEC, splitByTag: true });
+        const entries = await provider();
+        expect(entries.some((e) => e.tag === "default")).toBe(true);
+    });
+});
+
+// ─── File path loading ────────────────────────────────────────────────────────
+
+describe("createApifnProvider — specPath loading", () => {
+    it("loads and parses a YAML spec from file", async () => {
+        const specPath = path.join(import.meta.dirname, "../../cli/__tests__/fixtures/diff/before.yml");
+        const provider = createApifnProvider({ specPath, splitByTag: false });
+        const entries = await provider();
+        expect(entries.length).toBeGreaterThan(0);
+        expect(entries[0].kind).toBe("api");
+    });
+
+    it("throws if neither spec nor specPath provided", async () => {
+        const provider = createApifnProvider({});
+        await expect(provider()).rejects.toThrow();
+    });
+});

--- a/apifn/docsfn/package.json
+++ b/apifn/docsfn/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@apifn/docsfn",
+  "version": "0.0.1",
+  "description": "docsfn plugin for ApiFn API reference",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "@apifn/core": "0.0.1",
+    "@apifn/react": "0.0.1",
+    "@apifn/svelte": "0.0.1"
+  },
+  "peerDependencies": {
+    "docsfn": "*"
+  },
+  "peerDependenciesMeta": {
+    "docsfn": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.6.0"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/docsfn"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/apifn/docsfn/src/index.ts
+++ b/apifn/docsfn/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @apifn/docsfn — public API
+ *
+ * Provides a DocsContentProvider and API reference renderer components
+ * for embedding ApiFn API documentation in docsfn sites.
+ */
+
+// Provider
+export { createApifnProvider } from "./provider.js";
+
+// Types
+export type {
+    DocsContentProvider,
+    RawContentEntry,
+    ApiEndpoint,
+    SidebarItem,
+    SidebarLink,
+    SidebarGroup,
+    CreateApifnProviderOptions,
+    ApifnApiReferenceProps,
+    OpenAPIDocument,
+    OperationObject,
+} from "./types.js";

--- a/apifn/docsfn/src/provider.ts
+++ b/apifn/docsfn/src/provider.ts
@@ -1,0 +1,186 @@
+/**
+ * createApifnProvider — DocsContentProvider implementation (DOCS-001, DOCS-004, DOCS-006).
+ *
+ * Accepts an OpenAPI document (object or file path), groups endpoints by tag,
+ * and returns RawContentEntry[] suitable for docsfn's manifest pipeline.
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parseOpenAPI, type OpenAPIDocument, type OperationObject } from "@apifn/core";
+import type {
+    CreateApifnProviderOptions,
+    DocsContentProvider,
+    RawContentEntry,
+    ApiEndpoint,
+    SidebarGroup,
+    SidebarLink,
+} from "./types.js";
+
+const HTTP_METHODS = [
+    "get", "post", "put", "patch", "delete", "head", "options",
+] as const;
+
+type OperationParameters = NonNullable<OperationObject["parameters"]>;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function tagToSlug(tag: string, basePath: string): string {
+    const segment = tag.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    return `${basePath.replace(/\/$/, "")}/${segment}`;
+}
+
+function collectEndpoints(spec: OpenAPIDocument): ApiEndpoint[] {
+    const items: ApiEndpoint[] = [];
+    for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+        if (!pathItem) continue;
+        const pathParameters = Array.isArray(pathItem.parameters) ? pathItem.parameters : [];
+        for (const method of HTTP_METHODS) {
+            const op = pathItem[method] as OperationObject | undefined;
+            if (!op) continue;
+            const operation = mergePathParameters(pathParameters, op);
+            const tags = (op.tags as string[]) ?? ["default"];
+            items.push({ path, method, operation, tag: tags[0] ?? "default" });
+        }
+    }
+    return items;
+}
+
+function parameterKey(parameter: unknown): string | undefined {
+    if (!parameter || typeof parameter !== "object") {
+        return undefined;
+    }
+
+    const reference = parameter as { $ref?: unknown };
+    if (typeof reference.$ref === "string") {
+        return `$ref:${reference.$ref}`;
+    }
+
+    const candidate = parameter as { name?: unknown; in?: unknown };
+    if (typeof candidate.name !== "string" || typeof candidate.in !== "string") {
+        return undefined;
+    }
+
+    return `${candidate.in}:${candidate.name}`;
+}
+
+function mergePathParameters(pathParameters: OperationParameters, operation: OperationObject): OperationObject {
+    if (pathParameters.length === 0) {
+        return operation;
+    }
+
+    const operationParameters: OperationParameters = Array.isArray(operation.parameters) ? operation.parameters : [];
+    const operationKeys = new Set(operationParameters.map(parameterKey).filter((key): key is string => Boolean(key)));
+    const inheritedParameters = pathParameters.filter((parameter) => {
+        const key = parameterKey(parameter);
+        return !key || !operationKeys.has(key);
+    });
+
+    if (inheritedParameters.length === 0) {
+        return operation;
+    }
+
+    return {
+        ...operation,
+        parameters: [...inheritedParameters, ...operationParameters],
+    };
+}
+
+function buildSidebarGroup(
+    groupLabel: string,
+    endpoints: ApiEndpoint[],
+    slug: string
+): SidebarGroup {
+    const links: SidebarLink[] = endpoints.map((e) => ({
+        type: "link",
+        label: `${e.method.toUpperCase()} ${e.path}`,
+        href: `${slug}#${e.method.toLowerCase()}-${e.path.replace(/[^a-z0-9]/gi, "-")}`,
+    }));
+    return { type: "group", label: groupLabel, items: links };
+}
+
+function buildEntries(
+    spec: OpenAPIDocument,
+    options: CreateApifnProviderOptions
+): RawContentEntry[] {
+    const {
+        basePath = "/api",
+        splitByTag = true,
+    } = options;
+
+    const info = spec.info as { title?: string; version?: string } | undefined;
+    const allEndpoints = collectEndpoints(spec);
+
+    if (!splitByTag) {
+        // Single full-spec entry
+        const slug = basePath.replace(/\/$/, "") || "/api";
+        const title = info?.title ?? "API Reference";
+        const sidebar = buildSidebarGroup(title, allEndpoints, slug);
+        return [{
+            kind: "api",
+            slug,
+            title,
+            endpoints: allEndpoints,
+            sidebar,
+            spec,
+        }];
+    }
+
+    // Split by tag — one entry per tag (DOCS-006)
+    const tagMap = new Map<string, ApiEndpoint[]>();
+    for (const endpoint of allEndpoints) {
+        if (!tagMap.has(endpoint.tag)) tagMap.set(endpoint.tag, []);
+        tagMap.get(endpoint.tag)!.push(endpoint);
+    }
+
+    return [...tagMap.entries()].map(([tag, endpoints]) => {
+        const slug = tagToSlug(tag, basePath);
+        const title = `${tag.charAt(0).toUpperCase()}${tag.slice(1)}`;
+        const sidebar = buildSidebarGroup(title, endpoints, slug);
+        return {
+            kind: "api" as const,
+            slug,
+            title,
+            tag,
+            endpoints,
+            sidebar,
+            spec,
+        };
+    });
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Creates a DocsContentProvider that produces RawContentEntry[] for docsfn.
+ *
+ * @example
+ * const provider = createApifnProvider({ specPath: "./openapi.yml", splitByTag: true });
+ * const entries = await provider();
+ */
+export function createApifnProvider(
+    options: CreateApifnProviderOptions
+): DocsContentProvider {
+    let cachedEntries: RawContentEntry[] | null = null;
+
+    async function loadSpec(): Promise<OpenAPIDocument> {
+        if (options.spec) return options.spec;
+        if (options.specPath) {
+            const abs = resolve(options.specPath);
+            const raw = await readFile(abs, "utf8");
+            return parseOpenAPI(raw);
+        }
+        throw new Error("createApifnProvider: must provide either `spec` or `specPath`");
+    }
+
+    const provider = async (): Promise<RawContentEntry[]> => {
+        if (cachedEntries) return cachedEntries;
+        const spec = await loadSpec();
+        cachedEntries = buildEntries(spec, options);
+        provider.entries = cachedEntries;
+        return cachedEntries;
+    };
+
+    provider.entries = [] as RawContentEntry[];
+    return provider as DocsContentProvider;
+}

--- a/apifn/docsfn/src/react/ApifnApiReference.tsx
+++ b/apifn/docsfn/src/react/ApifnApiReference.tsx
@@ -1,0 +1,168 @@
+/**
+ * ApifnApiReference (React) — renders a docsfn RawContentEntry as an API reference page (DOCS-002, DOCS-005).
+ */
+
+import React, { useState } from "react";
+import { EndpointViewer, TryIt, PerformanceOverlay } from "@apifn/react";
+import type { ApifnApiReferenceProps, PerformanceMetrics } from "../types.js";
+import type { OperationObject } from "@apifn/core";
+
+export type { ApifnApiReferenceProps };
+
+// Inline method colors — avoids importing internal @apifn/react paths
+const METHOD_COLORS: Record<string, { bg: string; text: string }> = {
+    get: { bg: "#065f46", text: "#6ee7b7" },
+    post: { bg: "#1e3a5f", text: "#93c5fd" },
+    put: { bg: "#78350f", text: "#fcd34d" },
+    patch: { bg: "#5b21b6", text: "#c4b5fd" },
+    delete: { bg: "#7f1d1d", text: "#fca5a5" },
+    head: { bg: "#1f2937", text: "#9ca3af" },
+    options: { bg: "#1f2937", text: "#9ca3af" },
+};
+
+function getThemeStyle(theme: "light" | "dark" | "auto"): string {
+    const dark = `
+    --apifn-bg:#0f1117;--apifn-bg-surface:#1a1d2e;--apifn-bg-surface-hover:#252840;
+    --apifn-border:#2d3748;--apifn-text:#e2e8f0;--apifn-text-muted:#64748b;
+    --apifn-accent:#7c3aed;--apifn-accent-text:#c4b5fd;--apifn-green:#6ee7b7;
+    --apifn-blue:#93c5fd;--apifn-yellow:#fcd34d;--apifn-red:#fca5a5;
+    --apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif
+  `;
+    const light = `
+    --apifn-bg:#ffffff;--apifn-bg-surface:#f8fafc;--apifn-bg-surface-hover:#f1f5f9;
+    --apifn-border:#e2e8f0;--apifn-text:#0f172a;--apifn-text-muted:#64748b;
+    --apifn-accent:#7c3aed;--apifn-accent-text:#6d28d9;--apifn-green:#059669;
+    --apifn-blue:#2563eb;--apifn-yellow:#d97706;--apifn-red:#dc2626;
+    --apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif
+  `;
+    if (theme === "dark") return `.apifn-root{${dark}}`;
+    if (theme === "light") return `.apifn-root{${light}}`;
+    return `@media(prefers-color-scheme:dark){.apifn-root{${dark}}}.apifn-root{${light}}`;
+}
+
+const s = {
+    root: {
+        fontFamily: "var(--apifn-font-sans)",
+        color: "var(--apifn-text)",
+        background: "var(--apifn-bg)",
+        maxWidth: "960px",
+        margin: "0 auto",
+        padding: "0 24px 48px",
+    } as React.CSSProperties,
+    pageTitle: { fontSize: "28px", fontWeight: 800, marginBottom: "8px" } as React.CSSProperties,
+    pageSubtitle: { fontSize: "14px", color: "var(--apifn-text-muted)", marginBottom: "40px" } as React.CSSProperties,
+    card: {
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        marginBottom: "24px",
+        overflow: "hidden",
+        background: "var(--apifn-bg-surface)",
+    } as React.CSSProperties,
+    cardHeader: {
+        display: "flex", alignItems: "center", gap: "12px",
+        padding: "14px 20px", cursor: "pointer",
+        borderBottom: "1px solid var(--apifn-border)",
+    } as React.CSSProperties,
+    badge: (method: string): React.CSSProperties => {
+        const c = METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+        return { padding: "3px 10px", borderRadius: "3px", background: c.bg, color: c.text, fontWeight: 700, fontSize: "12px", fontFamily: "var(--apifn-font-mono)", textTransform: "uppercase" };
+    },
+    cardPath: { fontFamily: "var(--apifn-font-mono)", fontSize: "14px", fontWeight: 600, flex: 1 } as React.CSSProperties,
+    cardSummary: { fontSize: "13px", color: "var(--apifn-text-muted)" } as React.CSSProperties,
+    tabs: {
+        display: "flex", borderBottom: "1px solid var(--apifn-border)", padding: "0 20px",
+    } as React.CSSProperties,
+    tab: (active: boolean): React.CSSProperties => ({
+        padding: "10px 14px", fontSize: "13px",
+        fontWeight: active ? 600 : 400,
+        color: active ? "var(--apifn-text)" : "var(--apifn-text-muted)",
+        border: "none", borderBottomWidth: "2px", borderBottomStyle: "solid",
+        borderBottomColor: active ? "var(--apifn-accent)" : "transparent",
+        background: "none", cursor: "pointer",
+    }),
+};
+
+function EndpointCard({
+    path, method, operation, tryIt, baseUrl, performanceMetrics,
+}: {
+    path: string;
+    method: string;
+    operation: OperationObject;
+    tryIt: boolean;
+    baseUrl: string;
+    performanceMetrics?: ApifnApiReferenceProps["performanceMetrics"];
+}) {
+    const [open, setOpen] = useState(false);
+    const [tab, setTab] = useState<"docs" | "tryit" | "perf">("docs");
+
+    const perfKey = `${method.toUpperCase()} ${path}`;
+    const rawMetrics = performanceMetrics?.[perfKey];
+    const anchorId = `${method.toLowerCase()}-${path.replace(/[^a-z0-9]/gi, "-")}`;
+
+    const perfMetrics: PerformanceMetrics | undefined = rawMetrics
+        ? { endpoint: path, method, lastUpdated: new Date().toISOString(), ...rawMetrics }
+        : undefined;
+
+    return (
+        <div id={anchorId} style={s.card}>
+            <div style={s.cardHeader} onClick={() => setOpen((o) => !o)}>
+                <span style={s.badge(method)}>{method.toUpperCase()}</span>
+                <span style={s.cardPath}>{path}</span>
+                {operation.summary && <span style={s.cardSummary}>{operation.summary as string}</span>}
+                <span style={{ color: "var(--apifn-text-muted)", fontSize: "12px", transform: open ? "rotate(180deg)" : "none", transition: "transform .15s" }}>▼</span>
+            </div>
+
+            {open && (
+                <>
+                    <div style={s.tabs}>
+                        <button style={s.tab(tab === "docs")} onClick={() => setTab("docs")}>Docs</button>
+                        {tryIt && <button style={s.tab(tab === "tryit")} onClick={() => setTab("tryit")}>Try It</button>}
+                        {perfMetrics && <button style={s.tab(tab === "perf")} onClick={() => setTab("perf")}>Performance</button>}
+                    </div>
+                    {tab === "docs" && <EndpointViewer path={path} method={method} operation={operation} />}
+                    {tab === "tryit" && tryIt && <TryIt path={path} method={method} operation={operation} baseUrl={baseUrl} />}
+                    {tab === "perf" && perfMetrics && (
+                        <div style={{ padding: "20px" }}>
+                            <PerformanceOverlay metrics={perfMetrics} />
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+}
+
+export function ApifnApiReference({
+    entry, tryIt = false, baseUrl = "https://api.example.com", theme = "auto", performanceMetrics,
+}: ApifnApiReferenceProps): React.ReactElement {
+    const themeStyle = getThemeStyle(theme);
+    const effectiveBaseUrl =
+        (entry.spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url ?? baseUrl;
+
+    return (
+        <div className="apifn-root">
+            <style>{themeStyle}</style>
+            <div style={s.root}>
+                <h1 style={s.pageTitle}>{entry.title}</h1>
+                {entry.tag && (
+                    <div style={s.pageSubtitle}>
+                        Tag: <code style={{ fontFamily: "var(--apifn-font-mono)" }}>{entry.tag}</code>
+                        {" — "}
+                        {entry.endpoints.length} endpoint{entry.endpoints.length !== 1 ? "s" : ""}
+                    </div>
+                )}
+                {entry.endpoints.map((ep) => (
+                    <EndpointCard
+                        key={`${ep.method}-${ep.path}`}
+                        path={ep.path}
+                        method={ep.method}
+                        operation={ep.operation}
+                        tryIt={tryIt}
+                        baseUrl={effectiveBaseUrl}
+                        performanceMetrics={performanceMetrics}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/apifn/docsfn/src/svelte/ApifnApiReference.svelte
+++ b/apifn/docsfn/src/svelte/ApifnApiReference.svelte
@@ -1,0 +1,120 @@
+<!-- ApifnApiReference.svelte — Svelte API reference renderer (DOCS-003, DOCS-005) -->
+<script lang="ts">
+  import EndpointViewer from "@apifn/svelte/EndpointViewer.svelte";
+  import TryIt from "@apifn/svelte/TryIt.svelte";
+  import PerformanceOverlay from "@apifn/svelte/PerformanceOverlay.svelte";
+  import type { ApifnApiReferenceProps, RawContentEntry, ApiEndpoint } from "../types.js";
+
+  export let entry: RawContentEntry;
+  export let tryIt: boolean = false;
+  export let baseUrl: string = "https://api.example.com";
+  export let theme: "light" | "dark" | "auto" = "auto";
+  export let performanceMetrics: ApifnApiReferenceProps["performanceMetrics"] = undefined;
+
+  const METHOD_COLORS: Record<string, { bg: string; text: string }> = {
+    get: { bg: "#065f46", text: "#6ee7b7" }, post: { bg: "#1e3a5f", text: "#93c5fd" },
+    put: { bg: "#78350f", text: "#fcd34d" }, patch: { bg: "#5b21b6", text: "#c4b5fd" },
+    delete: { bg: "#7f1d1d", text: "#fca5a5" },
+  };
+
+  function mc(method: string) {
+    return METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+  }
+
+  $: effectiveBaseUrl = (entry.spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url ?? baseUrl;
+
+  // Per-endpoint card open/tab state
+  let openStates: Record<string, boolean> = {};
+  let tabStates: Record<string, "docs" | "tryit" | "perf"> = {};
+
+  function toggle(key: string) { openStates[key] = !openStates[key]; openStates = openStates; }
+  function setTab(key: string, t: "docs" | "tryit" | "perf") { tabStates[key] = t; tabStates = tabStates; }
+
+  function anchorId(ep: ApiEndpoint) { return `${ep.method.toLowerCase()}-${ep.path.replace(/[^a-z0-9]/gi, "-")}`; }
+  function perfKey(ep: ApiEndpoint) { return `${ep.method.toUpperCase()} ${ep.path}`; }
+
+  function getThemeVars(t: "light" | "dark" | "auto"): string {
+    const dark = `--apifn-bg:#0f1117;--apifn-bg-surface:#1a1d2e;--apifn-bg-surface-hover:#252840;--apifn-border:#2d3748;--apifn-text:#e2e8f0;--apifn-text-muted:#64748b;--apifn-accent:#7c3aed;--apifn-accent-text:#c4b5fd;--apifn-green:#6ee7b7;--apifn-blue:#93c5fd;--apifn-yellow:#fcd34d;--apifn-red:#fca5a5;--apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif`;
+    const light = `--apifn-bg:#ffffff;--apifn-bg-surface:#f8fafc;--apifn-bg-surface-hover:#f1f5f9;--apifn-border:#e2e8f0;--apifn-text:#0f172a;--apifn-text-muted:#64748b;--apifn-accent:#7c3aed;--apifn-accent-text:#6d28d9;--apifn-green:#059669;--apifn-blue:#2563eb;--apifn-yellow:#d97706;--apifn-red:#dc2626;--apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif`;
+    return t === "dark" ? dark : light;
+  }
+</script>
+
+<div class="apifn-root" style={getThemeVars(theme)}>
+  <div class="page">
+    <h1 class="page-title">{entry.title}</h1>
+    {#if entry.tag}
+      <div class="page-subtitle">
+        Tag: <code>{entry.tag}</code>
+        — {entry.endpoints.length} endpoint{entry.endpoints.length !== 1 ? "s" : ""}
+      </div>
+    {/if}
+
+    {#each entry.endpoints as ep}
+      {@const key = `${ep.method}-${ep.path}`}
+      {@const isOpen = openStates[key] ?? false}
+      {@const tab = tabStates[key] ?? "docs"}
+      {@const metrics = performanceMetrics?.[perfKey(ep)]}
+
+      <div id={anchorId(ep)} class="card">
+        <!-- Card Header -->
+        <div class="card-header" role="button" tabindex="0"
+          on:click={() => toggle(key)}
+          on:keydown={(e) => e.key === "Enter" && toggle(key)}
+        >
+          <span class="method-badge" style="background:{mc(ep.method).bg};color:{mc(ep.method).text}">
+            {ep.method.toUpperCase()}
+          </span>
+          <span class="card-path">{ep.path}</span>
+          {#if ep.operation.summary}
+            <span class="card-summary">{ep.operation.summary}</span>
+          {/if}
+          <span class="chevron" class:open={isOpen}>▼</span>
+        </div>
+
+        {#if isOpen}
+          <!-- Tabs -->
+          <div class="tabs">
+            <button class="tab" class:active={tab === "docs"} on:click={() => setTab(key, "docs")}>Docs</button>
+            {#if tryIt}
+              <button class="tab" class:active={tab === "tryit"} on:click={() => setTab(key, "tryit")}>Try It</button>
+            {/if}
+            {#if metrics}
+              <button class="tab" class:active={tab === "perf"} on:click={() => setTab(key, "perf")}>Performance</button>
+            {/if}
+          </div>
+
+          <!-- Tab Content -->
+          {#if tab === "docs"}
+            <EndpointViewer path={ep.path} method={ep.method} operation={ep.operation} />
+          {:else if tab === "tryit" && tryIt}
+            <TryIt path={ep.path} method={ep.method} operation={ep.operation} baseUrl={effectiveBaseUrl} />
+          {:else if tab === "perf" && metrics}
+            <div class="perf-wrap">
+              <PerformanceOverlay metrics={{ endpoint: ep.path, method: ep.method, lastUpdated: new Date().toISOString(), ...metrics }} />
+            </div>
+          {/if}
+        {/if}
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .apifn-root { font-family: var(--apifn-font-sans, sans-serif); color: var(--apifn-text); background: var(--apifn-bg); }
+  .page { max-width: 960px; margin: 0 auto; padding: 0 24px 48px; }
+  .page-title { font-size: 28px; font-weight: 800; margin-bottom: 8px; }
+  .page-subtitle { font-size: 14px; color: var(--apifn-text-muted); margin-bottom: 40px; }
+  code { font-family: var(--apifn-font-mono); }
+  .card { border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); margin-bottom: 24px; overflow: hidden; background: var(--apifn-bg-surface); }
+  .card-header { display: flex; align-items: center; gap: 12px; padding: 14px 20px; cursor: pointer; border-bottom: 1px solid var(--apifn-border); }
+  .method-badge { padding: 3px 10px; border-radius: 3px; font-weight: 700; font-size: 12px; font-family: var(--apifn-font-mono); text-transform: uppercase; }
+  .card-path { font-family: var(--apifn-font-mono); font-size: 14px; font-weight: 600; flex: 1; }
+  .card-summary { font-size: 13px; color: var(--apifn-text-muted); }
+  .chevron { color: var(--apifn-text-muted); font-size: 12px; transition: transform .15s; }
+  .chevron.open { transform: rotate(180deg); }
+  .tabs { display: flex; border-bottom: 1px solid var(--apifn-border); padding: 0 20px; }
+  .tab { padding: 10px 14px; font-size: 13px; font-weight: 400; color: var(--apifn-text-muted); border: none; border-bottom: 2px solid transparent; background: none; cursor: pointer; }
+  .tab.active { font-weight: 600; color: var(--apifn-text); border-bottom-color: var(--apifn-accent); }
+  .perf-wrap { padding: 20px; }
+</style>

--- a/apifn/docsfn/src/types.ts
+++ b/apifn/docsfn/src/types.ts
@@ -1,0 +1,108 @@
+/**
+ * docsfn integration types for @apifn/docsfn.
+ *
+ * docsfn is an optional peer dependency that may not be installed.
+ * We define the minimal interfaces needed for our provider here so
+ * consumers get correct types even without the full docsfn package.
+ */
+
+import type { OpenAPIDocument, OperationObject } from "@apifn/core";
+export type { OpenAPIDocument, OperationObject };
+
+// ─── docsfn content types ────────────────────────────────────────────────────
+
+/** Sidebar leaf link. */
+export interface SidebarLink {
+    type: "link";
+    label: string;
+    href: string;
+}
+
+/** Sidebar group containing links. */
+export interface SidebarGroup {
+    type: "group";
+    label: string;
+    items: Array<SidebarLink | SidebarGroup>;
+}
+
+export type SidebarItem = SidebarLink | SidebarGroup;
+
+/** A processed endpoint grouped in a docsfn page. */
+export interface ApiEndpoint {
+    path: string;
+    method: string;
+    operation: OperationObject;
+    tag: string;
+}
+
+/**
+ * A single raw content entry produced by a DocsContentProvider.
+ * `kind: "api"` signals to docsfn that this is an API reference page.
+ */
+export interface RawContentEntry {
+    kind: "api";
+    /** URL slug for this page (e.g. "/api/users") */
+    slug: string;
+    /** Human-readable page title */
+    title: string;
+    /** Tag name when split by tag */
+    tag?: string;
+    /** Endpoint list for this page */
+    endpoints: ApiEndpoint[];
+    /** Sidebar items generated for this entry */
+    sidebar: SidebarGroup;
+    /** Full OpenAPI spec (so renderers can look up $refs etc.) */
+    spec: OpenAPIDocument;
+}
+
+/** A DocsContentProvider is a callable that returns RawContentEntry[]. */
+export interface DocsContentProvider {
+    (): Promise<RawContentEntry[]>;
+    entries: RawContentEntry[];
+}
+
+// ─── createApifnProvider options ─────────────────────────────────────────────
+
+export interface CreateApifnProviderOptions {
+    /** OpenAPI document (object) */
+    spec?: OpenAPIDocument;
+    /** File path to a JSON or YAML OpenAPI spec */
+    specPath?: string;
+    /** Base path prefix for slug generation (default: "/api") */
+    basePath?: string;
+    /**
+     * Split the spec into one page per tag.
+     * - `true`  → one RawContentEntry per tag
+     * - `false` → one RawContentEntry with all endpoints
+     * @default true
+     */
+    splitByTag?: boolean;
+    /** Optional base URL to embed in entries (for TryIt) */
+    baseUrl?: string;
+}
+
+// ─── ApifnApiReference component props ───────────────────────────────────────
+
+export interface PerformanceMetrics {
+    endpoint: string;
+    method: string;
+    p50Ms: number;
+    p95Ms: number;
+    p99Ms: number;
+    errorRatePct: number;
+    requestsPerMinute: number;
+    lastUpdated: string;
+}
+
+export interface ApifnApiReferenceProps {
+    /** Single content entry from createApifnProvider */
+    entry: RawContentEntry;
+    /** Show embedded Try-It console per endpoint (DOCS-005) */
+    tryIt?: boolean;
+    /** Base URL for Try-It requests */
+    baseUrl?: string;
+    /** Theme for the embedded components */
+    theme?: "light" | "dark" | "auto";
+    /** Optional watchfn metrics per endpoint key ("METHOD /path") */
+    performanceMetrics?: Record<string, Omit<PerformanceMetrics, "endpoint" | "method" | "lastUpdated">>;
+}

--- a/apifn/docsfn/tsconfig.json
+++ b/apifn/docsfn/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/apifn/docsfn/tsup.config.ts
+++ b/apifn/docsfn/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/apifn/docsfn/vitest.config.ts
+++ b/apifn/docsfn/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/apifn/examples/ci-cd/github-actions.yml
+++ b/apifn/examples/ci-cd/github-actions.yml
@@ -1,0 +1,18 @@
+name: API Contract Check
+
+on:
+  pull_request:
+    paths:
+      - "apifn/**"
+      - ".apifn/**"
+
+jobs:
+  api-check:
+    uses: ./apifn/.github/workflows/api-check.yml
+    with:
+      spec_path: .apifn/openapi.yml
+      collection_dir: .apifn/collection
+      environment: development
+      base_branch: main
+      fail_on_breaking: true
+      post_pr_comment: true

--- a/apifn/mock/__tests__/mock-server.test.ts
+++ b/apifn/mock/__tests__/mock-server.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Integration tests for the mock server.
+ *
+ * Covers: TV-MOCK-001 through TV-MOCK-007.
+ * Starts a real HTTP server on a random port for each test.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { OpenAPIDocument } from "@apifn/core";
+import { createMockServer } from "../src/server.js";
+import { generateFromSchema, generateRandom, generateResponse } from "../src/response-generator.js";
+import { validateRequestBody, validateParameters } from "../src/request-validator.js";
+import type { SchemaObject, OperationObject } from "@apifn/core";
+
+// ─── Test spec ───────────────────────────────────────────────────────────────
+
+const TEST_SPEC: OpenAPIDocument = {
+    openapi: "3.1.0",
+    info: { title: "Mock Test API", version: "1.0.0" },
+    paths: {
+        "/users": {
+            get: {
+                summary: "List users",
+                responses: {
+                    "200": {
+                        description: "OK",
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    type: "object",
+                                    properties: {
+                                        id: { type: "string" },
+                                        name: { type: "string" },
+                                        age: { type: "integer" },
+                                        active: { type: "boolean" },
+                                        tags: { type: "array", items: { type: "string" } },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            post: {
+                summary: "Create user",
+                requestBody: {
+                    required: true,
+                    content: {
+                        "application/json": {
+                            schema: {
+                                type: "object",
+                                required: ["name"],
+                                properties: {
+                                    name: { type: "string" },
+                                    age: { type: "integer", minimum: 0 },
+                                },
+                            },
+                        },
+                    },
+                },
+                responses: {
+                    "201": {
+                        description: "Created",
+                        content: {
+                            "application/json": {
+                                example: { id: "abc-123", name: "Alice" },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        "/users/{id}": {
+            get: {
+                summary: "Get user",
+                parameters: [{ name: "id", in: "path", required: true }],
+                responses: {
+                    "200": {
+                        description: "OK",
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    type: "object",
+                                    properties: { id: { type: "string" }, name: { type: "string" } },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        "/health": {
+            get: {
+                summary: "Health check",
+                responses: { "204": { description: "No Content" } },
+            },
+        },
+    },
+};
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+async function get(port: number, path: string): Promise<Response> {
+    return fetch(`http://localhost:${port}${path}`);
+}
+
+async function post(port: number, path: string, body: unknown): Promise<Response> {
+    return fetch(`http://localhost:${port}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+// ─── TV-MOCK-001: All paths served ───────────────────────────────────────────
+
+describe("TV-MOCK-001: all paths served", () => {
+    let mock = createMockServer({ spec: TEST_SPEC, port: 0 });
+
+    beforeAll(() => mock.start());
+    afterAll(() => mock.stop());
+
+    it("GET /users returns 200", async () => {
+        const res = await get(mock.port, "/users");
+        expect(res.status).toBe(200);
+    });
+
+    it("GET /users/123 (path param) returns 200", async () => {
+        const res = await get(mock.port, "/users/123");
+        expect(res.status).toBe(200);
+    });
+
+    it("GET /health returns 204", async () => {
+        const res = await get(mock.port, "/health");
+        expect(res.status).toBe(204);
+    });
+
+    it("undefined path returns 404", async () => {
+        const res = await get(mock.port, "/nonexistent");
+        expect(res.status).toBe(404);
+    });
+});
+
+// ─── TV-MOCK-002: Schema mode ─────────────────────────────────────────────────
+
+describe("TV-MOCK-002: schema mode (deterministic defaults)", () => {
+    it("string schema → 'string'", () => {
+        const result = generateFromSchema({ type: "string" } as SchemaObject);
+        expect(result).toBe("string");
+    });
+
+    it("integer schema → 0", () => {
+        expect(generateFromSchema({ type: "integer" } as SchemaObject)).toBe(0);
+    });
+
+    it("number schema → 0", () => {
+        expect(generateFromSchema({ type: "number" } as SchemaObject)).toBe(0);
+    });
+
+    it("boolean schema → true", () => {
+        expect(generateFromSchema({ type: "boolean" } as SchemaObject)).toBe(true);
+    });
+
+    it("null schema → null", () => {
+        expect(generateFromSchema({ type: "null" } as SchemaObject)).toBe(null);
+    });
+
+    it("array schema → [item]", () => {
+        const result = generateFromSchema({ type: "array", items: { type: "string" } } as SchemaObject);
+        expect(Array.isArray(result)).toBe(true);
+        expect((result as unknown[])[0]).toBe("string");
+    });
+
+    it("object schema → object with all properties", () => {
+        const result = generateFromSchema({
+            type: "object",
+            properties: { id: { type: "string" }, count: { type: "integer" } },
+        } as SchemaObject) as Record<string, unknown>;
+        expect(result.id).toBe("string");
+        expect(result.count).toBe(0);
+    });
+
+    it("is deterministic (same schema → same output)", () => {
+        const schema: SchemaObject = {
+            type: "object",
+            properties: { name: { type: "string" }, active: { type: "boolean" } },
+        } as SchemaObject;
+        const r1 = generateFromSchema(schema);
+        const r2 = generateFromSchema(schema);
+        expect(JSON.stringify(r1)).toBe(JSON.stringify(r2));
+    });
+
+    it("HTTP response via schema mode returns structured object", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, responseMode: "schema", port: 0 });
+        await mock.start();
+        const res = await get(mock.port, "/users");
+        const data = await res.json() as Record<string, unknown>;
+        await mock.stop();
+        expect(data.id).toBe("string");
+        expect(data.active).toBe(true);
+    });
+});
+
+// ─── TV-MOCK-003: Examples mode ───────────────────────────────────────────────
+
+describe("TV-MOCK-003: examples mode", () => {
+    it("returns spec example when available", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, responseMode: "examples", port: 0 });
+        await mock.start();
+        const res = await post(mock.port, "/users", { name: "Alice" });
+        const data = await res.json() as Record<string, unknown>;
+        await mock.stop();
+        expect(data.name).toBe("Alice");
+        expect(data.id).toBe("abc-123");
+    });
+
+    it("falls back to schema when no example", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, responseMode: "examples", port: 0 });
+        await mock.start();
+        const res = await get(mock.port, "/users/42");
+        const data = await res.json() as Record<string, unknown>;
+        await mock.stop();
+        // Falls back to schema generation
+        expect(typeof data.id).toBe("string");
+    });
+
+    it("generateResponse returns example body for examples mode", () => {
+        const op: OperationObject = {
+            responses: {
+                "200": {
+                    description: "OK",
+                    content: { "application/json": { example: { hello: "world" } } },
+                },
+            },
+        };
+        const { body } = generateResponse(op, "examples");
+        expect((body as Record<string, unknown>).hello).toBe("world");
+    });
+});
+
+// ─── TV-MOCK-004: Random mode ─────────────────────────────────────────────────
+
+describe("TV-MOCK-004: random mode", () => {
+    it("generateRandom returns different values on subsequent calls", () => {
+        const schema: SchemaObject = { type: "string" } as SchemaObject;
+        // Run many times; with sufficiently long random strings, at least some differ
+        const values = new Set<string>();
+        for (let i = 0; i < 50; i++) {
+            values.add(String(generateRandom(schema)));
+        }
+        expect(values.size).toBeGreaterThan(1);
+    });
+
+    it("random integer is a number", () => {
+        const result = generateRandom({ type: "integer" } as SchemaObject);
+        expect(typeof result).toBe("number");
+    });
+
+    it("random object has all properties", () => {
+        const schema: SchemaObject = {
+            type: "object",
+            properties: { x: { type: "string" }, y: { type: "number" } },
+        } as SchemaObject;
+        const result = generateRandom(schema) as Record<string, unknown>;
+        expect("x" in result).toBe(true);
+        expect("y" in result).toBe(true);
+    });
+
+    it("HTTP response via random mode responds 200", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, responseMode: "random", port: 0 });
+        await mock.start();
+        const res = await get(mock.port, "/users");
+        await mock.stop();
+        expect(res.status).toBe(200);
+    });
+});
+
+// ─── TV-MOCK-005: Request validation ─────────────────────────────────────────
+
+describe("TV-MOCK-005: request validation", () => {
+    let mock = createMockServer({ spec: TEST_SPEC, validateRequests: true, port: 0 });
+
+    beforeAll(() => mock.start());
+    afterAll(() => mock.stop());
+
+    it("valid body proceeds normally → 201", async () => {
+        const res = await post(mock.port, "/users", { name: "Bob" });
+        expect(res.status).toBe(201);
+    });
+
+    it("missing required field → 400", async () => {
+        const res = await post(mock.port, "/users", { age: 25 }); // name is required
+        expect(res.status).toBe(400);
+        const data = await res.json() as { error: string };
+        expect(data.error).toContain("Validation");
+    });
+
+    it("invalid body JSON → 400", async () => {
+        const res = await fetch(`http://localhost:${mock.port}/users`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: "not-json",
+        });
+        expect(res.status).toBe(400);
+    });
+
+    it("validateRequestBody unit: missing required field", () => {
+        const op: OperationObject = {
+            requestBody: {
+                required: true,
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            required: ["name"],
+                            properties: { name: { type: "string" } },
+                        },
+                    },
+                },
+            },
+            responses: {},
+        };
+        const result = validateRequestBody({}, op);
+        expect(result.valid).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors[0]?.message).toContain("name");
+    });
+
+    it("validateRequestBody unit: valid body", () => {
+        const op: OperationObject = {
+            requestBody: {
+                required: true,
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            required: ["name"],
+                            properties: { name: { type: "string" } },
+                        },
+                    },
+                },
+            },
+            responses: {},
+        };
+        const result = validateRequestBody({ name: "Alice" }, op);
+        expect(result.valid).toBe(true);
+    });
+
+    it("validateParameters unit: missing required path param", () => {
+        const op: OperationObject = {
+            parameters: [{ name: "id", in: "path", required: true }],
+            responses: {},
+        };
+        const result = validateParameters({}, {}, op);
+        expect(result.valid).toBe(false);
+    });
+
+    it("rejects request bodies over the configured byte limit", async () => {
+        const mock = createMockServer({
+            spec: TEST_SPEC,
+            validateRequests: true,
+            maxRequestBodyBytes: 8,
+            port: 0,
+        });
+        await mock.start();
+        const res = await fetch(`http://localhost:${mock.port}/users`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name: "Oversized" }),
+        });
+        await mock.stop();
+
+        expect(res.status).toBe(400);
+        const data = await res.json() as { error: string };
+        expect(data.error).toContain("Request body exceeds");
+    });
+});
+
+// ─── TV-MOCK-006: Configurable delay ─────────────────────────────────────────
+
+describe("TV-MOCK-006: delay", () => {
+    it("adds configured delay to response", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, delay: 50, port: 0 });
+        await mock.start();
+        const start = Date.now();
+        await get(mock.port, "/users");
+        const elapsed = Date.now() - start;
+        await mock.stop();
+        expect(elapsed).toBeGreaterThanOrEqual(45);
+    });
+});
+
+// ─── TV-MOCK-007: CORS support ────────────────────────────────────────────────
+
+describe("TV-MOCK-007: CORS", () => {
+    it("cors: true adds permissive CORS headers", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, cors: true, port: 0 });
+        await mock.start();
+        const res = await get(mock.port, "/users");
+        await mock.stop();
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    });
+
+    it("OPTIONS preflight returns 204", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, cors: true, port: 0 });
+        await mock.start();
+        const res = await fetch(`http://localhost:${mock.port}/users`, { method: "OPTIONS" });
+        await mock.stop();
+        expect(res.status).toBe(204);
+    });
+
+    it("no cors: false means no CORS headers", async () => {
+        const mock = createMockServer({ spec: TEST_SPEC, cors: false, port: 0 });
+        await mock.start();
+        const res = await get(mock.port, "/users");
+        await mock.stop();
+        expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    });
+});

--- a/apifn/mock/package.json
+++ b/apifn/mock/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@apifn/mock",
+  "version": "0.0.1",
+  "description": "Mock server for ApiFn",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@apifn/core": "0.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/mock"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/apifn/mock/src/index.ts
+++ b/apifn/mock/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @apifn/mock — public API
+ */
+
+export { createMockServer } from "./server.js";
+export type { MockServer } from "./server.js";
+export { generateFromSchema, generateRandom, generateResponse } from "./response-generator.js";
+export type { ResponseMode } from "./response-generator.js";
+export { validateRequestBody, validateParameters } from "./request-validator.js";
+export type { ValidationError, ValidationResult } from "./request-validator.js";

--- a/apifn/mock/src/request-validator.ts
+++ b/apifn/mock/src/request-validator.ts
@@ -1,0 +1,193 @@
+/**
+ * Request validator for the mock server.
+ *
+ * Implements MOCK-005: validates incoming request bodies and parameters against
+ * their operation schemas. Returns 400 with validation errors when invalid.
+ */
+
+import type { OperationObject, SchemaObject } from "@apifn/core";
+
+export interface ValidationError {
+    path: string;
+    message: string;
+}
+
+export interface ValidationResult {
+    valid: boolean;
+    errors: ValidationError[];
+}
+
+// ---------------------------------------------------------------------------
+// Simple JSON Schema validator (no external deps)
+// Handles: type, required, properties, minimum/maximum,
+//          minLength/maxLength, enum
+// ---------------------------------------------------------------------------
+
+function validateValue(
+    value: unknown,
+    schema: SchemaObject,
+    path: string,
+    errors: ValidationError[]
+): void {
+    const type = schema.type as string | string[] | undefined;
+    const types = Array.isArray(type) ? type : type ? [type] : [];
+
+    if (types.length > 0) {
+        const actualType = value === null ? "null"
+            : Array.isArray(value) ? "array"
+                : typeof value;
+
+        const matches = types.some((t) => {
+            if (t === "integer") return typeof value === "number" && Number.isInteger(value);
+            return actualType === t;
+        });
+
+        if (!matches) {
+            errors.push({ path, message: `Expected type ${types.join("|")} but got ${actualType}` });
+            return; // no further checks on wrong type
+        }
+    }
+
+    if (schema.enum) {
+        if (!(schema.enum as unknown[]).includes(value)) {
+            errors.push({ path, message: `Value not in enum: ${JSON.stringify(schema.enum)}` });
+        }
+    }
+
+    if (typeof value === "string") {
+        const minLen = schema.minLength !== undefined && schema.minLength !== null ? Number(schema.minLength) : undefined;
+        const maxLen = schema.maxLength !== undefined && schema.maxLength !== null ? Number(schema.maxLength) : undefined;
+        if (minLen !== undefined && value.length < minLen) {
+            errors.push({ path, message: `String too short (min ${minLen})` });
+        }
+        if (maxLen !== undefined && value.length > maxLen) {
+            errors.push({ path, message: `String too long (max ${maxLen})` });
+        }
+    }
+
+    if (typeof value === "number") {
+        const schMin = schema.minimum !== undefined && schema.minimum !== null ? Number(schema.minimum) : undefined;
+        const schMax = schema.maximum !== undefined && schema.maximum !== null ? Number(schema.maximum) : undefined;
+        if (schMin !== undefined && value < schMin) {
+            errors.push({ path, message: `Value ${value} below minimum ${schMin}` });
+        }
+        if (schMax !== undefined && value > schMax) {
+            errors.push({ path, message: `Value ${value} above maximum ${schMax}` });
+        }
+    }
+
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        const obj = value as Record<string, unknown>;
+
+        // required fields
+        if (schema.required) {
+            for (const req of schema.required as string[]) {
+                if (!(req in obj)) {
+                    errors.push({ path: `${path}.${req}`, message: `Required field '${req}' is missing` });
+                }
+            }
+        }
+
+        // properties
+        if (schema.properties) {
+            for (const [key, propSchema] of Object.entries(schema.properties)) {
+                if (key in obj) {
+                    validateValue(obj[key], propSchema as SchemaObject, `${path}.${key}`, errors);
+                }
+            }
+        }
+    }
+
+    if (Array.isArray(value) && schema.items) {
+        for (let i = 0; i < value.length; i++) {
+            validateValue(value[i], schema.items as SchemaObject, `${path}[${i}]`, errors);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validate body against requestBody schema
+// ---------------------------------------------------------------------------
+
+export function validateRequestBody(
+    body: unknown,
+    operation: OperationObject
+): ValidationResult {
+    const errors: ValidationError[] = [];
+
+    const reqBody = operation.requestBody;
+    if (!reqBody || "$ref" in reqBody) {
+        return { valid: true, errors: [] };
+    }
+
+    if (reqBody.required && (body === null || body === undefined)) {
+        errors.push({ path: "body", message: "Request body is required" });
+        return { valid: false, errors };
+    }
+
+    if (body === null || body === undefined) {
+        return { valid: true, errors: [] };
+    }
+
+    const schema = reqBody.content?.["application/json"]?.schema as SchemaObject | undefined;
+    if (schema) {
+        validateValue(body, schema, "body", errors);
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Validate query/path parameters
+// ---------------------------------------------------------------------------
+
+export function validateParameters(
+    queryParams: Record<string, string | string[]>,
+    pathParams: Record<string, string>,
+    operation: OperationObject
+): ValidationResult {
+    const errors: ValidationError[] = [];
+
+    const params = (operation.parameters ?? []) as Array<{
+        name: string;
+        in: string;
+        required?: boolean;
+        schema?: SchemaObject;
+    }>;
+
+    for (const param of params) {
+        if ("$ref" in param) continue;
+
+        let rawValue: string | string[] | undefined;
+        if (param.in === "query") {
+            rawValue = queryParams[param.name];
+        } else if (param.in === "path") {
+            rawValue = pathParams[param.name];
+        }
+
+        if (rawValue === undefined) {
+            if (param.required) {
+                errors.push({
+                    path: `${param.in}.${param.name}`,
+                    message: `Required parameter '${param.name}' is missing`,
+                });
+            }
+            continue;
+        }
+
+        // Basic schema validation on the string value
+        if (param.schema) {
+            const schema = param.schema;
+            const typeVal = schema.type as string | undefined;
+
+            if (typeVal === "integer" || typeVal === "number") {
+                const num = Number(rawValue);
+                if (isNaN(num)) {
+                    errors.push({ path: `${param.in}.${param.name}`, message: `Expected ${typeVal}` });
+                }
+            }
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}

--- a/apifn/mock/src/response-generator.ts
+++ b/apifn/mock/src/response-generator.ts
@@ -1,0 +1,181 @@
+/**
+ * Response generator for the mock server.
+ *
+ * Implements MOCK-002 (schema mode), MOCK-003 (examples mode), MOCK-004 (random mode).
+ * Per SPEC Section 7.6.
+ */
+
+import type { OperationObject, SchemaObject, ResponseObject } from "@apifn/core";
+
+export type ResponseMode = "schema" | "examples" | "random";
+
+// ---------------------------------------------------------------------------
+// Schema-based generation (MOCK-002)
+// Deterministic: given same schema → same output
+// ---------------------------------------------------------------------------
+
+export function generateFromSchema(schema: SchemaObject | undefined): unknown {
+    if (!schema) return null;
+
+    const type = schema.type as string | string[] | undefined;
+    const primaryType = Array.isArray(type) ? type[0] : type;
+
+    switch (primaryType) {
+        case "string": {
+            if (schema.enum) return (schema.enum as unknown[])[0];
+            if (schema.format === "date-time") return "2026-01-01T00:00:00Z";
+            if (schema.format === "date") return "2026-01-01";
+            if (schema.format === "email") return "user@example.com";
+            if (schema.format === "uri" || schema.format === "url") return "https://example.com";
+            if (schema.format === "uuid") return "00000000-0000-0000-0000-000000000000";
+            return "string";
+        }
+        case "integer":
+        case "number":
+            return 0;
+        case "boolean":
+            return true;
+        case "null":
+            return null;
+        case "array": {
+            const itemSchema = schema.items as SchemaObject | undefined;
+            return [generateFromSchema(itemSchema)];
+        }
+        case "object":
+        default: {
+            if (schema.properties) {
+                const obj: Record<string, unknown> = {};
+                for (const [key, propSchema] of Object.entries(schema.properties)) {
+                    obj[key] = generateFromSchema(propSchema as SchemaObject);
+                }
+                return obj;
+            }
+            return {};
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Random mode (MOCK-004)
+// Valid against schema but with randomized values
+// ---------------------------------------------------------------------------
+
+function randomString(length = 8): string {
+    const chars = "abcdefghijklmnopqrstuvwxyz";
+    let s = "";
+    for (let i = 0; i < length; i++) {
+        s += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return s;
+}
+
+export function generateRandom(schema: SchemaObject | undefined): unknown {
+    if (!schema) return null;
+
+    const type = schema.type as string | string[] | undefined;
+    const primaryType = Array.isArray(type) ? type[0] : type;
+
+    switch (primaryType) {
+        case "string": {
+            if (schema.enum) {
+                const enums = schema.enum as unknown[];
+                return enums[Math.floor(Math.random() * enums.length)];
+            }
+            if (schema.format === "date-time") return new Date(Date.now() + Math.random() * 1e10).toISOString();
+            if (schema.format === "email") return `${randomString(5)}@example.com`;
+            return randomString();
+        }
+        case "integer":
+            return Math.floor(Math.random() * 1000);
+        case "number":
+            return Math.random() * 1000;
+        case "boolean":
+            return Math.random() > 0.5;
+        case "null":
+            return null;
+        case "array": {
+            const itemSchema = schema.items as SchemaObject | undefined;
+            return [generateRandom(itemSchema)];
+        }
+        case "object":
+        default: {
+            if (schema.properties) {
+                const obj: Record<string, unknown> = {};
+                for (const [key, propSchema] of Object.entries(schema.properties)) {
+                    obj[key] = generateRandom(propSchema as SchemaObject);
+                }
+                return obj;
+            }
+            return {};
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Examples mode (MOCK-003)
+// Falls back to schema generation if no examples found
+// ---------------------------------------------------------------------------
+
+function getResponseSchema(
+    response: ResponseObject
+): SchemaObject | undefined {
+    return response.content?.["application/json"]?.schema as SchemaObject | undefined;
+}
+
+function getResponseExample(
+    response: ResponseObject
+): unknown {
+    const json = response.content?.["application/json"];
+    if (!json) return undefined;
+    if (json.example !== undefined) return json.example;
+    if (json.examples) {
+        const first = Object.values(json.examples)[0];
+        if (first && !("$ref" in first)) return (first as { value?: unknown }).value;
+    }
+    // schema-level example
+    const schema = json.schema as (SchemaObject & { example?: unknown }) | undefined;
+    if (schema?.example !== undefined) return schema.example;
+    return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Main: pick the right generation strategy
+// ---------------------------------------------------------------------------
+
+export function generateResponse(
+    operation: OperationObject,
+    mode: ResponseMode
+): { statusCode: number; body: unknown } {
+    const responses = operation.responses ?? {};
+    const codes = Object.keys(responses).sort();
+
+    // Pick first successful status code (2xx), fall back to first
+    const successCode = codes.find((c) => c.startsWith("2")) ?? codes[0];
+    const statusCode = successCode ? parseInt(successCode, 10) : 200;
+
+    const responseObj = successCode ? responses[successCode] : undefined;
+
+    // Handle $ref (skip, return null body)
+    if (!responseObj || "$ref" in responseObj) {
+        return { statusCode: statusCode || 200, body: null };
+    }
+
+    const response = responseObj as ResponseObject;
+
+    if (mode === "examples") {
+        const example = getResponseExample(response);
+        if (example !== undefined) {
+            return { statusCode, body: example };
+        }
+        // fallback to schema
+    }
+
+    if (mode === "random") {
+        const schema = getResponseSchema(response);
+        return { statusCode, body: schema ? generateRandom(schema) : null };
+    }
+
+    // schema mode (default + examples fallback)
+    const schema = getResponseSchema(response);
+    return { statusCode, body: schema ? generateFromSchema(schema) : null };
+}

--- a/apifn/mock/src/server.ts
+++ b/apifn/mock/src/server.ts
@@ -1,0 +1,278 @@
+/**
+ * Mock server implementation.
+ *
+ * Implements MOCK-001 (all paths served), MOCK-006 (delay), MOCK-007 (CORS).
+ * Uses Node's built-in `http` module — no external HTTP framework required.
+ */
+
+import http from "node:http";
+import { URL } from "node:url";
+import type { OpenAPIDocument, MockServerOptions, OperationObject } from "@apifn/core";
+import type { ResponseMode } from "./response-generator.js";
+import { generateResponse } from "./response-generator.js";
+import { validateRequestBody, validateParameters } from "./request-validator.js";
+
+// ─── Internal types ───────────────────────────────────────────────────────────
+
+interface RouteHandler {
+    method: string;
+    pattern: RegExp;
+    paramNames: string[];
+    operation: OperationObject;
+}
+
+export interface MockServer {
+    /** Start the server on the configured port */
+    start(): Promise<void>;
+    /** Stop the server */
+    stop(): Promise<void>;
+    /** The underlying http.Server */
+    server: http.Server;
+    /** The port actually bound to */
+    port: number;
+}
+
+const DEFAULT_MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
+
+// ─── Path pattern conversion ──────────────────────────────────────────────────
+
+/**
+ * Convert OpenAPI path `/users/{id}` to a regex and extract param names.
+ */
+function compilePath(apiPath: string): { pattern: RegExp; paramNames: string[] } {
+    const paramNames: string[] = [];
+    let regex = "";
+    let cursor = 0;
+
+    while (cursor < apiPath.length) {
+        const start = apiPath.indexOf("{", cursor);
+        if (start === -1) {
+            regex += escapeRegExp(apiPath.slice(cursor));
+            break;
+        }
+
+        const end = apiPath.indexOf("}", start + 1);
+        if (end === -1) {
+            regex += escapeRegExp(apiPath.slice(cursor));
+            break;
+        }
+
+        regex += escapeRegExp(apiPath.slice(cursor, start));
+        paramNames.push(apiPath.slice(start + 1, end));
+        regex += "([^/]+)";
+        cursor = end + 1;
+    }
+
+    return { pattern: new RegExp(`^${regex}$`), paramNames };
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ─── CORS headers ─────────────────────────────────────────────────────────────
+
+function applyCors(
+    res: http.ServerResponse,
+    cors: MockServerOptions["cors"]
+): void {
+    if (!cors) return;
+
+    const origins = cors === true ? "*"
+        : typeof cors === "object" && cors.origin
+            ? Array.isArray(cors.origin) ? cors.origin.join(", ") : String(cors.origin)
+            : "*";
+
+    res.setHeader("Access-Control-Allow-Origin", origins);
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key");
+    if (cors !== true && typeof cors === "object" && cors.credentials) {
+        res.setHeader("Access-Control-Allow-Credentials", "true");
+    }
+}
+
+// ─── Request body reader ──────────────────────────────────────────────────────
+
+function readBody(req: http.IncomingMessage, maxBytes = DEFAULT_MAX_REQUEST_BODY_BYTES): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        let size = 0;
+        let rejected = false;
+        req.on("data", (chunk: Buffer) => {
+            if (rejected) return;
+            size += chunk.byteLength;
+            if (size > maxBytes) {
+                rejected = true;
+                reject(new Error(`Request body exceeds ${maxBytes} bytes`));
+                return;
+            }
+            chunks.push(chunk);
+        });
+        req.on("end", () => {
+            if (rejected) return;
+            const raw = Buffer.concat(chunks).toString("utf8");
+            if (!raw) {
+                resolve(undefined);
+                return;
+            }
+            try {
+                resolve(JSON.parse(raw));
+            } catch {
+                reject(new Error("Invalid JSON body"));
+            }
+        });
+        req.on("error", reject);
+    });
+}
+
+// ─── JSON response helper ─────────────────────────────────────────────────────
+
+function sendJson(
+    res: http.ServerResponse,
+    statusCode: number,
+    body: unknown
+): void {
+    const payload = body !== null && body !== undefined
+        ? JSON.stringify(body)
+        : "";
+    res.setHeader("Content-Type", "application/json");
+    res.writeHead(statusCode);
+    res.end(payload);
+}
+
+// ─── createMockServer ─────────────────────────────────────────────────────────
+
+const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const;
+
+/**
+ * Create a mock server from an OpenAPI spec.
+ *
+ * @returns MockServer with start() and stop() lifecycle methods.
+ */
+export function createMockServer(options: MockServerOptions): MockServer {
+    const spec = options.spec as OpenAPIDocument;
+    const port = options.port ?? 4010;
+    const mode: ResponseMode = options.responseMode ?? "schema";
+    const validateReqs = options.validateRequests ?? false;
+    const delay = options.delay ?? 0;
+    const cors = options.cors;
+    const maxRequestBodyBytes = options.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES;
+
+    // Build route table
+    const routes: RouteHandler[] = [];
+
+    for (const [apiPath, pathItem] of Object.entries(spec.paths ?? {})) {
+        if (!pathItem) continue;
+        const { pattern, paramNames } = compilePath(apiPath);
+
+        for (const method of HTTP_METHODS) {
+            const op = pathItem[method] as OperationObject | undefined;
+            if (op) {
+                routes.push({ method, pattern, paramNames, operation: op });
+            }
+        }
+    }
+
+    // Node HTTP server
+    const server = http.createServer(async (req, res) => {
+        const rawMethod = (req.method ?? "GET").toLowerCase();
+
+        // Parse URL
+        const urlObj = new URL(req.url ?? "/", "http://localhost");
+        const pathname = urlObj.pathname;
+        const queryParams: Record<string, string> = {};
+        for (const [k, v] of urlObj.searchParams.entries()) {
+            queryParams[k] = v;
+        }
+
+        // Apply CORS
+        applyCors(res, cors);
+
+        // Handle CORS preflight
+        if (rawMethod === "options") {
+            res.writeHead(204);
+            res.end();
+            return;
+        }
+
+        // Find matching route
+        const match = routes.find((r) => {
+            return r.method === rawMethod && r.pattern.test(pathname);
+        });
+
+        if (!match) {
+            sendJson(res, 404, { error: "Not Found", path: pathname });
+            return;
+        }
+
+        // Extract path params
+        const pathParamValues = pathname.match(match.pattern) ?? [];
+        const pathParams: Record<string, string> = {};
+        match.paramNames.forEach((name, i) => {
+            pathParams[name] = pathParamValues[i + 1] ?? "";
+        });
+
+        // Optional delay (MOCK-006)
+        if (delay > 0) {
+            await new Promise<void>((resolve) => setTimeout(resolve, delay));
+        }
+
+        // Optional request validation (MOCK-005)
+        if (validateReqs) {
+            const paramValidation = validateParameters(queryParams, pathParams, match.operation);
+            if (!paramValidation.valid) {
+                sendJson(res, 400, { error: "Validation Error", errors: paramValidation.errors });
+                return;
+            }
+
+            // Read body for validation
+            if (rawMethod === "post" || rawMethod === "put" || rawMethod === "patch") {
+                let body: unknown;
+                try {
+                    body = await readBody(req, maxRequestBodyBytes);
+                } catch (error) {
+                    sendJson(res, 400, { error: error instanceof Error ? error.message : "Invalid JSON body" });
+                    return;
+                }
+                const bodyValidation = validateRequestBody(body, match.operation);
+                if (!bodyValidation.valid) {
+                    sendJson(res, 400, { error: "Validation Error", errors: bodyValidation.errors });
+                    return;
+                }
+            }
+        }
+
+        // Generate response
+        const { statusCode, body } = generateResponse(match.operation, mode);
+        sendJson(res, statusCode, body);
+    });
+
+    let boundPort = port;
+
+    return {
+        server,
+        get port() {
+            return boundPort;
+        },
+        start() {
+            return new Promise((resolve, reject) => {
+                server.listen(port, () => {
+                    const addr = server.address();
+                    if (addr && typeof addr === "object") {
+                        boundPort = addr.port;
+                    }
+                    resolve();
+                });
+                server.once("error", reject);
+            });
+        },
+        stop() {
+            return new Promise((resolve, reject) => {
+                server.close((err) => {
+                    if (err) reject(err);
+                    else resolve();
+                });
+            });
+        },
+    };
+}

--- a/apifn/mock/tsconfig.json
+++ b/apifn/mock/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apifn/mock/tsup.config.ts
+++ b/apifn/mock/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/apifn/mock/vitest.config.ts
+++ b/apifn/mock/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/apifn/python/apifn/__init__.py
+++ b/apifn/python/apifn/__init__.py
@@ -1,0 +1,18 @@
+"""ApiFn — Self-hosted API development platform (Python package)."""
+
+from .collections import read_collection, run_collection
+from .config import ApifnConfig
+from .diff import diff_openapi
+from .fastapi import introspect_fastapi
+from .flask import introspect_flask
+from .openapi import augment_openapi
+
+__all__ = [
+    "ApifnConfig",
+    "augment_openapi",
+    "introspect_fastapi",
+    "introspect_flask",
+    "read_collection",
+    "run_collection",
+    "diff_openapi",
+]

--- a/apifn/python/apifn/collections.py
+++ b/apifn/python/apifn/collections.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+
+
+_VAR_RE = re.compile(r"{{\s*([\w.-]+)\s*}}")
+
+
+def _interpolate(value: str, context: dict[str, str]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        key = match.group(1)
+        return str(context.get(key, match.group(0)))
+
+    return _VAR_RE.sub(repl, value)
+
+
+def _walk_requests(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in items:
+        kind = item.get("kind")
+        if kind == "request" and item.get("request"):
+            out.append(item)
+        elif kind == "folder":
+            out.extend(_walk_requests(item.get("children") or []))
+    return out
+
+
+def read_collection(directory: str | Path) -> dict[str, Any]:
+    root = Path(directory)
+    top = root / "opencollection.yml"
+    if not top.exists():
+        raise FileNotFoundError(f"Missing opencollection.yml in {root}")
+
+    with top.open("r", encoding="utf-8") as f:
+        collection = yaml.safe_load(f) or {}
+
+    collection.setdefault("info", {})
+    collection.setdefault("items", [])
+    collection.setdefault("environments", {})
+    return collection
+
+
+def run_collection(collection: dict[str, Any], options: dict[str, Any] | None = None) -> dict[str, Any]:
+    options = options or {}
+    env_name = options.get("environment", "default")
+    overrides = options.get("overrides") or {}
+    timeout = float(options.get("timeout", 30.0))
+
+    envs = collection.get("environments") or {}
+    if env_name not in envs:
+        raise ValueError(f"Environment '{env_name}' not found")
+
+    env = (envs.get(env_name) or {}).copy()
+    variables = (env.get("variables") or {}).copy()
+    variables.update(overrides)
+    context = {k: str(v) for k, v in variables.items()}
+
+    requests = _walk_requests(collection.get("items") or [])
+    started = time.time()
+
+    own_client = False
+    client = options.get("client")
+    if client is None:
+        own_client = True
+        client = httpx.Client(timeout=timeout)
+
+    results: list[dict[str, Any]] = []
+
+    try:
+        for item in requests:
+            req = item["request"]["http"]
+            method = req["method"].upper()
+            url = _interpolate(req["url"], context)
+            headers = {
+                h["name"]: _interpolate(h.get("value", ""), context)
+                for h in req.get("headers", [])
+            }
+
+            body = None
+            if req.get("body") and req["body"].get("data") is not None:
+                body = _interpolate(str(req["body"]["data"]), context)
+
+            started_req = time.time()
+            try:
+                resp = client.request(method, url, headers=headers, content=body)
+                duration_ms = int((time.time() - started_req) * 1000)
+                status = "passed" if resp.status_code < 400 else "failed"
+                results.append(
+                    {
+                        "name": item["name"],
+                        "status": status,
+                        "duration": duration_ms,
+                        "statusCode": resp.status_code,
+                        "assertions": [],
+                    }
+                )
+            except Exception as exc:  # pragma: no cover - defensive mapping
+                duration_ms = int((time.time() - started_req) * 1000)
+                results.append(
+                    {
+                        "name": item["name"],
+                        "status": "error",
+                        "duration": duration_ms,
+                        "assertions": [],
+                        "error": str(exc),
+                    }
+                )
+    finally:
+        if own_client:
+            client.close()
+
+    duration = int((time.time() - started) * 1000)
+    summary = {
+        "total": len(results),
+        "passed": sum(1 for r in results if r["status"] == "passed"),
+        "failed": sum(1 for r in results if r["status"] == "failed"),
+        "skipped": sum(1 for r in results if r["status"] == "skipped"),
+        "errors": sum(1 for r in results if r["status"] == "error"),
+        "duration": duration,
+    }
+
+    return {
+        "collectionName": collection.get("info", {}).get("name", "collection"),
+        "environment": env_name,
+        "duration": duration,
+        "results": results,
+        "summary": summary,
+    }

--- a/apifn/python/apifn/config.py
+++ b/apifn/python/apifn/config.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ApifnConfig:
+    title: str = "ApiFn API"
+    version: str = "1.0.0"
+    base_url: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/apifn/python/apifn/diff.py
+++ b/apifn/python/apifn/diff.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _iter_operations(spec: dict[str, Any]) -> dict[tuple[str, str], dict[str, Any]]:
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    for path, path_item in (spec.get("paths") or {}).items():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            method_l = str(method).lower()
+            if method_l in {"get", "post", "put", "patch", "delete", "head", "options", "trace"}:
+                out[(method_l, path)] = operation or {}
+    return out
+
+
+def _required_params(op: dict[str, Any]) -> set[tuple[str, str]]:
+    required: set[tuple[str, str]] = set()
+    for p in op.get("parameters") or []:
+        if isinstance(p, dict) and p.get("required"):
+            required.add((str(p.get("in", "query")), str(p.get("name", ""))))
+    return required
+
+
+def diff_openapi(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    before_ops = _iter_operations(before)
+    after_ops = _iter_operations(after)
+
+    entries: list[dict[str, Any]] = []
+
+    for key in sorted(before_ops.keys() - after_ops.keys()):
+        method, path = key
+        entries.append(
+            {
+                "type": "endpoint_removed",
+                "level": "breaking",
+                "method": method.upper(),
+                "path": path,
+                "message": f"Endpoint removed: {method.upper()} {path}",
+            }
+        )
+
+    for key in sorted(before_ops.keys() & after_ops.keys()):
+        b = before_ops[key]
+        a = after_ops[key]
+
+        added_required = sorted(_required_params(a) - _required_params(b))
+        for where, name in added_required:
+            method, path = key
+            entries.append(
+                {
+                    "type": "required_param_added",
+                    "level": "breaking",
+                    "method": method.upper(),
+                    "path": path,
+                    "message": f"Required parameter added: {where}.{name}",
+                }
+            )
+
+    for key in sorted(after_ops.keys() - before_ops.keys()):
+        method, path = key
+        entries.append(
+            {
+                "type": "endpoint_added",
+                "level": "non-breaking",
+                "method": method.upper(),
+                "path": path,
+                "message": f"Endpoint added: {method.upper()} {path}",
+            }
+        )
+
+    summary = {
+        "total": len(entries),
+        "breaking": sum(1 for e in entries if e["level"] == "breaking"),
+        "nonBreaking": sum(1 for e in entries if e["level"] == "non-breaking"),
+    }
+
+    return {
+        "entries": entries,
+        "summary": summary,
+        "hasBreaking": summary["breaking"] > 0,
+    }

--- a/apifn/python/apifn/fastapi.py
+++ b/apifn/python/apifn/fastapi.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .config import ApifnConfig
+from .openapi import augment_openapi
+
+
+def introspect_fastapi(app: Any, config: ApifnConfig) -> dict[str, Any]:
+    """Use FastAPI's native OpenAPI generation and augment with ApiFn metadata."""
+    raw = app.openapi()
+    return augment_openapi(raw, config)

--- a/apifn/python/apifn/flask.py
+++ b/apifn/python/apifn/flask.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .config import ApifnConfig
+from .openapi import augment_openapi
+
+_FLASK_PARAM_RE = re.compile(r"<(?:(?P<converter>[^:>]+):)?(?P<name>[^>]+)>")
+
+
+def _flask_path_to_openapi(path: str) -> tuple[str, list[dict[str, Any]]]:
+    parameters: list[dict[str, Any]] = []
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group("name")
+        converter = (match.group("converter") or "string").lower()
+        schema_type = "integer" if converter in {"int", "integer"} else "string"
+        parameters.append(
+            {
+                "name": name,
+                "in": "path",
+                "required": True,
+                "schema": {"type": schema_type},
+            }
+        )
+        return "{" + name + "}"
+
+    return _FLASK_PARAM_RE.sub(replace, path), parameters
+
+
+def introspect_flask(app: Any, config: ApifnConfig) -> dict[str, Any]:
+    """Build a minimal OpenAPI spec from Flask URL rules, then augment."""
+    paths: dict[str, Any] = {}
+
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint == "static":
+            continue
+
+        methods = sorted(m for m in rule.methods if m not in {"HEAD", "OPTIONS"})
+        if not methods:
+            continue
+
+        openapi_path, parameters = _flask_path_to_openapi(rule.rule)
+        path_item = paths.setdefault(openapi_path, {})
+
+        for method in methods:
+            operation: dict[str, Any] = {
+                "operationId": f"{rule.endpoint}_{method.lower()}",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {"type": "object"}
+                            }
+                        },
+                    }
+                },
+            }
+            if parameters:
+                operation["parameters"] = parameters
+            path_item[method.lower()] = operation
+
+    doc = {
+        "openapi": "3.1.0",
+        "info": {
+            "title": config.title,
+            "version": config.version,
+        },
+        "paths": paths,
+    }
+    return augment_openapi(doc, config)

--- a/apifn/python/apifn/openapi.py
+++ b/apifn/python/apifn/openapi.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+from .config import ApifnConfig
+
+
+def augment_openapi(spec: dict[str, Any], config: ApifnConfig) -> dict[str, Any]:
+    """Return an augmented copy of an OpenAPI document with ApiFn extensions."""
+    out = deepcopy(spec)
+    out.setdefault("openapi", "3.1.0")
+
+    info = out.setdefault("info", {})
+    info.setdefault("title", config.title)
+    info.setdefault("version", config.version)
+
+    generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    out["x-apifn-generated-by"] = "apifn-python"
+    out["x-apifn-generated-at"] = generated_at
+    out["x-apifn-config"] = {
+        "title": config.title,
+        "version": config.version,
+        "base_url": config.base_url,
+        **config.metadata,
+    }
+    return out

--- a/apifn/python/pyproject.toml
+++ b/apifn/python/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "apifn"
+version = "0.0.1"
+description = "Self-hosted API development platform — Python SDK"
+license = "MIT"
+authors = [
+    { name = "21n" }
+]
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.6",
+    "pyyaml>=6.0",
+    "httpx>=0.27",
+    "fastapi>=0.110",
+    "flask>=3.0",
+]
+
+[project.optional-dependencies]
+fastapi = ["fastapi", "uvicorn"]
+flask = ["flask"]
+dev = ["pytest>=8.0"]
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/apifn/python/setup.py
+++ b/apifn/python/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/apifn/python/tests/test_collections.py
+++ b/apifn/python/tests/test_collections.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import yaml
+
+from apifn import read_collection, run_collection
+
+
+def test_tv_py_004_collection_read_and_run(tmp_path: Path) -> None:
+    collection_dir = tmp_path / "collection"
+    collection_dir.mkdir()
+
+    (collection_dir / "opencollection.yml").write_text(
+        yaml.safe_dump(
+            {
+                "info": {"name": "Sample"},
+                "environments": {
+                    "default": {
+                        "variables": {
+                            "baseUrl": "https://api.test",
+                        }
+                    }
+                },
+                "items": [
+                    {
+                        "kind": "request",
+                        "name": "Ping",
+                        "request": {
+                            "http": {
+                                "method": "GET",
+                                "url": "{{baseUrl}}/ping",
+                                "headers": [],
+                            }
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    collection = read_collection(collection_dir)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://api.test/ping"
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        report = run_collection(collection, {"environment": "default", "client": client})
+    finally:
+        client.close()
+
+    assert report["summary"]["total"] == 1
+    assert report["summary"]["passed"] == 1
+    assert report["results"][0]["status"] == "passed"
+
+
+def test_run_collection_raises_for_missing_environment() -> None:
+    collection = {
+        "info": {"name": "Sample"},
+        "environments": {"default": {"variables": {"baseUrl": "https://api.test"}}},
+        "items": [],
+    }
+
+    try:
+        run_collection(collection, {"environment": "staging"})
+    except ValueError as exc:
+        assert str(exc) == "Environment 'staging' not found"
+    else:
+        raise AssertionError("expected missing environment to raise")

--- a/apifn/python/tests/test_diff.py
+++ b/apifn/python/tests/test_diff.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from apifn import diff_openapi
+
+
+def test_tv_py_005_diff_classification() -> None:
+    before = {
+        "openapi": "3.1.0",
+        "info": {"title": "API", "version": "1.0.0"},
+        "paths": {
+            "/users": {
+                "get": {
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        },
+    }
+
+    after = {
+        "openapi": "3.1.0",
+        "info": {"title": "API", "version": "1.1.0"},
+        "paths": {
+            "/users": {
+                "get": {
+                    "parameters": [
+                        {"name": "tenant", "in": "query", "required": True, "schema": {"type": "string"}}
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+            "/orders": {
+                "get": {
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+        },
+    }
+
+    result = diff_openapi(before, after)
+
+    assert result["hasBreaking"] is True
+    assert result["summary"]["breaking"] == 1
+    assert result["summary"]["nonBreaking"] == 1
+    types = {entry["type"] for entry in result["entries"]}
+    assert "required_param_added" in types
+    assert "endpoint_added" in types

--- a/apifn/python/tests/test_fastapi.py
+++ b/apifn/python/tests/test_fastapi.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from apifn import ApifnConfig, introspect_fastapi
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="FastAPI adapter vector is defined for Python 3.10+")
+def test_tv_py_001_fastapi_introspection() -> None:
+    fastapi = pytest.importorskip("fastapi")
+    FastAPI = fastapi.FastAPI
+    app = FastAPI()
+
+    @app.get("/users")
+    async def list_users() -> list[dict[str, str]]:
+        return []
+
+    spec = introspect_fastapi(app, ApifnConfig(title="Test", version="1.0.0"))
+
+    assert spec["openapi"] == "3.1.0"
+    assert "/users" in spec["paths"]
+    assert "get" in spec["paths"]["/users"]
+    assert spec["x-apifn-generated-by"] == "apifn-python"

--- a/apifn/python/tests/test_flask.py
+++ b/apifn/python/tests/test_flask.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from flask import Flask, jsonify
+
+from apifn import ApifnConfig, introspect_flask
+
+
+def test_tv_py_002_flask_introspection() -> None:
+    app = Flask(__name__)
+
+    @app.get("/users/<int:user_id>")
+    def get_user(user_id: int):
+        return jsonify({"id": user_id})
+
+    spec = introspect_flask(app, ApifnConfig(title="Flask Test", version="1.0.0"))
+
+    assert spec["openapi"] == "3.1.0"
+    assert "/users/{user_id}" in spec["paths"]
+    op = spec["paths"]["/users/{user_id}"]["get"]
+    assert op["parameters"][0]["name"] == "user_id"
+    assert op["parameters"][0]["schema"]["type"] == "integer"
+
+
+def test_tv_py_003_openapi_augmentation_preserves_content() -> None:
+    app = Flask(__name__)
+
+    @app.get("/health")
+    def health():
+        return jsonify({"ok": True})
+
+    spec = introspect_flask(app, ApifnConfig(title="Keep", version="2.0.0", metadata={"env": "test"}))
+
+    assert "/health" in spec["paths"]
+    assert spec["x-apifn-config"]["env"] == "test"
+    assert spec["info"]["title"] == "Keep"

--- a/apifn/react/package.json
+++ b/apifn/react/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@apifn/react",
+  "version": "0.0.1",
+  "description": "React UI components for ApiFn",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "node -e \"console.log('No tests configured')\""
+  },
+  "dependencies": {
+    "@apifn/core": "0.0.1"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/react"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/apifn/react/src/ApiExplorer.tsx
+++ b/apifn/react/src/ApiExplorer.tsx
@@ -1,0 +1,466 @@
+/**
+ * ApiExplorer — full API explorer shell (UI-R-001).
+ *
+ * Layout: sidebar (endpoint list + search + tag groups) + main area (EndpointViewer + TryIt).
+ * Theming (light/dark/auto) via CSS variables.
+ * Responsive: sidebar collapses to hamburger on mobile (≤768px).
+ */
+
+import React, { useState, useMemo, useCallback, useEffect } from "react";
+import type { OpenAPIDocument, OperationObject, Theme, HistoryEntry } from "./types.js";
+import { EndpointViewer } from "./EndpointViewer.js";
+import { TryIt } from "./TryIt.js";
+import { RequestHistory } from "./RequestHistory.js";
+import { PerformanceOverlay } from "./PerformanceOverlay.js";
+import { getThemeStyle, METHOD_COLORS } from "./styles/tokens.js";
+import type { TryItResponse } from "./types.js";
+import type { EndpointMetrics, RateLimitInfo } from "@apifn/core";
+
+export interface ApiExplorerProps {
+    /** OpenAPI document to render */
+    spec: OpenAPIDocument;
+    /** Base URL for TryIt requests (falls back to spec.servers[0].url) */
+    baseUrl?: string;
+    /** Light / dark / auto (default: auto) */
+    theme?: Theme;
+    /** Show request history panel */
+    showHistory?: boolean;
+    /** Optional watchfn client for performance metrics */
+    watchfn?: import("@apifn/core").WatchFnClient;
+    /** Polling interval for watchfn metrics in ms (default: 10000) */
+    watchfnInterval?: number;
+    /** Optional secfn rate limits mapping (e.g. "GET /path" -> RateLimitInfo) */
+    rateLimits?: Record<string, RateLimitInfo>;
+    /** Custom class name */
+    className?: string;
+}
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
+
+interface EndpointItem {
+    path: string;
+    method: string;
+    operation: OperationObject;
+    tag: string;
+}
+
+function collectEndpoints(spec: OpenAPIDocument): EndpointItem[] {
+    const items: EndpointItem[] = [];
+    for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+        if (!pathItem) continue;
+        for (const method of HTTP_METHODS) {
+            const op = pathItem[method] as OperationObject | undefined;
+            if (!op) continue;
+            const tags = (op.tags as string[]) ?? ["default"];
+            items.push({ path, method, operation: op, tag: tags[0] ?? "default" });
+        }
+    }
+    return items;
+}
+
+// ─── Styled helpers ───────────────────────────────────────────────────────────
+
+const SIDEBAR_W = "280px";
+
+const s = {
+    root: {
+        fontFamily: "var(--apifn-font-sans)",
+        background: "var(--apifn-bg)",
+        color: "var(--apifn-text)",
+        display: "flex",
+        flexDirection: "column" as const,
+        height: "100vh",
+        overflow: "hidden",
+    } as React.CSSProperties,
+    topbar: {
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        padding: "0 20px",
+        height: "52px",
+        borderBottom: "1px solid var(--apifn-border)",
+        background: "var(--apifn-bg-surface)",
+        flexShrink: 0,
+    } as React.CSSProperties,
+    logo: {
+        fontSize: "16px",
+        fontWeight: 800,
+        color: "var(--apifn-accent)",
+        letterSpacing: "-0.5px",
+    } as React.CSSProperties,
+    apiTitle: {
+        fontSize: "14px",
+        color: "var(--apifn-text-muted)",
+        flex: 1,
+    } as React.CSSProperties,
+    version: {
+        fontSize: "11px",
+        padding: "2px 8px",
+        borderRadius: "12px",
+        background: "var(--apifn-accent)22",
+        color: "var(--apifn-accent-text)",
+        border: "1px solid var(--apifn-accent)44",
+    } as React.CSSProperties,
+    hamburger: {
+        background: "none",
+        border: "none",
+        color: "var(--apifn-text)",
+        cursor: "pointer",
+        fontSize: "20px",
+        padding: "4px",
+        display: "none" as const,
+    } as React.CSSProperties,
+    body: {
+        display: "flex",
+        flex: 1,
+        overflow: "hidden",
+    } as React.CSSProperties,
+    sidebar: (open: boolean): React.CSSProperties => ({
+        width: SIDEBAR_W,
+        minWidth: SIDEBAR_W,
+        borderRight: "1px solid var(--apifn-border)",
+        background: "var(--apifn-bg-surface)",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        flexShrink: 0,
+        transition: "transform 0.2s ease",
+    }),
+    search: {
+        margin: "12px",
+        padding: "8px 12px",
+        background: "var(--apifn-bg)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        color: "var(--apifn-text)",
+        fontSize: "13px",
+        fontFamily: "var(--apifn-font-sans)",
+        outline: "none",
+        width: "calc(100% - 24px)",
+    } as React.CSSProperties,
+    endpointList: {
+        flex: 1,
+        overflowY: "auto" as const,
+        padding: "4px 0",
+    } as React.CSSProperties,
+    tagGroup: {
+        marginBottom: "4px",
+    } as React.CSSProperties,
+    tagHeader: {
+        fontSize: "11px",
+        fontWeight: 700,
+        textTransform: "uppercase" as const,
+        letterSpacing: "0.06em",
+        color: "var(--apifn-text-muted)",
+        padding: "8px 12px 4px",
+    } as React.CSSProperties,
+    endpointRow: (active: boolean): React.CSSProperties => ({
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "7px 12px",
+        cursor: "pointer",
+        background: active ? "var(--apifn-bg-surface-hover)" : "transparent",
+        borderLeft: active ? "2px solid var(--apifn-accent)" : "2px solid transparent",
+    }),
+    methodTag: (method: string): React.CSSProperties => {
+        const c = METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+        return { fontSize: "10px", fontWeight: 700, padding: "1px 5px", borderRadius: "3px", background: c.bg, color: c.text, fontFamily: "var(--apifn-font-mono)", minWidth: "40px", textAlign: "center", textTransform: "uppercase" };
+    },
+    endpointPath: {
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "12px",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap" as const,
+    } as React.CSSProperties,
+    main: {
+        flex: 1,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column" as const,
+    } as React.CSSProperties,
+    tabs: {
+        display: "flex",
+        borderBottom: "1px solid var(--apifn-border)",
+        background: "var(--apifn-bg-surface)",
+        padding: "0 20px",
+        gap: "0",
+        flexShrink: 0,
+    } as React.CSSProperties,
+    tab: (active: boolean): React.CSSProperties => ({
+        padding: "12px 16px",
+        fontSize: "13px",
+        fontWeight: active ? 600 : 400,
+        color: active ? "var(--apifn-text)" : "var(--apifn-text-muted)",
+        borderBottom: active ? "2px solid var(--apifn-accent)" : "2px solid transparent",
+        cursor: "pointer",
+        background: "none",
+        border: "none",
+        borderBottomWidth: "2px",
+        borderBottomStyle: "solid",
+        borderBottomColor: active ? "var(--apifn-accent)" : "transparent",
+    }),
+    content: {
+        flex: 1,
+        overflowY: "auto" as const,
+    } as React.CSSProperties,
+    empty: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100%",
+        color: "var(--apifn-text-muted)",
+        fontSize: "14px",
+        flexDirection: "column" as const,
+        gap: "12px",
+    } as React.CSSProperties,
+    perfBadge: { fontSize: "11px", fontWeight: 600, padding: "2px 8px", background: "var(--apifn-bg-surface-hover)", borderRadius: "12px", color: "var(--apifn-text-muted)" } as React.CSSProperties,
+    rateLimitBadge: { fontSize: "10px", fontWeight: 600, padding: "2px 6px", background: "var(--apifn-bg-surface)", border: "1px solid var(--apifn-border)", borderRadius: "4px", color: "var(--apifn-text-muted)", whiteSpace: "nowrap" as const } as React.CSSProperties,
+};
+
+type MainTab = "docs" | "tryit" | "perf" | "history";
+
+export function ApiExplorer({ spec, theme = "auto", baseUrl, showHistory = true, watchfn, watchfnInterval = 10000, rateLimits, className }: ApiExplorerProps): React.ReactElement {
+    const [query, setQuery] = useState("");
+    const [selected, setSelected] = useState<EndpointItem | null>(null);
+    const [tab, setTab] = useState<MainTab>("docs");
+    const [sidebarOpen, setSidebarOpen] = useState(true);
+    const [history, setHistory] = useState<HistoryEntry[]>([]);
+    const [isMobile, setIsMobile] = useState(false);
+    const [metrics, setMetrics] = useState<Record<string, EndpointMetrics>>({});
+
+    // Detect mobile viewport
+    useEffect(() => {
+        const mq = window.matchMedia("(max-width: 768px)");
+        const handler = (e: MediaQueryListEvent) => {
+            setIsMobile(e.matches);
+            setSidebarOpen(!e.matches);
+        };
+        setIsMobile(mq.matches);
+        setSidebarOpen(!mq.matches);
+        mq.addEventListener("change", handler);
+        return () => mq.removeEventListener("change", handler);
+    }, []);
+
+    const title = (spec.info as { title?: string })?.title ?? "API Explorer";
+    const version = (spec.info as { version?: string })?.version ?? "1.0.0";
+
+    const endpoints = useMemo(() => collectEndpoints(spec), [spec]);
+
+    const filtered = useMemo(() => {
+        const q = query.toLowerCase();
+        if (!q) return endpoints;
+        return endpoints.filter(
+            (e) => e.path.toLowerCase().includes(q) || e.method.toLowerCase().includes(q) || ((e.operation.summary as string) ?? "").toLowerCase().includes(q)
+        );
+    }, [endpoints, query]);
+
+    // Group by tag
+    const grouped = useMemo(() => {
+        const map = new Map<string, EndpointItem[]>();
+        for (const e of filtered) {
+            if (!map.has(e.tag)) map.set(e.tag, []);
+            map.get(e.tag)!.push(e);
+        }
+        return map;
+    }, [filtered]);
+
+    const effectiveBaseUrl = baseUrl ?? (spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url ?? "https://api.example.com";
+
+    // Metrics polling
+    useEffect(() => {
+        if (!watchfn) return;
+
+        let mounted = true;
+        let timer: ReturnType<typeof setTimeout>;
+
+        async function poll() {
+            if (!watchfn || !mounted) return;
+            try {
+                const list = await watchfn.fetchMetrics({ timeRange: "PT1H" });
+                if (!mounted) return;
+                const m: Record<string, EndpointMetrics> = {};
+                for (const item of list) {
+                    m[`${item.method.toUpperCase()} ${item.path}`] = item;
+                }
+                setMetrics(m);
+            } catch (err) {
+                console.warn("[ApiExplorer] Failed to fetch watchfn metrics:", err);
+            }
+            if (mounted) {
+                timer = setTimeout(poll, watchfnInterval);
+            }
+        }
+
+        poll();
+        return () => {
+            mounted = false;
+            clearTimeout(timer);
+        };
+    }, [watchfn, watchfnInterval]);
+
+    const handleResponse = useCallback((response: TryItResponse) => {
+        if (!selected) return;
+        setHistory((h) => [{
+            id: `${Date.now()}-${Math.random()}`,
+            timestamp: Date.now(),
+            method: selected.method,
+            url: `${effectiveBaseUrl}${selected.path}`,
+            statusCode: response.statusCode,
+            duration: response.durationMs,
+            responseBody: response.body,
+            responseHeaders: response.headers,
+        }, ...h].slice(0, 500));
+    }, [selected, effectiveBaseUrl]);
+
+    // Theme injection
+    const themeStyle = useMemo(() => getThemeStyle(theme), [theme]);
+
+    return (
+        <div className={`apifn-root ${className ?? ""}`} style={s.root}>
+            <style>{themeStyle}</style>
+
+            {/* Top Bar */}
+            <div style={s.topbar}>
+                <button
+                    style={{ ...s.hamburger, display: isMobile ? "block" : "none" }}
+                    onClick={() => setSidebarOpen((o) => !o)}
+                    aria-label="Toggle sidebar"
+                >
+                    ☰
+                </button>
+                <span style={s.logo}>ApiFn</span>
+                <span style={s.apiTitle}>{title}</span>
+                <span style={s.version}>v{version}</span>
+            </div>
+
+            {/* Body */}
+            <div style={s.body}>
+                {/* Sidebar */}
+                {sidebarOpen && (
+                    <div style={s.sidebar(sidebarOpen)}>
+                        <input
+                            style={s.search}
+                            placeholder="Search endpoints…"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            aria-label="Search endpoints"
+                        />
+                        <div style={s.endpointList}>
+                            {filtered.length === 0 && (
+                                <div style={{ padding: "20px", color: "var(--apifn-text-muted)", fontSize: "13px", textAlign: "center" }}>
+                                    No endpoints match
+                                </div>
+                            )}
+                            {[...grouped.entries()].map(([tag, items]) => (
+                                <div key={tag} style={s.tagGroup}>
+                                    <div style={s.tagHeader}>{tag}</div>
+                                    {items.map((item) => {
+                                        const isActive = selected?.path === item.path && selected?.method === item.method;
+                                        return (
+                                            <div
+                                                key={`${item.method}-${item.path}`}
+                                                style={s.endpointRow(isActive)}
+                                                onClick={() => {
+                                                    setSelected(item);
+                                                    setTab("docs");
+                                                    if (isMobile) setSidebarOpen(false);
+                                                }}
+                                                role="button"
+                                                tabIndex={0}
+                                            >
+                                                <span style={s.methodTag(item.method)}>{item.method}</span>
+                                                <span style={s.endpointPath}>{item.path}</span>
+                                                {metrics[`${item.method.toUpperCase()} ${item.path}`] && (
+                                                    <span style={s.perfBadge} title="Performance data available">⚡</span>
+                                                )}
+                                                {rateLimits && rateLimits[`${item.method.toUpperCase()} ${item.path}`] && (
+                                                    <span style={{
+                                                        ...s.rateLimitBadge,
+                                                        color: rateLimits[`${item.method.toUpperCase()} ${item.path}`].remaining / rateLimits[`${item.method.toUpperCase()} ${item.path}`].limit < 0.1 ? "var(--apifn-red)" : s.rateLimitBadge.color
+                                                    }} title={`Rate Limit: ${rateLimits[`${item.method.toUpperCase()} ${item.path}`].remaining}/${rateLimits[`${item.method.toUpperCase()} ${item.path}`].limit}`}>
+                                                        {rateLimits[`${item.method.toUpperCase()} ${item.path}`].remaining}/{rateLimits[`${item.method.toUpperCase()} ${item.path}`].limit}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Main Area */}
+                <div style={s.main}>
+                    {selected ? (
+                        <>
+                            {/* Tabs */}
+                            <div style={s.tabs}>
+                                {(["docs", "tryit", ...(watchfn ? ["perf"] : []), ...(showHistory ? ["history"] : [])] as MainTab[]).map((t) => (
+                                    <button key={t} style={s.tab(tab === t)} onClick={() => setTab(t)}>
+                                        {t === "docs" ? "Documentation" : t === "tryit" ? "Try It" : t === "perf" ? "Performance" : "History"}
+                                    </button>
+                                ))}
+                            </div>
+
+                            {/* Tab Content */}
+                            <div style={s.content}>
+                                {tab === "docs" && (
+                                    <EndpointViewer
+                                        path={selected.path}
+                                        method={selected.method}
+                                        operation={selected.operation}
+                                    />
+                                )}
+                                {tab === "tryit" && (
+                                    <TryIt
+                                        path={selected.path}
+                                        method={selected.method}
+                                        operation={selected.operation}
+                                        baseUrl={effectiveBaseUrl}
+                                        onResponse={handleResponse}
+                                    />
+                                )}
+                                {tab === "perf" && watchfn && (
+                                    <div style={{ padding: "20px" }}>
+                                        {(() => {
+                                            const raw = metrics[`${selected.method.toUpperCase()} ${selected.path}`];
+                                            if (!raw) return <div style={s.empty}>No performance data available yet.</div>;
+                                            return (
+                                                <PerformanceOverlay
+                                                    metrics={{
+                                                        endpoint: selected.path,
+                                                        method: selected.method,
+                                                        p50Ms: raw.latency.p50,
+                                                        p95Ms: raw.latency.p95,
+                                                        p99Ms: raw.latency.p99,
+                                                        errorRatePct: raw.errors.rate * 100,
+                                                        requestsPerMinute: raw.throughput.rpm,
+                                                        lastUpdated: raw.lastUpdated
+                                                    }}
+                                                />
+                                            );
+                                        })()}
+                                    </div>
+                                )}
+                                {tab === "history" && showHistory && (
+                                    <RequestHistory
+                                        entries={history}
+                                        onClear={() => setHistory([])}
+                                    />
+                                )}
+                            </div>
+                        </>
+                    ) : (
+                        <div style={s.empty}>
+                            <div style={{ fontSize: "32px" }}>⚡</div>
+                            <div>Select an endpoint from the sidebar</div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apifn/react/src/EndpointViewer.tsx
+++ b/apifn/react/src/EndpointViewer.tsx
@@ -1,0 +1,258 @@
+/**
+ * EndpointViewer — displays full documentation for a single API endpoint (UI-R-002).
+ * Method badge, path, summary, parameters table, request body, and response schemas.
+ */
+
+import React, { useState } from "react";
+import type { OperationObject, SchemaObject } from "./types.js";
+import { SchemaViewer } from "./SchemaViewer.js";
+import { METHOD_COLORS } from "./styles/tokens.js";
+
+export interface EndpointViewerProps {
+    path: string;
+    method: string;
+    operation: OperationObject;
+}
+
+const s = {
+    container: {
+        padding: "24px",
+        color: "var(--apifn-text)",
+        fontFamily: "var(--apifn-font-sans)",
+    } as React.CSSProperties,
+    header: {
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        marginBottom: "20px",
+        flexWrap: "wrap" as const,
+    } as React.CSSProperties,
+    methodBadge: (method: string): React.CSSProperties => {
+        const colors = METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+        return {
+            padding: "4px 12px",
+            borderRadius: "4px",
+            background: colors.bg,
+            color: colors.text,
+            fontWeight: 700,
+            fontSize: "13px",
+            fontFamily: "var(--apifn-font-mono)",
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+        };
+    },
+    path: {
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "18px",
+        fontWeight: 600,
+        color: "var(--apifn-text)",
+    } as React.CSSProperties,
+    summary: {
+        fontSize: "15px",
+        color: "var(--apifn-text-muted)",
+        marginBottom: "8px",
+    } as React.CSSProperties,
+    description: {
+        fontSize: "14px",
+        color: "var(--apifn-text-muted)",
+        lineHeight: 1.6,
+        marginBottom: "24px",
+    } as React.CSSProperties,
+    section: {
+        marginBottom: "24px",
+    } as React.CSSProperties,
+    sectionTitle: {
+        fontSize: "13px",
+        fontWeight: 700,
+        textTransform: "uppercase" as const,
+        letterSpacing: "0.08em",
+        color: "var(--apifn-text-muted)",
+        marginBottom: "12px",
+        borderBottom: "1px solid var(--apifn-border)",
+        paddingBottom: "6px",
+    } as React.CSSProperties,
+    table: {
+        width: "100%",
+        borderCollapse: "collapse" as const,
+        fontSize: "13px",
+    } as React.CSSProperties,
+    th: {
+        textAlign: "left" as const,
+        padding: "6px 8px",
+        color: "var(--apifn-text-muted)",
+        fontWeight: 600,
+        fontSize: "12px",
+        borderBottom: "1px solid var(--apifn-border)",
+    } as React.CSSProperties,
+    td: {
+        padding: "8px 8px",
+        borderBottom: "1px solid var(--apifn-border)",
+        verticalAlign: "top" as const,
+    } as React.CSSProperties,
+    paramName: {
+        fontFamily: "var(--apifn-font-mono)",
+        color: "var(--apifn-accent-text)",
+    } as React.CSSProperties,
+    badge: (color: string): React.CSSProperties => ({
+        fontSize: "11px",
+        padding: "1px 6px",
+        borderRadius: "3px",
+        background: `${color}22`,
+        color,
+        border: `1px solid ${color}44`,
+    }),
+    responseTab: (active: boolean): React.CSSProperties => ({
+        padding: "6px 14px",
+        borderRadius: "4px 4px 0 0",
+        border: "1px solid var(--apifn-border)",
+        borderBottom: active ? "1px solid var(--apifn-bg-surface)" : "none",
+        background: active ? "var(--apifn-bg-surface)" : "transparent",
+        color: active ? "var(--apifn-text)" : "var(--apifn-text-muted)",
+        cursor: "pointer",
+        fontSize: "13px",
+        fontFamily: "var(--apifn-font-mono)",
+        marginBottom: "-1px",
+    }),
+    schemaBox: {
+        background: "var(--apifn-bg-surface)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "16px",
+    } as React.CSSProperties,
+};
+
+function statusColor(code: string): string {
+    const n = parseInt(code, 10);
+    if (n >= 500) return "var(--apifn-red)";
+    if (n >= 400) return "var(--apifn-orange, #fdba74)";
+    if (n >= 300) return "var(--apifn-yellow)";
+    if (n >= 200) return "var(--apifn-green)";
+    return "var(--apifn-text-muted)";
+}
+
+export function EndpointViewer({ path, method, operation }: EndpointViewerProps): React.ReactElement {
+    const responses = operation.responses ?? {};
+    const responseCodes = Object.keys(responses);
+    const [activeCode, setActiveCode] = useState<string>(responseCodes[0] ?? "200");
+
+    const params = (operation.parameters ?? []) as Array<{
+        name: string;
+        in: string;
+        required?: boolean;
+        description?: string;
+        schema?: SchemaObject;
+        example?: unknown;
+    }>;
+
+    const reqBody = operation.requestBody as {
+        required?: boolean;
+        description?: string;
+        content?: Record<string, { schema?: SchemaObject }>;
+    } | undefined;
+
+    const reqBodySchema = reqBody?.content?.["application/json"]?.schema;
+
+    const activeResponse = responses[activeCode] as {
+        description?: string;
+        content?: Record<string, { schema?: SchemaObject }>;
+    } | undefined;
+    const responseSchema = activeResponse?.content?.["application/json"]?.schema;
+
+    return (
+        <div style={s.container}>
+            {/* Header */}
+            <div style={s.header}>
+                <span style={s.methodBadge(method)}>{method}</span>
+                <span style={s.path}>{path}</span>
+                {operation.deprecated && (
+                    <span style={s.badge("var(--apifn-yellow)")}>deprecated</span>
+                )}
+            </div>
+
+            {operation.summary && <div style={s.summary}>{operation.summary as string}</div>}
+            {operation.description && (
+                <div style={s.description}>{operation.description as string}</div>
+            )}
+
+            {/* Parameters */}
+            {params.length > 0 && (
+                <div style={s.section}>
+                    <div style={s.sectionTitle}>Parameters</div>
+                    <table style={s.table}>
+                        <thead>
+                            <tr>
+                                <th style={s.th}>Name</th>
+                                <th style={s.th}>In</th>
+                                <th style={s.th}>Type</th>
+                                <th style={s.th}>Required</th>
+                                <th style={s.th}>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {params.map((p) => (
+                                <tr key={`${p.in}-${p.name}`}>
+                                    <td style={{ ...s.td, ...s.paramName }}>{p.name}</td>
+                                    <td style={s.td}>
+                                        <span style={s.badge("var(--apifn-text-muted)")}>{p.in}</span>
+                                    </td>
+                                    <td style={s.td}>
+                                        <span style={{ fontFamily: "var(--apifn-font-mono)", fontSize: "12px" }}>
+                                            {(p.schema?.type as string) ?? "string"}
+                                        </span>
+                                    </td>
+                                    <td style={s.td}>
+                                        {p.required && <span style={s.badge("var(--apifn-red)")}>✓</span>}
+                                    </td>
+                                    <td style={{ ...s.td, color: "var(--apifn-text-muted)", fontSize: "12px" }}>
+                                        {p.description}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            {/* Request Body */}
+            {reqBodySchema && (
+                <div style={s.section}>
+                    <div style={s.sectionTitle}>
+                        Request Body {reqBody?.required && <span style={{ color: "var(--apifn-red)" }}>*</span>}
+                    </div>
+                    <div style={s.schemaBox}>
+                        <SchemaViewer schema={reqBodySchema} />
+                    </div>
+                </div>
+            )}
+
+            {/* Responses */}
+            {responseCodes.length > 0 && (
+                <div style={s.section}>
+                    <div style={s.sectionTitle}>Responses</div>
+                    <div style={{ display: "flex", gap: "2px", flexWrap: "wrap", marginBottom: "0" }}>
+                        {responseCodes.map((code) => (
+                            <button
+                                key={code}
+                                style={s.responseTab(code === activeCode)}
+                                onClick={() => setActiveCode(code)}
+                            >
+                                <span style={{ color: statusColor(code) }}>{code}</span>
+                            </button>
+                        ))}
+                    </div>
+                    <div style={s.schemaBox}>
+                        <div style={{ marginBottom: "8px", color: "var(--apifn-text-muted)", fontSize: "13px" }}>
+                            {activeResponse?.description}
+                        </div>
+                        {responseSchema && <SchemaViewer schema={responseSchema} />}
+                        {!responseSchema && (
+                            <span style={{ color: "var(--apifn-text-muted)", fontSize: "13px" }}>
+                                No response body schema defined.
+                            </span>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apifn/react/src/PerformanceOverlay.tsx
+++ b/apifn/react/src/PerformanceOverlay.tsx
@@ -1,0 +1,173 @@
+/**
+ * PerformanceOverlay — watchfn metrics display (UI-R-007).
+ * Latency percentiles (p50/p95/p99), error rate, throughput, last updated.
+ */
+
+import React from "react";
+import type { PerformanceMetrics } from "./types.js";
+
+export interface PerformanceOverlayProps {
+    metrics: PerformanceMetrics;
+    compact?: boolean;
+}
+
+const s = {
+    container: {
+        background: "var(--apifn-bg-surface)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "16px",
+        fontFamily: "var(--apifn-font-sans)",
+        color: "var(--apifn-text)",
+    } as React.CSSProperties,
+    title: {
+        fontSize: "12px",
+        fontWeight: 700,
+        textTransform: "uppercase" as const,
+        letterSpacing: "0.06em",
+        color: "var(--apifn-text-muted)",
+        marginBottom: "12px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+    } as React.CSSProperties,
+    grid: {
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gap: "12px",
+        marginBottom: "12px",
+    } as React.CSSProperties,
+    metric: {
+        background: "var(--apifn-bg)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "10px 12px",
+    } as React.CSSProperties,
+    metricLabel: {
+        fontSize: "11px",
+        color: "var(--apifn-text-muted)",
+        marginBottom: "4px",
+    } as React.CSSProperties,
+    metricValue: (warn: boolean): React.CSSProperties => ({
+        fontSize: "20px",
+        fontWeight: 700,
+        fontFamily: "var(--apifn-font-mono)",
+        color: warn ? "var(--apifn-red)" : "var(--apifn-text)",
+    }),
+    metricUnit: {
+        fontSize: "12px",
+        color: "var(--apifn-text-muted)",
+        marginLeft: "2px",
+    } as React.CSSProperties,
+    barRow: {
+        marginBottom: "8px",
+    } as React.CSSProperties,
+    barLabel: {
+        display: "flex",
+        justifyContent: "space-between",
+        fontSize: "12px",
+        color: "var(--apifn-text-muted)",
+        marginBottom: "3px",
+    } as React.CSSProperties,
+    barTrack: {
+        height: "6px",
+        background: "var(--apifn-border)",
+        borderRadius: "3px",
+        overflow: "hidden",
+    } as React.CSSProperties,
+    barFill: (pct: number, color: string): React.CSSProperties => ({
+        height: "100%",
+        width: `${Math.min(100, pct)}%`,
+        background: color,
+        borderRadius: "3px",
+        transition: "width 0.4s ease",
+    }),
+    footer: {
+        fontSize: "11px",
+        color: "var(--apifn-text-muted)",
+        borderTop: "1px solid var(--apifn-border)",
+        paddingTop: "8px",
+        marginTop: "8px",
+    } as React.CSSProperties,
+};
+
+// Reference ceiling for bar charts
+const P99_CEIL = 2000; // 2s
+const RPM_CEIL = 1000;
+
+export function PerformanceOverlay({ metrics, compact = false }: PerformanceOverlayProps): React.ReactElement {
+    const errorHigh = metrics.errorRatePct > 5;
+
+    if (compact) {
+        return (
+            <div style={{ display: "flex", gap: "12px", alignItems: "center", fontSize: "12px", fontFamily: "var(--apifn-font-mono)", color: "var(--apifn-text-muted)" }}>
+                <span>p50 <strong style={{ color: "var(--apifn-text)" }}>{metrics.p50Ms}ms</strong></span>
+                <span>p99 <strong style={{ color: "var(--apifn-text)" }}>{metrics.p99Ms}ms</strong></span>
+                <span>err <strong style={{ color: errorHigh ? "var(--apifn-red)" : "var(--apifn-text)" }}>{metrics.errorRatePct.toFixed(1)}%</strong></span>
+                <span>{metrics.requestsPerMinute} rpm</span>
+            </div>
+        );
+    }
+
+    return (
+        <div style={s.container}>
+            <div style={s.title}>
+                <span>⚡ Performance</span>
+                <span style={{ fontSize: "11px", fontWeight: 400 }}>
+                    {metrics.method.toUpperCase()} {metrics.endpoint}
+                </span>
+            </div>
+
+            {/* KPI grid */}
+            <div style={s.grid}>
+                <div style={s.metric}>
+                    <div style={s.metricLabel}>p50 Latency</div>
+                    <div>
+                        <span style={s.metricValue(false)}>{metrics.p50Ms}</span>
+                        <span style={s.metricUnit}>ms</span>
+                    </div>
+                </div>
+                <div style={s.metric}>
+                    <div style={s.metricLabel}>p99 Latency</div>
+                    <div>
+                        <span style={s.metricValue(metrics.p99Ms > 1000)}>{metrics.p99Ms}</span>
+                        <span style={s.metricUnit}>ms</span>
+                    </div>
+                </div>
+                <div style={s.metric}>
+                    <div style={s.metricLabel}>Error Rate</div>
+                    <div>
+                        <span style={s.metricValue(errorHigh)}>{metrics.errorRatePct.toFixed(1)}</span>
+                        <span style={s.metricUnit}>%</span>
+                    </div>
+                </div>
+            </div>
+
+            {/* Latency bar charts */}
+            {[
+                { label: `p50 — ${metrics.p50Ms}ms`, val: metrics.p50Ms, color: "var(--apifn-green)" },
+                { label: `p95 — ${metrics.p95Ms}ms`, val: metrics.p95Ms, color: "var(--apifn-yellow)" },
+                { label: `p99 — ${metrics.p99Ms}ms`, val: metrics.p99Ms, color: metrics.p99Ms > 1000 ? "var(--apifn-red)" : "var(--apifn-blue)" },
+            ].map(({ label, val, color }) => (
+                <div key={label} style={s.barRow}>
+                    <div style={s.barLabel}><span>{label}</span></div>
+                    <div style={s.barTrack}>
+                        <div style={s.barFill((val / P99_CEIL) * 100, color)} />
+                    </div>
+                </div>
+            ))}
+
+            {/* Throughput */}
+            <div style={{ ...s.barRow, marginTop: "8px" }}>
+                <div style={s.barLabel}><span>Throughput</span><span>{metrics.requestsPerMinute} rpm</span></div>
+                <div style={s.barTrack}>
+                    <div style={s.barFill((metrics.requestsPerMinute / RPM_CEIL) * 100, "var(--apifn-accent)")} />
+                </div>
+            </div>
+
+            <div style={s.footer}>
+                Last updated: {new Date(metrics.lastUpdated).toLocaleTimeString()}
+            </div>
+        </div>
+    );
+}

--- a/apifn/react/src/RequestHistory.tsx
+++ b/apifn/react/src/RequestHistory.tsx
@@ -1,0 +1,158 @@
+/**
+ * RequestHistory — list of past requests (UI-R-005).
+ * Chronological list, click to inspect, clear button, max 500 entries.
+ */
+
+import React, { useState } from "react";
+import type { HistoryEntry } from "./types.js";
+import { METHOD_COLORS } from "./styles/tokens.js";
+
+export interface RequestHistoryProps {
+    entries: HistoryEntry[];
+    onClear?: () => void;
+    onSelect?: (entry: HistoryEntry) => void;
+    maxEntries?: number;
+}
+
+const s = {
+    container: {
+        fontFamily: "var(--apifn-font-sans)",
+        color: "var(--apifn-text)",
+        fontSize: "13px",
+    } as React.CSSProperties,
+    header: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "12px 16px",
+        borderBottom: "1px solid var(--apifn-border)",
+    } as React.CSSProperties,
+    title: {
+        fontWeight: 700,
+        fontSize: "13px",
+        textTransform: "uppercase" as const,
+        letterSpacing: "0.06em",
+        color: "var(--apifn-text-muted)",
+    } as React.CSSProperties,
+    clearBtn: {
+        background: "none",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "3px 10px",
+        color: "var(--apifn-text-muted)",
+        fontSize: "12px",
+        cursor: "pointer",
+    } as React.CSSProperties,
+    empty: {
+        padding: "32px",
+        textAlign: "center" as const,
+        color: "var(--apifn-text-muted)",
+    } as React.CSSProperties,
+    entry: (selected: boolean): React.CSSProperties => ({
+        display: "flex",
+        alignItems: "center",
+        gap: "10px",
+        padding: "10px 16px",
+        borderBottom: "1px solid var(--apifn-border)",
+        cursor: "pointer",
+        background: selected ? "var(--apifn-bg-surface-hover)" : "transparent",
+    }),
+    method: (m: string): React.CSSProperties => {
+        const c = METHOD_COLORS[m.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+        return { fontSize: "11px", fontWeight: 700, padding: "1px 6px", borderRadius: "3px", background: c.bg, color: c.text, fontFamily: "var(--apifn-font-mono)", minWidth: "46px", textAlign: "center" };
+    },
+    url: {
+        flex: 1,
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "12px",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap" as const,
+    } as React.CSSProperties,
+    status: (code?: number): React.CSSProperties => ({
+        fontSize: "12px",
+        fontWeight: 700,
+        color: !code ? "var(--apifn-text-muted)" : code >= 200 && code < 300 ? "var(--apifn-green)" : code >= 400 ? "var(--apifn-red)" : "var(--apifn-yellow)",
+    }),
+    duration: {
+        fontSize: "11px",
+        color: "var(--apifn-text-muted)",
+        minWidth: "50px",
+        textAlign: "right" as const,
+    } as React.CSSProperties,
+    detail: {
+        padding: "16px",
+        background: "var(--apifn-bg-surface)",
+        borderBottom: "1px solid var(--apifn-border)",
+    } as React.CSSProperties,
+    pre: {
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "12px",
+        whiteSpace: "pre-wrap" as const,
+        wordBreak: "break-all" as const,
+        color: "var(--apifn-text)",
+        margin: 0,
+    } as React.CSSProperties,
+};
+
+export function RequestHistory({ entries, onClear, onSelect, maxEntries = 500 }: RequestHistoryProps): React.ReactElement {
+    const [selected, setSelected] = useState<string | null>(null);
+
+    const visible = entries.slice(0, maxEntries).sort((a, b) => b.timestamp - a.timestamp);
+    const selectedEntry = visible.find((e) => e.id === selected);
+
+    function handleSelect(entry: HistoryEntry) {
+        setSelected((s) => s === entry.id ? null : entry.id);
+        onSelect?.(entry);
+    }
+
+    return (
+        <div style={s.container}>
+            <div style={s.header}>
+                <span style={s.title}>Request History ({visible.length})</span>
+                {onClear && (
+                    <button style={s.clearBtn} onClick={onClear}>Clear</button>
+                )}
+            </div>
+
+            {visible.length === 0 && <div style={s.empty}>No requests yet</div>}
+
+            {visible.map((entry) => (
+                <React.Fragment key={entry.id}>
+                    <div style={s.entry(entry.id === selected)} onClick={() => handleSelect(entry)}>
+                        <span style={s.method(entry.method)}>{entry.method.toUpperCase()}</span>
+                        <span style={s.url}>{entry.url}</span>
+                        {entry.statusCode && <span style={s.status(entry.statusCode)}>{entry.statusCode}</span>}
+                        {entry.duration !== undefined && (
+                            <span style={s.duration}>{entry.duration}ms</span>
+                        )}
+                        {entry.error && <span style={{ color: "var(--apifn-red)", fontSize: "12px" }}>✖</span>}
+                    </div>
+
+                    {entry.id === selected && selectedEntry && (
+                        <div style={s.detail}>
+                            <div style={{ marginBottom: "8px", fontSize: "12px", color: "var(--apifn-text-muted)" }}>
+                                {new Date(selectedEntry.timestamp).toLocaleString()}
+                            </div>
+                            {selectedEntry.error && (
+                                <div style={{ color: "var(--apifn-red)", marginBottom: "8px" }}>{selectedEntry.error}</div>
+                            )}
+                            {selectedEntry.requestBody !== undefined && (
+                                <div style={{ marginBottom: "8px" }}>
+                                    <div style={{ fontSize: "11px", fontWeight: 700, color: "var(--apifn-text-muted)", marginBottom: "4px" }}>REQUEST BODY</div>
+                                    <pre style={s.pre}>{JSON.stringify(selectedEntry.requestBody, null, 2)}</pre>
+                                </div>
+                            )}
+                            {selectedEntry.responseBody !== undefined && (
+                                <div>
+                                    <div style={{ fontSize: "11px", fontWeight: 700, color: "var(--apifn-text-muted)", marginBottom: "4px" }}>RESPONSE BODY</div>
+                                    <pre style={s.pre}>{typeof selectedEntry.responseBody === "string" ? selectedEntry.responseBody : JSON.stringify(selectedEntry.responseBody, null, 2)}</pre>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </React.Fragment>
+            ))}
+        </div>
+    );
+}

--- a/apifn/react/src/ResponseDiff.tsx
+++ b/apifn/react/src/ResponseDiff.tsx
@@ -1,0 +1,149 @@
+/**
+ * ResponseDiff — side-by-side comparison of two API responses (UI-R-006).
+ */
+
+import React, { useMemo } from "react";
+import type { TryItResponse } from "./types.js";
+
+export interface ResponseDiffProps {
+    left: TryItResponse;
+    right: TryItResponse;
+    leftLabel?: string;
+    rightLabel?: string;
+}
+
+const s = {
+    container: {
+        fontFamily: "var(--apifn-font-sans)",
+        color: "var(--apifn-text)",
+    } as React.CSSProperties,
+    header: {
+        display: "flex",
+        borderBottom: "1px solid var(--apifn-border)",
+    } as React.CSSProperties,
+    colHeader: {
+        flex: 1,
+        padding: "10px 16px",
+        fontWeight: 700,
+        fontSize: "13px",
+        color: "var(--apifn-text-muted)",
+    } as React.CSSProperties,
+    summary: {
+        display: "flex",
+        gap: "24px",
+        padding: "12px 16px",
+        background: "var(--apifn-bg-surface)",
+        borderBottom: "1px solid var(--apifn-border)",
+        fontSize: "13px",
+    } as React.CSSProperties,
+    cols: {
+        display: "flex",
+        gap: "1px",
+        background: "var(--apifn-border)",
+    } as React.CSSProperties,
+    col: {
+        flex: 1,
+        background: "var(--apifn-bg)",
+        padding: "16px",
+        overflow: "auto",
+        maxHeight: "400px",
+    } as React.CSSProperties,
+    status: (code: number): React.CSSProperties => ({
+        fontWeight: 700,
+        color: code >= 200 && code < 300 ? "var(--apifn-green)" : code >= 400 ? "var(--apifn-red)" : "var(--apifn-yellow)",
+    }),
+    pre: {
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "12px",
+        whiteSpace: "pre-wrap" as const,
+        wordBreak: "break-all" as const,
+        color: "var(--apifn-text)",
+        margin: 0,
+    } as React.CSSProperties,
+    diffLine: (kind: "added" | "removed" | "same"): React.CSSProperties => ({
+        display: "block",
+        background: kind === "added" ? "#065f4615" : kind === "removed" ? "#7f1d1d15" : "transparent",
+        color: kind === "added" ? "var(--apifn-green)" : kind === "removed" ? "var(--apifn-red)" : "inherit",
+        padding: "0 2px",
+    }),
+};
+
+function diffLines(a: string, b: string): { kind: "same" | "added" | "removed"; text: string }[][] {
+    const aLines = a.split("\n");
+    const bLines = b.split("\n");
+    const leftDiff: { kind: "same" | "added" | "removed"; text: string }[] = [];
+    const rightDiff: { kind: "same" | "added" | "removed"; text: string }[] = [];
+
+    const maxLen = Math.max(aLines.length, bLines.length);
+    for (let i = 0; i < maxLen; i++) {
+        const al = aLines[i] ?? "";
+        const bl = bLines[i] ?? "";
+        if (al === bl) {
+            leftDiff.push({ kind: "same", text: al });
+            rightDiff.push({ kind: "same", text: bl });
+        } else {
+            leftDiff.push({ kind: "removed", text: al });
+            rightDiff.push({ kind: "added", text: bl });
+        }
+    }
+
+    return [leftDiff, rightDiff];
+}
+
+function bodyToString(body: unknown): string {
+    if (typeof body === "string") return body;
+    return JSON.stringify(body, null, 2);
+}
+
+export function ResponseDiff({ left, right, leftLabel = "Before", rightLabel = "After" }: ResponseDiffProps): React.ReactElement {
+    const [leftLines, rightLines] = useMemo(
+        () => diffLines(bodyToString(left.body), bodyToString(right.body)),
+        [left.body, right.body]
+    );
+
+    return (
+        <div style={s.container}>
+            <div style={s.header}>
+                <div style={s.colHeader}>{leftLabel}</div>
+                <div style={{ width: "1px", background: "var(--apifn-border)" }} />
+                <div style={s.colHeader}>{rightLabel}</div>
+            </div>
+
+            {/* Summary comparison */}
+            <div style={s.summary}>
+                <span>
+                    Status:{" "}
+                    <span style={s.status(left.statusCode)}>{left.statusCode}</span>{" "}
+                    →{" "}
+                    <span style={s.status(right.statusCode)}>{right.statusCode}</span>
+                </span>
+                <span>
+                    Duration:{" "}
+                    <span style={{ fontFamily: "var(--apifn-font-mono)" }}>{left.durationMs}ms</span>{" "}
+                    →{" "}
+                    <span style={{ fontFamily: "var(--apifn-font-mono)", color: right.durationMs > left.durationMs ? "var(--apifn-red)" : "var(--apifn-green)" }}>
+                        {right.durationMs}ms
+                    </span>
+                </span>
+            </div>
+
+            {/* Side-by-side body diff */}
+            <div style={s.cols}>
+                <div style={s.col}>
+                    <pre style={s.pre}>
+                        {leftLines.map((line, i) => (
+                            <span key={i} style={s.diffLine(line.kind)}>{line.text}{"\n"}</span>
+                        ))}
+                    </pre>
+                </div>
+                <div style={s.col}>
+                    <pre style={s.pre}>
+                        {rightLines.map((line, i) => (
+                            <span key={i} style={s.diffLine(line.kind)}>{line.text}{"\n"}</span>
+                        ))}
+                    </pre>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apifn/react/src/SchemaViewer.tsx
+++ b/apifn/react/src/SchemaViewer.tsx
@@ -1,0 +1,147 @@
+/**
+ * SchemaViewer — renders a JSON Schema as a collapsible tree (UI-R-003).
+ */
+
+import React, { useState } from "react";
+import type { SchemaObject } from "./types.js";
+
+export interface SchemaViewerProps {
+    schema: SchemaObject;
+    name?: string;
+    required?: boolean;
+    expandDepth?: number;
+    /** Current depth (internal) */
+    depth?: number;
+}
+
+const s = {
+    node: {
+        fontFamily: "var(--apifn-font-mono, monospace)",
+        fontSize: "13px",
+        lineHeight: "1.6",
+    } as React.CSSProperties,
+    row: {
+        display: "flex",
+        alignItems: "baseline",
+        gap: "6px",
+        cursor: "pointer",
+        padding: "2px 0",
+    } as React.CSSProperties,
+    toggle: {
+        color: "var(--apifn-text-muted)",
+        userSelect: "none" as const,
+        width: "14px",
+        flexShrink: 0,
+    },
+    name: {
+        color: "var(--apifn-accent)",
+        fontWeight: 600,
+    } as React.CSSProperties,
+    required: {
+        color: "var(--apifn-red)",
+        fontSize: "11px",
+        fontWeight: 700,
+    } as React.CSSProperties,
+    typeBadge: (type: string): React.CSSProperties => ({
+        fontSize: "11px",
+        padding: "1px 6px",
+        borderRadius: "4px",
+        background:
+            type === "string" ? "#065f4622" :
+                type === "integer" || type === "number" ? "#1e3a5f22" :
+                    type === "boolean" ? "#78350f22" :
+                        type === "array" ? "#5b21b622" :
+                            "#2d3748",
+        color:
+            type === "string" ? "var(--apifn-green)" :
+                type === "integer" || type === "number" ? "var(--apifn-blue)" :
+                    type === "boolean" ? "var(--apifn-yellow)" :
+                        type === "array" ? "var(--apifn-purple)" :
+                            "var(--apifn-text-muted)",
+        border: "1px solid currentColor",
+        opacity: 0.9,
+    }),
+    description: {
+        color: "var(--apifn-text-muted)",
+        fontSize: "12px",
+    } as React.CSSProperties,
+    children: {
+        borderLeft: "1px solid var(--apifn-border)",
+        marginLeft: "8px",
+        paddingLeft: "12px",
+    } as React.CSSProperties,
+};
+
+export function SchemaViewer({
+    schema,
+    name,
+    required = false,
+    expandDepth = 2,
+    depth = 0,
+}: SchemaViewerProps): React.ReactElement {
+    const schemaType = schema.type as string | string[] | undefined;
+    const primaryType = Array.isArray(schemaType) ? schemaType[0] : schemaType ?? "object";
+    const hasChildren = primaryType === "object" && schema.properties;
+    const isArray = primaryType === "array";
+    const itemSchema = schema.items as SchemaObject | undefined;
+
+    const [expanded, setExpanded] = useState(depth < expandDepth);
+
+    return (
+        <div style={s.node}>
+            <div style={s.row} onClick={() => hasChildren && setExpanded((e) => !e)}>
+                <span style={s.toggle}>
+                    {hasChildren ? (expanded ? "▾" : "▸") : " "}
+                </span>
+                {name && <span style={s.name}>{name}</span>}
+                {required && <span style={s.required}>required</span>}
+                <span style={s.typeBadge(primaryType)}>{primaryType}</span>
+                {isArray && itemSchema && (
+                    <span style={{ ...s.typeBadge("array"), opacity: 0.6 }}>
+                        {"of "}
+                        {(itemSchema.type as string) ?? "object"}
+                    </span>
+                )}
+                {typeof schema.description === "string" && (
+                    <span style={s.description}>{schema.description}</span>
+                )}
+                {Array.isArray(schema.enum) && (
+                    <span style={s.description}>
+                        enum: {(schema.enum as unknown[]).map(String).join(" | ")}
+                    </span>
+                )}
+            </div>
+
+            {/* Object properties */}
+            {(hasChildren && expanded && typeof schema.properties === "object" && schema.properties !== null) ? (
+                <div style={s.children}>
+                    {Object.entries(schema.properties as Record<string, unknown>).map(([propName, propSchema]) => {
+                        const requiredFields = (schema.required ?? []) as string[];
+                        return (
+                            <SchemaViewer
+                                key={propName}
+                                schema={propSchema as SchemaObject}
+                                name={propName}
+                                required={requiredFields.includes(propName)}
+                                expandDepth={expandDepth}
+                                depth={depth + 1}
+                            />
+                        );
+                    })}
+                </div>
+            ) : null}
+
+            {/* Array items */}
+            {(isArray && itemSchema && expanded && typeof itemSchema.properties === "object" && itemSchema.properties !== null) ? (
+                <div style={s.children}>
+                    <SchemaViewer
+                        schema={itemSchema}
+                        name="items"
+                        expandDepth={expandDepth}
+                        depth={depth + 1}
+                    />
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/apifn/react/src/TryIt.tsx
+++ b/apifn/react/src/TryIt.tsx
@@ -1,0 +1,314 @@
+/**
+ * TryIt — interactive request builder and sender (UI-R-004).
+ * URL bar, param inputs, body editor, auth config, send button, response display.
+ */
+
+import React, { useState, useCallback } from "react";
+import type { OperationObject, AuthConfig, TryItResponse } from "./types.js";
+import { METHOD_COLORS } from "./styles/tokens.js";
+
+export interface TryItProps {
+    path: string;
+    method: string;
+    operation: OperationObject;
+    baseUrl?: string;
+    defaultAuth?: AuthConfig;
+    onResponse?: (response: TryItResponse) => void;
+}
+
+const s = {
+    container: {
+        padding: "20px",
+        fontFamily: "var(--apifn-font-sans)",
+        color: "var(--apifn-text)",
+    } as React.CSSProperties,
+    row: {
+        display: "flex",
+        gap: "8px",
+        alignItems: "center",
+        marginBottom: "16px",
+    } as React.CSSProperties,
+    methodBadge: (method: string): React.CSSProperties => {
+        const c = METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+        return { padding: "6px 12px", borderRadius: "4px", background: c.bg, color: c.text, fontWeight: 700, fontSize: "13px", fontFamily: "var(--apifn-font-mono)" };
+    },
+    input: {
+        flex: 1,
+        background: "var(--apifn-bg-surface)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "8px 12px",
+        color: "var(--apifn-text)",
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "13px",
+        outline: "none",
+    } as React.CSSProperties,
+    sendBtn: {
+        padding: "8px 20px",
+        background: "var(--apifn-accent)",
+        color: "#fff",
+        border: "none",
+        borderRadius: "var(--apifn-radius)",
+        fontSize: "14px",
+        fontWeight: 600,
+        cursor: "pointer",
+        flexShrink: 0,
+    } as React.CSSProperties,
+    label: {
+        fontSize: "12px",
+        fontWeight: 600,
+        textTransform: "uppercase" as const,
+        letterSpacing: "0.06em",
+        color: "var(--apifn-text-muted)",
+        marginBottom: "6px",
+        display: "block",
+    } as React.CSSProperties,
+    section: { marginBottom: "16px" } as React.CSSProperties,
+    textarea: {
+        width: "100%",
+        background: "var(--apifn-bg-surface)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "10px 12px",
+        color: "var(--apifn-text)",
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "13px",
+        resize: "vertical" as const,
+        outline: "none",
+        minHeight: "100px",
+    } as React.CSSProperties,
+    select: {
+        background: "var(--apifn-bg-surface)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "6px 10px",
+        color: "var(--apifn-text)",
+        fontSize: "13px",
+        outline: "none",
+        cursor: "pointer",
+    } as React.CSSProperties,
+    responseBox: {
+        background: "var(--apifn-bg-surface)",
+        border: "1px solid var(--apifn-border)",
+        borderRadius: "var(--apifn-radius)",
+        padding: "16px",
+        marginTop: "16px",
+    } as React.CSSProperties,
+    statusLine: (status: number): React.CSSProperties => ({
+        fontWeight: 700,
+        fontSize: "16px",
+        color: status >= 200 && status < 300 ? "var(--apifn-green)"
+            : status >= 400 ? "var(--apifn-red)"
+                : "var(--apifn-yellow)",
+        marginBottom: "8px",
+    }),
+    pre: {
+        fontFamily: "var(--apifn-font-mono)",
+        fontSize: "12px",
+        whiteSpace: "pre-wrap" as const,
+        wordBreak: "break-all" as const,
+        color: "var(--apifn-text)",
+        margin: 0,
+    } as React.CSSProperties,
+};
+
+function buildAuthHeaders(auth: AuthConfig): Record<string, string> {
+    if (auth.type === "bearer" && auth.token) return { Authorization: `Bearer ${auth.token}` };
+    if (auth.type === "apikey" && auth.key && auth.keyIn === "header") return { [auth.keyName ?? "X-API-Key"]: auth.key };
+    if (auth.type === "basic" && auth.username) {
+        const encoded = btoa(`${auth.username}:${auth.password ?? ""}`);
+        return { Authorization: `Basic ${encoded}` };
+    }
+    return {};
+}
+
+export function TryIt({ path, method, operation, baseUrl = "https://api.example.com", defaultAuth, onResponse }: TryItProps): React.ReactElement {
+    const params = (operation.parameters ?? []) as Array<{ name: string; in: string; required?: boolean; schema?: { type?: string } }>;
+    const pathParams = params.filter((p) => p.in === "path");
+    const queryParams = params.filter((p) => p.in === "query");
+
+    const [pathValues, setPathValues] = useState<Record<string, string>>({});
+    const [queryValues, setQueryValues] = useState<Record<string, string>>({});
+    const [headerValues] = useState<Record<string, string>>({});
+    const [body, setBody] = useState("");
+    const [auth, setAuth] = useState<AuthConfig>(defaultAuth ?? { type: "none" });
+    const [response, setResponse] = useState<TryItResponse | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const resolvedPath = (() => {
+        let result = "";
+        let cursor = 0;
+        while (cursor < path.length) {
+            const start = path.indexOf("{", cursor);
+            if (start === -1) {
+                result += path.slice(cursor);
+                break;
+            }
+            const end = path.indexOf("}", start + 1);
+            if (end === -1) {
+                result += path.slice(cursor);
+                break;
+            }
+            const name = path.slice(start + 1, end);
+            result += path.slice(cursor, start);
+            result += pathValues[name] ?? `{${name}}`;
+            cursor = end + 1;
+        }
+        return result;
+    })();
+    const queryString = Object.entries(queryValues)
+        .filter(([, v]) => v)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join("&");
+    const url = `${baseUrl.replace(/\/$/, "")}${resolvedPath}${queryString ? "?" + queryString : ""}`;
+
+    const sendRequest = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        const start = Date.now();
+        try {
+            const headers: Record<string, string> = { ...buildAuthHeaders(auth) };
+            for (const [k, v] of Object.entries(headerValues)) {
+                if (v) headers[k] = v;
+            }
+            let parsedBody: string | undefined;
+            if (body.trim()) {
+                headers["Content-Type"] = "application/json";
+                parsedBody = body;
+            }
+            const res = await fetch(url, {
+                method: method.toUpperCase(),
+                headers,
+                body: parsedBody,
+            });
+            const durationMs = Date.now() - start;
+            const resHeaders: Record<string, string> = {};
+            res.headers.forEach((v, k) => { resHeaders[k] = v; });
+            let resBody: unknown;
+            const ct = res.headers.get("content-type") ?? "";
+            if (ct.includes("application/json")) {
+                resBody = await res.json();
+            } else {
+                resBody = await res.text();
+            }
+            const result: TryItResponse = { statusCode: res.status, statusText: res.statusText, headers: resHeaders, body: resBody, durationMs };
+            setResponse(result);
+            onResponse?.(result);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+        } finally {
+            setLoading(false);
+        }
+    }, [url, method, body, auth, headerValues, onResponse]);
+
+    return (
+        <div style={s.container}>
+            {/* URL Bar */}
+            <div style={s.row}>
+                <span style={s.methodBadge(method)}>{method.toUpperCase()}</span>
+                <input readOnly value={url} style={s.input} />
+                <button style={s.sendBtn} onClick={sendRequest} disabled={loading}>
+                    {loading ? "Sending…" : "Send"}
+                </button>
+            </div>
+
+            {/* Path Params */}
+            {pathParams.length > 0 && (
+                <div style={s.section}>
+                    <label style={s.label}>Path Parameters</label>
+                    {pathParams.map((p) => (
+                        <div key={p.name} style={{ ...s.row, marginBottom: "8px" }}>
+                            <span style={{ width: "120px", fontFamily: "var(--apifn-font-mono)", fontSize: "13px", color: "var(--apifn-accent-text)" }}>{p.name}</span>
+                            <input
+                                style={s.input}
+                                placeholder={`{${p.name}}`}
+                                value={pathValues[p.name] ?? ""}
+                                onChange={(e) => setPathValues((v) => ({ ...v, [p.name]: e.target.value }))}
+                            />
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Query Params */}
+            {queryParams.length > 0 && (
+                <div style={s.section}>
+                    <label style={s.label}>Query Parameters</label>
+                    {queryParams.map((p) => (
+                        <div key={p.name} style={{ ...s.row, marginBottom: "8px" }}>
+                            <span style={{ width: "120px", fontFamily: "var(--apifn-font-mono)", fontSize: "13px", color: "var(--apifn-accent-text)" }}>{p.name}</span>
+                            <input
+                                style={s.input}
+                                placeholder={p.name}
+                                value={queryValues[p.name] ?? ""}
+                                onChange={(e) => setQueryValues((v) => ({ ...v, [p.name]: e.target.value }))}
+                            />
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Auth */}
+            <div style={s.section}>
+                <label style={s.label}>Auth</label>
+                <div style={s.row}>
+                    <select style={s.select} value={auth.type} onChange={(e) => setAuth({ type: e.target.value as AuthConfig["type"] })}>
+                        <option value="none">None</option>
+                        <option value="bearer">Bearer Token</option>
+                        <option value="apikey">API Key</option>
+                        <option value="basic">Basic Auth</option>
+                    </select>
+                    {auth.type === "bearer" && (
+                        <input style={s.input} placeholder="Bearer token" value={auth.token ?? ""} onChange={(e) => setAuth((a) => ({ ...a, token: e.target.value }))} />
+                    )}
+                    {auth.type === "apikey" && (
+                        <input style={s.input} placeholder="API key value" value={auth.key ?? ""} onChange={(e) => setAuth((a) => ({ ...a, key: e.target.value }))} />
+                    )}
+                    {auth.type === "basic" && (
+                        <>
+                            <input style={{ ...s.input, flex: "0 0 auto", width: "140px" }} placeholder="Username" value={auth.username ?? ""} onChange={(e) => setAuth((a) => ({ ...a, username: e.target.value }))} />
+                            <input style={{ ...s.input, flex: "0 0 auto", width: "140px" }} type="password" placeholder="Password" value={auth.password ?? ""} onChange={(e) => setAuth((a) => ({ ...a, password: e.target.value }))} />
+                        </>
+                    )}
+                </div>
+            </div>
+
+            {/* Body */}
+            {["post", "put", "patch"].includes(method.toLowerCase()) && (
+                <div style={s.section}>
+                    <label style={s.label}>Request Body</label>
+                    <textarea style={s.textarea} value={body} onChange={(e) => setBody(e.target.value)} placeholder="{}" spellCheck={false} />
+                </div>
+            )}
+
+            {/* Error */}
+            {error && (
+                <div style={{ background: "#7f1d1d22", border: "1px solid #7f1d1d", borderRadius: "var(--apifn-radius)", padding: "10px 14px", color: "var(--apifn-red)", fontSize: "13px", marginBottom: "12px" }}>
+                    {error}
+                </div>
+            )}
+
+            {/* Response */}
+            {response && (
+                <div style={s.responseBox}>
+                    <div style={s.statusLine(response.statusCode)}>
+                        {response.statusCode} {response.statusText}
+                        <span style={{ fontSize: "13px", fontWeight: 400, color: "var(--apifn-text-muted)", marginLeft: "12px" }}>
+                            {response.durationMs}ms
+                        </span>
+                    </div>
+                    <details style={{ marginBottom: "8px" }}>
+                        <summary style={{ cursor: "pointer", color: "var(--apifn-text-muted)", fontSize: "12px" }}>
+                            Response Headers ({Object.keys(response.headers).length})
+                        </summary>
+                        <pre style={s.pre}>{Object.entries(response.headers).map(([k, v]) => `${k}: ${v}`).join("\n")}</pre>
+                    </details>
+                    <pre style={s.pre}>
+                        {typeof response.body === "string" ? response.body : JSON.stringify(response.body, null, 2)}
+                    </pre>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apifn/react/src/index.ts
+++ b/apifn/react/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @apifn/react — public API
+ */
+
+// Components
+export { ApiExplorer } from "./ApiExplorer.js";
+export { EndpointViewer } from "./EndpointViewer.js";
+export { SchemaViewer } from "./SchemaViewer.js";
+export { TryIt } from "./TryIt.js";
+export { RequestHistory } from "./RequestHistory.js";
+export { ResponseDiff } from "./ResponseDiff.js";
+export { PerformanceOverlay } from "./PerformanceOverlay.js";
+
+// Props types
+export type { ApiExplorerProps } from "./ApiExplorer.js";
+export type { EndpointViewerProps } from "./EndpointViewer.js";
+export type { SchemaViewerProps } from "./SchemaViewer.js";
+export type { TryItProps } from "./TryIt.js";
+export type { RequestHistoryProps } from "./RequestHistory.js";
+export type { ResponseDiffProps } from "./ResponseDiff.js";
+export type { PerformanceOverlayProps } from "./PerformanceOverlay.js";
+
+// Domain types
+export type {
+    Theme,
+    HistoryEntry,
+    PerformanceMetrics,
+    AuthConfig,
+    TryItResponse,
+} from "./types.js";

--- a/apifn/react/src/styles/tokens.ts
+++ b/apifn/react/src/styles/tokens.ts
@@ -1,0 +1,85 @@
+/**
+ * Design tokens — CSS variable names and helper to inject theme styles.
+ * Supports light, dark, and auto (prefers-color-scheme) themes.
+ */
+
+export const CSS_VARS = {
+    bg: "--apifn-bg",
+    bgSurface: "--apifn-bg-surface",
+    bgSurfaceHover: "--apifn-bg-surface-hover",
+    border: "--apifn-border",
+    text: "--apifn-text",
+    textMuted: "--apifn-text-muted",
+    accent: "--apifn-accent",
+    accentText: "--apifn-accent-text",
+    green: "--apifn-green",
+    blue: "--apifn-blue",
+    yellow: "--apifn-yellow",
+    red: "--apifn-red",
+    purple: "--apifn-purple",
+    orange: "--apifn-orange",
+    radius: "--apifn-radius",
+    fontMono: "--apifn-font-mono",
+    fontSans: "--apifn-font-sans",
+} as const;
+
+const DARK_THEME = `
+  --apifn-bg: #0f1117;
+  --apifn-bg-surface: #1a1d2e;
+  --apifn-bg-surface-hover: #252840;
+  --apifn-border: #2d3748;
+  --apifn-text: #e2e8f0;
+  --apifn-text-muted: #64748b;
+  --apifn-accent: #7c3aed;
+  --apifn-accent-text: #c4b5fd;
+  --apifn-green: #6ee7b7;
+  --apifn-blue: #93c5fd;
+  --apifn-yellow: #fcd34d;
+  --apifn-red: #fca5a5;
+  --apifn-purple: #c4b5fd;
+  --apifn-orange: #fdba74;
+  --apifn-radius: 6px;
+  --apifn-font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --apifn-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+`;
+
+const LIGHT_THEME = `
+  --apifn-bg: #ffffff;
+  --apifn-bg-surface: #f8fafc;
+  --apifn-bg-surface-hover: #f1f5f9;
+  --apifn-border: #e2e8f0;
+  --apifn-text: #0f172a;
+  --apifn-text-muted: #64748b;
+  --apifn-accent: #7c3aed;
+  --apifn-accent-text: #6d28d9;
+  --apifn-green: #059669;
+  --apifn-blue: #2563eb;
+  --apifn-yellow: #d97706;
+  --apifn-red: #dc2626;
+  --apifn-purple: #7c3aed;
+  --apifn-orange: #ea580c;
+  --apifn-radius: 6px;
+  --apifn-font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --apifn-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+`;
+
+export function getThemeStyle(theme: "light" | "dark" | "auto"): string {
+    if (theme === "light") return `.apifn-root { ${LIGHT_THEME} }`;
+    if (theme === "dark") return `.apifn-root { ${DARK_THEME} }`;
+    return `
+    @media (prefers-color-scheme: dark) { .apifn-root { ${DARK_THEME} } }
+    @media (prefers-color-scheme: light) { .apifn-root { ${LIGHT_THEME} } }
+    .apifn-root { ${LIGHT_THEME} }
+  `;
+}
+
+/** Method badge colors */
+export const METHOD_COLORS: Record<string, { bg: string; text: string }> = {
+    get: { bg: "#065f46", text: "#6ee7b7" },
+    post: { bg: "#1e3a5f", text: "#93c5fd" },
+    put: { bg: "#78350f", text: "#fcd34d" },
+    patch: { bg: "#5b21b6", text: "#c4b5fd" },
+    delete: { bg: "#7f1d1d", text: "#fca5a5" },
+    head: { bg: "#1f2937", text: "#9ca3af" },
+    options: { bg: "#1f2937", text: "#9ca3af" },
+};

--- a/apifn/react/src/types.ts
+++ b/apifn/react/src/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared types for @apifn/react components.
+ */
+
+import type { OpenAPIDocument, OperationObject, SchemaObject } from "@apifn/core";
+export type { OpenAPIDocument, OperationObject, SchemaObject };
+
+export type Theme = "light" | "dark" | "auto";
+
+export interface HistoryEntry {
+    id: string;
+    timestamp: number;
+    method: string;
+    url: string;
+    statusCode?: number;
+    duration?: number;
+    requestBody?: unknown;
+    responseBody?: unknown;
+    responseHeaders?: Record<string, string>;
+    error?: string;
+}
+
+export interface PerformanceMetrics {
+    endpoint: string;
+    method: string;
+    p50Ms: number;
+    p95Ms: number;
+    p99Ms: number;
+    errorRatePct: number;
+    requestsPerMinute: number;
+    lastUpdated: string;
+}
+
+export interface AuthConfig {
+    type: "none" | "bearer" | "apikey" | "basic";
+    token?: string;
+    key?: string;
+    keyName?: string;
+    keyIn?: "header" | "query";
+    username?: string;
+    password?: string;
+}
+
+export interface TryItResponse {
+    statusCode: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: unknown;
+    durationMs: number;
+}

--- a/apifn/react/tsconfig.json
+++ b/apifn/react/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apifn/react/tsup.config.ts
+++ b/apifn/react/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/apifn/snippets/__tests__/snippets.test.ts
+++ b/apifn/snippets/__tests__/snippets.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for @apifn/snippets — TV-SNIP-001 through TV-SNIP-007
+ */
+
+import { describe, it, expect } from "vitest";
+import type { OperationObject, SnippetOptions, OpenAPIDocument } from "@apifn/core";
+import { generateSnippet, generateAllSnippets, SUPPORTED_TARGETS } from "../src/generator.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const BASE_OPTS: Omit<SnippetOptions, "target"> = {
+    baseUrl: "https://api.example.com",
+    indent: 2,
+};
+
+const GET_OP: OperationObject = {
+    summary: "List users",
+    responses: { "200": { description: "OK" } },
+};
+
+const POST_OP: OperationObject = {
+    summary: "Create user",
+    requestBody: {
+        required: true,
+        content: {
+            "application/json": {
+                schema: {
+                    type: "object",
+                    properties: {
+                        name: { type: "string", example: "Alice" },
+                        email: { type: "string", example: "alice@example.com" },
+                    },
+                },
+            },
+        },
+    },
+    responses: { "201": { description: "Created" } },
+};
+
+const AUTH_BEARER: SnippetOptions["auth"] = { type: "bearer", token: "my-secret-token" };
+const AUTH_APIKEY: SnippetOptions["auth"] = { type: "apikey", key: "MY_KEY", keyName: "X-API-Key", keyIn: "header" } as SnippetOptions["auth"];
+const AUTH_BASIC: SnippetOptions["auth"] = { type: "basic" } as SnippetOptions["auth"] & { username?: string; password?: string };
+
+const SPEC: OpenAPIDocument = {
+    openapi: "3.1.0",
+    info: { title: "Test", version: "1.0.0" },
+    paths: {
+        "/users": {
+            get: GET_OP,
+            post: POST_OP,
+        },
+        "/users/{id}": {
+            get: {
+                summary: "Get user",
+                parameters: [{ name: "id", in: "path", example: "123" }],
+                responses: { "200": { description: "OK" } },
+            },
+        },
+    },
+};
+
+// ─── TV-SNIP-001: curl ────────────────────────────────────────────────────────
+
+describe("TV-SNIP-001: curl target", () => {
+    it("generates a valid curl GET command with method and URL", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", { ...BASE_OPTS, target: "curl" });
+        expect(code).toContain("curl -X GET");
+        expect(code).toContain("https://api.example.com/users");
+    });
+
+    it("generates curl POST with body", () => {
+        const code = generateSnippet(POST_OP, "/users", "post", { ...BASE_OPTS, target: "curl" });
+        expect(code).toContain("-X POST");
+        expect(code).toContain("-d");
+        expect(code).toContain("Content-Type: application/json");
+    });
+
+    it("curl does not throw for DELETE", () => {
+        const op: OperationObject = { responses: { "204": { description: "No Content" } } };
+        expect(() => generateSnippet(op, "/users/1", "delete", { ...BASE_OPTS, target: "curl" })).not.toThrow();
+    });
+});
+
+// ─── TV-SNIP-002: fetch ───────────────────────────────────────────────────────
+
+describe("TV-SNIP-002: fetch target", () => {
+    it("generates valid JavaScript fetch with async/await", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", { ...BASE_OPTS, target: "fetch" });
+        expect(code).toContain("await fetch(");
+        expect(code).toContain("'GET'");
+        expect(code).toContain("https://api.example.com/users");
+        expect(code).toContain("await response.json()");
+    });
+
+    it("fetch POST includes JSON.stringify body", () => {
+        const code = generateSnippet(POST_OP, "/users", "post", { ...BASE_OPTS, target: "fetch" });
+        expect(code).toContain("JSON.stringify(");
+        expect(code).toContain("Content-Type");
+        expect(code).toContain("application/json");
+    });
+});
+
+// ─── TV-SNIP-003: axios ───────────────────────────────────────────────────────
+
+describe("TV-SNIP-003: axios target", () => {
+    it("generates axios GET", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", { ...BASE_OPTS, target: "axios" });
+        expect(code).toContain("axios");
+        expect(code).toContain(".get(");
+        expect(code).toContain("https://api.example.com/users");
+    });
+
+    it("generates axios POST with body arg", () => {
+        const code = generateSnippet(POST_OP, "/users", "post", { ...BASE_OPTS, target: "axios" });
+        expect(code).toContain(".post(");
+        expect(code).toContain("import axios");
+    });
+});
+
+// ─── TV-SNIP-004: python-requests ────────────────────────────────────────────
+
+describe("TV-SNIP-004: python-requests target", () => {
+    it("generates valid Python with requests library", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", { ...BASE_OPTS, target: "python-requests" });
+        expect(code).toContain("import requests");
+        expect(code).toContain("requests.get(");
+        expect(code).toContain("https://api.example.com/users");
+        expect(code).toContain("response.json()");
+    });
+
+    it("POST includes json= kwarg", () => {
+        const code = generateSnippet(POST_OP, "/users", "post", { ...BASE_OPTS, target: "python-requests" });
+        expect(code).toContain("requests.post(");
+        expect(code).toContain("json=");
+    });
+});
+
+// ─── TV-SNIP-005: additional targets ─────────────────────────────────────────
+
+describe("TV-SNIP-005: additional targets", () => {
+    const targets: Array<SnippetOptions["target"]> = [
+        "python-httpx",
+        "node-fetch",
+        "go-http",
+        "ruby-net-http",
+        "php-curl",
+        "csharp-httpclient",
+        "java-okhttp",
+    ];
+
+    for (const target of targets) {
+        it(`${target} generates non-empty code`, () => {
+            const code = generateSnippet(GET_OP, "/users", "get", { ...BASE_OPTS, target });
+            expect(code.length).toBeGreaterThan(10);
+            expect(code).toContain("https://api.example.com/users");
+        });
+
+        it(`${target} POST also generates valid code`, () => {
+            const code = generateSnippet(POST_OP, "/users", "post", { ...BASE_OPTS, target });
+            expect(code.length).toBeGreaterThan(10);
+        });
+    }
+
+    it("supported targets count is 11", () => {
+        expect(SUPPORTED_TARGETS.length).toBe(11);
+    });
+
+    it("escapes generated string literals for C#, Java, and PHP targets", () => {
+        const csharp = generateSnippet(GET_OP, "/users", "get", {
+            ...BASE_OPTS,
+            target: "csharp-httpclient",
+            baseUrl: "https://api.example.com/\"quoted\"/line\nbreak",
+        });
+        const java = generateSnippet(POST_OP, "/users", "post", {
+            ...BASE_OPTS,
+            target: "java-okhttp",
+            baseUrl: "https://api.example.com/\"quoted\"",
+        });
+        const php = generateSnippet(GET_OP, "/users", "get", {
+            ...BASE_OPTS,
+            target: "php-curl",
+            baseUrl: "https://api.example.com/o'hara",
+        });
+
+        expect(csharp).toContain("https://api.example.com/\\\"quoted\\\"/line\\nbreak/users");
+        expect(java).toContain("https://api.example.com/\\\"quoted\\\"/users");
+        expect(java).toContain("\\\"name\\\"");
+        expect(php).toContain("https://api.example.com/o\\'hara/users");
+    });
+
+    it("unsupported target throws", () => {
+        expect(() =>
+            generateSnippet(GET_OP, "/users", "get", { ...BASE_OPTS, target: "unknown-target" as SnippetOptions["target"] })
+        ).toThrow("Unsupported snippet target");
+    });
+});
+
+// ─── TV-SNIP-006: auth injection ─────────────────────────────────────────────
+
+describe("TV-SNIP-006: auth injection", () => {
+    it("Bearer token → Authorization: Bearer header in curl", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", {
+            ...BASE_OPTS,
+            target: "curl",
+            auth: AUTH_BEARER,
+        });
+        expect(code).toContain("Authorization: Bearer my-secret-token");
+    });
+
+    it("Bearer token → Authorization header in fetch", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", {
+            ...BASE_OPTS,
+            target: "fetch",
+            auth: AUTH_BEARER,
+        });
+        expect(code).toContain("Authorization");
+        expect(code).toContain("Bearer my-secret-token");
+    });
+
+    it("API Key → X-API-Key header in curl", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", {
+            ...BASE_OPTS,
+            target: "curl",
+            auth: AUTH_APIKEY,
+        });
+        expect(code).toContain("X-API-Key: MY_KEY");
+    });
+
+    it("Basic auth → Authorization: Basic header in python-requests", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", {
+            ...BASE_OPTS,
+            target: "python-requests",
+            auth: AUTH_BASIC,
+        });
+        expect(code).toContain("Authorization");
+        expect(code).toContain("Basic");
+    });
+
+    it("No auth → no Authorization header", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", { ...BASE_OPTS, target: "curl" });
+        expect(code).not.toContain("Authorization");
+    });
+});
+
+// ─── TV-SNIP-007: variable substitution ──────────────────────────────────────
+
+describe("TV-SNIP-007: variable substitution", () => {
+    it("baseUrl is substituted into the URL", () => {
+        const code = generateSnippet(GET_OP, "/users", "get", {
+            ...BASE_OPTS,
+            baseUrl: "https://staging.example.com",
+            target: "curl",
+        });
+        expect(code).toContain("https://staging.example.com/users");
+        expect(code).not.toContain("api.example.com");
+    });
+
+    it("path parameters are substituted from operation examples", () => {
+        const op: OperationObject = {
+            parameters: [{ name: "id", in: "path", example: "42" }],
+            responses: { "200": { description: "OK" } },
+        };
+        const code = generateSnippet(op, "/users/{id}", "get", { ...BASE_OPTS, target: "curl" });
+        expect(code).toContain("/users/42");
+        expect(code).not.toContain("{id}");
+    });
+
+    it("path parameters without example retain placeholder", () => {
+        const op: OperationObject = {
+            parameters: [{ name: "id", in: "path" }],
+            responses: { "200": { description: "OK" } },
+        };
+        const code = generateSnippet(op, "/users/{id}", "get", { ...BASE_OPTS, target: "curl" });
+        expect(code).toContain("/users/{id}");
+    });
+});
+
+// ─── generateAllSnippets ──────────────────────────────────────────────────────
+
+describe("generateAllSnippets", () => {
+    it("generates one snippet per operation in the spec", () => {
+        const result = generateAllSnippets(SPEC, { ...BASE_OPTS, target: "curl" });
+        // /users GET + /users POST + /users/{id} GET = 3 operations
+        expect(result.snippets.length).toBe(3);
+        expect(result.snippets.every((s) => s.target === "curl")).toBe(true);
+    });
+
+    it("each snippet has path, method, code", () => {
+        const result = generateAllSnippets(SPEC, { ...BASE_OPTS, target: "fetch" });
+        for (const snippet of result.snippets) {
+            expect(snippet.path).toBeTruthy();
+            expect(snippet.method).toBeTruthy();
+            expect(snippet.code.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("empty spec generates no snippets", () => {
+        const emptySpec: OpenAPIDocument = {
+            openapi: "3.1.0",
+            info: { title: "Empty", version: "1.0.0" },
+            paths: {},
+        };
+        const result = generateAllSnippets(emptySpec, { ...BASE_OPTS, target: "curl" });
+        expect(result.snippets.length).toBe(0);
+    });
+});

--- a/apifn/snippets/package.json
+++ b/apifn/snippets/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@apifn/snippets",
+  "version": "0.0.2",
+  "description": "Code snippet generation for ApiFn",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@apifn/core": "0.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/snippets"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/apifn/snippets/src/context.ts
+++ b/apifn/snippets/src/context.ts
@@ -1,0 +1,102 @@
+/**
+ * Context builder — shared by all snippet targets.
+ * Resolves URL, headers, and body from the operation and options.
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import type { SnippetContext } from "./types.js";
+
+const SPACES: Record<number, string> = {};
+function getIndent(n: number): string {
+    if (!SPACES[n]) SPACES[n] = " ".repeat(n);
+    return SPACES[n];
+}
+
+/** Build auth headers from SnippetOptions.auth */
+function authHeaders(auth: SnippetOptions["auth"]): Record<string, string> {
+    if (!auth) return {};
+    const headers: Record<string, string> = {};
+
+    if (auth.type === "bearer") {
+        headers["Authorization"] = `Bearer ${auth.token ?? "YOUR_BEARER_TOKEN"}`;
+    } else if (auth.type === "apikey") {
+        const keyName = (auth as { keyName?: string }).keyName ?? "X-API-Key";
+        const keyIn = (auth as { keyIn?: string }).keyIn ?? "header";
+        if (keyIn === "header") {
+            headers[keyName] = auth.key ?? "YOUR_API_KEY";
+        }
+        // query key is handled at URL level (not in headers, but we skip for simplicity)
+    } else if (auth.type === "basic") {
+        const user = (auth as { username?: string }).username ?? "user";
+        const pass = (auth as { password?: string }).password ?? "pass";
+        const encoded = Buffer.from(`${user}:${pass}`).toString("base64");
+        headers["Authorization"] = `Basic ${encoded}`;
+    }
+
+    return headers;
+}
+
+/** Resolve path parameters from the operation's first path parameter example or placeholder */
+function resolvePathParams(apiPath: string, operation: OperationObject): string {
+    let resolved = apiPath;
+    const params = (operation.parameters ?? []) as Array<{ name: string; in: string; example?: unknown; schema?: { example?: unknown } }>;
+    for (const param of params) {
+        if (param.in !== "path") continue;
+        const example = param.example ?? param.schema?.example ?? `{${param.name}}`;
+        resolved = resolved.replace(`{${param.name}}`, String(example));
+    }
+    return resolved;
+}
+
+/** Pick example body from requestBody if available */
+function resolveBody(operation: OperationObject): string | undefined {
+    const rb = operation.requestBody;
+    if (!rb || (rb as { $ref?: string }).$ref) return undefined;
+    const reqBody = rb as { content?: Record<string, { example?: unknown; schema?: { example?: unknown; properties?: Record<string, unknown> } }> };
+    const json = reqBody.content?.["application/json"];
+    if (!json) return undefined;
+
+    if (json.example !== undefined) return JSON.stringify(json.example);
+    if (json.schema?.example !== undefined) return JSON.stringify(json.schema.example);
+
+    // Build a minimal example from schema properties
+    if (json.schema?.properties) {
+        const example: Record<string, unknown> = {};
+        for (const [key, propVal] of Object.entries(json.schema.properties)) {
+            const prop = propVal as { type?: string; example?: unknown };
+            if (prop.example !== undefined) {
+                example[key] = prop.example;
+            } else {
+                example[key] = prop.type === "integer" || prop.type === "number" ? 0
+                    : prop.type === "boolean" ? true
+                        : `<${key}>`;
+            }
+        }
+        return JSON.stringify(example);
+    }
+
+    return undefined;
+}
+
+export function buildContext(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): SnippetContext {
+    const indent = getIndent(options.indent ?? 2);
+
+    // Build base URL
+    const base = options.baseUrl.replace(/\/$/, "");
+    const resolvedPath = resolvePathParams(apiPath, operation);
+    const url = `${base}${resolvedPath}`;
+
+    // Build headers
+    const headers: Record<string, string> = {};
+    Object.assign(headers, authHeaders(options.auth));
+
+    // Body
+    const body = resolveBody(operation);
+
+    return { method, url, headers, body, indent };
+}

--- a/apifn/snippets/src/generator.ts
+++ b/apifn/snippets/src/generator.ts
@@ -1,0 +1,111 @@
+/**
+ * Snippet generator — SNIP-001 through SNIP-007
+ *
+ * `generateSnippet(operation, path, method, options)` — single endpoint
+ * `generateAllSnippets(spec, options)` — all endpoints in a spec
+ */
+
+import type { OperationObject, OpenAPIDocument, SnippetTarget, SnippetOptions } from "@apifn/core";
+import type { AllSnippetsResult, OperationSnippet } from "./types.js";
+
+import { generateCurl } from "./targets/curl.js";
+import { generateFetch } from "./targets/fetch.js";
+import { generateAxios } from "./targets/axios.js";
+import { generatePythonRequests } from "./targets/python-requests.js";
+import { generatePythonHttpx } from "./targets/python-httpx.js";
+import { generateNodeFetch } from "./targets/node-fetch.js";
+import { generateGoHttp } from "./targets/go-http.js";
+import { generateRubyNetHttp } from "./targets/ruby-net-http.js";
+import { generatePhpCurl } from "./targets/php-curl.js";
+import { generateCsharpHttpclient } from "./targets/csharp-httpclient.js";
+import { generateJavaOkhttp } from "./targets/java-okhttp.js";
+
+/** All supported snippet targets */
+export const SUPPORTED_TARGETS: SnippetTarget[] = [
+    "curl",
+    "fetch",
+    "axios",
+    "node-fetch",
+    "python-requests",
+    "python-httpx",
+    "go-http",
+    "ruby-net-http",
+    "php-curl",
+    "csharp-httpclient",
+    "java-okhttp",
+];
+
+type TargetFn = (op: OperationObject, path: string, method: string, opts: SnippetOptions) => string;
+
+const TARGET_MAP: Record<SnippetTarget, TargetFn> = {
+    "curl": generateCurl,
+    "fetch": generateFetch,
+    "axios": generateAxios,
+    "node-fetch": generateNodeFetch,
+    "python-requests": generatePythonRequests,
+    "python-httpx": generatePythonHttpx,
+    "go-http": generateGoHttp,
+    "ruby-net-http": generateRubyNetHttp,
+    "php-curl": generatePhpCurl,
+    "csharp-httpclient": generateCsharpHttpclient,
+    "java-okhttp": generateJavaOkhttp,
+};
+
+/**
+ * Generate a code snippet for a single operation.
+ *
+ * @param operation — The OpenAPI OperationObject
+ * @param apiPath   — The path string (e.g. "/users/{id}")
+ * @param method    — HTTP method (e.g. "get")
+ * @param options   — Snippet options (target, baseUrl, auth, indent)
+ * @returns The generated code string
+ */
+export function generateSnippet(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const gen = TARGET_MAP[options.target];
+    if (!gen) {
+        throw new Error(`Unsupported snippet target: ${options.target}`);
+    }
+    return gen(operation, apiPath, method, options);
+}
+
+const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const;
+
+/**
+ * Generate snippets for all operations in an OpenAPI document.
+ *
+ * @param spec    — OpenAPI document
+ * @param options — Snippet options (target, baseUrl, auth, indent)
+ * @returns AllSnippetsResult containing one snippet per operation
+ */
+export function generateAllSnippets(
+    spec: OpenAPIDocument,
+    options: SnippetOptions
+): AllSnippetsResult {
+    const snippets: OperationSnippet[] = [];
+
+    const paths = spec.paths ?? {};
+    for (const [apiPath, pathItem] of Object.entries(paths)) {
+        if (!pathItem) continue;
+
+        for (const method of HTTP_METHODS) {
+            const operation = pathItem[method] as OperationObject | undefined;
+            if (!operation) continue;
+
+            const code = generateSnippet(operation, apiPath, method, options);
+            snippets.push({
+                path: apiPath,
+                method,
+                operationId: operation.operationId,
+                target: options.target,
+                code,
+            });
+        }
+    }
+
+    return { snippets };
+}

--- a/apifn/snippets/src/index.ts
+++ b/apifn/snippets/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @apifn/snippets — public API
+ */
+
+export { generateSnippet, generateAllSnippets, SUPPORTED_TARGETS } from "./generator.js";
+export type { SnippetContext, OperationSnippet, AllSnippetsResult, SnippetTargetGenerator } from "./types.js";

--- a/apifn/snippets/src/targets/axios.ts
+++ b/apifn/snippets/src/targets/axios.ts
@@ -1,0 +1,59 @@
+/**
+ * axios snippet target — SNIP-003
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generateAxios(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const m = method.toLowerCase();
+    const lines: string[] = [];
+
+    lines.push(`import axios from 'axios';`);
+    lines.push("");
+
+    const allHeaders = { ...ctx.headers };
+    const hasHeaders = Object.keys(allHeaders).length > 0;
+
+    const useConfig = hasHeaders;
+
+    if (m === "get" || m === "delete" || m === "head" || m === "options") {
+        if (useConfig) {
+            lines.push(`const response = await axios.${m}('${ctx.url}', {`);
+            lines.push(`${ind}headers: {`);
+            for (const [k, v] of Object.entries(allHeaders)) {
+                lines.push(`${ind}${ind}'${k}': '${v}',`);
+            }
+            lines.push(`${ind}},`);
+            lines.push(`});`);
+        } else {
+            lines.push(`const response = await axios.${m}('${ctx.url}');`);
+        }
+    } else {
+        // POST / PUT / PATCH
+        const bodyArg = ctx.body ? ctx.body : "{}";
+        if (useConfig) {
+            lines.push(`const response = await axios.${m}('${ctx.url}', ${bodyArg}, {`);
+            lines.push(`${ind}headers: {`);
+            for (const [k, v] of Object.entries(allHeaders)) {
+                lines.push(`${ind}${ind}'${k}': '${v}',`);
+            }
+            lines.push(`${ind}},`);
+            lines.push(`});`);
+        } else {
+            lines.push(`const response = await axios.${m}('${ctx.url}', ${bodyArg});`);
+        }
+    }
+
+    lines.push("");
+    lines.push("console.log(response.data);");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/csharp-httpclient.ts
+++ b/apifn/snippets/src/targets/csharp-httpclient.ts
@@ -1,0 +1,79 @@
+/**
+ * C# HttpClient snippet target
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+function escapeCsharpString(value: string): string {
+    return Array.from(value, (char) => {
+        switch (char) {
+            case "\\":
+                return "\\\\";
+            case "\"":
+                return "\\\"";
+            case "\n":
+                return "\\n";
+            case "\r":
+                return "\\r";
+            case "\t":
+                return "\\t";
+            case "\b":
+                return "\\b";
+            case "\f":
+                return "\\f";
+            case "\0":
+                return "\\0";
+            default: {
+                const code = char.charCodeAt(0);
+                return code < 0x20 ? `\\u${code.toString(16).padStart(4, "0")}` : char;
+            }
+        }
+    }).join("");
+}
+
+export function generateCsharpHttpclient(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const m = method.charAt(0).toUpperCase() + method.slice(1).toLowerCase();
+    const lines: string[] = [];
+
+    lines.push("using System.Net.Http;");
+    lines.push("using System.Text;");
+    lines.push("using System.Text.Json;");
+    lines.push("");
+    lines.push("using var client = new HttpClient();");
+    lines.push("");
+
+    const allHeaders = { ...ctx.headers };
+    for (const [k, v] of Object.entries(allHeaders)) {
+        lines.push(`client.DefaultRequestHeaders.Add("${escapeCsharpString(k)}", "${escapeCsharpString(v)}");`);
+    }
+
+    if (ctx.body) {
+        lines.push(`var content = new StringContent(`);
+        lines.push(`${ind}"${escapeCsharpString(ctx.body)}",`);
+        lines.push(`${ind}Encoding.UTF8,`);
+        lines.push(`${ind}"application/json"`);
+        lines.push(");");
+        lines.push("");
+        if (m === "Post" || m === "Put" || m === "Patch") {
+            lines.push(`var response = await client.${m}Async("${escapeCsharpString(ctx.url)}", content);`);
+        } else {
+            lines.push(`var response = await client.${m}Async("${escapeCsharpString(ctx.url)}");`);
+        }
+    } else {
+        lines.push(`var response = await client.${m}Async("${escapeCsharpString(ctx.url)}");`);
+    }
+
+    lines.push("");
+    lines.push("var body = await response.Content.ReadAsStringAsync();");
+    lines.push("Console.WriteLine(body);");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/curl.ts
+++ b/apifn/snippets/src/targets/curl.ts
@@ -1,0 +1,30 @@
+/**
+ * curl snippet target — SNIP-001
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generateCurl(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const lines: string[] = [];
+
+    lines.push(`curl -X ${method.toUpperCase()} '${ctx.url}'`);
+
+    for (const [key, value] of Object.entries(ctx.headers)) {
+        lines.push(`${ind}-H '${key}: ${value}'`);
+    }
+
+    if (ctx.body) {
+        lines.push(`${ind}-H 'Content-Type: application/json'`);
+        lines.push(`${ind}-d '${ctx.body.replace(/'/g, "'\\''")}'`);
+    }
+
+    return lines.join(" \\\n");
+}

--- a/apifn/snippets/src/targets/fetch.ts
+++ b/apifn/snippets/src/targets/fetch.ts
@@ -1,0 +1,42 @@
+/**
+ * fetch (browser/Node) snippet target — SNIP-002
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generateFetch(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const lines: string[] = [];
+
+    lines.push(`const response = await fetch('${ctx.url}', {`);
+    lines.push(`${ind}method: '${method.toUpperCase()}',`);
+
+    const allHeaders = { ...ctx.headers };
+    if (ctx.body) allHeaders["Content-Type"] = "application/json";
+
+    if (Object.keys(allHeaders).length > 0) {
+        lines.push(`${ind}headers: {`);
+        for (const [k, v] of Object.entries(allHeaders)) {
+            lines.push(`${ind}${ind}'${k}': '${v}',`);
+        }
+        lines.push(`${ind}},`);
+    }
+
+    if (ctx.body) {
+        lines.push(`${ind}body: JSON.stringify(${ctx.body}),`);
+    }
+
+    lines.push("});");
+    lines.push("");
+    lines.push("const data = await response.json();");
+    lines.push("console.log(data);");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/go-http.ts
+++ b/apifn/snippets/src/targets/go-http.ts
@@ -1,0 +1,58 @@
+/**
+ * Go net/http snippet target
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generateGoHttp(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const m = method.toUpperCase();
+    const lines: string[] = [];
+
+    lines.push("package main");
+    lines.push("");
+    lines.push("import (");
+    lines.push(`${ind}"fmt"`);
+    lines.push(`${ind}"io"`);
+    lines.push(`${ind}"net/http"`);
+    if (ctx.body) lines.push(`${ind}"strings"`);
+    lines.push(")");
+    lines.push("");
+    lines.push("func main() {");
+
+    if (ctx.body) {
+        const escaped = ctx.body.replace(/`/g, "` + \"`\" + `");
+        lines.push(`${ind}body := strings.NewReader(\`${escaped}\`)`);
+        lines.push(`${ind}req, _ := http.NewRequest("${m}", "${ctx.url}", body)`);
+    } else {
+        lines.push(`${ind}req, _ := http.NewRequest("${m}", "${ctx.url}", nil)`);
+    }
+
+    const allHeaders = { ...ctx.headers };
+    if (ctx.body) allHeaders["Content-Type"] = "application/json";
+
+    for (const [k, v] of Object.entries(allHeaders)) {
+        lines.push(`${ind}req.Header.Set("${k}", "${v}")`);
+    }
+
+    lines.push("");
+    lines.push(`${ind}client := &http.Client{}`);
+    lines.push(`${ind}resp, err := client.Do(req)`);
+    lines.push(`${ind}if err != nil {`);
+    lines.push(`${ind}${ind}panic(err)`);
+    lines.push(`${ind}}`);
+    lines.push(`${ind}defer resp.Body.Close()`);
+    lines.push("");
+    lines.push(`${ind}data, _ := io.ReadAll(resp.Body)`);
+    lines.push(`${ind}fmt.Println(string(data))`);
+    lines.push("}");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/java-okhttp.ts
+++ b/apifn/snippets/src/targets/java-okhttp.ts
@@ -1,0 +1,61 @@
+/**
+ * Java OkHttp snippet target
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+function escapeJavaString(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export function generateJavaOkhttp(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const m = method.toUpperCase();
+    const lines: string[] = [];
+
+    lines.push("import okhttp3.*;");
+    lines.push("");
+    lines.push("OkHttpClient client = new OkHttpClient();");
+    lines.push("");
+
+    const allHeaders = { ...ctx.headers };
+
+    if (ctx.body) {
+        const escaped = escapeJavaString(ctx.body);
+        lines.push(`MediaType mediaType = MediaType.parse("application/json");`);
+        lines.push(`RequestBody body = RequestBody.create("${escaped}", mediaType);`);
+        lines.push("");
+    }
+
+    lines.push("Request request = new Request.Builder()");
+    lines.push(`${ind}.url("${escapeJavaString(ctx.url)}")`);
+
+    for (const [k, v] of Object.entries(allHeaders)) {
+        lines.push(`${ind}.addHeader("${escapeJavaString(k)}", "${escapeJavaString(v)}")`);
+    }
+
+    if (ctx.body) {
+        lines.push(`${ind}.method("${m}", body)`);
+    } else if (m === "GET") {
+        lines.push(`${ind}.get()`);
+    } else if (m === "DELETE") {
+        lines.push(`${ind}.delete()`);
+    } else {
+        lines.push(`${ind}.method("${m}", RequestBody.create("", null))`);
+    }
+
+    lines.push(`${ind}.build();`);
+    lines.push("");
+    lines.push("try (Response response = client.newCall(request).execute()) {");
+    lines.push(`${ind}System.out.println(response.body().string());`);
+    lines.push("}");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/node-fetch.ts
+++ b/apifn/snippets/src/targets/node-fetch.ts
@@ -1,0 +1,45 @@
+/**
+ * node-fetch snippet target
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generateNodeFetch(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const lines: string[] = [];
+
+    lines.push("import fetch from 'node-fetch';");
+    lines.push("");
+
+    const allHeaders = { ...ctx.headers };
+    if (ctx.body) allHeaders["Content-Type"] = "application/json";
+
+    lines.push(`const response = await fetch('${ctx.url}', {`);
+    lines.push(`${ind}method: '${method.toUpperCase()}',`);
+
+    if (Object.keys(allHeaders).length > 0) {
+        lines.push(`${ind}headers: {`);
+        for (const [k, v] of Object.entries(allHeaders)) {
+            lines.push(`${ind}${ind}'${k}': '${v}',`);
+        }
+        lines.push(`${ind}},`);
+    }
+
+    if (ctx.body) {
+        lines.push(`${ind}body: JSON.stringify(${ctx.body}),`);
+    }
+
+    lines.push("});");
+    lines.push("");
+    lines.push("const data = await response.json();");
+    lines.push("console.log(data);");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/php-curl.ts
+++ b/apifn/snippets/src/targets/php-curl.ts
@@ -1,0 +1,52 @@
+/**
+ * PHP cURL snippet target
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+function escapePhpSingleQuoted(value: string): string {
+    return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+export function generatePhpCurl(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const m = method.toUpperCase();
+    const lines: string[] = [];
+
+    lines.push("<?php");
+    lines.push("");
+    lines.push(`$ch = curl_init('${escapePhpSingleQuoted(ctx.url)}');`);
+
+    const allHeaders = { ...ctx.headers };
+    if (ctx.body) allHeaders["Content-Type"] = "application/json";
+
+    lines.push(`curl_setopt($ch, CURLOPT_CUSTOMREQUEST, '${m}');`);
+    lines.push("curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);");
+
+    if (Object.keys(allHeaders).length > 0) {
+        lines.push("curl_setopt($ch, CURLOPT_HTTPHEADER, [");
+        for (const [k, v] of Object.entries(allHeaders)) {
+            lines.push(`${ind}'${escapePhpSingleQuoted(`${k}: ${v}`)}',`);
+        }
+        lines.push("]);");
+    }
+
+    if (ctx.body) {
+        lines.push(`curl_setopt($ch, CURLOPT_POSTFIELDS, '${escapePhpSingleQuoted(ctx.body)}');`);
+    }
+
+    lines.push("");
+    lines.push("$response = curl_exec($ch);");
+    lines.push("curl_close($ch);");
+    lines.push("");
+    lines.push("echo $response;");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/python-httpx.ts
+++ b/apifn/snippets/src/targets/python-httpx.ts
@@ -1,0 +1,43 @@
+/**
+ * Python httpx snippet target
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generatePythonHttpx(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const m = method.toLowerCase();
+    const lines: string[] = [];
+
+    lines.push("import httpx");
+    lines.push("");
+
+    const allHeaders = { ...ctx.headers };
+    const hasHeaders = Object.keys(allHeaders).length > 0;
+
+    if (hasHeaders) {
+        lines.push("headers = {");
+        for (const [k, v] of Object.entries(allHeaders)) {
+            lines.push(`${ind}'${k}': '${v}',`);
+        }
+        lines.push("}");
+        lines.push("");
+    }
+
+    lines.push("async with httpx.AsyncClient() as client:");
+    let callArgs = `'${ctx.url}'`;
+    if (hasHeaders) callArgs += ", headers=headers";
+    if (ctx.body) callArgs += `, json=${ctx.body}`;
+
+    lines.push(`${ind}response = await client.${m}(${callArgs})`);
+    lines.push(`${ind}print(response.json())`);
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/python-requests.ts
+++ b/apifn/snippets/src/targets/python-requests.ts
@@ -1,0 +1,43 @@
+/**
+ * Python requests snippet target — SNIP-004
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generatePythonRequests(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const ind = ctx.indent;
+    const m = method.toLowerCase();
+    const lines: string[] = [];
+
+    lines.push("import requests");
+    lines.push("");
+
+    const allHeaders = { ...ctx.headers };
+    const hasHeaders = Object.keys(allHeaders).length > 0;
+
+    if (hasHeaders) {
+        lines.push("headers = {");
+        for (const [k, v] of Object.entries(allHeaders)) {
+            lines.push(`${ind}'${k}': '${v}',`);
+        }
+        lines.push("}");
+        lines.push("");
+    }
+
+    let callArgs = `'${ctx.url}'`;
+    if (hasHeaders) callArgs += ", headers=headers";
+    if (ctx.body) callArgs += `, json=${ctx.body}`;
+
+    lines.push(`response = requests.${m}(${callArgs})`);
+    lines.push("");
+    lines.push("print(response.json())");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/targets/ruby-net-http.ts
+++ b/apifn/snippets/src/targets/ruby-net-http.ts
@@ -1,0 +1,43 @@
+/**
+ * Ruby Net::HTTP snippet target
+ */
+
+import type { OperationObject, SnippetOptions } from "@apifn/core";
+import { buildContext } from "../context.js";
+
+export function generateRubyNetHttp(
+    operation: OperationObject,
+    apiPath: string,
+    method: string,
+    options: SnippetOptions
+): string {
+    const ctx = buildContext(operation, apiPath, method, options);
+    const m = method.charAt(0).toUpperCase() + method.slice(1).toLowerCase();
+    const lines: string[] = [];
+
+    lines.push("require 'net/http'");
+    lines.push("require 'json'");
+    lines.push("");
+    lines.push(`uri = URI('${ctx.url}')`);
+    lines.push(`http = Net::HTTP.new(uri.host, uri.port)`);
+    lines.push("http.use_ssl = uri.scheme == 'https'");
+    lines.push("");
+    lines.push(`request = Net::HTTP::${m}.new(uri)`);
+
+    const allHeaders = { ...ctx.headers };
+    if (ctx.body) allHeaders["Content-Type"] = "application/json";
+
+    for (const [k, v] of Object.entries(allHeaders)) {
+        lines.push(`request['${k}'] = '${v}'`);
+    }
+
+    if (ctx.body) {
+        lines.push(`request.body = ${ctx.body}.to_json`);
+    }
+
+    lines.push("");
+    lines.push("response = http.request(request)");
+    lines.push("puts JSON.parse(response.body)");
+
+    return lines.join("\n");
+}

--- a/apifn/snippets/src/types.ts
+++ b/apifn/snippets/src/types.ts
@@ -1,0 +1,40 @@
+/**
+ * @apifn/snippets — Types
+ */
+
+import type { OperationObject, SnippetTarget, SnippetOptions } from "@apifn/core";
+
+export type { SnippetTarget, SnippetOptions };
+
+/** A snippet target generator */
+export interface SnippetTargetGenerator {
+    generate(
+        operation: OperationObject,
+        apiPath: string,
+        method: string,
+        options: SnippetOptions
+    ): string;
+}
+
+/** The resolved operation details passed to targets */
+export interface SnippetContext {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body?: string;
+    indent: string;
+}
+
+/** A snippet for one operation across all (or selected) targets */
+export interface OperationSnippet {
+    path: string;
+    method: string;
+    operationId?: string;
+    target: SnippetTarget;
+    code: string;
+}
+
+/** Result from generateAllSnippets */
+export interface AllSnippetsResult {
+    snippets: OperationSnippet[];
+}

--- a/apifn/snippets/tsconfig.json
+++ b/apifn/snippets/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apifn/snippets/tsup.config.ts
+++ b/apifn/snippets/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/apifn/snippets/vitest.config.ts
+++ b/apifn/snippets/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    passWithNoTests: true,
+  },
+});

--- a/apifn/svelte/package.json
+++ b/apifn/svelte/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@apifn/svelte",
+  "version": "0.0.1",
+  "description": "Svelte UI components for ApiFn",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "svelte": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./src/index.ts",
+      "import": "./dist/index.js"
+    },
+    "./ApiExplorer.svelte": {
+      "svelte": "./src/ApiExplorer.svelte",
+      "default": "./src/ApiExplorer.svelte"
+    },
+    "./EndpointViewer.svelte": {
+      "svelte": "./src/EndpointViewer.svelte",
+      "default": "./src/EndpointViewer.svelte"
+    },
+    "./PerformanceOverlay.svelte": {
+      "svelte": "./src/PerformanceOverlay.svelte",
+      "default": "./src/PerformanceOverlay.svelte"
+    },
+    "./RequestHistory.svelte": {
+      "svelte": "./src/RequestHistory.svelte",
+      "default": "./src/RequestHistory.svelte"
+    },
+    "./ResponseDiff.svelte": {
+      "svelte": "./src/ResponseDiff.svelte",
+      "default": "./src/ResponseDiff.svelte"
+    },
+    "./SchemaViewer.svelte": {
+      "svelte": "./src/SchemaViewer.svelte",
+      "default": "./src/SchemaViewer.svelte"
+    },
+    "./TryIt.svelte": {
+      "svelte": "./src/TryIt.svelte",
+      "default": "./src/TryIt.svelte"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "node -e \"console.log('No tests configured')\""
+  },
+  "dependencies": {
+    "@apifn/core": "0.0.1"
+  },
+  "peerDependencies": {
+    "svelte": "^4.0.0 || ^5.0.0"
+  },
+  "devDependencies": {
+    "svelte": "^4.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0"
+  },
+  "author": "21n",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21nCo/super-functions/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/21nCo/super-functions.git",
+    "directory": "apifn/svelte"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
+}

--- a/apifn/svelte/src/ApiExplorer.svelte
+++ b/apifn/svelte/src/ApiExplorer.svelte
@@ -1,0 +1,313 @@
+<!-- ApiExplorer.svelte — full API explorer shell (UI-S-001) -->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { OpenAPIDocument, OperationObject } from "@apifn/core";
+  import EndpointViewer from "./EndpointViewer.svelte";
+  import TryIt from "./TryIt.svelte";
+  import RequestHistory from "./RequestHistory.svelte";
+  import PerformanceOverlay from "./PerformanceOverlay.svelte";
+  import type { WatchFnClient, EndpointMetrics } from "@apifn/core";
+
+  export let spec: OpenAPIDocument;
+  export let baseUrl: string | undefined = undefined;
+  export let theme: "light" | "dark" | "auto" = "auto";
+  export let showHistory: boolean = true;
+  export let watchfn: WatchFnClient | undefined = undefined;
+  export let watchfnInterval: number = 10000;
+  export let rateLimits: Record<string, RateLimitInfo> | undefined = undefined;
+
+  interface EndpointItem { path: string; method: string; operation: OperationObject; tag: string; }
+  interface HistoryEntry {
+    id: string; timestamp: number; method: string; url: string;
+    statusCode?: number; duration?: number; responseBody?: unknown; responseHeaders?: Record<string, string>;
+  }
+
+  const HTTP_METHODS = ["get","post","put","patch","delete","head","options"] as const;
+  const METHOD_COLORS: Record<string, { bg: string; text: string }> = {
+    get: { bg: "#065f46", text: "#6ee7b7" }, post: { bg: "#1e3a5f", text: "#93c5fd" },
+    put: { bg: "#78350f", text: "#fcd34d" }, patch: { bg: "#5b21b6", text: "#c4b5fd" },
+    delete: { bg: "#7f1d1d", text: "#fca5a5" },
+  };
+
+  function collectEndpoints(spec: OpenAPIDocument): EndpointItem[] {
+    const items: EndpointItem[] = [];
+    for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+      if (!pathItem) continue;
+      for (const method of HTTP_METHODS) {
+        const op = pathItem[method] as OperationObject | undefined;
+        if (!op) continue;
+        const tags = (op.tags as string[]) ?? ["default"];
+        items.push({ path, method, operation: op, tag: tags[0] ?? "default" });
+      }
+    }
+    return items;
+  }
+
+  function getThemeCSS(t: "light" | "dark" | "auto"): string {
+    const dark = `--apifn-bg:#0f1117;--apifn-bg-surface:#1a1d2e;--apifn-bg-surface-hover:#252840;--apifn-border:#2d3748;--apifn-text:#e2e8f0;--apifn-text-muted:#64748b;--apifn-accent:#7c3aed;--apifn-accent-text:#c4b5fd;--apifn-green:#6ee7b7;--apifn-blue:#93c5fd;--apifn-yellow:#fcd34d;--apifn-red:#fca5a5;--apifn-purple:#c4b5fd;--apifn-orange:#fdba74;--apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif`;
+    const light = `--apifn-bg:#ffffff;--apifn-bg-surface:#f8fafc;--apifn-bg-surface-hover:#f1f5f9;--apifn-border:#e2e8f0;--apifn-text:#0f172a;--apifn-text-muted:#64748b;--apifn-accent:#7c3aed;--apifn-accent-text:#6d28d9;--apifn-green:#059669;--apifn-blue:#2563eb;--apifn-yellow:#d97706;--apifn-red:#dc2626;--apifn-purple:#7c3aed;--apifn-orange:#ea580c;--apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif`;
+    if (t === "dark") return dark;
+    if (t === "light") return light;
+    return light; // auto defaults to light; media query in style handles dark
+  }
+
+  $: endpoints = collectEndpoints(spec);
+  $: info = spec.info as { title?: string; version?: string } | undefined;
+  $: effectiveBaseUrl = baseUrl ?? (spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url ?? "https://api.example.com";
+
+  let query = "";
+  let selected: EndpointItem | null = null;
+  let tab: "docs" | "tryit" | "history" = "docs";
+  let sidebarOpen = true;
+  let isMobile = false;
+  let history: HistoryEntry[] = [];
+  let metrics: Record<string, EndpointMetrics> = {};
+
+  $: filtered = query
+    ? endpoints.filter((e) =>
+        e.path.toLowerCase().includes(query.toLowerCase()) ||
+        e.method.toLowerCase().includes(query.toLowerCase()) ||
+        ((e.operation.summary as string) ?? "").toLowerCase().includes(query.toLowerCase())
+      )
+    : endpoints;
+
+  $: grouped = (() => {
+    const map = new Map<string, EndpointItem[]>();
+    for (const e of filtered) {
+      if (!map.has(e.tag)) map.set(e.tag, []);
+      map.get(e.tag)!.push(e);
+    }
+    return map;
+  })();
+
+  onMount(() => {
+    const mq = window.matchMedia("(max-width: 768px)");
+    isMobile = mq.matches;
+    sidebarOpen = !mq.matches;
+    const handler = (e: MediaQueryListEvent) => {
+      isMobile = e.matches;
+      sidebarOpen = !e.matches;
+    };
+    mq.addEventListener("change", handler);
+
+    let mounted = true;
+    let timer: ReturnType<typeof setTimeout>;
+
+    async function poll() {
+      if (!watchfn || !mounted) return;
+      try {
+        const list = await watchfn.fetchMetrics({ timeRange: "PT1H" });
+        if (!mounted) return;
+        const m: Record<string, EndpointMetrics> = {};
+        for (const item of list) {
+          m[`${item.method.toUpperCase()} ${item.path}`] = item;
+        }
+        metrics = m;
+      } catch (err) {
+        console.warn("[ApiExplorer] Failed to fetch watchfn metrics:", err);
+      }
+      if (mounted) {
+        timer = setTimeout(poll, watchfnInterval);
+      }
+    }
+
+    if (watchfn) poll();
+
+    return () => {
+      mounted = false;
+      clearTimeout(timer);
+      mq.removeEventListener("change", handler);
+    };
+  });
+
+  function selectEndpoint(item: EndpointItem) {
+    selected = item;
+    tab = "docs";
+    if (isMobile) sidebarOpen = false;
+  }
+
+  function handleResponse(e: CustomEvent) {
+    if (!selected) return;
+    const r = e.detail;
+    history = [{
+      id: `${Date.now()}-${Math.random()}`,
+      timestamp: Date.now(),
+      method: selected.method,
+      url: `${effectiveBaseUrl}${selected.path}`,
+      statusCode: r.statusCode,
+      duration: r.durationMs,
+      responseBody: r.body,
+      responseHeaders: r.headers,
+    }, ...history].slice(0, 500);
+  }
+
+  function mc(method: string) {
+    return METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+  }
+
+  $: themeVars = getThemeCSS(theme);
+</script>
+
+<div class="apifn-root" style={themeVars}>
+  <!-- Top Bar -->
+  <header class="topbar">
+    <button
+      class="hamburger"
+      class:show={isMobile}
+      on:click={() => (sidebarOpen = !sidebarOpen)}
+      aria-label="Toggle sidebar"
+    >☰</button>
+    <span class="logo">ApiFn</span>
+    <span class="api-title">{info?.title ?? "API Explorer"}</span>
+    <span class="version">v{info?.version ?? "1.0.0"}</span>
+  </header>
+
+  <div class="body">
+    <!-- Sidebar -->
+    {#if sidebarOpen}
+      <aside class="sidebar">
+        <input
+          class="search"
+          placeholder="Search endpoints…"
+          bind:value={query}
+          aria-label="Search endpoints"
+        />
+        <div class="endpoint-list">
+          {#if filtered.length === 0}
+            <div class="empty-list">No endpoints match</div>
+          {/if}
+          {#each [...grouped.entries()] as [tag, items]}
+            <div class="tag-group">
+              <div class="tag-header">{tag}</div>
+              {#each items as item}
+                <div
+                  class="endpoint-row"
+                  class:active={selected?.path === item.path && selected?.method === item.method}
+                  role="button"
+                  tabindex="0"
+                  on:click={() => selectEndpoint(item)}
+                  on:keydown={(e) => e.key === "Enter" && selectEndpoint(item)}
+                >
+                  <span class="method-tag" style="background:{mc(item.method).bg};color:{mc(item.method).text}">
+                    {item.method.toUpperCase()}
+                  </span>
+                  <span class="ep-path">{item.path}</span>
+                  {#if metrics[`${item.method.toUpperCase()} ${item.path}`]}
+                    <span class="perf-badge" title="Performance data available">⚡</span>
+                  {/if}
+                  {#if rateLimits && rateLimits[`${item.method.toUpperCase()} ${item.path}`]}
+                    {@const rl = rateLimits[`${item.method.toUpperCase()} ${item.path}`]}
+                    <span class="rl-badge" style="color: {rl.remaining / rl.limit < 0.1 ? 'var(--apifn-red)' : 'var(--apifn-text-muted)'}" title={`Rate Limit: ${rl.remaining}/${rl.limit}`}>
+                      {rl.remaining}/{rl.limit}
+                    </span>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/each}
+        </div>
+      </aside>
+    {/if}
+
+    <!-- Main -->
+    <main class="main">
+      {#if selected}
+        <!-- Tabs -->
+        <nav class="tabs">
+          <button class="tab" class:active={tab === "docs"} on:click={() => (tab = "docs")}>Documentation</button>
+          <button class="tab" class:active={tab === "tryit"} on:click={() => (tab = "tryit")}>Try It</button>
+          {#if watchfn}
+            <button class="tab" class:active={tab === "perf"} on:click={() => (tab = "perf" as any)}>Performance</button>
+          {/if}
+          {#if showHistory}
+            <button class="tab" class:active={tab === "history"} on:click={() => (tab = "history")}>History</button>
+          {/if}
+        </nav>
+
+        <div class="content">
+          {#if tab === "docs"}
+            <EndpointViewer path={selected.path} method={selected.method} operation={selected.operation} />
+          {:else if tab === "tryit"}
+            <TryIt path={selected.path} method={selected.method} operation={selected.operation} baseUrl={effectiveBaseUrl} on:response={handleResponse} />
+          {:else if tab === "perf" && watchfn}
+            <div style="padding: 20px;">
+              {#if metrics[`${selected.method.toUpperCase()} ${selected.path}`]}
+                {@const raw = metrics[`${selected.method.toUpperCase()} ${selected.path}`]}
+                <PerformanceOverlay metrics={{
+                  endpoint: selected.path,
+                  method: selected.method,
+                  p50Ms: raw.latency.p50,
+                  p95Ms: raw.latency.p95,
+                  p99Ms: raw.latency.p99,
+                  errorRatePct: raw.errors.rate * 100,
+                  requestsPerMinute: raw.throughput.rpm,
+                  lastUpdated: raw.lastUpdated
+                }} />
+              {:else}
+                <div class="empty-main" style="height: auto;">No performance data available yet.</div>
+              {/if}
+            </div>
+          {:else if tab === "history" && showHistory}
+            <RequestHistory entries={history} on:clear={() => (history = [])} />
+          {/if}
+        </div>
+      {:else}
+        <div class="empty-main">
+          <div class="empty-icon">⚡</div>
+          <div>Select an endpoint from the sidebar</div>
+        </div>
+      {/if}
+    </main>
+  </div>
+</div>
+
+<style>
+  .apifn-root {
+    font-family: var(--apifn-font-sans, sans-serif);
+    background: var(--apifn-bg, #0f1117);
+    color: var(--apifn-text, #e2e8f0);
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+  @media (prefers-color-scheme: dark) {
+    .apifn-root {
+      --apifn-bg: #0f1117; --apifn-bg-surface: #1a1d2e; --apifn-bg-surface-hover: #252840;
+      --apifn-border: #2d3748; --apifn-text: #e2e8f0; --apifn-text-muted: #64748b;
+      --apifn-accent: #7c3aed; --apifn-accent-text: #c4b5fd; --apifn-green: #6ee7b7;
+      --apifn-blue: #93c5fd; --apifn-yellow: #fcd34d; --apifn-red: #fca5a5;
+    }
+  }
+  .topbar { display: flex; align-items: center; gap: 12px; padding: 0 20px; height: 52px; border-bottom: 1px solid var(--apifn-border); background: var(--apifn-bg-surface); flex-shrink: 0; }
+  .logo { font-size: 16px; font-weight: 800; color: var(--apifn-accent); letter-spacing: -.5px; }
+  .api-title { font-size: 14px; color: var(--apifn-text-muted); flex: 1; }
+  .version { font-size: 11px; padding: 2px 8px; border-radius: 12px; background: var(--apifn-accent, #7c3aed)22; color: var(--apifn-accent-text); border: 1px solid var(--apifn-accent, #7c3aed)44; }
+  .hamburger { background: none; border: none; color: var(--apifn-text); cursor: pointer; font-size: 20px; padding: 4px; display: none; }
+  .hamburger.show { display: block; }
+  .body { display: flex; flex: 1; overflow: hidden; }
+  .sidebar { width: 280px; min-width: 280px; border-right: 1px solid var(--apifn-border); background: var(--apifn-bg-surface); display: flex; flex-direction: column; overflow: hidden; flex-shrink: 0; }
+  .search { margin: 12px; padding: 8px 12px; background: var(--apifn-bg); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); color: var(--apifn-text); font-size: 13px; outline: none; width: calc(100% - 24px); box-sizing: border-box; }
+  .endpoint-list { flex: 1; overflow-y: auto; padding: 4px 0; }
+  .empty-list { padding: 20px; color: var(--apifn-text-muted); font-size: 13px; text-align: center; }
+  .tag-group { margin-bottom: 4px; }
+  .tag-header { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: var(--apifn-text-muted); padding: 8px 12px 4px; }
+  .endpoint-row { display: flex; align-items: center; gap: 8px; padding: 7px 12px; cursor: pointer; border-left: 2px solid transparent; transition: background .1s; }
+  .endpoint-row:hover { background: var(--apifn-bg-surface-hover); }
+  .endpoint-row.active { background: var(--apifn-bg-surface-hover); border-left-color: var(--apifn-accent); }
+  .method-tag { font-size: 10px; font-weight: 700; padding: 1px 5px; border-radius: 3px; font-family: var(--apifn-font-mono); min-width: 40px; text-align: center; text-transform: uppercase; }
+  .ep-path { font-family: var(--apifn-font-mono); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .perf-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; background: var(--apifn-bg-surface-hover); border-radius: 12px; color: var(--apifn-text-muted); }
+  .rl-badge { font-size: 10px; font-weight: 600; padding: 2px 6px; background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: 4px; color: var(--apifn-text-muted); white-space: nowrap; }
+  .main { flex: 1; overflow: hidden; display: flex; flex-direction: column; }
+  .tabs { display: flex; border-bottom: 1px solid var(--apifn-border); background: var(--apifn-bg-surface); padding: 0 20px; flex-shrink: 0; }
+  .tab { padding: 12px 16px; font-size: 13px; font-weight: 400; color: var(--apifn-text-muted); border: none; border-bottom: 2px solid transparent; cursor: pointer; background: none; transition: color .1s; }
+  .tab.active { font-weight: 600; color: var(--apifn-text); border-bottom-color: var(--apifn-accent); }
+  .content { flex: 1; overflow-y: auto; }
+  .empty-main { display: flex; align-items: center; justify-content: center; height: 100%; flex-direction: column; gap: 12px; color: var(--apifn-text-muted); font-size: 14px; }
+  .empty-icon { font-size: 32px; }
+  @media (max-width: 768px) {
+    .hamburger { display: block !important; }
+    .sidebar { position: absolute; z-index: 100; height: 100%; }
+  }
+</style>

--- a/apifn/svelte/src/EndpointViewer.svelte
+++ b/apifn/svelte/src/EndpointViewer.svelte
@@ -1,0 +1,154 @@
+<!-- EndpointViewer.svelte — single endpoint documentation (UI-S-002) -->
+<script lang="ts">
+  import type { OperationObject, SchemaObject } from "@apifn/core";
+  import SchemaViewer from "./SchemaViewer.svelte";
+
+  export let path: string;
+  export let method: string;
+  export let operation: OperationObject;
+
+  const METHOD_COLORS: Record<string, { bg: string; text: string }> = {
+    get:     { bg: "#065f46", text: "#6ee7b7" },
+    post:    { bg: "#1e3a5f", text: "#93c5fd" },
+    put:     { bg: "#78350f", text: "#fcd34d" },
+    patch:   { bg: "#5b21b6", text: "#c4b5fd" },
+    delete:  { bg: "#7f1d1d", text: "#fca5a5" },
+    head:    { bg: "#1f2937", text: "#9ca3af" },
+    options: { bg: "#1f2937", text: "#9ca3af" },
+  };
+
+  function statusColor(code: string): string {
+    const n = parseInt(code, 10);
+    if (n >= 500) return "var(--apifn-red)";
+    if (n >= 400) return "var(--apifn-orange, #fdba74)";
+    if (n >= 300) return "var(--apifn-yellow)";
+    if (n >= 200) return "var(--apifn-green)";
+    return "var(--apifn-text-muted)";
+  }
+
+  $: mc = METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+  $: params = (operation.parameters ?? []) as Array<{
+    name: string; in: string; required?: boolean;
+    description?: string; schema?: SchemaObject;
+  }>;
+  $: reqBody = operation.requestBody as {
+    required?: boolean; content?: Record<string, { schema?: SchemaObject }>;
+  } | undefined;
+  $: reqSchema = reqBody?.content?.["application/json"]?.schema;
+  $: responses = operation.responses ?? {};
+  $: responseCodes = Object.keys(responses);
+
+  let activeCode = responseCodes[0] ?? "200";
+
+  $: activeResponse = responses[activeCode] as {
+    description?: string; content?: Record<string, { schema?: SchemaObject }>;
+  } | undefined;
+  $: responseSchema = activeResponse?.content?.["application/json"]?.schema;
+</script>
+
+<div class="container">
+  <div class="header">
+    <span class="method-badge" style="background:{mc.bg};color:{mc.text}">{method.toUpperCase()}</span>
+    <span class="path">{path}</span>
+    {#if operation.deprecated}
+      <span class="badge-yellow">deprecated</span>
+    {/if}
+  </div>
+
+  {#if operation.summary}
+    <div class="summary">{operation.summary}</div>
+  {/if}
+  {#if operation.description}
+    <div class="description">{operation.description}</div>
+  {/if}
+
+  <!-- Parameters -->
+  {#if params.length > 0}
+    <div class="section">
+      <div class="section-title">Parameters</div>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th><th>In</th><th>Type</th><th>Required</th><th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each params as p}
+            <tr>
+              <td class="mono accent">{p.name}</td>
+              <td><span class="badge-muted">{p.in}</span></td>
+              <td class="mono small">{(p.schema?.type as string) ?? "string"}</td>
+              <td>{#if p.required}<span class="badge-red">✓</span>{/if}</td>
+              <td class="muted small">{p.description ?? ""}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+
+  <!-- Request Body -->
+  {#if reqSchema}
+    <div class="section">
+      <div class="section-title">
+        Request Body {#if reqBody?.required}<span class="red">*</span>{/if}
+      </div>
+      <div class="schema-box">
+        <SchemaViewer schema={reqSchema} />
+      </div>
+    </div>
+  {/if}
+
+  <!-- Responses -->
+  {#if responseCodes.length > 0}
+    <div class="section">
+      <div class="section-title">Responses</div>
+      <div class="response-tabs">
+        {#each responseCodes as code}
+          <button
+            class="response-tab"
+            class:active={code === activeCode}
+            on:click={() => (activeCode = code)}
+            style="color:{statusColor(code)}"
+          >{code}</button>
+        {/each}
+      </div>
+      <div class="schema-box">
+        {#if activeResponse?.description}
+          <div class="muted small" style="margin-bottom:8px">{activeResponse.description}</div>
+        {/if}
+        {#if responseSchema}
+          <SchemaViewer schema={responseSchema} />
+        {:else}
+          <span class="muted small">No response body schema defined.</span>
+        {/if}
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .container { padding: 24px; color: var(--apifn-text); font-family: var(--apifn-font-sans); }
+  .header { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 20px; }
+  .method-badge { padding: 4px 12px; border-radius: 4px; font-weight: 700; font-size: 13px; font-family: var(--apifn-font-mono); text-transform: uppercase; letter-spacing: .05em; }
+  .path { font-family: var(--apifn-font-mono); font-size: 18px; font-weight: 600; }
+  .summary { font-size: 15px; color: var(--apifn-text-muted); margin-bottom: 8px; }
+  .description { font-size: 14px; color: var(--apifn-text-muted); line-height: 1.6; margin-bottom: 24px; }
+  .section { margin-bottom: 24px; }
+  .section-title { font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--apifn-text-muted); margin-bottom: 12px; border-bottom: 1px solid var(--apifn-border); padding-bottom: 6px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th { text-align: left; padding: 6px 8px; color: var(--apifn-text-muted); font-weight: 600; font-size: 12px; border-bottom: 1px solid var(--apifn-border); }
+  td { padding: 8px; border-bottom: 1px solid var(--apifn-border); vertical-align: top; }
+  .mono { font-family: var(--apifn-font-mono); }
+  .accent { color: var(--apifn-accent-text); }
+  .small { font-size: 12px; }
+  .muted { color: var(--apifn-text-muted); }
+  .red { color: var(--apifn-red); }
+  .schema-box { background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 16px; }
+  .badge-muted { font-size: 11px; padding: 1px 6px; border-radius: 3px; background: #2d374844; color: var(--apifn-text-muted); border: 1px solid var(--apifn-border); }
+  .badge-yellow { font-size: 11px; padding: 1px 6px; border-radius: 3px; background: #78350f22; color: var(--apifn-yellow); border: 1px solid #78350f44; }
+  .badge-red { font-size: 11px; padding: 1px 6px; border-radius: 3px; background: #7f1d1d22; color: var(--apifn-red); border: 1px solid #7f1d1d44; }
+  .response-tabs { display: flex; gap: 2px; flex-wrap: wrap; margin-bottom: 0; }
+  .response-tab { padding: 6px 14px; border-radius: 4px 4px 0 0; border: 1px solid var(--apifn-border); border-bottom: none; background: transparent; color: var(--apifn-text-muted); cursor: pointer; font-size: 13px; font-family: var(--apifn-font-mono); }
+  .response-tab.active { background: var(--apifn-bg-surface); color: var(--apifn-text); }
+</style>

--- a/apifn/svelte/src/PerformanceOverlay.svelte
+++ b/apifn/svelte/src/PerformanceOverlay.svelte
@@ -1,0 +1,91 @@
+<!-- PerformanceOverlay.svelte — watchfn metrics display (UI-S-007) -->
+<script lang="ts">
+  export interface PerformanceMetrics {
+    endpoint: string; method: string;
+    p50Ms: number; p95Ms: number; p99Ms: number;
+    errorRatePct: number; requestsPerMinute: number; lastUpdated: string;
+  }
+  export let metrics: PerformanceMetrics;
+  export let compact: boolean = false;
+
+  const P99_CEIL = 2000;
+  const RPM_CEIL = 1000;
+
+  function barPct(val: number, ceil: number): number { return Math.min(100, (val / ceil) * 100); }
+
+  $: errorHigh = metrics.errorRatePct > 5;
+  $: latencyBars = [
+    { label: `p50 — ${metrics.p50Ms}ms`, val: metrics.p50Ms, color: "var(--apifn-green)" },
+    { label: `p95 — ${metrics.p95Ms}ms`, val: metrics.p95Ms, color: "var(--apifn-yellow)" },
+    { label: `p99 — ${metrics.p99Ms}ms`, val: metrics.p99Ms, color: metrics.p99Ms > 1000 ? "var(--apifn-red)" : "var(--apifn-blue)" },
+  ];
+</script>
+
+{#if compact}
+  <div class="compact">
+    <span>p50 <strong>{metrics.p50Ms}ms</strong></span>
+    <span>p99 <strong style="color:{errorHigh ? 'var(--apifn-red)' : 'inherit'}">{metrics.p99Ms}ms</strong></span>
+    <span>err <strong style="color:{errorHigh ? 'var(--apifn-red)' : 'inherit'}">{metrics.errorRatePct.toFixed(1)}%</strong></span>
+    <span>{metrics.requestsPerMinute} rpm</span>
+  </div>
+{:else}
+  <div class="container">
+    <div class="title">
+      <span>⚡ Performance</span>
+      <span class="endpoint">{metrics.method.toUpperCase()} {metrics.endpoint}</span>
+    </div>
+
+    <!-- KPI grid -->
+    <div class="grid">
+      <div class="metric">
+        <div class="metric-label">p50 Latency</div>
+        <div class="metric-value">{metrics.p50Ms}<span class="unit">ms</span></div>
+      </div>
+      <div class="metric">
+        <div class="metric-label">p99 Latency</div>
+        <div class="metric-value" style="color:{metrics.p99Ms > 1000 ? 'var(--apifn-red)' : 'inherit'}">{metrics.p99Ms}<span class="unit">ms</span></div>
+      </div>
+      <div class="metric">
+        <div class="metric-label">Error Rate</div>
+        <div class="metric-value" style="color:{errorHigh ? 'var(--apifn-red)' : 'inherit'}">{metrics.errorRatePct.toFixed(1)}<span class="unit">%</span></div>
+      </div>
+    </div>
+
+    <!-- Latency bars -->
+    {#each latencyBars as bar}
+      <div class="bar-row">
+        <div class="bar-label"><span>{bar.label}</span></div>
+        <div class="bar-track">
+          <div class="bar-fill" style="width:{barPct(bar.val, P99_CEIL)}%;background:{bar.color}"></div>
+        </div>
+      </div>
+    {/each}
+
+    <!-- Throughput -->
+    <div class="bar-row" style="margin-top:8px">
+      <div class="bar-label"><span>Throughput</span><span>{metrics.requestsPerMinute} rpm</span></div>
+      <div class="bar-track">
+        <div class="bar-fill" style="width:{barPct(metrics.requestsPerMinute, RPM_CEIL)}%;background:var(--apifn-accent)"></div>
+      </div>
+    </div>
+
+    <div class="footer">Last updated: {new Date(metrics.lastUpdated).toLocaleTimeString()}</div>
+  </div>
+{/if}
+
+<style>
+  .compact { display: flex; gap: 12px; align-items: center; font-size: 12px; font-family: var(--apifn-font-mono); color: var(--apifn-text-muted); }
+  .container { background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 16px; font-family: var(--apifn-font-sans); color: var(--apifn-text); }
+  .title { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: var(--apifn-text-muted); margin-bottom: 12px; display: flex; align-items: center; justify-content: space-between; }
+  .endpoint { font-weight: 400; font-size: 11px; }
+  .grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 12px; margin-bottom: 16px; }
+  .metric { background: var(--apifn-bg); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 10px 12px; }
+  .metric-label { font-size: 11px; color: var(--apifn-text-muted); margin-bottom: 4px; }
+  .metric-value { font-size: 20px; font-weight: 700; font-family: var(--apifn-font-mono); }
+  .unit { font-size: 12px; color: var(--apifn-text-muted); margin-left: 2px; }
+  .bar-row { margin-bottom: 8px; }
+  .bar-label { display: flex; justify-content: space-between; font-size: 12px; color: var(--apifn-text-muted); margin-bottom: 3px; }
+  .bar-track { height: 6px; background: var(--apifn-border); border-radius: 3px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 3px; transition: width .4s ease; }
+  .footer { font-size: 11px; color: var(--apifn-text-muted); border-top: 1px solid var(--apifn-border); padding-top: 8px; margin-top: 8px; }
+</style>

--- a/apifn/svelte/src/RequestHistory.svelte
+++ b/apifn/svelte/src/RequestHistory.svelte
@@ -1,0 +1,120 @@
+<!-- RequestHistory.svelte — list of past requests (UI-S-005) -->
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export interface HistoryEntry {
+    id: string; timestamp: number; method: string; url: string;
+    statusCode?: number; duration?: number;
+    requestBody?: unknown; responseBody?: unknown;
+    responseHeaders?: Record<string, string>; error?: string;
+  }
+  export let entries: HistoryEntry[] = [];
+  export let maxEntries: number = 500;
+
+  const dispatch = createEventDispatcher<{ select: HistoryEntry; clear: void }>();
+
+  const METHOD_COLORS: Record<string, { bg: string; text: string }> = {
+    get: { bg: "#065f46", text: "#6ee7b7" }, post: { bg: "#1e3a5f", text: "#93c5fd" },
+    put: { bg: "#78350f", text: "#fcd34d" }, patch: { bg: "#5b21b6", text: "#c4b5fd" },
+    delete: { bg: "#7f1d1d", text: "#fca5a5" },
+  };
+
+  $: visible = entries.slice(0, maxEntries).sort((a, b) => b.timestamp - a.timestamp);
+  let selected: string | null = null;
+
+  function statusColor(code?: number): string {
+    if (!code) return "var(--apifn-text-muted)";
+    if (code >= 200 && code < 300) return "var(--apifn-green)";
+    if (code >= 400) return "var(--apifn-red)";
+    return "var(--apifn-yellow)";
+  }
+
+  function mc(method: string) {
+    return METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+  }
+
+  function toggleSelect(entry: HistoryEntry) {
+    selected = selected === entry.id ? null : entry.id;
+    dispatch("select", entry);
+  }
+
+  function clearHistory() { dispatch("clear"); }
+
+  $: selectedEntry = visible.find((e) => e.id === selected) ?? null;
+</script>
+
+<div class="container">
+  <div class="header">
+    <span class="title">Request History ({visible.length})</span>
+    <button class="clear-btn" on:click={clearHistory}>Clear</button>
+  </div>
+
+  {#if visible.length === 0}
+    <div class="empty">No requests yet</div>
+  {/if}
+
+  {#each visible as entry}
+    <div
+      class="entry"
+      class:active={entry.id === selected}
+      role="button"
+      tabindex="0"
+      on:click={() => toggleSelect(entry)}
+      on:keydown={(e) => e.key === "Enter" && toggleSelect(entry)}
+    >
+      <span class="method-tag" style="background:{mc(entry.method).bg};color:{mc(entry.method).text}">
+        {entry.method.toUpperCase()}
+      </span>
+      <span class="url">{entry.url}</span>
+      {#if entry.statusCode}
+        <span class="status" style="color:{statusColor(entry.statusCode)}">{entry.statusCode}</span>
+      {/if}
+      {#if entry.duration !== undefined}
+        <span class="duration">{entry.duration}ms</span>
+      {/if}
+      {#if entry.error}<span class="err-icon">✖</span>{/if}
+    </div>
+
+    {#if entry.id === selected && selectedEntry}
+      <div class="detail">
+        <div class="timestamp">{new Date(selectedEntry.timestamp).toLocaleString()}</div>
+        {#if selectedEntry.error}
+          <div class="error">{selectedEntry.error}</div>
+        {/if}
+        {#if selectedEntry.requestBody !== undefined}
+          <div class="detail-section">
+            <div class="detail-label">REQUEST BODY</div>
+            <pre>{JSON.stringify(selectedEntry.requestBody, null, 2)}</pre>
+          </div>
+        {/if}
+        {#if selectedEntry.responseBody !== undefined}
+          <div class="detail-section">
+            <div class="detail-label">RESPONSE BODY</div>
+            <pre>{typeof selectedEntry.responseBody === "string" ? selectedEntry.responseBody : JSON.stringify(selectedEntry.responseBody, null, 2)}</pre>
+          </div>
+        {/if}
+      </div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .container { font-family: var(--apifn-font-sans); color: var(--apifn-text); font-size: 13px; }
+  .header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--apifn-border); }
+  .title { font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .06em; color: var(--apifn-text-muted); }
+  .clear-btn { background: none; border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 3px 10px; color: var(--apifn-text-muted); font-size: 12px; cursor: pointer; }
+  .empty { padding: 32px; text-align: center; color: var(--apifn-text-muted); }
+  .entry { display: flex; align-items: center; gap: 10px; padding: 10px 16px; border-bottom: 1px solid var(--apifn-border); cursor: pointer; transition: background .1s; }
+  .entry:hover, .entry.active { background: var(--apifn-bg-surface-hover); }
+  .method-tag { font-size: 11px; font-weight: 700; padding: 1px 6px; border-radius: 3px; font-family: var(--apifn-font-mono); min-width: 46px; text-align: center; }
+  .url { flex: 1; font-family: var(--apifn-font-mono); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .status { font-size: 12px; font-weight: 700; }
+  .duration { font-size: 11px; color: var(--apifn-text-muted); min-width: 50px; text-align: right; }
+  .err-icon { color: var(--apifn-red); font-size: 12px; }
+  .detail { padding: 16px; background: var(--apifn-bg-surface); border-bottom: 1px solid var(--apifn-border); }
+  .timestamp { font-size: 12px; color: var(--apifn-text-muted); margin-bottom: 8px; }
+  .error { color: var(--apifn-red); margin-bottom: 8px; }
+  .detail-section { margin-bottom: 8px; }
+  .detail-label { font-size: 11px; font-weight: 700; color: var(--apifn-text-muted); margin-bottom: 4px; }
+  pre { font-family: var(--apifn-font-mono); font-size: 12px; white-space: pre-wrap; word-break: break-all; color: var(--apifn-text); margin: 0; }
+</style>

--- a/apifn/svelte/src/ResponseDiff.svelte
+++ b/apifn/svelte/src/ResponseDiff.svelte
@@ -1,0 +1,92 @@
+<!-- ResponseDiff.svelte — side-by-side response comparison (UI-S-006) -->
+<script lang="ts">
+  export interface TryItResponse {
+    statusCode: number; statusText: string;
+    headers: Record<string, string>; body: unknown; durationMs: number;
+  }
+  export let left: TryItResponse;
+  export let right: TryItResponse;
+  export let leftLabel: string = "Before";
+  export let rightLabel: string = "After";
+
+  function bodyStr(b: unknown): string {
+    return typeof b === "string" ? b : JSON.stringify(b, null, 2);
+  }
+
+  function diffLines(a: string, b: string): { left: { kind: string; text: string }[]; right: { kind: string; text: string }[] } {
+    const al = a.split("\n");
+    const bl = b.split("\n");
+    const leftDiff: { kind: string; text: string }[] = [];
+    const rightDiff: { kind: string; text: string }[] = [];
+    const max = Math.max(al.length, bl.length);
+    for (let i = 0; i < max; i++) {
+      const a = al[i] ?? "";
+      const b = bl[i] ?? "";
+      if (a === b) { leftDiff.push({ kind: "same", text: a }); rightDiff.push({ kind: "same", text: b }); }
+      else { leftDiff.push({ kind: "removed", text: a }); rightDiff.push({ kind: "added", text: b }); }
+    }
+    return { left: leftDiff, right: rightDiff };
+  }
+
+  $: diff = diffLines(bodyStr(left.body), bodyStr(right.body));
+
+  function statusColor(code: number): string {
+    if (code >= 200 && code < 300) return "var(--apifn-green)";
+    if (code >= 400) return "var(--apifn-red)";
+    return "var(--apifn-yellow)";
+  }
+
+  function lineStyle(kind: string): string {
+    if (kind === "added") return "background:#065f4615;color:var(--apifn-green)";
+    if (kind === "removed") return "background:#7f1d1d15;color:var(--apifn-red)";
+    return "";
+  }
+</script>
+
+<div class="container">
+  <div class="header">
+    <div class="col-header">{leftLabel}</div>
+    <div class="divider"></div>
+    <div class="col-header">{rightLabel}</div>
+  </div>
+
+  <!-- Summary -->
+  <div class="summary">
+    <span>
+      Status:
+      <span style="color:{statusColor(left.statusCode)};font-weight:700">{left.statusCode}</span>
+      →
+      <span style="color:{statusColor(right.statusCode)};font-weight:700">{right.statusCode}</span>
+    </span>
+    <span>
+      Duration:
+      <span class="mono">{left.durationMs}ms</span>
+      →
+      <span class="mono" style="color:{right.durationMs > left.durationMs ? 'var(--apifn-red)' : 'var(--apifn-green)'}">{right.durationMs}ms</span>
+    </span>
+  </div>
+
+  <!-- Side-by-side diff -->
+  <div class="cols">
+    <div class="col">
+      <pre>{#each diff.left as line}<span style={lineStyle(line.kind)}>{line.text + "\n"}</span>{/each}</pre>
+    </div>
+    <div class="separator"></div>
+    <div class="col">
+      <pre>{#each diff.right as line}<span style={lineStyle(line.kind)}>{line.text + "\n"}</span>{/each}</pre>
+    </div>
+  </div>
+</div>
+
+<style>
+  .container { font-family: var(--apifn-font-sans); color: var(--apifn-text); }
+  .header { display: flex; border-bottom: 1px solid var(--apifn-border); }
+  .col-header { flex: 1; padding: 10px 16px; font-weight: 700; font-size: 13px; color: var(--apifn-text-muted); }
+  .divider, .separator { width: 1px; background: var(--apifn-border); }
+  .summary { display: flex; gap: 24px; padding: 12px 16px; background: var(--apifn-bg-surface); border-bottom: 1px solid var(--apifn-border); font-size: 13px; }
+  .mono { font-family: var(--apifn-font-mono); }
+  .cols { display: flex; gap: 0; background: var(--apifn-border); }
+  .col { flex: 1; background: var(--apifn-bg); padding: 16px; overflow: auto; max-height: 400px; }
+  pre { font-family: var(--apifn-font-mono); font-size: 12px; white-space: pre-wrap; word-break: break-all; color: var(--apifn-text); margin: 0; }
+  span { display: block; padding: 0 2px; }
+</style>

--- a/apifn/svelte/src/SchemaViewer.svelte
+++ b/apifn/svelte/src/SchemaViewer.svelte
@@ -1,0 +1,139 @@
+<!-- SchemaViewer.svelte — renders a JSON Schema as a collapsible tree (UI-S-003) -->
+<script lang="ts">
+  import type { SchemaObject } from "@apifn/core";
+  import SchemaViewer from "./SchemaViewer.svelte";
+
+  export let schema: SchemaObject;
+  export let name: string | undefined = undefined;
+  export let required: boolean = false;
+  export let expandDepth: number = 2;
+  export let depth: number = 0;
+
+  const schemaType = schema.type as string | string[] | undefined;
+  const primaryType: string = Array.isArray(schemaType)
+    ? (schemaType[0] ?? "object")
+    : schemaType ?? "object";
+
+  const hasChildren =
+    primaryType === "object" &&
+    typeof schema.properties === "object" &&
+    schema.properties !== null;
+  const isArray = primaryType === "array";
+  const itemSchema = schema.items as SchemaObject | undefined;
+
+  let expanded = depth < expandDepth;
+
+  function typeColor(type: string): string {
+    const map: Record<string, string> = {
+      string: "var(--apifn-green)",
+      integer: "var(--apifn-blue)",
+      number: "var(--apifn-blue)",
+      boolean: "var(--apifn-yellow)",
+      array: "var(--apifn-purple)",
+    };
+    return map[type] ?? "var(--apifn-text-muted)";
+  }
+
+  function typeBg(type: string): string {
+    const map: Record<string, string> = {
+      string: "#065f4622",
+      integer: "#1e3a5f22",
+      number: "#1e3a5f22",
+      boolean: "#78350f22",
+      array: "#5b21b622",
+    };
+    return map[type] ?? "#2d3748";
+  }
+
+  $: requiredFields = (schema.required ?? []) as string[];
+  $: properties = hasChildren
+    ? Object.entries(schema.properties as Record<string, unknown>)
+    : [];
+</script>
+
+<div class="schema-node">
+  <!-- Row -->
+  <div
+    class="schema-row"
+    role="button"
+    tabindex="0"
+    on:click={() => hasChildren && (expanded = !expanded)}
+    on:keydown={(e) => e.key === "Enter" && hasChildren && (expanded = !expanded)}
+  >
+    <span class="toggle">{hasChildren ? (expanded ? "▾" : "▸") : " "}</span>
+    {#if name}<span class="prop-name">{name}</span>{/if}
+    {#if required}<span class="required">required</span>{/if}
+    <span
+      class="type-badge"
+      style="color:{typeColor(primaryType)};background:{typeBg(primaryType)};border:1px solid {typeColor(primaryType)}44"
+    >{primaryType}</span>
+    {#if isArray && itemSchema}
+      <span class="type-badge" style="opacity:0.6;color:var(--apifn-text-muted);background:#2d3748">
+        of {(itemSchema.type as string) ?? "object"}
+      </span>
+    {/if}
+    {#if typeof schema.description === "string"}
+      <span class="description">{schema.description}</span>
+    {/if}
+    {#if Array.isArray(schema.enum)}
+      <span class="description">enum: {(schema.enum as unknown[]).map(String).join(" | ")}</span>
+    {/if}
+  </div>
+
+  <!-- Object properties -->
+  {#if hasChildren && expanded}
+    <div class="children">
+      {#each properties as [propName, propSchema]}
+        <svelte:self
+          schema={propSchema}
+          name={propName}
+          required={requiredFields.includes(propName)}
+          {expandDepth}
+          depth={depth + 1}
+        />
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Array items -->
+  {#if isArray && itemSchema && expanded && typeof itemSchema.properties === "object" && itemSchema.properties !== null}
+    <div class="children">
+      <svelte:self schema={itemSchema} name="items" {expandDepth} depth={depth + 1} />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .schema-node {
+    font-family: var(--apifn-font-mono, monospace);
+    font-size: 13px;
+    line-height: 1.6;
+  }
+  .schema-row {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 2px 0;
+    cursor: pointer;
+  }
+  .toggle {
+    color: var(--apifn-text-muted);
+    user-select: none;
+    width: 14px;
+    flex-shrink: 0;
+  }
+  .prop-name { color: var(--apifn-accent); font-weight: 600; }
+  .required { color: var(--apifn-red); font-size: 11px; font-weight: 700; }
+  .type-badge {
+    font-size: 11px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    opacity: 0.9;
+  }
+  .description { color: var(--apifn-text-muted); font-size: 12px; }
+  .children {
+    border-left: 1px solid var(--apifn-border);
+    margin-left: 8px;
+    padding-left: 12px;
+  }
+</style>

--- a/apifn/svelte/src/TryIt.svelte
+++ b/apifn/svelte/src/TryIt.svelte
@@ -1,0 +1,180 @@
+<!-- TryIt.svelte — interactive request builder and sender (UI-S-004) -->
+<script lang="ts">
+  import type { OperationObject } from "@apifn/core";
+
+  export let path: string;
+  export let method: string;
+  export let operation: OperationObject;
+  export let baseUrl: string = "https://api.example.com";
+
+  // Dispatch
+  import { createEventDispatcher } from "svelte";
+  const dispatch = createEventDispatcher<{ response: { statusCode: number; statusText: string; headers: Record<string, string>; body: unknown; durationMs: number } }>();
+
+  const METHOD_COLORS: Record<string, { bg: string; text: string }> = {
+    get: { bg: "#065f46", text: "#6ee7b7" }, post: { bg: "#1e3a5f", text: "#93c5fd" },
+    put: { bg: "#78350f", text: "#fcd34d" }, patch: { bg: "#5b21b6", text: "#c4b5fd" },
+    delete: { bg: "#7f1d1d", text: "#fca5a5" },
+  };
+  $: mc = METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
+
+  $: params = (operation.parameters ?? []) as Array<{ name: string; in: string; required?: boolean }>;
+  $: pathParams = params.filter((p) => p.in === "path");
+  $: queryParams = params.filter((p) => p.in === "query");
+
+  let pathValues: Record<string, string> = {};
+  let queryValues: Record<string, string> = {};
+  let body = "";
+  let authType: "none" | "bearer" | "apikey" | "basic" = "none";
+  let authToken = "";
+  let authKey = "";
+  let authUser = "";
+  let authPass = "";
+  let loading = false;
+  let errorMsg: string | null = null;
+  let response: { statusCode: number; statusText: string; headers: Record<string, string>; body: unknown; durationMs: number } | null = null;
+
+  $: resolvedPath = path.replace(/\{([^}]+)\}/g, (_, n: string) => pathValues[n] ?? `{${n}}`);
+  $: queryString = Object.entries(queryValues).filter(([, v]) => v).map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`).join("&");
+  $: url = `${baseUrl.replace(/\/$/, "")}${resolvedPath}${queryString ? "?" + queryString : ""}`;
+
+  function statusColor(code: number): string {
+    if (code >= 200 && code < 300) return "var(--apifn-green)";
+    if (code >= 400) return "var(--apifn-red)";
+    return "var(--apifn-yellow)";
+  }
+
+  async function sendRequest() {
+    loading = true;
+    errorMsg = null;
+    const start = Date.now();
+    try {
+      const headers: Record<string, string> = {};
+      if (authType === "bearer" && authToken) headers["Authorization"] = `Bearer ${authToken}`;
+      if (authType === "apikey" && authKey) headers["X-API-Key"] = authKey;
+      if (authType === "basic" && authUser) headers["Authorization"] = `Basic ${btoa(`${authUser}:${authPass}`)}`;
+      let bodyArg: string | undefined;
+      if (body.trim()) { headers["Content-Type"] = "application/json"; bodyArg = body; }
+      const res = await fetch(url, { method: method.toUpperCase(), headers, body: bodyArg });
+      const durationMs = Date.now() - start;
+      const resHeaders: Record<string, string> = {};
+      res.headers.forEach((v, k) => { resHeaders[k] = v; });
+      const ct = res.headers.get("content-type") ?? "";
+      const resBody = ct.includes("application/json") ? await res.json() : await res.text();
+      response = { statusCode: res.status, statusText: res.statusText, headers: resHeaders, body: resBody, durationMs };
+      dispatch("response", response);
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="container">
+  <!-- URL Bar -->
+  <div class="row">
+    <span class="method-badge" style="background:{mc.bg};color:{mc.text}">{method.toUpperCase()}</span>
+    <input class="url-input" readonly value={url} />
+    <button class="send-btn" on:click={sendRequest} disabled={loading}>
+      {loading ? "Sending…" : "Send"}
+    </button>
+  </div>
+
+  <!-- Path Params -->
+  {#if pathParams.length > 0}
+    <div class="section">
+      <label class="label">Path Parameters</label>
+      {#each pathParams as p}
+        <div class="param-row">
+          <span class="param-name">{p.name}</span>
+          <input class="field" placeholder={`{${p.name}}`} bind:value={pathValues[p.name]} />
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Query Params -->
+  {#if queryParams.length > 0}
+    <div class="section">
+      <label class="label">Query Parameters</label>
+      {#each queryParams as p}
+        <div class="param-row">
+          <span class="param-name">{p.name}</span>
+          <input class="field" placeholder={p.name} bind:value={queryValues[p.name]} />
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Auth -->
+  <div class="section">
+    <label class="label">Auth</label>
+    <div class="row">
+      <select class="select" bind:value={authType}>
+        <option value="none">None</option>
+        <option value="bearer">Bearer Token</option>
+        <option value="apikey">API Key</option>
+        <option value="basic">Basic Auth</option>
+      </select>
+      {#if authType === "bearer"}
+        <input class="field" placeholder="Bearer token" bind:value={authToken} />
+      {:else if authType === "apikey"}
+        <input class="field" placeholder="API key" bind:value={authKey} />
+      {:else if authType === "basic"}
+        <input class="field" placeholder="Username" bind:value={authUser} style="width:140px;flex:none" />
+        <input class="field" type="password" placeholder="Password" bind:value={authPass} style="width:140px;flex:none" />
+      {/if}
+    </div>
+  </div>
+
+  <!-- Body -->
+  {#if ["post","put","patch"].includes(method.toLowerCase())}
+    <div class="section">
+      <label class="label">Request Body</label>
+      <textarea class="textarea" bind:value={body} placeholder="{}" spellcheck="false" />
+    </div>
+  {/if}
+
+  <!-- Error -->
+  {#if errorMsg}
+    <div class="error">{errorMsg}</div>
+  {/if}
+
+  <!-- Response -->
+  {#if response}
+    <div class="response-box">
+      <div class="status-line" style="color:{statusColor(response.statusCode)}">
+        {response.statusCode} {response.statusText}
+        <span class="duration">{response.durationMs}ms</span>
+      </div>
+      <details>
+        <summary>Response Headers ({Object.keys(response.headers).length})</summary>
+        <pre>{Object.entries(response.headers).map(([k,v]) => `${k}: ${v}`).join("\n")}</pre>
+      </details>
+      <pre>{typeof response.body === "string" ? response.body : JSON.stringify(response.body, null, 2)}</pre>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .container { padding: 20px; font-family: var(--apifn-font-sans); color: var(--apifn-text); }
+  .row { display: flex; gap: 8px; align-items: center; margin-bottom: 16px; }
+  .method-badge { padding: 6px 12px; border-radius: 4px; font-weight: 700; font-size: 13px; font-family: var(--apifn-font-mono); flex-shrink: 0; }
+  .url-input { flex: 1; background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 8px 12px; color: var(--apifn-text); font-family: var(--apifn-font-mono); font-size: 13px; outline: none; }
+  .send-btn { padding: 8px 20px; background: var(--apifn-accent); color: #fff; border: none; border-radius: var(--apifn-radius); font-size: 14px; font-weight: 600; cursor: pointer; flex-shrink: 0; }
+  .send-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+  .label { display: block; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; color: var(--apifn-text-muted); margin-bottom: 6px; }
+  .section { margin-bottom: 16px; }
+  .param-row { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+  .param-name { width: 120px; font-family: var(--apifn-font-mono); font-size: 13px; color: var(--apifn-accent-text); }
+  .field { flex: 1; background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 8px 12px; color: var(--apifn-text); font-family: var(--apifn-font-mono); font-size: 13px; outline: none; }
+  .select { background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 6px 10px; color: var(--apifn-text); font-size: 13px; outline: none; cursor: pointer; }
+  .textarea { width: 100%; background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 10px 12px; color: var(--apifn-text); font-family: var(--apifn-font-mono); font-size: 13px; resize: vertical; outline: none; min-height: 100px; box-sizing: border-box; }
+  .error { background: #7f1d1d22; border: 1px solid #7f1d1d; border-radius: var(--apifn-radius); padding: 10px 14px; color: var(--apifn-red); font-size: 13px; margin-bottom: 12px; }
+  .response-box { background: var(--apifn-bg-surface); border: 1px solid var(--apifn-border); border-radius: var(--apifn-radius); padding: 16px; margin-top: 16px; }
+  .status-line { font-weight: 700; font-size: 16px; margin-bottom: 8px; }
+  .duration { font-size: 13px; font-weight: 400; color: var(--apifn-text-muted); margin-left: 12px; }
+  details summary { cursor: pointer; color: var(--apifn-text-muted); font-size: 12px; margin-bottom: 4px; }
+  pre { font-family: var(--apifn-font-mono); font-size: 12px; white-space: pre-wrap; word-break: break-all; color: var(--apifn-text); margin: 0; }
+</style>

--- a/apifn/svelte/src/index.ts
+++ b/apifn/svelte/src/index.ts
@@ -1,0 +1,88 @@
+/**
+ * @apifn/svelte — public API
+ *
+ * Svelte components are shipped as source (.svelte files) and must be
+ * processed by the consuming app's Svelte compiler.
+ * This index.ts provides types for TypeScript consumers.
+ */
+
+// Re-export types from @apifn/core for convenience
+export type { OpenAPIDocument, OperationObject, SchemaObject } from "@apifn/core";
+
+// Component prop types (manually mirrored from .svelte files for DTS consumers)
+export interface ApiExplorerProps {
+    spec: import("@apifn/core").OpenAPIDocument;
+    baseUrl?: string;
+    theme?: "light" | "dark" | "auto";
+    showHistory?: boolean;
+}
+
+export interface EndpointViewerProps {
+    path: string;
+    method: string;
+    operation: import("@apifn/core").OperationObject;
+}
+
+export interface SchemaViewerProps {
+    schema: import("@apifn/core").SchemaObject;
+    name?: string;
+    required?: boolean;
+    expandDepth?: number;
+    depth?: number;
+}
+
+export interface TryItProps {
+    path: string;
+    method: string;
+    operation: import("@apifn/core").OperationObject;
+    baseUrl?: string;
+}
+
+export interface HistoryEntry {
+    id: string;
+    timestamp: number;
+    method: string;
+    url: string;
+    statusCode?: number;
+    duration?: number;
+    requestBody?: unknown;
+    responseBody?: unknown;
+    responseHeaders?: Record<string, string>;
+    error?: string;
+}
+
+export interface RequestHistoryProps {
+    entries: HistoryEntry[];
+    maxEntries?: number;
+}
+
+export interface TryItResponse {
+    statusCode: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: unknown;
+    durationMs: number;
+}
+
+export interface ResponseDiffProps {
+    left: TryItResponse;
+    right: TryItResponse;
+    leftLabel?: string;
+    rightLabel?: string;
+}
+
+export interface PerformanceMetrics {
+    endpoint: string;
+    method: string;
+    p50Ms: number;
+    p95Ms: number;
+    p99Ms: number;
+    errorRatePct: number;
+    requestsPerMinute: number;
+    lastUpdated: string;
+}
+
+export interface PerformanceOverlayProps {
+    metrics: PerformanceMetrics;
+    compact?: boolean;
+}

--- a/apifn/svelte/tsconfig.json
+++ b/apifn/svelte/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apifn/svelte/tsup.config.ts
+++ b/apifn/svelte/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "authfn/adapters/*",
         "authfn/examples/*",
         "authfn/examples/*/*",
+        "apifn/*",
         "extfn/*",
         "extfn/examples/*",
         "datafn/client",
@@ -47,12 +48,1109 @@
         "node": ">=18.0.0"
       }
     },
+    "apifn/cli": {
+      "name": "@apifn/cli",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@apifn/collections": "0.0.1",
+        "@apifn/core": "0.0.1",
+        "@apifn/mock": "0.0.1",
+        "@apifn/snippets": "0.0.2",
+        "cac": "^6.7.14",
+        "jiti": "^2.4.2",
+        "picocolors": "^1.1.1",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "apifn": "dist/bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^1.0.0"
+      }
+    },
+    "apifn/cli/node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/cli/node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/cli/node_modules/@vitest/ui": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-1.6.1.tgz",
+      "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "fast-glob": "^3.3.2",
+        "fflate": "^0.8.1",
+        "flatted": "^3.2.9",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
+    },
+    "apifn/cli/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "apifn/cli/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apifn/cli/node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "apifn/collections": {
+      "name": "@apifn/collections",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@apifn/core": "0.0.1",
+        "dotenv": "^16.6.1",
+        "glob": "^11.0.3",
+        "yaml": "^2.8.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^1.0.0"
+      }
+    },
+    "apifn/collections/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apifn/collections/node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/collections/node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/collections/node_modules/@vitest/ui": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-1.6.1.tgz",
+      "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "fast-glob": "^3.3.2",
+        "fflate": "^0.8.1",
+        "flatted": "^3.2.9",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
+    },
+    "apifn/collections/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "apifn/collections/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "apifn/collections/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apifn/collections/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apifn/collections/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "apifn/collections/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apifn/collections/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "apifn/collections/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "apifn/collections/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apifn/collections/node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "apifn/core": {
+      "name": "@apifn/core",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
+        "@testfn/core": "0.0.2",
+        "yaml": "^2.8.1",
+        "zod": "^3.25.28",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "devDependencies": {
+        "@sinclair/typebox": "^0.34.41",
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "@sinclair/typebox": "*",
+        "@superfunctions/http": "0.1.3"
+      },
+      "peerDependenciesMeta": {
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@superfunctions/http": {
+          "optional": false
+        }
+      }
+    },
+    "apifn/core/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apifn/docsfn": {
+      "name": "@apifn/docsfn",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@apifn/core": "0.0.1",
+        "@apifn/react": "0.0.1",
+        "@apifn/svelte": "0.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^1.6.0"
+      },
+      "peerDependencies": {
+        "docsfn": "*"
+      },
+      "peerDependenciesMeta": {
+        "docsfn": {
+          "optional": true
+        }
+      }
+    },
+    "apifn/docsfn/node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/docsfn/node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/docsfn/node_modules/@vitest/ui": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-1.6.1.tgz",
+      "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "fast-glob": "^3.3.2",
+        "fflate": "^0.8.1",
+        "flatted": "^3.2.9",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
+    },
+    "apifn/docsfn/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "apifn/docsfn/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apifn/docsfn/node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "apifn/mock": {
+      "name": "@apifn/mock",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@apifn/core": "0.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^1.0.0"
+      }
+    },
+    "apifn/mock/node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/mock/node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/mock/node_modules/@vitest/ui": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-1.6.1.tgz",
+      "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "fast-glob": "^3.3.2",
+        "fflate": "^0.8.1",
+        "flatted": "^3.2.9",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
+    },
+    "apifn/mock/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "apifn/mock/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apifn/mock/node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "apifn/react": {
+      "name": "@apifn/react",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@apifn/core": "0.0.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "apifn/react/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "apifn/react/node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "apifn/snippets": {
+      "name": "@apifn/snippets",
+      "version": "0.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@apifn/core": "0.0.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0",
+        "vitest": "^1.0.0"
+      }
+    },
+    "apifn/snippets/node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/snippets/node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apifn/snippets/node_modules/@vitest/ui": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-1.6.1.tgz",
+      "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "fast-glob": "^3.3.2",
+        "fflate": "^0.8.1",
+        "flatted": "^3.2.9",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "1.6.1"
+      }
+    },
+    "apifn/snippets/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "apifn/snippets/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apifn/snippets/node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "apifn/svelte": {
+      "name": "@apifn/svelte",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@apifn/core": "0.0.1"
+      },
+      "devDependencies": {
+        "svelte": "^4.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.3.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "apifn/svelte/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "apifn/svelte/node_modules/svelte": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
+      "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^4.0.0",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "authfn/adapters/lookup-cloudflare-do": {
       "name": "@authfn/lookup-cloudflare-do",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@authfn/core": "^0.1.0"
+        "@authfn/core": "0.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -75,7 +1173,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@authfn/core": "^0.1.0",
+        "@authfn/core": "0.1.0",
         "@aws-sdk/client-dynamodb": "^3.800.0",
         "@aws-sdk/lib-dynamodb": "^3.800.0"
       },
@@ -100,9 +1198,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@authfn/core": "^0.1.0",
-        "@superfunctions/db": "^0.1.3",
-        "@superfunctions/http": "*"
+        "@authfn/core": "0.1.0",
+        "@superfunctions/db": "0.1.4",
+        "@superfunctions/http": "0.1.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -7047,16 +8145,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "hostfn/node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "hostfn/node_modules/clone": {
       "version": "1.0.4",
       "license": "MIT",
@@ -7349,16 +8437,6 @@
     "hostfn/node_modules/inquirer/node_modules/signal-exit": {
       "version": "3.0.7",
       "license": "ISC"
-    },
-    "hostfn/node_modules/is-interactive": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "hostfn/node_modules/is-unicode-supported": {
       "version": "1.3.0",
@@ -7888,6 +8966,122 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@apifn/cli": {
+      "resolved": "apifn/cli",
+      "link": true
+    },
+    "node_modules/@apifn/collections": {
+      "resolved": "apifn/collections",
+      "link": true
+    },
+    "node_modules/@apifn/core": {
+      "resolved": "apifn/core",
+      "link": true
+    },
+    "node_modules/@apifn/docsfn": {
+      "resolved": "apifn/docsfn",
+      "link": true
+    },
+    "node_modules/@apifn/mock": {
+      "resolved": "apifn/mock",
+      "link": true
+    },
+    "node_modules/@apifn/react": {
+      "resolved": "apifn/react",
+      "link": true
+    },
+    "node_modules/@apifn/snippets": {
+      "resolved": "apifn/snippets",
+      "link": true
+    },
+    "node_modules/@apifn/svelte": {
+      "resolved": "apifn/svelte",
+      "link": true
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.1.2",
@@ -12097,7 +13291,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -12109,7 +13302,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -12117,7 +13309,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -14082,6 +15273,48 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@testfn/core": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@testfn/core/-/core-0.0.2.tgz",
+      "integrity": "sha512-oBGBaOmuWGJgNh7McYSFV600MO4B9TVdeY3P7Ytuai5RkziNeKCDuF5fk8ud2OasJEMOM1VFigXwmxdT7dndyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "fake-indexeddb": "^6.0.0",
+        "fast-glob": "^3.3.2",
+        "ora": "^8.0.1",
+        "pixelmatch": "^6.0.0",
+        "pngjs": "^7.0.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.40.0",
+        "playwright": ">=1.40.0",
+        "vitest": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testfn/core/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -14133,7 +15366,7 @@
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -14142,7 +15375,7 @@
     },
     "node_modules/@types/chai/node_modules/assertion-error": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14373,7 +15606,7 @@
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
@@ -14439,7 +15672,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -14485,6 +15717,13 @@
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
       }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/pug": {
       "version": "2.0.10",
@@ -14915,7 +16154,7 @@
     },
     "node_modules/@vitest/mocker": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "3.2.4",
@@ -14940,7 +16179,7 @@
     },
     "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^4.0.3"
@@ -14951,7 +16190,7 @@
     },
     "node_modules/@vitest/mocker/node_modules/tinyspy": {
       "version": "4.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -14959,7 +16198,7 @@
     },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -14970,7 +16209,7 @@
     },
     "node_modules/@vitest/runner": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "3.2.4",
@@ -14983,7 +16222,7 @@
     },
     "node_modules/@vitest/runner/node_modules/@vitest/utils": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -14996,17 +16235,17 @@
     },
     "node_modules/@vitest/runner/node_modules/loupe": {
       "version": "3.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitest/runner/node_modules/pathe": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitest/runner/node_modules/strip-literal": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
@@ -15017,7 +16256,7 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -15030,7 +16269,7 @@
     },
     "node_modules/@vitest/snapshot/node_modules/pathe": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitest/spy": {
@@ -15590,7 +16829,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -15709,7 +16947,6 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15739,6 +16976,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -15927,6 +17170,33 @@
       },
       "funding": {
         "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-width": {
@@ -17296,7 +18566,7 @@
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -18169,7 +19439,7 @@
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -18252,7 +19522,6 @@
     },
     "node_modules/fake-indexeddb": {
       "version": "6.2.5",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -18269,7 +19538,6 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -18350,7 +19618,6 @@
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18434,7 +19701,6 @@
     },
     "node_modules/fastq": {
       "version": "1.19.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -18478,7 +19744,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -18860,6 +20125,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "dev": true,
@@ -18967,7 +20244,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -19474,7 +20750,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19489,7 +20764,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -19506,6 +20780,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "dev": true,
@@ -19513,7 +20799,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -19548,6 +20833,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -19675,7 +20972,7 @@
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -20082,6 +21379,46 @@
       "version": "4.1.1",
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "license": "MIT",
@@ -20469,7 +21806,6 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -21158,7 +22494,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -21200,6 +22535,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -21973,6 +23320,13 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -21996,6 +23350,91 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/outvariant": {
@@ -22279,7 +23718,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -22328,6 +23766,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-6.0.0.tgz",
+      "integrity": "sha512-FYpL4XiIWakTnIqLqvt3uN4L9B3TsuHIvhLILzTiJZMJUsGvmKNeL4H3b6I99LRyerK9W4IuOXw+N28AtRgK2g==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
       }
     },
     "node_modules/pkg-types": {
@@ -22389,6 +23839,15 @@
       "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/points-on-curve": {
@@ -22669,7 +24128,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -23057,7 +24515,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23077,6 +24534,37 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ret": {
@@ -23117,7 +24605,6 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -23288,7 +24775,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24049,7 +25535,7 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -24197,7 +25683,7 @@
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stacktracey": {
@@ -24218,8 +25704,20 @@
     },
     "node_modules/std-env": {
       "version": "3.10.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
@@ -24894,12 +26392,12 @@
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -24951,7 +26449,7 @@
     },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -24983,7 +26481,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -26598,7 +28095,7 @@
     },
     "node_modules/vitest": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
@@ -26669,7 +28166,7 @@
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
@@ -26684,7 +28181,7 @@
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyspy": "^4.0.3"
@@ -26695,7 +28192,7 @@
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
@@ -26708,7 +28205,7 @@
     },
     "node_modules/vitest/node_modules/assertion-error": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -26716,7 +28213,7 @@
     },
     "node_modules/vitest/node_modules/chai": {
       "version": "5.3.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -26731,7 +28228,7 @@
     },
     "node_modules/vitest/node_modules/check-error": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -26739,7 +28236,7 @@
     },
     "node_modules/vitest/node_modules/deep-eql": {
       "version": "5.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -26747,17 +28244,17 @@
     },
     "node_modules/vitest/node_modules/loupe": {
       "version": "3.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vitest/node_modules/pathe": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vitest/node_modules/pathval": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
@@ -26765,7 +28262,7 @@
     },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -26776,7 +28273,7 @@
     },
     "node_modules/vitest/node_modules/tinypool": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -26784,7 +28281,7 @@
     },
     "node_modules/vitest/node_modules/tinyspy": {
       "version": "4.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -26792,7 +28289,7 @@
     },
     "node_modules/vitest/node_modules/vite-node": {
       "version": "3.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -26908,7 +28405,7 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
@@ -27646,8 +29143,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -27749,6 +29244,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {
@@ -28593,7 +30097,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@searchfn/adapter-contracts": "file:../adapter-contracts"
+        "@searchfn/adapter-contracts": "0.3.0"
       },
       "devDependencies": {
         "@types/node": "^24.9.1",
@@ -28623,7 +30127,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@searchfn/adapter-contracts": "file:../adapter-contracts"
+        "@searchfn/adapter-contracts": "0.3.0"
       },
       "devDependencies": {
         "@types/node": "^24.9.1",
@@ -28652,8 +30156,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@searchfn/adapter-contracts": "file:../adapter-contracts",
-        "@searchfn/adapter-elasticsearch": "file:../adapter-elasticsearch"
+        "@searchfn/adapter-contracts": "0.3.0",
+        "@searchfn/adapter-elasticsearch": "0.1.0"
       },
       "devDependencies": {
         "@types/node": "^24.9.1",
@@ -28667,7 +30171,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@searchfn/adapter-contracts": "file:../adapter-contracts",
+        "@searchfn/adapter-contracts": "0.3.0",
         "pg": "^8.17.2"
       },
       "devDependencies": {
@@ -28730,7 +30234,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@searchfn/core": "file:../core"
+        "@searchfn/core": "0.3.0"
       },
       "devDependencies": {
         "@types/node": "^24.9.1",
@@ -30035,11 +31539,11 @@
       "name": "@searchfn/server",
       "version": "0.1.0",
       "dependencies": {
-        "@searchfn/adapter-contracts": "^0.3.0",
-        "@superfunctions/http": "^0.1.2"
+        "@searchfn/adapter-contracts": "0.3.0",
+        "@superfunctions/http": "0.1.3"
       },
       "devDependencies": {
-        "@searchfn/adapter-memory": "^0.1.0",
+        "@searchfn/adapter-memory": "0.1.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
         "vitest": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "authfn/adapters/*",
     "authfn/examples/*",
     "authfn/examples/*/*",
+    "apifn/*",
     "extfn/*",
     "extfn/examples/*",
     "datafn/client",


### PR DESCRIPTION
## Summary
- Add ApiFn as a new function family with TypeScript packages for core OpenAPI/diff utilities, collection runner, mock server, snippets, CLI, React, Svelte, and docsfn integration.
- Add the Python ApiFn SDK with FastAPI/Flask/OpenAPI/diff/collection helpers and tests.
- Add ApiFn CI workflow/example docs, root `apifn/*` workspace wiring, and the corresponding root npm lockfile entries.

## Notes
- Excluded `apifn/.conduct` artifacts because this PR targets `origin/dev`.
- Did not stage generated build outputs, node_modules, Python virtualenv/cache, or egg-info artifacts.

## Verification
- `npm install --ignore-scripts`
- `npm --workspace @superfunctions/http run build`
- `npm --workspace @apifn/core run build`
- `npm --workspace @apifn/snippets run build`
- `npm --workspace @apifn/collections run build`
- `npm --workspace @apifn/mock run build`
- `npm --workspace @apifn/react run build`
- `npm --workspace @apifn/svelte run build`
- `npm --workspace @apifn/docsfn run build`
- `npm --workspace @apifn/cli run build`
- `npm --workspace @apifn/core test`
- `npm --workspace @apifn/collections test`
- `npm --workspace @apifn/snippets test`
- `npm --workspace @apifn/mock test`
- `npm --workspace @apifn/docsfn test`
- `npm --workspace @apifn/cli test`
- `uv run --python /Users/serro/.local/bin/python3.10 --with-editable . --with pytest --with fastapi --with flask --with pydantic --with pyyaml --with httpx pytest tests` from `apifn/python`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps ApiFn: a code-first toolkit for OpenAPI generation, diffing, and collection testing. Implements SF-34 by adding the `apifn` CLI, core libs, collections runner, and a reusable CI workflow to validate, diff, and test APIs in PRs. Fixes `zod` dependency in `@apifn/core`.

- **New Features**
  - `@apifn/core`: OpenAPI parse/generate/validate; deterministic diff (text/JSON, breaking status); `fromRouter` and router introspection; schema conversion (`zod`, TypeBox); integrations with `authfn`/`logfn`/`secfn`/`watchfn`/`testfn`; fixes `zod` dependency.
  - `@apifn/collections`: OpenCollection read/write; environments and `.env`; variable interpolation; fetch HTTP client (cookies, redirects); runner; reporters (`console`, `json`, `junit`, `silent`); script sandbox and assertions; generators from OpenAPI or router.
  - `@apifn/cli`: `validate`, `diff` (text/JSON, fail-on-breaking), `test` (reporters, JUnit XML, exit codes), `import`/`export`, `generate` (from router), `init`, `serve` (hot-reload explorer), `mock` (schema/examples/random, request validation, CORS), `snippet` (single/all, target). Config via `apifn.config.ts` (`openapi`, `router`, `collection`, `output`, `defaultEnvironment`, `diff`, `snippets`, `watchfn`).

- **CI**
  - Reusable workflow `apifn/.github/workflows/api-check.yml`: runs `validate`, `diff` (against base branch), and `test`; uploads JSON artifacts (`validate-report.json`, `diff-report.json`, `test-report.json`); optional PR comment.
  - Inputs: `spec_path`, `collection_dir`, `environment`, `base_branch`, `fail_on_breaking`, `post_pr_comment`. Non-zero exits on validation errors, breaking diffs (configurable), and test failures.

<sup>Written for commit 375ae33ed5a7668560798a1cc511d0b2c80d00c4. Summary will update on new commits. <a href="https://cubic.dev/pr/21nCo/super-functions/pull/97?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

