### PR TITLE
authfn and filefn - markdown links not working fix

### DIFF
--- a/authfn/docs/content/docs/core-concepts/sessions.md
+++ b/authfn/docs/content/docs/core-concepts/sessions.md
@@ -100,7 +100,7 @@ In bearer mode, the kernel:
 - Reads the bearer token from `Authorization: Bearer <token>`.
 - Skips the CSRF check (bearer tokens are not subject to browser-driven CSRF; the trade-off is that the client must protect token storage itself).
 
-The Swift SDK uses bearer mode by default. See [SDKs → Client → Token mode](../sdk/client/token-mode) and [SDKs → Swift](../sdk/swift).
+The Swift SDK uses bearer mode by default. See [SDKs → Client → Token mode](../sdk/client#bearer-mode) and [SDKs → Swift](../sdk/swift).
 
 ## Rotation
 

--- a/authfn/docs/content/docs/getting-started.md
+++ b/authfn/docs/content/docs/getting-started.md
@@ -167,7 +167,7 @@ console.log(`User has ${sessions.sessions.length} active sessions`);
 await client.signOut();
 ```
 
-By default the client uses cookie credentials (`credentials: "include"` plus CSRF double-submit on mutating routes). For mobile or CLI clients that can't store cookies, use bearer-token mode — see [SDKs → Client → Token mode](./sdk/client/token-mode).
+By default the client uses cookie credentials (`credentials: "include"` plus CSRF double-submit on mutating routes). For mobile or CLI clients that can't store cookies, use bearer-token mode — see [SDKs → Client → Token mode](./sdk/client#bearer-mode).
 
 ## 5. Add the plugins you actually need
 

--- a/authfn/docs/content/docs/quickstart/bun.md
+++ b/authfn/docs/content/docs/quickstart/bun.md
@@ -88,6 +88,6 @@ The same pattern works on Cloudflare Workers (or any Workers-compatible runtime)
 
 ## Next steps
 
-- [SDKs → Client → Token mode](../sdk/client/token-mode) for non-cookie clients (CLI, mobile, server-to-server).
+- [SDKs → Client → Token mode](../sdk/client#bearer-mode) for non-cookie clients (CLI, mobile, server-to-server).
 - [Adapters → Database](../adapters/database) — Bun-friendly Postgres and SQLite adapters.
 - [Frameworks → Bun](../frameworks/bun) for a deeper integration pattern.

--- a/authfn/docs/content/docs/sdk/client.md
+++ b/authfn/docs/content/docs/sdk/client.md
@@ -230,12 +230,6 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 await withRetry(() => client.sendOtp({ email, purpose: 'sign-in' }));
 ```
 
-## Token mode subpages
-
-For deep dives:
-
-- [Bearer-token mode](./client/token-mode) — how to safely store and rotate bearer tokens, integrate with native credential stores, and handle session augmentation.
-
 ## Related
 
 - [Concepts → Sessions](../core-concepts/sessions) — what the cookie / bearer carries.

--- a/authfn/docs/package.json
+++ b/authfn/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@21n/fonts": "^1.0.1",
-    "@docsfn/core": "0.0.4",
+    "@docsfn/core": "0.0.5",
     "@docsfn/provider-fs": "0.0.2",
     "@docsfn/svelte": "0.0.3",
     "@docsfn/sveltekit": "0.0.2"

--- a/authfn/docs/src/routes/blog/[slug]/+page.server.ts
+++ b/authfn/docs/src/routes/blog/[slug]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error } from "@sveltejs/kit";
+import { resolveMarkdownRelativeLinks } from "@docsfn/core";
 import { getPostData } from "@docsfn/sveltekit";
 import { getCompiledDocsPost } from "$lib/server/docs-site-source";
 import type { PageServerLoad } from "./$types";
@@ -11,7 +12,11 @@ export const load: PageServerLoad = async ({ params, parent }) => {
     throw error(404, "Post not found");
   }
 
-  const compiled = await getCompiledDocsPost(post.id);
+  const compiled = resolveMarkdownRelativeLinks({
+    compiled: await getCompiledDocsPost(post.id),
+    route: `/blog/${post.slug}`,
+    sourcePath: post.relativePath,
+  });
 
   return {
     post,

--- a/authfn/docs/src/routes/docs/[...slug]/+page.server.ts
+++ b/authfn/docs/src/routes/docs/[...slug]/+page.server.ts
@@ -6,6 +6,7 @@ import {
   resolveDocsRouteDataOrThrow,
   type SvelteDocsPageSurface,
 } from "@docsfn/sveltekit";
+import { resolveMarkdownRelativeLinks } from "@docsfn/core";
 import { getCompiledDocsPage } from "$lib/server/docs-site-source";
 import type { PageServerLoad } from "./$types";
 
@@ -25,6 +26,10 @@ function isRouteNotFoundError(input: unknown): input is { message: string } {
     "code" in input &&
     String((input as { code: unknown }).code) === "DOCS_ROUTE_NOT_FOUND"
   );
+}
+
+function hasNestedDocsRoutes(routes: Record<string, string>, route: string): boolean {
+  return Object.keys(routes).some((candidate) => candidate.startsWith(`${route}/`));
 }
 
 export const load: PageServerLoad = async ({ params, parent }) => {
@@ -94,7 +99,12 @@ export const load: PageServerLoad = async ({ params, parent }) => {
 
   const compiled =
     routeEntry.kind === "page"
-      ? await getCompiledDocsPage(routeEntry.page.id)
+      ? resolveMarkdownRelativeLinks({
+          compiled: await getCompiledDocsPage(routeEntry.page.id),
+          route: routeEntry.route,
+          sourcePath: routeEntry.page.relativePath,
+          isIndexRoute: hasNestedDocsRoutes(source.manifest.routes, routeEntry.route),
+        })
       : undefined;
 
   return {

--- a/authfn/docs/static/llms-full.txt
+++ b/authfn/docs/static/llms-full.txt
@@ -3866,7 +3866,7 @@ In bearer mode, the kernel:
 - Reads the bearer token from `Authorization: Bearer <token>`.
 - Skips the CSRF check (bearer tokens are not subject to browser-driven CSRF; the trade-off is that the client must protect token storage itself).
 
-The Swift SDK uses bearer mode by default. See [SDKs → Client → Token mode](../sdk/client/token-mode) and [SDKs → Swift](../sdk/swift).
+The Swift SDK uses bearer mode by default. See [SDKs → Client → Token mode](../sdk/client#bearer-mode) and [SDKs → Swift](../sdk/swift).
 
 ## Rotation
 
@@ -5197,7 +5197,7 @@ console.log(`User has ${sessions.sessions.length} active sessions`);
 await client.signOut();
 ```
 
-By default the client uses cookie credentials (`credentials: "include"` plus CSRF double-submit on mutating routes). For mobile or CLI clients that can't store cookies, use bearer-token mode — see [SDKs → Client → Token mode](./sdk/client/token-mode).
+By default the client uses cookie credentials (`credentials: "include"` plus CSRF double-submit on mutating routes). For mobile or CLI clients that can't store cookies, use bearer-token mode — see [SDKs → Client → Token mode](./sdk/client#bearer-mode).
 
 ## 5. Add the plugins you actually need
 
@@ -7210,7 +7210,7 @@ The same pattern works on Cloudflare Workers (or any Workers-compatible runtime)
 
 ## Next steps
 
-- [SDKs → Client → Token mode](../sdk/client/token-mode) for non-cookie clients (CLI, mobile, server-to-server).
+- [SDKs → Client → Token mode](../sdk/client#bearer-mode) for non-cookie clients (CLI, mobile, server-to-server).
 - [Adapters → Database](../adapters/database) — Bun-friendly Postgres and SQLite adapters.
 - [Frameworks → Bun](../frameworks/bun) for a deeper integration pattern.
 
@@ -10137,12 +10137,6 @@ async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
 
 await withRetry(() => client.sendOtp({ email, purpose: 'sign-in' }));
 ```
-
-## Token mode subpages
-
-For deep dives:
-
-- [Bearer-token mode](./client/token-mode) — how to safely store and rotate bearer tokens, integrate with native credential stores, and handle session augmentation.
 
 ## Related
 

--- a/datafn/docs/content/docs/index.mdx
+++ b/datafn/docs/content/docs/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: DataFn
 sidebarTitle: Introduction
-description: Self-hosted data sync SDK with offline-first storage, reactive signals, and a declarative query language.
+description: Self-hosted data management platform with offline-first storage, reactive signals, and a declarative query language.
 audience: landing
 applies_to: both
 ---
+DataFn is a full-stack data framework for building modern software applications. It provides a unified approach to defining schemas, querying data, managing mutations, and synchronizing state between client and server. 
 
-DataFn replaces your ORM, your query client, your sync layer, and your realtime stack with one type-safe, offline-first data platform you actually own.
+You define a schema. You get back a server, a client, a sync engine, optimistic UI primitives, multi-tenancy, sharing, search hooks, and a native Apple runtime — all with the same DFQL query shape across every layer. It replaces your ORM, query client, sync layer, and realtime stack with one type-safe, offline-first data platform you actually own.
 
-You define a schema. You get back a database, a server, a client, a sync engine, optimistic UI primitives, multi-tenancy, sharing, search hooks, and a native Apple runtime — all with the same DFQL query shape across every layer.
 
 Pick the entry point that matches what you're doing:
 

--- a/filefn/docs/package.json
+++ b/filefn/docs/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@21n/fonts": "^1.0.1",
-    "@docsfn/core": "0.0.4",
+    "@docsfn/core": "0.0.5",
     "@docsfn/provider-fs": "0.0.2",
     "@docsfn/svelte": "0.0.3",
     "@docsfn/sveltekit": "0.0.2"

--- a/filefn/docs/src/routes/blog/[slug]/+page.server.ts
+++ b/filefn/docs/src/routes/blog/[slug]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error } from "@sveltejs/kit";
+import { resolveMarkdownRelativeLinks } from "@docsfn/core";
 import { getPostData } from "@docsfn/sveltekit";
 import { getCompiledDocsPost } from "$lib/server/docs-site-source";
 import type { PageServerLoad } from "./$types";
@@ -11,7 +12,11 @@ export const load: PageServerLoad = async ({ params, parent }) => {
     throw error(404, "Post not found");
   }
 
-  const compiled = await getCompiledDocsPost(post.id);
+  const compiled = resolveMarkdownRelativeLinks({
+    compiled: await getCompiledDocsPost(post.id),
+    route: `/blog/${post.slug}`,
+    sourcePath: post.relativePath,
+  });
 
   return {
     post,

--- a/filefn/docs/src/routes/docs/[...slug]/+page.server.ts
+++ b/filefn/docs/src/routes/docs/[...slug]/+page.server.ts
@@ -6,6 +6,7 @@ import {
   resolveDocsRouteDataOrThrow,
   type SvelteDocsPageSurface,
 } from "@docsfn/sveltekit";
+import { resolveMarkdownRelativeLinks } from "@docsfn/core";
 import { getCompiledDocsPage } from "$lib/server/docs-site-source";
 import type { PageServerLoad } from "./$types";
 
@@ -25,6 +26,10 @@ function isRouteNotFoundError(input: unknown): input is { message: string } {
     "code" in input &&
     String((input as { code: unknown }).code) === "DOCS_ROUTE_NOT_FOUND"
   );
+}
+
+function hasNestedDocsRoutes(routes: Record<string, string>, route: string): boolean {
+  return Object.keys(routes).some((candidate) => candidate.startsWith(`${route}/`));
 }
 
 export const load: PageServerLoad = async ({ params, parent }) => {
@@ -94,7 +99,12 @@ export const load: PageServerLoad = async ({ params, parent }) => {
 
   const compiled =
     routeEntry.kind === "page"
-      ? await getCompiledDocsPage(routeEntry.page.id)
+      ? resolveMarkdownRelativeLinks({
+          compiled: await getCompiledDocsPage(routeEntry.page.id),
+          route: routeEntry.route,
+          sourcePath: routeEntry.page.relativePath,
+          isIndexRoute: hasNestedDocsRoutes(source.manifest.routes, routeEntry.route),
+        })
       : undefined;
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -513,7 +513,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@21n/fonts": "^1.0.1",
-        "@docsfn/core": "0.0.4",
+        "@docsfn/core": "0.0.5",
         "@docsfn/provider-fs": "0.0.2",
         "@docsfn/svelte": "0.0.3",
         "@docsfn/sveltekit": "0.0.2"
@@ -534,9 +534,9 @@
       }
     },
     "authfn/docs/node_modules/@docsfn/core": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@docsfn/core/-/core-0.0.4.tgz",
-      "integrity": "sha512-Zwwl/s8r10CO8ixdYCamdy5qsd6rnZqUZmsiCsOiwsOVH8SuE/MswmyuMATYOMP3Z3OZPXqIbB9arlUnWcqv0A==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@docsfn/core/-/core-0.0.5.tgz",
+      "integrity": "sha512-cLd9/0I2EN/dXg2EwP90ss9Q4JWeCDxjnnsLn3o3xvPx9ZQ/BhpWGKVZDBb9XN8MK11ClEwSFwxb3L8kTqn2IQ==",
       "license": "MIT",
       "dependencies": {
         "marked": "^12.0.0",
@@ -6146,7 +6146,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@21n/fonts": "^1.0.1",
-        "@docsfn/core": "0.0.4",
+        "@docsfn/core": "0.0.5",
         "@docsfn/provider-fs": "0.0.2",
         "@docsfn/svelte": "0.0.3",
         "@docsfn/sveltekit": "0.0.2"
@@ -6165,9 +6165,9 @@
       }
     },
     "filefn/docs/node_modules/@docsfn/core": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@docsfn/core/-/core-0.0.4.tgz",
-      "integrity": "sha512-Zwwl/s8r10CO8ixdYCamdy5qsd6rnZqUZmsiCsOiwsOVH8SuE/MswmyuMATYOMP3Z3OZPXqIbB9arlUnWcqv0A==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@docsfn/core/-/core-0.0.5.tgz",
+      "integrity": "sha512-cLd9/0I2EN/dXg2EwP90ss9Q4JWeCDxjnnsLn3o3xvPx9ZQ/BhpWGKVZDBb9XN8MK11ClEwSFwxb3L8kTqn2IQ==",
       "license": "MIT",
       "dependencies": {
         "marked": "^12.0.0",


### PR DESCRIPTION
## Summary by Sourcery

Fix documentation markdown link resolution for authfn and filefn docs and improve DataFn landing copy.

New Features:
- Support resolving relative markdown links for docs and blog pages in authfn and filefn sites, including index routes with nested docs.

Bug Fixes:
- Correct broken links to the client token mode section in multiple authfn docs pages by pointing to the bearer-mode heading anchor instead of a subpage.
- Address markdown links not working in blog and docs pages by running compiled content through a relative link resolver.

Enhancements:
- Refine DataFn introduction copy on the main docs index page to better describe its role as a full-stack data framework.

Build:
- Bump @docsfn/core dependency from 0.0.4 to 0.0.5 in authfn and filefn docs packages.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken Markdown relative links in `authfn` and `filefn` docs and blog pages by resolving links server-side and correcting token-mode anchors. Addresses SF-35.

- **Bug Fixes**
  - Resolve Markdown relative links in docs and blog routes using `resolveMarkdownRelativeLinks`, including index routes with nested paths.
  - Fix “Token mode” links to use `../sdk/client#bearer-mode` and remove the outdated subpage reference.
  - Update `llms-full.txt` to reflect docs changes.

- **Dependencies**
  - Bump `@docsfn/core` to `0.0.5` to use the link resolver (lockfile updated in both docs apps).

<sup>Written for commit 531da5e4981def7a48d3d24f84e889d1a98c0538. Summary will update on new commits. <a href="https://cubic.dev/pr/21nCo/super-functions/pull/100?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized bearer-token mode documentation for improved accessibility
  * Updated product positioning from "data sync SDK" to "data management platform"
  * Enhanced documentation link resolution and navigation reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/21nCo/super-functions/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->