### PR TITLE
Production readiness fixes across shared packages

### DIFF
--- a/billfn/svelte/package.json
+++ b/billfn/svelte/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "author": "21n",
   "license": "MIT",

--- a/datafn/server/__tests__/data-integrity-high.test.ts
+++ b/datafn/server/__tests__/data-integrity-high.test.ts
@@ -397,6 +397,62 @@ describe("transaction-bound runtime state", () => {
     expect(changes[0]).toMatchObject({ record_id: "task:committed", server_seq: 1 });
     await db.close();
   });
+
+  it("does not publish change notifications when transaction commit fails", async () => {
+    const db = memoryAdapter() as any;
+    await db.initialize();
+    let transactionCalls = 0;
+    const transaction = async (callback: (tx: any) => Promise<unknown>) => {
+      transactionCalls += 1;
+      const result = await callback(db);
+      if (transactionCalls > 1) {
+        throw new Error("forced commit failure");
+      }
+      return result;
+    };
+    const transactionalDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property === "capabilities") {
+          return {
+            ...target.capabilities,
+            transactions: { ...target.capabilities.transactions, supported: true },
+          };
+        }
+        if (property === "transaction") return transaction;
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const onChange = vi.fn();
+    const schema: DatafnSchema = {
+      resources: [{
+        name: "tasks",
+        version: 1,
+        fields: [{ name: "title", type: "string", required: true }],
+      }],
+      relations: [],
+    };
+
+    const result = await executePush({
+      clientId: "client",
+      mutations: [{
+        resource: "tasks",
+        version: 1,
+        operation: "insert",
+        id: "task:commit-fails",
+        clientId: "client",
+        mutationId: "m-commit-fails",
+        record: { title: "not published" },
+      }],
+    }, schema, transactionalDb, new MemoryIdempotencyStore(), "default", undefined, onChange);
+
+    expect(result.applied).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.objectContaining({ mutationId: "m-commit-fails", code: "INTERNAL" }),
+    ]);
+    expect(onChange).not.toHaveBeenCalled();
+    await db.close();
+  });
 });
 
 // ─── REL-008: Redis rate limiter uses Lua eval for atomic TTL ─────────────

--- a/datafn/server/__tests__/data-integrity-high.test.ts
+++ b/datafn/server/__tests__/data-integrity-high.test.ts
@@ -274,6 +274,38 @@ describe("transaction-bound runtime state", () => {
     expect(txInternal.ensureTable).not.toHaveBeenCalled();
   });
 
+  it("does not run sequence-table DDL after rebinding an initialized store", async () => {
+    const outerInternal = makeInternalApi();
+    const txInternal = makeInternalApi();
+    const store = new DatabaseSequenceStore({ internal: outerInternal } as any);
+
+    await store.ensureReady();
+    await store.withDb({ internal: txInternal } as any).getCurrent("default");
+
+    expect(outerInternal.ensureTable).toHaveBeenCalledOnce();
+    expect(txInternal.ensureTable).not.toHaveBeenCalled();
+  });
+
+  it("does not run change-tracking DDL after rebinding an initialized service", async () => {
+    const outerInternal = makeInternalApi();
+    const txInternal = makeInternalApi();
+    const service = new ChangeTrackingService({ internal: outerInternal } as any, "tenant");
+
+    await service.ensureReady();
+    const txService = service.withDb({ internal: txInternal } as any);
+    await txService.recordChange({
+      serverSeq: 1,
+      resource: "tasks",
+      id: "task:1",
+      op: "insert",
+      record: { title: "ready" },
+    });
+    await txService.getCurrentServerSeq();
+
+    expect(outerInternal.ensureTable).toHaveBeenCalledTimes(2);
+    expect(txInternal.ensureTable).not.toHaveBeenCalled();
+  });
+
   it("discards sequence-pool state when a mutation transaction rolls back", async () => {
     const db = memoryAdapter() as any;
     await db.initialize();

--- a/datafn/server/__tests__/data-integrity-high.test.ts
+++ b/datafn/server/__tests__/data-integrity-high.test.ts
@@ -9,8 +9,12 @@ import {
   DatabaseSequenceStore,
 } from "../src/execution/sync/sequence-store.js";
 import { ChangeTrackingService } from "../src/execution/sync/change-tracking.js";
+import { executePush } from "../src/execution/sync/push.js";
+import { DbIdempotencyStore } from "../src/execution/idempotency-db.js";
+import { MemoryIdempotencyStore } from "../src/execution/idempotency.js";
 import { executeModifyRelation } from "../src/execution/mutation/relations.js";
 import { RedisRateLimiter } from "../src/middleware/rate-limit.js";
+import { memoryAdapter } from "@superfunctions/db/adapters";
 import type { DatafnSchema } from "@datafn/core";
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
@@ -227,6 +231,139 @@ describe("DI-003: ChainedSequenceStore prevents duplicate sequences on Redis→D
       ],
       { next_server_seq: 11 },
     );
+  });
+
+  it("TV-DI-003e: transaction rebinding preserves the primary high-water mark", async () => {
+    let primaryCalls = 0;
+    const primary = {
+      getNext: vi.fn(),
+      getNextN: vi.fn(async () => {
+        primaryCalls += 1;
+        if (primaryCalls === 1) return [100];
+        throw new Error("Redis unavailable");
+      }),
+      getCurrent: vi.fn(async () => 100),
+      isHealthy: vi.fn(async () => true),
+    };
+    const outerDb = { internal: makeInternalApi() } as any;
+    const txDb = { internal: makeInternalApi() } as any;
+    const ensureMinSeq = vi
+      .spyOn(DatabaseSequenceStore.prototype, "ensureMinSeq")
+      .mockResolvedValue();
+    vi.spyOn(DatabaseSequenceStore.prototype, "getNextN").mockResolvedValue([101]);
+    const store = new ChainedSequenceStore(primary, new DatabaseSequenceStore(outerDb));
+
+    await store.getNextN("default", 1);
+    await store.withDb(txDb).getNextN("default", 1);
+
+    expect(ensureMinSeq).toHaveBeenCalledWith("default", 100);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("transaction-bound runtime state", () => {
+  it("does not re-run idempotency table DDL after rebinding an initialized store", async () => {
+    const outerInternal = makeInternalApi();
+    const txInternal = makeInternalApi();
+    const store = new DbIdempotencyStore({ internal: outerInternal } as any, "tenant");
+
+    await store.get("client", "mutation");
+    await store.withDb({ internal: txInternal } as any).get("client", "mutation");
+
+    expect(outerInternal.ensureTable).toHaveBeenCalledOnce();
+    expect(txInternal.ensureTable).not.toHaveBeenCalled();
+  });
+
+  it("discards sequence-pool state when a mutation transaction rolls back", async () => {
+    const db = memoryAdapter() as any;
+    await db.initialize();
+    const originalTransaction = db.transaction.bind(db);
+    let changeWriteFailures = 0;
+    const transaction = (callback: (tx: any) => Promise<unknown>) =>
+      originalTransaction(async (tx: any) => {
+        const internal = new Proxy(tx.internal, {
+          get(target, property, receiver) {
+            if (property === "create" || property === "createMany") {
+              return async (table: string, data: Record<string, unknown> | Record<string, unknown>[]) => {
+                if (table === "__datafn_changes" && changeWriteFailures < 3) {
+                  changeWriteFailures += 1;
+                  throw new Error("forced change-write failure");
+                }
+                return property === "createMany"
+                  ? target.createMany(table, data as Record<string, unknown>[])
+                  : target.create(table, data as Record<string, unknown>);
+              };
+            }
+            const value = Reflect.get(target, property, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+        const txProxy = new Proxy(tx, {
+          get(target, property, receiver) {
+            if (property === "internal") return internal;
+            const value = Reflect.get(target, property, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+        return callback(txProxy);
+      });
+    const transactionalDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property === "capabilities") {
+          return {
+            ...target.capabilities,
+            transactions: { ...target.capabilities.transactions, supported: true },
+          };
+        }
+        if (property === "transaction") return transaction;
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    const boundAllocations: number[][] = [];
+    const sequenceStore = {
+      getNext: vi.fn(async () => 1),
+      getNextN: vi.fn(async () => { throw new Error("outer allocation is unexpected"); }),
+      getCurrent: vi.fn(async () => 0),
+      withDb: vi.fn(() => ({
+        getNext: vi.fn(async () => 1),
+        getNextN: vi.fn(async (_namespace: string, count: number) => {
+          const allocation = Array.from({ length: count }, (_, index) => index + 1);
+          boundAllocations.push([...allocation]);
+          return allocation;
+        }),
+        getCurrent: vi.fn(async () => 0),
+      })),
+    };
+    const schema: DatafnSchema = {
+      resources: [{
+        name: "tasks",
+        version: 1,
+        fields: [{ name: "title", type: "string", required: true }],
+      }],
+      relations: [],
+    };
+    const result = await executePush({
+      clientId: "client",
+      mutations: [
+        {
+          resource: "tasks", version: 1, operation: "insert", id: "task:rolled-back",
+          clientId: "client", mutationId: "m1", record: { title: "first" },
+        },
+        {
+          resource: "tasks", version: 1, operation: "insert", id: "task:committed",
+          clientId: "client", mutationId: "m2", record: { title: "second" },
+        },
+      ],
+    }, schema, transactionalDb, new MemoryIdempotencyStore(), "default", sequenceStore as any);
+
+    expect(result.applied).toEqual(["m2"]);
+    expect(boundAllocations).toEqual([[1, 2], [1, 2]]);
+    const changes = await db.internal.findMany("__datafn_changes", []);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ record_id: "task:committed", server_seq: 1 });
+    await db.close();
   });
 });
 

--- a/datafn/server/__tests__/dfql-transact.test.ts
+++ b/datafn/server/__tests__/dfql-transact.test.ts
@@ -146,7 +146,8 @@ describe("DFQL Transactions", () => {
     expect(result.ok).toBe(false);
 
     expect(result.results).toHaveLength(2);
-    expect(result.results[0].ok).toBe(true);
+    expect(result.results[0].ok).toBe(false);
+    expect(result.results[0].rolledBack).toBe(true);
     expect(result.results[1].ok).toBe(false);
     expect(result.results[1].error.code).toBe("DFQL_UNSUPPORTED");
 
@@ -163,7 +164,7 @@ describe("DFQL Transactions", () => {
     const queryJson = await queryRes.json();
     expect(queryJson.ok).toBe(true);
     const ids = queryJson.result.data.map((row: { id: string }) => row.id);
-    expect(ids).toContain("t:2");
+    expect(ids).not.toContain("t:2");
     expect(ids).not.toContain("t:3");
   });
 

--- a/datafn/server/__tests__/performance.test.ts
+++ b/datafn/server/__tests__/performance.test.ts
@@ -354,6 +354,13 @@ describe("PER-005: Targeted relation filter (findRecords)", () => {
 // TV-EXE-018: Batched change-tracking writes
 // ---------------------------------------------------------------------------
 describe("EXE-018: Batched change-tracking writes", () => {
+  const withInternalOverrides = (db: any, overrides: Record<string, unknown>) => {
+    const wrapped = Object.create(db);
+    const internal = Object.assign(Object.create(db.internal), overrides);
+    Object.defineProperty(wrapped, "internal", { value: internal });
+    return wrapped;
+  };
+
   it("TV-EXE-018-P1: batch insert path is used when createMany capability exists", async () => {
     const db = memoryAdapter({ libraryNamespace: "datafn" });
     await db.initialize();
@@ -364,7 +371,7 @@ describe("EXE-018: Batched change-tracking writes", () => {
     let singleInsertCalls = 0;
 
     const originalCreateMany = db.internal.createMany!.bind(db.internal);
-    (db.internal as any).createMany = async (table: string, data: Record<string, unknown>[]) => {
+    const createMany = async (table: string, data: Record<string, unknown>[]) => {
       if (table === "__datafn_changes") {
         batchInsertCalls++;
         batchInsertRows += data.length;
@@ -373,14 +380,17 @@ describe("EXE-018: Batched change-tracking writes", () => {
     };
 
     const originalCreate = db.internal.create.bind(db.internal);
-    db.internal.create = async (table: string, data: Record<string, unknown>) => {
+    const create = async (table: string, data: Record<string, unknown>) => {
       if (table === "__datafn_changes") {
         singleInsertCalls++;
       }
       return originalCreate(table, data);
     };
 
-    const ct = new ChangeTrackingService(db, "datafn");
+    const ct = new ChangeTrackingService(
+      withInternalOverrides(db, { createMany, create }),
+      "datafn",
+    );
 
     const entries = Array.from({ length: 500 }, (_, i) => ({
       serverSeq: i + 1,
@@ -451,14 +461,9 @@ describe("EXE-018: Batched change-tracking writes", () => {
     const db = memoryAdapter({ libraryNamespace: "datafn" });
     await db.initialize();
 
-    // Remove createMany to use sequential path, then make 3rd create fail
-    delete (db.internal as any).createMany;
-
-    const ct = new ChangeTrackingService(db, "datafn");
-
     let callCount = 0;
     const originalCreate = db.internal.create.bind(db.internal);
-    db.internal.create = async (table: string, data: Record<string, unknown>) => {
+    const create = async (table: string, data: Record<string, unknown>) => {
       if (table === "__datafn_changes") {
         callCount++;
         if (callCount === 3) {
@@ -467,6 +472,10 @@ describe("EXE-018: Batched change-tracking writes", () => {
       }
       return originalCreate(table, data);
     };
+    const ct = new ChangeTrackingService(
+      withInternalOverrides(db, { createMany: undefined, create }),
+      "datafn",
+    );
 
     const entries = Array.from({ length: 5 }, (_, i) => ({
       serverSeq: i + 1,

--- a/datafn/server/__tests__/reliability-critical.test.ts
+++ b/datafn/server/__tests__/reliability-critical.test.ts
@@ -48,6 +48,33 @@ function makeMemoryIdempotencyStore() {
 // ─── REL-001: Transaction fallback ────────────────────────────────────
 
 describe("REL-001: Transaction atomicity — no silent fallthrough", () => {
+  it("initializes durable idempotency storage before opening an atomic transaction", async () => {
+    const order: string[] = [];
+    const db = memoryAdapter({ libraryNamespace: "datafn" });
+    (db as any).transaction = async () => {
+      order.push("transaction");
+      throw new Error("serialization failure");
+    };
+    const idempotencyStore = {
+      ...makeMemoryIdempotencyStore(),
+      ensureReady: vi.fn(async () => {
+        order.push("idempotency-ready");
+      })
+    };
+
+    await executeTransaction(
+      { atomic: true, steps: [] },
+      testSchema,
+      db,
+      idempotencyStore,
+      undefined,
+      "default",
+      undefined
+    );
+
+    expect(order).toEqual(["idempotency-ready", "transaction"]);
+  });
+
   it("TV-REL-001: DB error returns INTERNAL, no sequential fallback", async () => {
     const db = memoryAdapter({ libraryNamespace: "datafn" });
     // Patch the adapter to have a transaction function that throws

--- a/datafn/server/__tests__/reliability-critical.test.ts
+++ b/datafn/server/__tests__/reliability-critical.test.ts
@@ -48,6 +48,40 @@ function makeMemoryIdempotencyStore() {
 // ─── REL-001: Transaction fallback ────────────────────────────────────
 
 describe("REL-001: Transaction atomicity — no silent fallthrough", () => {
+  it("does not initialize mutation stores for a read-only atomic transaction", async () => {
+    const order: string[] = [];
+    const db = {
+      internal: {
+        ensureTable: vi.fn(async (tableName: string) => {
+          order.push(`table:${tableName}`);
+        })
+      },
+      transaction: async (callback: (tx: any) => Promise<unknown>) => {
+        order.push("transaction");
+        return callback(db);
+      }
+    } as any;
+    const idempotencyStore = {
+      ...makeMemoryIdempotencyStore(),
+      ensureReady: vi.fn(async () => {
+        order.push("idempotency-ready");
+      })
+    };
+
+    const result = await executeTransaction(
+      { atomic: true, steps: [] },
+      testSchema,
+      db,
+      idempotencyStore,
+      undefined,
+      "default",
+      undefined
+    );
+
+    expect(result.ok).toBe(true);
+    expect(order).toEqual(["transaction"]);
+  });
+
   it("initializes all durable runtime tables before opening an atomic transaction", async () => {
     const order: string[] = [];
     const db = {
@@ -69,7 +103,17 @@ describe("REL-001: Transaction atomicity — no silent fallthrough", () => {
     };
 
     await executeTransaction(
-      { atomic: true, steps: [] },
+      {
+        atomic: true,
+        steps: [{
+          mutation: {
+            resource: "tasks",
+            operation: "insert",
+            id: "task:ready",
+            record: { title: "ready" },
+          } as any,
+        }],
+      },
       testSchema,
       db,
       idempotencyStore,

--- a/datafn/server/__tests__/reliability-critical.test.ts
+++ b/datafn/server/__tests__/reliability-critical.test.ts
@@ -48,13 +48,19 @@ function makeMemoryIdempotencyStore() {
 // ─── REL-001: Transaction fallback ────────────────────────────────────
 
 describe("REL-001: Transaction atomicity — no silent fallthrough", () => {
-  it("initializes durable idempotency storage before opening an atomic transaction", async () => {
+  it("initializes all durable runtime tables before opening an atomic transaction", async () => {
     const order: string[] = [];
-    const db = memoryAdapter({ libraryNamespace: "datafn" });
-    (db as any).transaction = async () => {
-      order.push("transaction");
-      throw new Error("serialization failure");
-    };
+    const db = {
+      internal: {
+        ensureTable: vi.fn(async (tableName: string) => {
+          order.push(`table:${tableName}`);
+        })
+      },
+      transaction: async () => {
+        order.push("transaction");
+        throw new Error("serialization failure");
+      }
+    } as any;
     const idempotencyStore = {
       ...makeMemoryIdempotencyStore(),
       ensureReady: vi.fn(async () => {
@@ -72,7 +78,12 @@ describe("REL-001: Transaction atomicity — no silent fallthrough", () => {
       undefined
     );
 
-    expect(order).toEqual(["idempotency-ready", "transaction"]);
+    expect(order).toEqual([
+      "idempotency-ready",
+      "table:__datafn_changes",
+      "table:__datafn_meta",
+      "transaction"
+    ]);
   });
 
   it("TV-REL-001: DB error returns INTERNAL, no sequential fallback", async () => {

--- a/datafn/server/__tests__/security.test.ts
+++ b/datafn/server/__tests__/security.test.ts
@@ -601,7 +601,7 @@ describe("SEC-006: Batch size limit enforcement", () => {
     // Should not be a batch size error
     expect(body.error?.code).not.toBe("DFQL_BATCH_LIMIT");
     expect(res.status).not.toBe(400); // batch limit would be 400
-  });
+  }, 30_000);
 
   it("custom maxBatchSize below default — mutations within default limit are still processed", async () => {
     // Note: maxBatchSize enforcement is applied against the server's active limit.

--- a/datafn/server/__tests__/sync.test.ts
+++ b/datafn/server/__tests__/sync.test.ts
@@ -2032,6 +2032,7 @@ describe("MRG-003: push merge race retry behavior", () => {
   it("retries update once after create conflict and succeeds", async () => {
     const baseDb = memoryAdapter();
     await baseDb.initialize();
+    baseDb.capabilities.transactions.supported = false;
     const baseCreate = baseDb.create.bind(baseDb);
     const baseUpdate = baseDb.update.bind(baseDb);
     let updateCalls = 0;
@@ -2107,6 +2108,7 @@ describe("MRG-003: push merge race retry behavior", () => {
   it("returns NOT_FOUND when retry update still fails after create conflict", async () => {
     const baseDb = memoryAdapter();
     await baseDb.initialize();
+    baseDb.capabilities.transactions.supported = false;
     const baseCreate = baseDb.create.bind(baseDb);
 
     const db = new Proxy(baseDb, {

--- a/datafn/server/src/execution/idempotency-db.ts
+++ b/datafn/server/src/execution/idempotency-db.ts
@@ -19,12 +19,17 @@ export class DbIdempotencyStore implements IdempotencyStore {
     private db: Adapter,
     private namespace: string = "datafn",
     logger?: DatafnLogger,
+    ensured = false,
   ) {
     this.logger = logger;
+    this.ensured = ensured;
   }
 
   withDb(db: Adapter): IdempotencyStore {
-    return new DbIdempotencyStore(db, this.namespace, this.logger);
+    // The outer store performs initialization before transactional mutation
+    // execution. Preserve that state so rebinding does not issue DDL inside a
+    // transaction (which implicitly commits on MySQL).
+    return new DbIdempotencyStore(db, this.namespace, this.logger, this.ensured);
   }
 
   async get(

--- a/datafn/server/src/execution/idempotency-db.ts
+++ b/datafn/server/src/execution/idempotency-db.ts
@@ -23,6 +23,10 @@ export class DbIdempotencyStore implements IdempotencyStore {
     this.logger = logger;
   }
 
+  withDb(db: Adapter): IdempotencyStore {
+    return new DbIdempotencyStore(db, this.namespace, this.logger);
+  }
+
   async get(
     clientId: string,
     mutationId: string,

--- a/datafn/server/src/execution/idempotency-db.ts
+++ b/datafn/server/src/execution/idempotency-db.ts
@@ -32,15 +32,19 @@ export class DbIdempotencyStore implements IdempotencyStore {
     return new DbIdempotencyStore(db, this.namespace, this.logger, this.ensured);
   }
 
+  async ensureReady(): Promise<void> {
+    if (!this.ensured) {
+      await ensureInternalTable(this.db, "__datafn_idempotency");
+      this.ensured = true;
+    }
+  }
+
   async get(
     clientId: string,
     mutationId: string,
   ): Promise<MutationResult | null> {
     // EXE-007: DB errors propagate; only swallow JSON parse errors (SyntaxError)
-    if (!this.ensured) {
-      await ensureInternalTable(this.db, "__datafn_idempotency");
-      this.ensured = true;
-    }
+    await this.ensureReady();
 
     const record = await this.db.internal.findOne("__datafn_idempotency", [
       { field: "namespace", op: "eq", value: this.namespace },
@@ -71,10 +75,7 @@ export class DbIdempotencyStore implements IdempotencyStore {
    * Returns the number of rows deleted.
    */
   async pruneIdempotency(retentionDays: number): Promise<number> {
-    if (!this.ensured) {
-      await ensureInternalTable(this.db, "__datafn_idempotency");
-      this.ensured = true;
-    }
+    await this.ensureReady();
     const cutoff = new Date(Date.now() - retentionDays * 86400000).toISOString();
     return await this.db.internal.delete("__datafn_idempotency", [
       { field: "namespace", op: "eq", value: this.namespace },
@@ -88,10 +89,7 @@ export class DbIdempotencyStore implements IdempotencyStore {
     result: MutationResult,
   ): Promise<void> {
     try {
-      if (!this.ensured) {
-        await ensureInternalTable(this.db, "__datafn_idempotency");
-        this.ensured = true;
-      }
+      await this.ensureReady();
 
       await this.db.internal.create("__datafn_idempotency", {
         id: `${this.namespace}:${clientId}:${mutationId}`,

--- a/datafn/server/src/execution/idempotency.ts
+++ b/datafn/server/src/execution/idempotency.ts
@@ -16,6 +16,9 @@ export interface MutationResult {
 }
 
 export interface IdempotencyStore {
+  /** Initialize backing storage before an enclosing transaction begins. */
+  ensureReady?(): Promise<void>;
+
   /**
    * Get a previously stored mutation result
    */

--- a/datafn/server/src/execution/idempotency.ts
+++ b/datafn/server/src/execution/idempotency.ts
@@ -29,6 +29,9 @@ export interface IdempotencyStore {
     mutationId: string,
     result: MutationResult
   ): Promise<void>;
+
+  /** Return an equivalent store bound to a transaction-scoped adapter. */
+  withDb?(db: import("@superfunctions/db").Adapter): IdempotencyStore;
 }
 
 interface StoredEntry {

--- a/datafn/server/src/execution/mutation/execute.ts
+++ b/datafn/server/src/execution/mutation/execute.ts
@@ -232,12 +232,15 @@ async function executeMutationCore(
             id: mutation.id,
             delta: mergeData,
             update: async () => {
-              await db.update({
+              const updated = await db.update({
                 model: mutation.resource,
                 where: [{ field: "id", operator: "eq", value: mutation.id }],
                 data: mergeData,
                 namespace,
               });
+              if (strictUpdateNotFound && updated === undefined) {
+                throw { name: "NotFoundError", message: "Record not found after update" };
+              }
             },
             create: async (record) => {
               await db.create({

--- a/datafn/server/src/execution/mutation/execute.ts
+++ b/datafn/server/src/execution/mutation/execute.ts
@@ -952,6 +952,7 @@ export async function executeMutation(
     let guardFailed = false;
 
     try {
+      await changeTracking.ensureReady();
       await (db as any).transaction(async (txDb: Adapter) => {
         // DI-002: Re-read record inside transaction to prevent TOCTOU
         const guardResult = await evaluateGuard(

--- a/datafn/server/src/execution/mutation/execute.ts
+++ b/datafn/server/src/execution/mutation/execute.ts
@@ -238,7 +238,7 @@ async function executeMutationCore(
                 data: mergeData,
                 namespace,
               });
-              if (strictUpdateNotFound && updated === undefined) {
+              if (strictUpdateNotFound && !updated) {
                 throw { name: "NotFoundError", message: "Record not found after update" };
               }
             },

--- a/datafn/server/src/execution/sync/change-tracking.ts
+++ b/datafn/server/src/execution/sync/change-tracking.ts
@@ -115,7 +115,30 @@ export class ChangeTrackingService {
     private sequenceStore?: SequenceStore,
     private onChange?: (seq: number, namespace: string) => void,
     private logger?: DatafnLogger,
-  ) {}
+    metaEnsured = false,
+    changesEnsured = false,
+  ) {
+    this.metaEnsured = metaEnsured;
+    this.changesEnsured = changesEnsured;
+  }
+
+  /** Initialize every durable table before an enclosing transaction begins. */
+  async ensureReady(): Promise<void> {
+    if (!this.changesEnsured) {
+      await ensureInternalTable(this.db, "__datafn_changes");
+      this.changesEnsured = true;
+    }
+
+    if (this.sequenceStore) {
+      await this.sequenceStore.ensureReady?.();
+    }
+    // The service can fall back to its database sequence path if an external
+    // store fails, so its own metadata table must also exist before rebinding.
+    if (!this.metaEnsured) {
+      await ensureInternalTable(this.db, "__datafn_meta");
+      this.metaEnsured = true;
+    }
+  }
 
   /**
    * REL-011: Create a new ChangeTrackingService with a different db adapter.
@@ -124,7 +147,15 @@ export class ChangeTrackingService {
   */
   withDb(txDb: Adapter): ChangeTrackingService {
     const sequenceStore = this.sequenceStore?.withDb?.(txDb) ?? this.sequenceStore;
-    return new ChangeTrackingService(txDb, this.namespace, sequenceStore, this.onChange, this.logger);
+    return new ChangeTrackingService(
+      txDb,
+      this.namespace,
+      sequenceStore,
+      this.onChange,
+      this.logger,
+      this.metaEnsured,
+      this.changesEnsured,
+    );
   }
 
   /**

--- a/datafn/server/src/execution/sync/change-tracking.ts
+++ b/datafn/server/src/execution/sync/change-tracking.ts
@@ -145,13 +145,13 @@ export class ChangeTrackingService {
    * Used to run change tracking within a transaction (pass tx db here).
    * The namespace and sequenceStore are inherited from the original instance.
   */
-  withDb(txDb: Adapter): ChangeTrackingService {
+  withDb(txDb: Adapter, emitChanges = true): ChangeTrackingService {
     const sequenceStore = this.sequenceStore?.withDb?.(txDb) ?? this.sequenceStore;
     return new ChangeTrackingService(
       txDb,
       this.namespace,
       sequenceStore,
-      this.onChange,
+      emitChanges ? this.onChange : undefined,
       this.logger,
       this.metaEnsured,
       this.changesEnsured,

--- a/datafn/server/src/execution/sync/change-tracking.ts
+++ b/datafn/server/src/execution/sync/change-tracking.ts
@@ -121,9 +121,10 @@ export class ChangeTrackingService {
    * REL-011: Create a new ChangeTrackingService with a different db adapter.
    * Used to run change tracking within a transaction (pass tx db here).
    * The namespace and sequenceStore are inherited from the original instance.
-   */
+  */
   withDb(txDb: Adapter): ChangeTrackingService {
-    return new ChangeTrackingService(txDb, this.namespace, this.sequenceStore, this.onChange, this.logger);
+    const sequenceStore = this.sequenceStore?.withDb?.(txDb) ?? this.sequenceStore;
+    return new ChangeTrackingService(txDb, this.namespace, sequenceStore, this.onChange, this.logger);
   }
 
   /**

--- a/datafn/server/src/execution/sync/push.ts
+++ b/datafn/server/src/execution/sync/push.ts
@@ -219,15 +219,17 @@ export async function executePush(
 
   let initialSeqBatchAllocated = false;
   let seqPool: number[] = [];
-  async function takeNextServerSeq(): Promise<number> {
+  async function takeNextServerSeq(
+    targetChangeTracking = changeTracking,
+  ): Promise<number> {
     if (seqPool.length === 0) {
       if (!initialSeqBatchAllocated) {
         initialSeqBatchAllocated = true;
-        seqPool = await changeTracking.getNextServerSeqBatch(
+        seqPool = await targetChangeTracking.getNextServerSeqBatch(
           Math.max(1, request.mutations.length),
         );
       } else {
-        seqPool = await changeTracking.getNextServerSeqBatch(1);
+        seqPool = await targetChangeTracking.getNextServerSeqBatch(1);
       }
     }
     return seqPool.shift()!;
@@ -290,7 +292,10 @@ export async function executePush(
         const mergeResult = await executeSchemaAwareMerge({
           schema, resource: mut.resource, id: mut.id, delta: createData,
           update: async () => {
-            await targetDb.update({ model: mut.resource, where: [{ field: "id", operator: "eq", value: mut.id }], data: updateData, namespace });
+            const updated = await targetDb.update({ model: mut.resource, where: [{ field: "id", operator: "eq", value: mut.id }], data: updateData, namespace });
+            if (strictUpdateNotFound && updated === undefined) {
+              throw { name: "NotFoundError", message: "Record not found after update" };
+            }
           },
           create: async (record) => {
             await targetDb.create({ model: mut.resource, data: record, namespace });
@@ -755,7 +760,7 @@ export async function executePush(
           const changes = opResult.changes;
           const txChangeTracking = changeTracking.withDb(txDb);
           for (const change of changes) {
-            const seq = await takeNextServerSeq();
+            const seq = await takeNextServerSeq(txChangeTracking);
             latestSeq = Math.max(latestSeq, seq);
             resourceSeqs[change.resource] = Math.max(resourceSeqs[change.resource] || 0, seq);
             // FIX-REL-002: retry within transaction

--- a/datafn/server/src/execution/sync/push.ts
+++ b/datafn/server/src/execution/sync/push.ts
@@ -217,22 +217,29 @@ export async function executePush(
     });
   }
 
-  let initialSeqBatchAllocated = false;
-  let seqPool: number[] = [];
+  type SequenceAllocationState = {
+    initialBatchAllocated: boolean;
+    pool: number[];
+  };
+  const sequenceAllocation: SequenceAllocationState = {
+    initialBatchAllocated: false,
+    pool: [],
+  };
   async function takeNextServerSeq(
+    allocation: SequenceAllocationState,
     targetChangeTracking = changeTracking,
   ): Promise<number> {
-    if (seqPool.length === 0) {
-      if (!initialSeqBatchAllocated) {
-        initialSeqBatchAllocated = true;
-        seqPool = await targetChangeTracking.getNextServerSeqBatch(
+    if (allocation.pool.length === 0) {
+      if (!allocation.initialBatchAllocated) {
+        allocation.initialBatchAllocated = true;
+        allocation.pool = await targetChangeTracking.getNextServerSeqBatch(
           Math.max(1, request.mutations.length),
         );
       } else {
-        seqPool = await targetChangeTracking.getNextServerSeqBatch(1);
+        allocation.pool = await targetChangeTracking.getNextServerSeqBatch(1);
       }
     }
-    return seqPool.shift()!;
+    return allocation.pool.shift()!;
   }
 
   // Pending change entries for a mutation that executed successfully
@@ -293,7 +300,7 @@ export async function executePush(
           schema, resource: mut.resource, id: mut.id, delta: createData,
           update: async () => {
             const updated = await targetDb.update({ model: mut.resource, where: [{ field: "id", operator: "eq", value: mut.id }], data: updateData, namespace });
-            if (strictUpdateNotFound && updated === undefined) {
+            if (strictUpdateNotFound && !updated) {
               throw { name: "NotFoundError", message: "Record not found after update" };
             }
           },
@@ -747,6 +754,17 @@ export async function executePush(
     // FIX-REL-011: When transactions are supported, wrap operation + change tracking atomically
     if (hasTransaction) {
       let mutationSucceeded = false;
+      // Sequence reservations made through a transaction-bound database store
+      // are valid only if that transaction commits. Work on a copy and publish
+      // the remaining pool after commit; rollback leaves the shared state
+      // untouched. External primary stores may leave harmless gaps, but no
+      // rolled-back reservation can leak into a later transaction.
+      const txSequenceAllocation: SequenceAllocationState = {
+        initialBatchAllocated: sequenceAllocation.initialBatchAllocated,
+        pool: [...sequenceAllocation.pool],
+      };
+      let mutationLatestSeq = 0;
+      const mutationResourceSeqs: Record<string, number> = {};
       try {
         await (db as any).transaction(async (txDb: Adapter) => {
           // Execute operation inside transaction
@@ -760,15 +778,24 @@ export async function executePush(
           const changes = opResult.changes;
           const txChangeTracking = changeTracking.withDb(txDb);
           for (const change of changes) {
-            const seq = await takeNextServerSeq(txChangeTracking);
-            latestSeq = Math.max(latestSeq, seq);
-            resourceSeqs[change.resource] = Math.max(resourceSeqs[change.resource] || 0, seq);
+            const seq = await takeNextServerSeq(txSequenceAllocation, txChangeTracking);
+            mutationLatestSeq = Math.max(mutationLatestSeq, seq);
+            mutationResourceSeqs[change.resource] = Math.max(
+              mutationResourceSeqs[change.resource] || 0,
+              seq,
+            );
             // FIX-REL-002: retry within transaction
             await recordChangeWithRetry(txChangeTracking, {
               serverSeq: seq, resource: change.resource, id: change.id, op: change.op, record: change.record,
             }, 2, logger);
           }
         });
+        sequenceAllocation.initialBatchAllocated = txSequenceAllocation.initialBatchAllocated;
+        sequenceAllocation.pool = txSequenceAllocation.pool;
+        latestSeq = Math.max(latestSeq, mutationLatestSeq);
+        for (const [resource, seq] of Object.entries(mutationResourceSeqs)) {
+          resourceSeqs[resource] = Math.max(resourceSeqs[resource] || 0, seq);
+        }
         mutationSucceeded = true;
       } catch (err: any) {
         if (err?.__opFailed) {
@@ -798,7 +825,7 @@ export async function executePush(
         let changeTrackingFailed = false;
         try {
           for (const change of changes) {
-            const seq = await takeNextServerSeq();
+            const seq = await takeNextServerSeq(sequenceAllocation);
             latestSeq = Math.max(latestSeq, seq);
             resourceSeqs[change.resource] = Math.max(resourceSeqs[change.resource] || 0, seq);
             await recordChangeWithRetry(changeTracking, {

--- a/datafn/server/src/execution/sync/push.ts
+++ b/datafn/server/src/execution/sync/push.ts
@@ -215,6 +215,8 @@ export async function executePush(
       operation: "push",
       namespace,
     });
+  } else {
+    await changeTracking.ensureReady();
   }
 
   type SequenceAllocationState = {

--- a/datafn/server/src/execution/sync/push.ts
+++ b/datafn/server/src/execution/sync/push.ts
@@ -767,6 +767,7 @@ export async function executePush(
       };
       let mutationLatestSeq = 0;
       const mutationResourceSeqs: Record<string, number> = {};
+      const pendingChangeEvents: number[] = [];
       try {
         await (db as any).transaction(async (txDb: Adapter) => {
           // Execute operation inside transaction
@@ -778,7 +779,9 @@ export async function executePush(
 
           // Build and record changes inside the same transaction
           const changes = opResult.changes;
-          const txChangeTracking = changeTracking.withDb(txDb);
+          // Change notifications describe committed state, so suppress the
+          // transaction-bound service callback and publish only after commit.
+          const txChangeTracking = changeTracking.withDb(txDb, false);
           for (const change of changes) {
             const seq = await takeNextServerSeq(txSequenceAllocation, txChangeTracking);
             mutationLatestSeq = Math.max(mutationLatestSeq, seq);
@@ -790,6 +793,7 @@ export async function executePush(
             await recordChangeWithRetry(txChangeTracking, {
               serverSeq: seq, resource: change.resource, id: change.id, op: change.op, record: change.record,
             }, 2, logger);
+            pendingChangeEvents.push(seq);
           }
         });
         sequenceAllocation.initialBatchAllocated = txSequenceAllocation.initialBatchAllocated;
@@ -797,6 +801,19 @@ export async function executePush(
         latestSeq = Math.max(latestSeq, mutationLatestSeq);
         for (const [resource, seq] of Object.entries(mutationResourceSeqs)) {
           resourceSeqs[resource] = Math.max(resourceSeqs[resource] || 0, seq);
+        }
+        for (const seq of pendingChangeEvents) {
+          try {
+            onChange?.(seq, namespace);
+          } catch (error) {
+            // The transaction has already committed; notification failures
+            // must not report the durable mutation as rolled back.
+            logger?.error("Push change notification failed", {
+              error: String(error),
+              operation: "push.onChange",
+              resource: mut.resource,
+            });
+          }
         }
         mutationSucceeded = true;
       } catch (err: any) {

--- a/datafn/server/src/execution/sync/sequence-store.ts
+++ b/datafn/server/src/execution/sync/sequence-store.ts
@@ -26,6 +26,12 @@ export interface SequenceStore {
   /** Get current sequence value (without incrementing) */
   getCurrent(namespace: string): Promise<number>;
 
+  /** Ensure the current sequence is at least minSeq. */
+  ensureMinSeq?(namespace: string, minSeq: number): Promise<void>;
+
+  /** Return an equivalent store bound to a transaction-scoped adapter. */
+  withDb?(db: Adapter): SequenceStore;
+
   /** Check if the store is healthy/available */
   isHealthy?(): Promise<boolean>;
 }
@@ -113,6 +119,10 @@ export class DatabaseSequenceStore implements SequenceStore {
   private ensured = false;
 
   constructor(private db: Adapter, private logger?: DatafnLogger) {}
+
+  withDb(db: Adapter): SequenceStore {
+    return new DatabaseSequenceStore(db, this.logger);
+  }
 
   /**
    * DI-003: Ensure next_server_seq in meta is at least (minSeq + 1).
@@ -296,6 +306,14 @@ export class ChainedSequenceStore implements SequenceStore {
     private secondary: SequenceStore,
     private logger?: DatafnLogger,
   ) {}
+
+  withDb(db: Adapter): SequenceStore {
+    return new ChainedSequenceStore(
+      this.primary,
+      this.secondary.withDb?.(db) ?? this.secondary,
+      this.logger,
+    );
+  }
 
   async getNext(namespace: string): Promise<number> {
     return (await this.getNextN(namespace, 1))[0];

--- a/datafn/server/src/execution/sync/sequence-store.ts
+++ b/datafn/server/src/execution/sync/sequence-store.ts
@@ -118,10 +118,16 @@ export class KVSequenceStore implements SequenceStore {
 export class DatabaseSequenceStore implements SequenceStore {
   private ensured = false;
 
-  constructor(private db: Adapter, private logger?: DatafnLogger) {}
+  constructor(
+    private db: Adapter,
+    private logger?: DatafnLogger,
+    ensured = false,
+  ) {
+    this.ensured = ensured;
+  }
 
   withDb(db: Adapter): SequenceStore {
-    return new DatabaseSequenceStore(db, this.logger);
+    return new DatabaseSequenceStore(db, this.logger, this.ensured);
   }
 
   /**
@@ -299,12 +305,11 @@ export class DatabaseSequenceStore implements SequenceStore {
  */
 export class ChainedSequenceStore implements SequenceStore {
   /** DI-003: Track last-issued seq per namespace from the primary store */
-  private lastKnownPrimarySeq = new Map<string, number>();
-
   constructor(
     private primary: SequenceStore,
     private secondary: SequenceStore,
     private logger?: DatafnLogger,
+    private lastKnownPrimarySeq = new Map<string, number>(),
   ) {}
 
   withDb(db: Adapter): SequenceStore {
@@ -312,6 +317,10 @@ export class ChainedSequenceStore implements SequenceStore {
       this.primary,
       this.secondary.withDb?.(db) ?? this.secondary,
       this.logger,
+      // Primary allocations are external to the database transaction. Share
+      // their high-water marks so a transaction-bound fallback can never
+      // allocate an already-issued sequence.
+      this.lastKnownPrimarySeq,
     );
   }
 

--- a/datafn/server/src/execution/sync/sequence-store.ts
+++ b/datafn/server/src/execution/sync/sequence-store.ts
@@ -17,6 +17,9 @@ import { withAdapterNamespaceLock } from "./namespace-lock.js";
  * Interface for sequence generation stores
  */
 export interface SequenceStore {
+  /** Initialize durable backing storage before an enclosing transaction. */
+  ensureReady?(): Promise<void>;
+
   /** Get and increment sequence atomically, returns the next value */
   getNext(namespace: string): Promise<number>;
 
@@ -130,15 +133,19 @@ export class DatabaseSequenceStore implements SequenceStore {
     return new DatabaseSequenceStore(db, this.logger, this.ensured);
   }
 
+  async ensureReady(): Promise<void> {
+    if (!this.ensured) {
+      await ensureInternalTable(this.db, "__datafn_meta");
+      this.ensured = true;
+    }
+  }
+
   /**
    * DI-003: Ensure next_server_seq in meta is at least (minSeq + 1).
    * Called by ChainedSequenceStore during primary→database failover to prevent duplicate sequences.
    */
   async ensureMinSeq(namespace: string, minSeq: number): Promise<void> {
-    if (!this.ensured) {
-      await ensureInternalTable(this.db, "__datafn_meta");
-      this.ensured = true;
-    }
+    await this.ensureReady();
     const needed = minSeq + 1;
     try {
       await withAdapterNamespaceLock(this.db, namespace, async () => {
@@ -200,10 +207,7 @@ export class DatabaseSequenceStore implements SequenceStore {
     }
 
     return await withAdapterNamespaceLock(this.db, namespace, async () => {
-      if (!this.ensured) {
-        await ensureInternalTable(this.db, "__datafn_meta");
-        this.ensured = true;
-      }
+      await this.ensureReady();
 
       const MAX_RETRIES = 10;
 
@@ -273,10 +277,7 @@ export class DatabaseSequenceStore implements SequenceStore {
   }
 
   async getCurrent(namespace: string): Promise<number> {
-    if (!this.ensured) {
-      await ensureInternalTable(this.db, "__datafn_meta");
-      this.ensured = true;
-    }
+    await this.ensureReady();
 
     try {
       const meta = await this.db.internal.findOne("__datafn_meta", [
@@ -322,6 +323,10 @@ export class ChainedSequenceStore implements SequenceStore {
       // allocate an already-issued sequence.
       this.lastKnownPrimarySeq,
     );
+  }
+
+  async ensureReady(): Promise<void> {
+    await this.secondary.ensureReady?.();
   }
 
   async getNext(namespace: string): Promise<number> {

--- a/datafn/server/src/execution/transact.ts
+++ b/datafn/server/src/execution/transact.ts
@@ -52,6 +52,7 @@ export async function executeTransaction(
 ): Promise<TransactResult> {
   const steps = request.steps;
   const isAtomic = request.atomic !== false; // Default true
+  const hasMutations = steps.some((step) => Boolean(step.mutation));
 
   // SRV-012: Step limit check moved to route handler; skip duplicate check here
   // (createTransactHandler validates before calling executeTransaction)
@@ -107,11 +108,14 @@ export async function executeTransaction(
   if (isAtomic && typeof (db as any).transaction === "function") {
     // REL-001: Atomic execution with DB transaction support
     try {
-      // Initialize durable idempotency storage on the outer adapter. Some
-      // databases implicitly commit DDL, so table creation must never occur
-      // after the atomic transaction has begun.
-      await idempotencyStore.ensureReady?.();
-      await changeTracking.ensureReady();
+      if (hasMutations) {
+        // Initialize durable mutation storage on the outer adapter. Some
+        // databases implicitly commit DDL, so table creation must never occur
+        // after the atomic transaction has begun. Read-only transactions do
+        // not need these tables and must not perform mutation-side DDL.
+        await idempotencyStore.ensureReady?.();
+        await changeTracking.ensureReady();
+      }
       await (db as any).transaction(async (tx: Adapter) => {
         for (let i = 0; i < steps.length; i++) {
           const step = steps[i];

--- a/datafn/server/src/execution/transact.ts
+++ b/datafn/server/src/execution/transact.ts
@@ -111,6 +111,7 @@ export async function executeTransaction(
       // databases implicitly commit DDL, so table creation must never occur
       // after the atomic transaction has begun.
       await idempotencyStore.ensureReady?.();
+      await changeTracking.ensureReady();
       await (db as any).transaction(async (tx: Adapter) => {
         for (let i = 0; i < steps.length; i++) {
           const step = steps[i];

--- a/datafn/server/src/execution/transact.ts
+++ b/datafn/server/src/execution/transact.ts
@@ -76,12 +76,14 @@ export async function executeTransaction(
       const queryResult = executeQuery(step.query, schema, store);
       return queryResult;
     } else if (step.mutation) {
+      const stepIdempotencyStore =
+        idempotencyStore.withDb?.(stepDb) ?? idempotencyStore;
       // Execute mutation
       const mutationResult = await executeMutation(
         step.mutation,
         schema,
         stepDb,
-        idempotencyStore,
+        stepIdempotencyStore,
         changeTracking,
         plugins,
         namespace,

--- a/datafn/server/src/execution/transact.ts
+++ b/datafn/server/src/execution/transact.ts
@@ -107,6 +107,10 @@ export async function executeTransaction(
   if (isAtomic && typeof (db as any).transaction === "function") {
     // REL-001: Atomic execution with DB transaction support
     try {
+      // Initialize durable idempotency storage on the outer adapter. Some
+      // databases implicitly commit DDL, so table creation must never occur
+      // after the atomic transaction has begun.
+      await idempotencyStore.ensureReady?.();
       await (db as any).transaction(async (tx: Adapter) => {
         for (let i = 0; i < steps.length; i++) {
           const step = steps[i];

--- a/filefn/server/src/__tests__/upload-sessions.test.ts
+++ b/filefn/server/src/__tests__/upload-sessions.test.ts
@@ -702,6 +702,16 @@ describe('@filefn/server upload sessions', () => {
         async check(_input: any) {
           return { allowed: false, remaining: 0, resetAt: new Date(Date.now() + 60000).toISOString(), total: 10 };
         },
+        async checkMany(input: { keys: string[] }) {
+          const resetAt = new Date(Date.now() + 60000).toISOString();
+          return {
+            allowed: false,
+            remainingByKey: new Map(input.keys.map(key => [key, 0])),
+            resetAtByKey: new Map(input.keys.map(key => [key, resetAt])),
+            resetAt,
+            total: 10,
+          };
+        },
         async reset(_key: string) {},
       };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.17.0"
       }
     },
     "apifn/cli": {
@@ -12416,6 +12416,7 @@
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -29417,6 +29418,7 @@
     },
     "node_modules/undici": {
       "version": "5.29.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -31747,7 +31749,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "undici": "^5.29.0"
+        "undici": "^6.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -31763,6 +31765,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "packages/webhooks/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "plugfn/cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12416,7 +12416,6 @@
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -29418,7 +29417,6 @@
     },
     "node_modules/undici": {
       "version": "5.29.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -31748,6 +31746,9 @@
       "name": "@superfunctions/webhooks",
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "undici": "^5.29.0"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   },
   "author": "21n",
   "repository": {

--- a/packages/auth/src/middleware.test.ts
+++ b/packages/auth/src/middleware.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { createBearerAuthMiddleware, extractBearerTokenFromHeader } from './middleware.js';
+import {
+  createBearerAuthMiddleware,
+  createResourceAuthMiddleware,
+  extractBearerTokenFromHeader,
+} from './middleware.js';
 
 describe('bearer auth middleware', () => {
   it('extracts bearer token from valid header', () => {
@@ -45,5 +49,56 @@ describe('bearer auth middleware', () => {
 
     expect(response.status).toBe(204);
     expect(context.auth).toEqual({ token: 'api-key-123', namespace: 'ns' });
+  });
+});
+
+describe('resource auth middleware', () => {
+  const provider = {
+    validateToken: () => null,
+  } as any;
+
+  it('fails closed when no session is present in context', async () => {
+    const middleware = createResourceAuthMiddleware(provider);
+
+    await expect(
+      middleware(
+        new Request('http://localhost/api', {
+          headers: { 'x-resource-id': 'r1' },
+        }),
+        {},
+        async () => new Response(null, { status: 200 })
+      )
+    ).rejects.toMatchObject({
+      code: 'AUTHENTICATION_FAILED',
+      statusCode: 401,
+    });
+  });
+
+  it('skips authorization for configured skip paths without a session', async () => {
+    const middleware = createResourceAuthMiddleware(provider, { skipPaths: ['/health'] });
+
+    const response = await middleware(
+      new Request('http://localhost/health'),
+      {},
+      async () => new Response(null, { status: 200 })
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it('authorizes when the session grants access to the resource', async () => {
+    const context: Record<string, unknown> = { auth: { resourceIds: ['r1'] } };
+    const middleware = createResourceAuthMiddleware({ validateToken: () => null } as any);
+
+    const response = await middleware(
+      new Request('http://localhost/api', {
+        headers: { 'x-resource-id': 'r1' },
+      }),
+      context,
+      async () => new Response(null, { status: 204 })
+    );
+
+    expect(response.status).toBe(204);
+    expect(context.resourceId).toBe('r1');
   });
 });

--- a/packages/auth/src/middleware.ts
+++ b/packages/auth/src/middleware.ts
@@ -104,9 +104,12 @@ export function createResourceAuthMiddleware<TSession extends AuthSession>(
 
     const session = context[contextKey] as TSession;
 
-    // If no session exists, skip (auth middleware should have already handled this)
+    // Fail closed: resource authorization must never run without a session.
+    // If this middleware is registered without (or before) the auth middleware,
+    // or with a mismatched contextKey, proceeding would silently bypass the
+    // control. Deny by default instead.
     if (!session) {
-      return next();
+      throw new AuthenticationError('Authentication required');
     }
 
     // Get resource ID from header

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -154,6 +154,9 @@ export interface AuthContextProvider<TContext extends AuthContext = AuthContext>
 // ============================================================================
 
 export class AuthError extends Error {
+  /** Explicit opt-in for HTTP routers that safely expose cross-package errors. */
+  public readonly isHttpError = true;
+
   constructor(message: string, public code: string, public statusCode: number = 401) {
     super(message);
     this.name = 'AuthError';

--- a/packages/db/src/adapter/__tests__/row-level-namespace.test.ts
+++ b/packages/db/src/adapter/__tests__/row-level-namespace.test.ts
@@ -172,6 +172,31 @@ describe('wrapWithRowLevelNamespace', () => {
     });
   });
 
+  describe('singular write guards', () => {
+    it('rejects empty update and delete filters before namespace injection', async () => {
+      await db.create({
+        model: 'task',
+        data: { id: 't1', title: 'Original' },
+        namespace: 'user:A',
+      });
+
+      await expect(db.update({
+        model: 'task',
+        where: [],
+        data: { title: 'Changed' },
+        namespace: 'user:A',
+      })).rejects.toThrow('update requires a non-empty where clause');
+      await expect(db.delete({
+        model: 'task',
+        where: [],
+        namespace: 'user:A',
+      })).rejects.toThrow('delete requires a non-empty where clause');
+
+      expect(await db.findMany({ model: 'task', where: [], namespace: 'user:A' }))
+        .toEqual([{ id: 't1', title: 'Original' }]);
+    });
+  });
+
   // -----------------------------------------------------------------------
   // TV-RLN-006 & TV-RLN-007: missing/empty namespace throws
   // -----------------------------------------------------------------------

--- a/packages/db/src/adapter/__tests__/row-level-namespace.test.ts
+++ b/packages/db/src/adapter/__tests__/row-level-namespace.test.ts
@@ -610,6 +610,29 @@ describe('wrapWithRowLevelNamespace', () => {
       });
       expect(found).toEqual([{ id: 'optional-hidden', title: 'Hidden namespace' }]);
     });
+
+    it('rejects singular mutations whose only filter is the hidden namespace column', async () => {
+      await optionalDb.create({
+        model: 'task',
+        data: { id: 'optional-safe', title: 'Safe' },
+      });
+      const namespaceOnlyWhere = [{ field: '__ns', operator: 'eq' as const, value: 'forged' }];
+
+      await expect(optionalDb.update({
+        model: 'task',
+        where: namespaceOnlyWhere,
+        data: { title: 'Changed' },
+      })).rejects.toThrow('update requires a non-empty where clause');
+      await expect(optionalDb.delete({
+        model: 'task',
+        where: namespaceOnlyWhere,
+      })).rejects.toThrow('delete requires a non-empty where clause');
+
+      await expect(optionalBase.findOne({
+        model: 'task',
+        where: [{ field: 'id', operator: 'eq', value: 'optional-safe' }],
+      })).resolves.toMatchObject({ title: 'Safe' });
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/db/src/adapter/row-level-namespace.ts
+++ b/packages/db/src/adapter/row-level-namespace.ts
@@ -219,6 +219,9 @@ function createNamespaceWrappedBase(
 
     async update(params) {
       const namespace = resolveNamespace(params.namespace, mandatory);
+      if (!params.where || params.where.length === 0) {
+        throw new Error('update requires a non-empty where clause; use updateMany to update all rows');
+      }
       const data = removeColumnFromData(params.data, col);
       const result = await adapter.update({
         ...params,
@@ -240,6 +243,9 @@ function createNamespaceWrappedBase(
 
     async delete(params) {
       const namespace = resolveNamespace(params.namespace, mandatory);
+      if (!params.where || params.where.length === 0) {
+        throw new Error('delete requires a non-empty where clause; use deleteMany to delete all rows');
+      }
       return adapter.delete({
         ...params,
         where: buildScopedWhere(params.where, col, namespace),

--- a/packages/db/src/adapter/row-level-namespace.ts
+++ b/packages/db/src/adapter/row-level-namespace.ts
@@ -219,13 +219,14 @@ function createNamespaceWrappedBase(
 
     async update(params) {
       const namespace = resolveNamespace(params.namespace, mandatory);
-      if (!params.where || params.where.length === 0) {
+      const visibleWhere = removeNamespaceWhere(params.where, col);
+      if (!visibleWhere || visibleWhere.length === 0) {
         throw new Error('update requires a non-empty where clause; use updateMany to update all rows');
       }
       const data = removeColumnFromData(params.data, col);
       const result = await adapter.update({
         ...params,
-        where: buildScopedWhere(params.where, col, namespace),
+        where: withNamespaceWhere(visibleWhere, col, namespace) ?? [],
         data,
       });
       return stripColumn(result, col);
@@ -243,12 +244,13 @@ function createNamespaceWrappedBase(
 
     async delete(params) {
       const namespace = resolveNamespace(params.namespace, mandatory);
-      if (!params.where || params.where.length === 0) {
+      const visibleWhere = removeNamespaceWhere(params.where, col);
+      if (!visibleWhere || visibleWhere.length === 0) {
         throw new Error('delete requires a non-empty where clause; use deleteMany to delete all rows');
       }
       return adapter.delete({
         ...params,
-        where: buildScopedWhere(params.where, col, namespace),
+        where: withNamespaceWhere(visibleWhere, col, namespace) ?? [],
       });
     },
 

--- a/packages/db/src/adapters/drizzle/index.ts
+++ b/packages/db/src/adapters/drizzle/index.ts
@@ -229,6 +229,9 @@ export function drizzleAdapter(config: DrizzleAdapterConfig): Adapter {
 
       async update<T = any>({ model, where, data, select }: UpdateParams): Promise<T> {
         const tbl = resolveTable(model);
+        if (!where || where.length === 0) {
+          throw new Error('update requires a non-empty where clause; use updateMany to update all rows');
+        }
         const cond = buildWhere(drizzleOps, tbl, where);
         const q = db.update(tbl).set(data as any).where(cond);
         if (dialect === 'mysql') {
@@ -257,6 +260,9 @@ export function drizzleAdapter(config: DrizzleAdapterConfig): Adapter {
 
       async delete({ model, where }: DeleteParams): Promise<void> {
         const tbl = resolveTable(model);
+        if (!where || where.length === 0) {
+          throw new Error('delete requires a non-empty where clause; use deleteMany to delete all rows');
+        }
         const cond = buildWhere(drizzleOps, tbl, where);
         await db.delete(tbl).where(cond).execute();
       },

--- a/packages/db/src/adapters/kysely/index.test.ts
+++ b/packages/db/src/adapters/kysely/index.test.ts
@@ -4,9 +4,19 @@ import { kyselyAdapter } from './index.js';
 describe('kyselyAdapter', () => {
   it('uses IS NULL and IS NOT NULL for public adapter null predicates', async () => {
     const predicates: unknown[][] = [];
+    const expressionBuilder = Object.assign(
+      (...args: unknown[]) => args,
+      {
+        and: (expressions: unknown[]) => ['and', ...expressions],
+        or: (expressions: unknown[]) => ['or', ...expressions],
+      }
+    );
     const query = {
       where(...args: unknown[]) {
-        predicates.push(args);
+        const expression = args[0];
+        predicates.push(
+          typeof expression === 'function' ? expression(expressionBuilder) : args
+        );
         return this;
       },
       orWhere(...args: unknown[]) {

--- a/packages/db/src/adapters/kysely/index.ts
+++ b/packages/db/src/adapters/kysely/index.ts
@@ -55,59 +55,58 @@ function escapeLikeWildcards(value: string): string {
 /**
  * Apply where clauses to Kysely query builder
  */
+/**
+ * Build a single Kysely expression for one WHERE clause.
+ */
+function buildClauseExpression(eb: any, clause: WhereClause): any {
+  const { field, operator, value } = clause;
+
+  switch (operator) {
+    case 'eq':
+      return value === null ? eb(field, 'is', null) : eb(field, '=', value);
+    case 'ne':
+      return value === null ? eb(field, 'is not', null) : eb(field, '!=', value);
+    case 'gt':
+      return eb(field, '>', value);
+    case 'gte':
+      return eb(field, '>=', value);
+    case 'lt':
+      return eb(field, '<', value);
+    case 'lte':
+      return eb(field, '<=', value);
+    case 'in':
+      return eb(field, 'in', Array.isArray(value) ? value : [value]);
+    case 'not_in':
+      return eb(field, 'not in', Array.isArray(value) ? value : [value]);
+    case 'contains':
+      return eb(field, 'like', `%${escapeLikeWildcards(String(value))}%`);
+    case 'starts_with':
+      return eb(field, 'like', `${escapeLikeWildcards(String(value))}%`);
+    case 'ends_with':
+      return eb(field, 'like', `%${escapeLikeWildcards(String(value))}`);
+    default:
+      throw new Error(`Unsupported operator: ${operator}`);
+  }
+}
+
 function applyWhere(qb: any, where: WhereClause[]): any {
   if (!where || where.length === 0) return qb;
 
-  let builder = qb;
-  for (let i = 0; i < where.length; i++) {
-    const clause = where[i];
-    const { field, operator, value, connector } = clause;
-    const method = i === 0 || connector === 'AND' ? 'where' : 'orWhere';
-
-    switch (operator) {
-      case 'eq':
-        builder = value === null
-          ? builder[method](field, 'is', null)
-          : builder[method](field, '=', value);
-        break;
-      case 'ne':
-        builder = value === null
-          ? builder[method](field, 'is not', null)
-          : builder[method](field, '!=', value);
-        break;
-      case 'gt':
-        builder = builder[method](field, '>', value);
-        break;
-      case 'gte':
-        builder = builder[method](field, '>=', value);
-        break;
-      case 'lt':
-        builder = builder[method](field, '<', value);
-        break;
-      case 'lte':
-        builder = builder[method](field, '<=', value);
-        break;
-      case 'in':
-        builder = builder[method](field, 'in', Array.isArray(value) ? value : [value]);
-        break;
-      case 'not_in':
-        builder = builder[method](field, 'not in', Array.isArray(value) ? value : [value]);
-        break;
-      case 'contains':
-        builder = builder[method](field, 'like', `%${escapeLikeWildcards(String(value))}%`);
-        break;
-      case 'starts_with':
-        builder = builder[method](field, 'like', `${escapeLikeWildcards(String(value))}%`);
-        break;
-      case 'ends_with':
-        builder = builder[method](field, 'like', `%${escapeLikeWildcards(String(value))}`);
-        break;
-      default:
-        throw new Error(`Unsupported operator: ${operator}`);
+  // Build a single grouped expression so connector precedence is explicit.
+  // The connector on clause i joins the running combination with clause i
+  // (left-associative), matching the Drizzle/Prisma adapters. Previously the
+  // flat `.where(...).orWhere(...)` chaining left grouping to SQL operator
+  // precedence, so an intended `(a OR b) AND __ns=...` became
+  // `a OR (b AND __ns=...)`, which could leak rows across namespaces.
+  return qb.where((eb: any) => {
+    let combined = buildClauseExpression(eb, where[0]);
+    for (let i = 1; i < where.length; i++) {
+      const clause = where[i];
+      const expr = buildClauseExpression(eb, clause);
+      combined = clause.connector === 'OR' ? eb.or([combined, expr]) : eb.and([combined, expr]);
     }
-  }
-
-  return builder;
+    return combined;
+  });
 }
 
 /**
@@ -193,6 +192,9 @@ export function kyselyAdapter(config: KyselyAdapterConfig): Adapter {
 
       async update<T = any>({ model, where, data, select }: UpdateParams): Promise<T> {
         const table = resolveTable(model);
+        if (!where || where.length === 0) {
+          throw new Error('update requires a non-empty where clause; use updateMany to update all rows');
+        }
         let qb = db.updateTable(table).set(data);
         qb = applyWhere(qb, where);
 
@@ -215,6 +217,9 @@ export function kyselyAdapter(config: KyselyAdapterConfig): Adapter {
 
       async delete({ model, where }: DeleteParams): Promise<void> {
         const table = resolveTable(model);
+        if (!where || where.length === 0) {
+          throw new Error('delete requires a non-empty where clause; use deleteMany to delete all rows');
+        }
         let qb = db.deleteFrom(table);
         qb = applyWhere(qb, where);
         await qb.execute();

--- a/packages/db/src/adapters/memory/index.test.ts
+++ b/packages/db/src/adapters/memory/index.test.ts
@@ -137,3 +137,28 @@ describe('memoryAdapter transactions', () => {
     ).resolves.toBeNull();
   });
 });
+
+describe('memoryAdapter filter semantics', () => {
+  it('evaluates mixed connectors left-associatively like SQL adapters', async () => {
+    const adapter = memoryAdapter({ debug: false });
+    await adapter.createMany({
+      model: 'records',
+      data: [
+        { id: 'a', first: true, second: false, third: true },
+        { id: 'b', first: false, second: true, third: true },
+        { id: 'c', first: true, second: false, third: false },
+      ],
+    });
+
+    const rows = await adapter.findMany({
+      model: 'records',
+      where: [
+        { field: 'first', operator: 'eq', value: true },
+        { field: 'second', operator: 'eq', value: true, connector: 'OR' },
+        { field: 'third', operator: 'eq', value: true, connector: 'AND' },
+      ],
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(['a', 'b']);
+  });
+});

--- a/packages/db/src/adapters/memory/index.ts
+++ b/packages/db/src/adapters/memory/index.ts
@@ -100,7 +100,7 @@ function createMemoryInternalCrud(): MemoryInternalCrudState {
         internalStore.set(table, new Map());
       }
       const store = internalStore.get(table)!;
-      const id = (data.id as string) ?? randomUUID();
+      const id = (data.id as string) || randomUUID();
       const record = { ...data, id };
       store.set(id, record);
       return record;
@@ -186,7 +186,7 @@ function createMemoryInternalCrud(): MemoryInternalCrudState {
       const tableStore = internalStore.get(table)!;
       const results: Record<string, unknown>[] = [];
       for (const item of data) {
-        const id = (item.id as string) ?? randomUUID();
+        const id = (item.id as string) || randomUUID();
         const record = { ...item, id };
         tableStore.set(id, record);
         results.push(record);

--- a/packages/db/src/adapters/memory/index.ts
+++ b/packages/db/src/adapters/memory/index.ts
@@ -2,6 +2,7 @@
  * In-memory adapter for testing
  */
 
+import { randomUUID } from 'node:crypto';
 import { createAdapterFactory } from '../../adapter/factory.js';
 import { NotFoundError } from '../../adapter/errors.js';
 import type {
@@ -99,7 +100,7 @@ function createMemoryInternalCrud(): MemoryInternalCrudState {
         internalStore.set(table, new Map());
       }
       const store = internalStore.get(table)!;
-      const id = (data.id as string) ?? Math.random().toString(36).substr(2, 9);
+      const id = (data.id as string) ?? randomUUID();
       const record = { ...data, id };
       store.set(id, record);
       return record;
@@ -185,7 +186,7 @@ function createMemoryInternalCrud(): MemoryInternalCrudState {
       const tableStore = internalStore.get(table)!;
       const results: Record<string, unknown>[] = [];
       for (const item of data) {
-        const id = (item.id as string) ?? Math.random().toString(36).substr(2, 9);
+        const id = (item.id as string) ?? randomUUID();
         const record = { ...item, id };
         tableStore.set(id, record);
         results.push(record);
@@ -287,7 +288,7 @@ export function memoryAdapter(config?: MemoryAdapterConfig): Adapter {
           customTypes: false,
         },
       },
-      customIdGenerator: () => Math.random().toString(36).substr(2, 9),
+      customIdGenerator: () => randomUUID(),
       namespace: config?.namespace,
       debug: config?.debug,
     },
@@ -330,7 +331,7 @@ export function memoryAdapter(config?: MemoryAdapterConfig): Adapter {
           }
 
           const table = store.get(tableName)!;
-          const id = params.data.id || Math.random().toString(36).substr(2, 9);
+          const id = params.data.id || randomUUID();
 
           // Enforce uniqueness: create must fail if record with this ID already exists
           if (table.has(id)) {
@@ -416,6 +417,9 @@ export function memoryAdapter(config?: MemoryAdapterConfig): Adapter {
         },
 
         async update<T>(params: UpdateParams): Promise<T> {
+          if (!params.where || params.where.length === 0) {
+            throw new Error('update requires a non-empty where clause; use updateMany to update all rows');
+          }
           const tableName = context.getModelName(params.model);
           const table = store.get(tableName);
 
@@ -444,6 +448,9 @@ export function memoryAdapter(config?: MemoryAdapterConfig): Adapter {
         },
 
         async delete(params: DeleteParams): Promise<void> {
+          if (!params.where || params.where.length === 0) {
+            throw new Error('delete requires a non-empty where clause; use deleteMany to delete all rows');
+          }
           const tableName = context.getModelName(params.model);
           const table = store.get(tableName);
 

--- a/packages/db/src/adapters/memory/index.ts
+++ b/packages/db/src/adapters/memory/index.ts
@@ -672,36 +672,18 @@ function matchesWhere(record: any, where: WhereClause[]): boolean {
     return true;
   }
 
-  let hasOrClause = false;
-  let orMatched = false;
-  let andMatched = true;
-
-  for (const clause of where) {
-    const value = record[clause.field];
-    const matches = matchesClause(value, clause);
-
-    if (clause.connector === 'OR') {
-      hasOrClause = true;
-      if (matches) orMatched = true;
-    } else {
-      // Default AND - all AND clauses must match
-      if (!matches) {
-        andMatched = false;
-      }
-    }
+  // A connector belongs to the clause it introduces. Evaluate in the same
+  // left-associative order used by the SQL and Prisma adapters so a mixed
+  // `A, OR B, AND C` filter consistently means `(A OR B) AND C`.
+  let matched = matchesClause(record[where[0].field], where[0]);
+  for (let index = 1; index < where.length; index += 1) {
+    const clause = where[index];
+    const clauseMatched = matchesClause(record[clause.field], clause);
+    matched = clause.connector === 'OR'
+      ? matched || clauseMatched
+      : matched && clauseMatched;
   }
-
-  // All AND clauses must match
-  if (!andMatched) {
-    return false;
-  }
-
-  // If we had OR clauses, at least one must have matched
-  if (hasOrClause && !orMatched) {
-    return false;
-  }
-
-  return true;
+  return matched;
 }
 
 /**

--- a/packages/db/src/adapters/prisma/index.test.ts
+++ b/packages/db/src/adapters/prisma/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { prismaAdapter } from './index.js';
+
+describe('prismaAdapter singular write guards', () => {
+  it('rejects empty update and delete filters without calling Prisma', async () => {
+    const model = {
+      updateMany: vi.fn(),
+      deleteMany: vi.fn(),
+    };
+    const adapter = prismaAdapter({
+      prisma: { user: model },
+      provider: 'postgresql',
+      modelMap: { users: 'user' },
+    });
+
+    await expect(adapter.update({ model: 'users', where: [], data: { name: 'Changed' } }))
+      .rejects.toThrow('update requires a non-empty where clause');
+    await expect(adapter.delete({ model: 'users', where: [] }))
+      .rejects.toThrow('delete requires a non-empty where clause');
+    expect(model.updateMany).not.toHaveBeenCalled();
+    expect(model.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/adapters/prisma/index.ts
+++ b/packages/db/src/adapters/prisma/index.ts
@@ -173,6 +173,9 @@ export function prismaAdapter(config: PrismaAdapterConfig): Adapter {
        * @throws {Error} If no rows were updated
        */
       async update<T = any>({ model, where, data, select }: UpdateParams): Promise<T> {
+        if (!where || where.length === 0) {
+          throw new Error('update requires a non-empty where clause; use updateMany to update all rows');
+        }
         const m = resolveModel(model);
         const prismaWhere = buildPrismaWhere(where);
         const prismaSelect = buildPrismaSelect(select);
@@ -187,6 +190,9 @@ export function prismaAdapter(config: PrismaAdapterConfig): Adapter {
       },
 
       async delete({ model, where }: DeleteParams): Promise<void> {
+        if (!where || where.length === 0) {
+          throw new Error('delete requires a non-empty where clause; use deleteMany to delete all rows');
+        }
         const m = resolveModel(model);
         const prismaWhere = buildPrismaWhere(where);
         // Use deleteMany to support complex where clauses

--- a/packages/db/src/adapters/prisma/index.ts
+++ b/packages/db/src/adapters/prisma/index.ts
@@ -80,40 +80,20 @@ function buildPrismaWhere(where: WhereClause[]): any {
     }
   });
 
-  // Combine with AND/OR based on connector
+  // Combine with AND/OR based on each clause's connector.
+  //
+  // The connector on clause i joins the running combination with clause i
+  // (left-associative), matching the Drizzle/Kysely adapters. Previously the
+  // presence of any OR connector caused every clause to be flattened into a
+  // single AND, silently dropping the OR semantics and returning wrong rows.
   if (conditions.length === 1) return conditions[0];
 
-  // Check if any conditions use OR connector
-  const hasOr = where.some((c, i) => i > 0 && c.connector === 'OR');
-
-  if (hasOr) {
-    // Mixed AND/OR: group by connector
-    const result: any = { AND: [] };
-    let currentGroup: any[] = [conditions[0]];
-
-    for (let i = 1; i < conditions.length; i++) {
-      if (where[i].connector === 'OR') {
-        // Flush current AND group before starting OR
-        if (currentGroup.length > 0) {
-          result.AND.push(currentGroup.length === 1 ? currentGroup[0] : { AND: currentGroup });
-        }
-        // Start new group with the OR condition
-        currentGroup = [conditions[i]];
-      } else {
-        // Continue building AND group
-        currentGroup.push(conditions[i]);
-      }
-    }
-
-    if (currentGroup.length > 0) {
-      result.AND.push(currentGroup.length === 1 ? currentGroup[0] : { AND: currentGroup });
-    }
-
-    return result.AND.length === 1 ? result.AND[0] : result;
-  } else {
-    // All AND
-    return { AND: conditions };
+  let combined: any = conditions[0];
+  for (let i = 1; i < conditions.length; i++) {
+    const connector = where[i]?.connector ?? 'AND';
+    combined = connector === 'OR' ? { OR: [combined, conditions[i]] } : { AND: [combined, conditions[i]] };
   }
+  return combined;
 }
 
 /**

--- a/packages/http/src/__tests__/router.test.ts
+++ b/packages/http/src/__tests__/router.test.ts
@@ -406,6 +406,43 @@ describe('createRouter', () => {
     expect(res.headers.get('Allow')).toBe('GET');
   });
 
+  it('preserves immutable onError responses when adding the Allow header', async () => {
+    const router = createRouter({
+      routes: [{ method: 'GET', path: '/users', handler: async () => Response.json({}) }],
+      onError: async () => Response.redirect('https://example.com/method-error', 302),
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/users', { method: 'POST' })
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://example.com/method-error');
+    expect(res.headers.get('Allow')).toBe('GET');
+  });
+
+  it('maps HTTP-shaped middleware errors without exposing unknown exceptions', async () => {
+    const router = createRouter({
+      routes: [{
+        method: 'GET',
+        path: '/protected',
+        handler: async () => {
+          throw Object.assign(new Error('Authentication required'), {
+            code: 'AUTHENTICATION_FAILED',
+            statusCode: 401,
+          });
+        },
+      }],
+    });
+
+    const res = await router.handle(new Request('http://localhost/protected'));
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Authentication required',
+      code: 'AUTHENTICATION_FAILED',
+    });
+  });
+
   it('still returns 404 for a genuinely unknown path', async () => {
     const router = createRouter({
       routes: [{ method: 'GET', path: '/users', handler: async () => Response.json({}) }],

--- a/packages/http/src/__tests__/router.test.ts
+++ b/packages/http/src/__tests__/router.test.ts
@@ -428,6 +428,7 @@ describe('createRouter', () => {
         path: '/protected',
         handler: async () => {
           throw Object.assign(new Error('Authentication required'), {
+            isHttpError: true,
             code: 'AUTHENTICATION_FAILED',
             statusCode: 401,
           });
@@ -441,6 +442,25 @@ describe('createRouter', () => {
       error: 'Authentication required',
       code: 'AUTHENTICATION_FAILED',
     });
+  });
+
+  it('redacts arbitrary errors even when they contain HTTP-shaped metadata', async () => {
+    const router = createRouter({
+      routes: [{
+        method: 'GET',
+        path: '/upstream',
+        handler: async () => {
+          throw Object.assign(new Error('private upstream details'), {
+            code: 'UPSTREAM_FAILURE',
+            statusCode: 500,
+          });
+        },
+      }],
+    });
+
+    const res = await router.handle(new Request('http://localhost/upstream'));
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({ error: 'Internal Server Error' });
   });
 
   it('still returns 404 for a genuinely unknown path', async () => {

--- a/packages/http/src/__tests__/router.test.ts
+++ b/packages/http/src/__tests__/router.test.ts
@@ -421,7 +421,7 @@ describe('createRouter', () => {
     expect(res.headers.get('Allow')).toBe('GET');
   });
 
-  it('maps HTTP-shaped middleware errors without exposing unknown exceptions', async () => {
+  it('maps HTTP-shaped handler errors without exposing unknown exceptions', async () => {
     const router = createRouter({
       routes: [{
         method: 'GET',

--- a/packages/http/src/__tests__/router.test.ts
+++ b/packages/http/src/__tests__/router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createRouter } from '../router.js';
 import { NotFoundError, UnauthorizedError } from '../errors.js';
 
@@ -444,5 +444,106 @@ describe('createRouter', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('cancels a streaming body as soon as maxBodyBytes is exceeded', async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"value":"too large"}'));
+      },
+      cancel,
+    });
+    const router = createRouter({
+      maxBodyBytes: 10,
+      routes: [
+        {
+          method: 'POST',
+          path: '/echo',
+          handler: async (_req, ctx) => Response.json(await ctx.json()),
+        },
+      ],
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/echo', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+        duplex: 'half',
+      } as RequestInit & { duplex: 'half' })
+    );
+
+    expect(res.status).toBe(413);
+    expect(cancel).toHaveBeenCalledWith('PAYLOAD_TOO_LARGE');
+  });
+
+  it('enforces maxBodyBytes for streamed multipart form data', async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            '--boundary\r\nContent-Disposition: form-data; name="value"\r\n\r\ntoo large\r\n'
+          )
+        );
+      },
+      cancel,
+    });
+    const router = createRouter({
+      maxBodyBytes: 16,
+      routes: [
+        {
+          method: 'POST',
+          path: '/form',
+          handler: async (_req, ctx) => {
+            const form = await ctx.formData();
+            return Response.json({ value: form.get('value') });
+          },
+        },
+      ],
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/form', {
+        method: 'POST',
+        headers: { 'content-type': 'multipart/form-data; boundary=boundary' },
+        body,
+        duplex: 'half',
+      } as RequestInit & { duplex: 'half' })
+    );
+
+    expect(res.status).toBe(413);
+    expect(cancel).toHaveBeenCalledWith('PAYLOAD_TOO_LARGE');
+  });
+
+  it('preserves binary multipart fields while enforcing maxBodyBytes', async () => {
+    const form = new FormData();
+    form.set('note', 'hello');
+    form.set('file', new Blob([new Uint8Array([0, 255, 1, 128])]), 'bytes.bin');
+    const router = createRouter({
+      maxBodyBytes: 4096,
+      routes: [
+        {
+          method: 'POST',
+          path: '/form',
+          handler: async (_req, ctx) => {
+            const parsed = await ctx.formData();
+            const file = parsed.get('file');
+            return Response.json({
+              note: parsed.get('note'),
+              bytes: file instanceof Blob ? [...new Uint8Array(await file.arrayBuffer())] : null,
+            });
+          },
+        },
+      ],
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/form', { method: 'POST', body: form })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ note: 'hello', bytes: [0, 255, 1, 128] });
   });
 });

--- a/packages/http/src/__tests__/router.test.ts
+++ b/packages/http/src/__tests__/router.test.ts
@@ -388,6 +388,24 @@ describe('createRouter', () => {
     expect(allow.split(', ').sort()).toEqual(['DELETE', 'GET']);
   });
 
+  it('routes 405 errors through onError while preserving the Allow header', async () => {
+    const onError = vi.fn(async (error: Error) =>
+      Response.json({ name: error.name }, { status: 405 })
+    );
+    const router = createRouter({
+      routes: [{ method: 'GET', path: '/users', handler: async () => Response.json({}) }],
+      onError,
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/users', { method: 'POST' })
+    );
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(res.status).toBe(405);
+    expect(res.headers.get('Allow')).toBe('GET');
+  });
+
   it('still returns 404 for a genuinely unknown path', async () => {
     const router = createRouter({
       routes: [{ method: 'GET', path: '/users', handler: async () => Response.json({}) }],
@@ -420,6 +438,33 @@ describe('createRouter', () => {
     );
 
     expect(res.status).toBe(413);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1, 1.5])(
+    'rejects invalid maxBodyBytes configuration: %s',
+    (maxBodyBytes) => {
+      expect(() => createRouter({ maxBodyBytes, routes: [] })).toThrow(
+        'maxBodyBytes must be a non-negative integer'
+      );
+    }
+  );
+
+  it('preserves Request.json rejection semantics for an empty bounded body', async () => {
+    const onError = vi.fn(async () => Response.json({ invalid: true }, { status: 400 }));
+    const router = createRouter({
+      maxBodyBytes: 1024,
+      onError,
+      routes: [{
+        method: 'POST',
+        path: '/json',
+        handler: async (_request, ctx) => Response.json(await ctx.json()),
+      }],
+    });
+
+    const res = await router.handle(new Request('http://localhost/json', { method: 'POST' }));
+
+    expect(res.status).toBe(400);
+    expect(onError).toHaveBeenCalledOnce();
   });
 
   it('accepts request bodies within maxBodyBytes', async () => {

--- a/packages/http/src/__tests__/router.test.ts
+++ b/packages/http/src/__tests__/router.test.ts
@@ -370,4 +370,79 @@ describe('createRouter', () => {
     expect(calls).toContain('route-mw');
     expect(calls).toContain('handler');
   });
+
+  it('returns 405 with an Allow header when the path exists under another method', async () => {
+    const router = createRouter({
+      routes: [
+        { method: 'GET', path: '/users/:id', handler: async () => Response.json({}) },
+        { method: 'DELETE', path: '/users/:id', handler: async () => new Response(null, { status: 204 }) },
+      ],
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/users/1', { method: 'POST' })
+    );
+
+    expect(res.status).toBe(405);
+    const allow = res.headers.get('Allow') ?? '';
+    expect(allow.split(', ').sort()).toEqual(['DELETE', 'GET']);
+  });
+
+  it('still returns 404 for a genuinely unknown path', async () => {
+    const router = createRouter({
+      routes: [{ method: 'GET', path: '/users', handler: async () => Response.json({}) }],
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/nope', { method: 'POST' })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects request bodies exceeding maxBodyBytes via Content-Length', async () => {
+    const router = createRouter({
+      maxBodyBytes: 10,
+      routes: [
+        {
+          method: 'POST',
+          path: '/echo',
+          handler: async (_req, ctx) => Response.json(await ctx.json()),
+        },
+      ],
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/echo', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ value: 'this is definitely more than ten bytes' }),
+      })
+    );
+
+    expect(res.status).toBe(413);
+  });
+
+  it('accepts request bodies within maxBodyBytes', async () => {
+    const router = createRouter({
+      maxBodyBytes: 1024,
+      routes: [
+        {
+          method: 'POST',
+          path: '/echo',
+          handler: async (_req, ctx) => Response.json(await ctx.json()),
+        },
+      ],
+    });
+
+    const res = await router.handle(
+      new Request('http://localhost/echo', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ok: true }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
 });

--- a/packages/http/src/context.ts
+++ b/packages/http/src/context.ts
@@ -3,43 +3,144 @@
  */
 
 import type { RouteContext } from './types.js';
+import { PayloadTooLargeError } from './errors.js';
+
+/**
+ * Read a request body fully while enforcing a maximum byte length.
+ *
+ * Rejects early via the Content-Length header when present, and otherwise
+ * streams the body and aborts as soon as the accumulated size exceeds the
+ * limit — so an attacker cannot exhaust memory by omitting Content-Length.
+ */
+async function readBodyWithLimit(request: Request, maxBodyBytes: number): Promise<string> {
+  const contentLength = request.headers.get('content-length');
+  if (contentLength !== null) {
+    const declared = Number(contentLength);
+    if (Number.isFinite(declared) && declared > maxBodyBytes) {
+      throw new PayloadTooLargeError(
+        `Request body exceeds the maximum allowed size of ${maxBodyBytes} bytes`,
+        'PAYLOAD_TOO_LARGE'
+      );
+    }
+  }
+
+  const body = request.body;
+  // No stream available (e.g. already-buffered mock): fall back to text() but
+  // still enforce the limit on the resulting length.
+  if (!body) {
+    const text = await request.text();
+    if (byteLength(text) > maxBodyBytes) {
+      throw new PayloadTooLargeError(
+        `Request body exceeds the maximum allowed size of ${maxBodyBytes} bytes`,
+        'PAYLOAD_TOO_LARGE'
+      );
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > maxBodyBytes) {
+          throw new PayloadTooLargeError(
+            `Request body exceeds the maximum allowed size of ${maxBodyBytes} bytes`,
+            'PAYLOAD_TOO_LARGE'
+          );
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return new TextDecoder().decode(concatChunks(chunks, total));
+}
+
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).byteLength;
+}
+
+function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
 
 /**
  * Create a RouteContext from a Request and path params
  */
 export function createRouteContext(
   request: Request,
-  params: Record<string, string>
+  params: Record<string, string>,
+  options?: { maxBodyBytes?: number }
 ): RouteContext {
   const url = new URL(request.url);
   const query = url.searchParams;
+  const maxBodyBytes = options?.maxBodyBytes;
 
   // Cache for parsed bodies to avoid multiple parsing
   let jsonCache: Promise<any> | null = null;
   let textCache: Promise<string> | null = null;
   let formDataCache: Promise<FormData> | null = null;
 
+  // When a limit is configured, buffer the body once (with enforcement) and
+  // derive json/text/formData from that single read. Otherwise defer to the
+  // native Request parsers.
+  const readText = (): Promise<string> => {
+    if (!textCache) {
+      textCache =
+        maxBodyBytes !== undefined ? readBodyWithLimit(request, maxBodyBytes) : request.text();
+    }
+    return textCache;
+  };
+
   return {
     params,
     query,
     url,
-    
+
     json: async <T = any>(): Promise<T> => {
       if (!jsonCache) {
-        jsonCache = request.json();
+        jsonCache =
+          maxBodyBytes !== undefined
+            ? readText().then((text) => (text.length === 0 ? undefined : JSON.parse(text)))
+            : request.json();
       }
       return jsonCache as Promise<T>;
     },
-    
+
     text: async (): Promise<string> => {
-      if (!textCache) {
-        textCache = request.text();
-      }
-      return textCache;
+      return readText();
     },
-    
+
     formData: async (): Promise<FormData> => {
       if (!formDataCache) {
+        if (maxBodyBytes !== undefined) {
+          const contentLength = request.headers.get('content-length');
+          if (contentLength !== null) {
+            const declared = Number(contentLength);
+            if (Number.isFinite(declared) && declared > maxBodyBytes) {
+              formDataCache = Promise.reject(
+                new PayloadTooLargeError(
+                  `Request body exceeds the maximum allowed size of ${maxBodyBytes} bytes`,
+                  'PAYLOAD_TOO_LARGE'
+                )
+              );
+              return formDataCache;
+            }
+          }
+        }
         formDataCache = request.formData();
       }
       return formDataCache;

--- a/packages/http/src/context.ts
+++ b/packages/http/src/context.ts
@@ -131,7 +131,7 @@ export function createRouteContext(
       if (!jsonCache) {
         jsonCache =
           maxBodyBytes !== undefined
-            ? readText().then((text) => (text.length === 0 ? undefined : JSON.parse(text)))
+            ? readText().then((text) => JSON.parse(text))
             : request.json();
       }
       return jsonCache as Promise<T>;
@@ -147,9 +147,7 @@ export function createRouteContext(
           formDataCache = readBuffer().then((bytes) => {
             // Parse from the same bounded binary buffer used by json() and
             // text(). Response.formData() preserves multipart file bytes.
-            const body = new Uint8Array(bytes.byteLength);
-            body.set(bytes);
-            return new Response(body.buffer, { headers: request.headers }).formData();
+            return new Response(bytes.buffer as ArrayBuffer, { headers: request.headers }).formData();
           });
         } else {
           formDataCache = request.formData();

--- a/packages/http/src/context.ts
+++ b/packages/http/src/context.ts
@@ -12,7 +12,10 @@ import { PayloadTooLargeError } from './errors.js';
  * streams the body and aborts as soon as the accumulated size exceeds the
  * limit — so an attacker cannot exhaust memory by omitting Content-Length.
  */
-async function readBodyWithLimit(request: Request, maxBodyBytes: number): Promise<string> {
+async function readBodyBufferWithLimit(
+  request: Request,
+  maxBodyBytes: number
+): Promise<Uint8Array> {
   const contentLength = request.headers.get('content-length');
   if (contentLength !== null) {
     const declared = Number(contentLength);
@@ -25,17 +28,17 @@ async function readBodyWithLimit(request: Request, maxBodyBytes: number): Promis
   }
 
   const body = request.body;
-  // No stream available (e.g. already-buffered mock): fall back to text() but
-  // still enforce the limit on the resulting length.
+  // No stream available (e.g. an already-buffered mock): fall back to
+  // arrayBuffer() so multipart and other binary payloads are not corrupted.
   if (!body) {
-    const text = await request.text();
-    if (byteLength(text) > maxBodyBytes) {
+    const bytes = new Uint8Array(await request.arrayBuffer());
+    if (bytes.byteLength > maxBodyBytes) {
       throw new PayloadTooLargeError(
         `Request body exceeds the maximum allowed size of ${maxBodyBytes} bytes`,
         'PAYLOAD_TOO_LARGE'
       );
     }
-    return text;
+    return bytes;
   }
 
   const reader = body.getReader();
@@ -48,6 +51,14 @@ async function readBodyWithLimit(request: Request, maxBodyBytes: number): Promis
       if (value) {
         total += value.byteLength;
         if (total > maxBodyBytes) {
+          // Stop the producer immediately. Releasing the lock alone leaves the
+          // source free to continue buffering an attacker-controlled body.
+          try {
+            await reader.cancel('PAYLOAD_TOO_LARGE');
+          } catch {
+            // Preserve the stable payload-limit error even if cancellation
+            // itself fails in a custom stream implementation.
+          }
           throw new PayloadTooLargeError(
             `Request body exceeds the maximum allowed size of ${maxBodyBytes} bytes`,
             'PAYLOAD_TOO_LARGE'
@@ -60,11 +71,7 @@ async function readBodyWithLimit(request: Request, maxBodyBytes: number): Promis
     reader.releaseLock();
   }
 
-  return new TextDecoder().decode(concatChunks(chunks, total));
-}
-
-function byteLength(text: string): number {
-  return new TextEncoder().encode(text).byteLength;
+  return concatChunks(chunks, total);
 }
 
 function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
@@ -93,14 +100,24 @@ export function createRouteContext(
   let jsonCache: Promise<any> | null = null;
   let textCache: Promise<string> | null = null;
   let formDataCache: Promise<FormData> | null = null;
+  let bodyBufferCache: Promise<Uint8Array> | null = null;
 
   // When a limit is configured, buffer the body once (with enforcement) and
   // derive json/text/formData from that single read. Otherwise defer to the
   // native Request parsers.
+  const readBuffer = (): Promise<Uint8Array> => {
+    if (!bodyBufferCache) {
+      bodyBufferCache = readBodyBufferWithLimit(request, maxBodyBytes!);
+    }
+    return bodyBufferCache;
+  };
+
   const readText = (): Promise<string> => {
     if (!textCache) {
       textCache =
-        maxBodyBytes !== undefined ? readBodyWithLimit(request, maxBodyBytes) : request.text();
+        maxBodyBytes !== undefined
+          ? readBuffer().then((bytes) => new TextDecoder().decode(bytes))
+          : request.text();
     }
     return textCache;
   };
@@ -127,21 +144,16 @@ export function createRouteContext(
     formData: async (): Promise<FormData> => {
       if (!formDataCache) {
         if (maxBodyBytes !== undefined) {
-          const contentLength = request.headers.get('content-length');
-          if (contentLength !== null) {
-            const declared = Number(contentLength);
-            if (Number.isFinite(declared) && declared > maxBodyBytes) {
-              formDataCache = Promise.reject(
-                new PayloadTooLargeError(
-                  `Request body exceeds the maximum allowed size of ${maxBodyBytes} bytes`,
-                  'PAYLOAD_TOO_LARGE'
-                )
-              );
-              return formDataCache;
-            }
-          }
+          formDataCache = readBuffer().then((bytes) => {
+            // Parse from the same bounded binary buffer used by json() and
+            // text(). Response.formData() preserves multipart file bytes.
+            const body = new Uint8Array(bytes.byteLength);
+            body.set(bytes);
+            return new Response(body.buffer, { headers: request.headers }).formData();
+          });
+        } else {
+          formDataCache = request.formData();
         }
-        formDataCache = request.formData();
       }
       return formDataCache;
     },

--- a/packages/http/src/errors.ts
+++ b/packages/http/src/errors.ts
@@ -73,6 +73,13 @@ export class UnprocessableEntityError extends RouterError {
   }
 }
 
+export class PayloadTooLargeError extends RouterError {
+  constructor(message: string = 'Payload Too Large', code?: string) {
+    super(message, 413, code);
+    this.name = 'PayloadTooLargeError';
+  }
+}
+
 export class TooManyRequestsError extends RouterError {
   constructor(message: string = 'Too Many Requests', code?: string) {
     super(message, 429, code);

--- a/packages/http/src/errors.ts
+++ b/packages/http/src/errors.ts
@@ -10,7 +10,7 @@ export class RouterError extends Error {
   ) {
     super(message);
     this.name = 'RouterError';
-    Object.setPrototypeOf(this, RouterError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 
   toResponse(): Response {
@@ -53,9 +53,21 @@ export class NotFoundError extends RouterError {
 }
 
 export class MethodNotAllowedError extends RouterError {
-  constructor(message: string = 'Method Not Allowed', code?: string) {
+  constructor(
+    message: string = 'Method Not Allowed',
+    code?: string,
+    public readonly allowedMethods: readonly string[] = []
+  ) {
     super(message, 405, code);
     this.name = 'MethodNotAllowedError';
+  }
+
+  override toResponse(): Response {
+    const response = super.toResponse();
+    if (this.allowedMethods.length > 0) {
+      response.headers.set('Allow', this.allowedMethods.join(', '));
+    }
+    return response;
   }
 }
 

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -33,6 +33,7 @@ export {
   MethodNotAllowedError,
   ConflictError,
   UnprocessableEntityError,
+  PayloadTooLargeError,
   TooManyRequestsError,
   InternalServerError,
   NotImplementedError,

--- a/packages/http/src/middleware/cors.test.ts
+++ b/packages/http/src/middleware/cors.test.ts
@@ -35,6 +35,9 @@ describe('corsMiddleware', () => {
     expect(() => corsMiddleware({ credentials: true })).toThrow(
       'CORS_CREDENTIALS_WILDCARD_ORIGIN'
     );
+    expect(() => corsMiddleware({ origin: ['https://app.example', '*'], credentials: true })).toThrow(
+      'CORS_CREDENTIALS_WILDCARD_ORIGIN'
+    );
   });
 
   it('uses a static wildcard origin without Vary when credentials are disabled', async () => {

--- a/packages/http/src/middleware/cors.test.ts
+++ b/packages/http/src/middleware/cors.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { corsMiddleware } from './cors.js';
+
+const okHandler = async () => new Response('ok', { status: 200 });
+
+describe('corsMiddleware', () => {
+  it('sets Vary: Origin when the allowed origin is an array (reflected)', async () => {
+    const mw = corsMiddleware({ origin: ['https://app.example'] });
+    const response = await mw(
+      new Request('http://localhost/api', { headers: { Origin: 'https://app.example' } }),
+      {},
+      okHandler
+    );
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
+    expect(response.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('sets Vary: Origin even when the request origin is not allowed', async () => {
+    const mw = corsMiddleware({ origin: ['https://app.example'] });
+    const response = await mw(
+      new Request('http://localhost/api', { headers: { Origin: 'https://evil.example' } }),
+      {},
+      okHandler
+    );
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(response.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('does not emit wildcard origin together with credentials', async () => {
+    const mw = corsMiddleware({ origin: '*', credentials: true });
+    const response = await mw(
+      new Request('http://localhost/api', { headers: { Origin: 'https://app.example' } }),
+      {},
+      okHandler
+    );
+
+    // Must reflect a concrete origin, never `*`, when credentials are enabled.
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(response.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('uses a static wildcard origin without Vary when credentials are disabled', async () => {
+    const mw = corsMiddleware();
+    const response = await mw(
+      new Request('http://localhost/api', { headers: { Origin: 'https://app.example' } }),
+      {},
+      okHandler
+    );
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Vary')).toBeNull();
+  });
+
+  it('adds Vary: Origin to preflight responses for reflected origins', async () => {
+    const mw = corsMiddleware({ origin: ['https://app.example'] });
+    const response = await mw(
+      new Request('http://localhost/api', {
+        method: 'OPTIONS',
+        headers: { Origin: 'https://app.example' },
+      }),
+      {},
+      okHandler
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Vary')).toBe('Origin');
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
+  });
+});

--- a/packages/http/src/middleware/cors.test.ts
+++ b/packages/http/src/middleware/cors.test.ts
@@ -28,18 +28,13 @@ describe('corsMiddleware', () => {
     expect(response.headers.get('Vary')).toBe('Origin');
   });
 
-  it('does not emit wildcard origin together with credentials', async () => {
-    const mw = corsMiddleware({ origin: '*', credentials: true });
-    const response = await mw(
-      new Request('http://localhost/api', { headers: { Origin: 'https://app.example' } }),
-      {},
-      okHandler
+  it('rejects wildcard origin together with credentials', () => {
+    expect(() => corsMiddleware({ origin: '*', credentials: true })).toThrow(
+      'CORS_CREDENTIALS_WILDCARD_ORIGIN'
     );
-
-    // Must reflect a concrete origin, never `*`, when credentials are enabled.
-    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example');
-    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true');
-    expect(response.headers.get('Vary')).toBe('Origin');
+    expect(() => corsMiddleware({ credentials: true })).toThrow(
+      'CORS_CREDENTIALS_WILDCARD_ORIGIN'
+    );
   });
 
   it('uses a static wildcard origin without Vary when credentials are disabled', async () => {

--- a/packages/http/src/middleware/cors.test.ts
+++ b/packages/http/src/middleware/cors.test.ts
@@ -52,6 +52,18 @@ describe('corsMiddleware', () => {
     expect(response.headers.get('Vary')).toBeNull();
   });
 
+  it('supports a wildcard inside an origin array when credentials are disabled', async () => {
+    const mw = corsMiddleware({ origin: ['https://app.example', '*'] });
+    const response = await mw(
+      new Request('http://localhost/api', { headers: { Origin: 'https://other.example' } }),
+      {},
+      okHandler
+    );
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Vary')).toBeNull();
+  });
+
   it('adds Vary: Origin to preflight responses for reflected origins', async () => {
     const mw = corsMiddleware({ origin: ['https://app.example'] });
     const response = await mw(

--- a/packages/http/src/middleware/cors.ts
+++ b/packages/http/src/middleware/cors.ts
@@ -37,9 +37,13 @@ export function corsMiddleware<TContext = any>(
     if (typeof origin === 'string') {
       allowedOrigin = origin;
     } else if (Array.isArray(origin)) {
-      varyOnOrigin = true;
-      if (origin.includes(requestOrigin)) {
-        allowedOrigin = requestOrigin;
+      if (origin.includes('*')) {
+        allowedOrigin = '*';
+      } else {
+        varyOnOrigin = true;
+        if (origin.includes(requestOrigin)) {
+          allowedOrigin = requestOrigin;
+        }
       }
     } else if (typeof origin === 'function') {
       varyOnOrigin = true;

--- a/packages/http/src/middleware/cors.ts
+++ b/packages/http/src/middleware/cors.ts
@@ -22,7 +22,7 @@ export function corsMiddleware<TContext = any>(
   // Reflecting an arbitrary request Origin here would turn the wildcard into
   // an allow-all credentialed policy. Require callers to name trusted origins
   // explicitly (or supply a predicate) instead.
-  if (credentials && origin === '*') {
+  if (credentials && (origin === '*' || (Array.isArray(origin) && origin.includes('*')))) {
     throw new Error('CORS_CREDENTIALS_WILDCARD_ORIGIN');
   }
 

--- a/packages/http/src/middleware/cors.ts
+++ b/packages/http/src/middleware/cors.ts
@@ -19,11 +19,12 @@ export function corsMiddleware<TContext = any>(
     maxAge = 86400, // 24 hours
   } = options;
 
-  // `Access-Control-Allow-Origin: *` together with credentials is rejected by
-  // browsers, so credentialed responses must reflect a concrete origin. When
-  // credentials are enabled with the wildcard default, reflect the request
-  // origin (and set Vary: Origin) instead of emitting the invalid combination.
-  const reflectForCredentials = credentials && origin === '*';
+  // Reflecting an arbitrary request Origin here would turn the wildcard into
+  // an allow-all credentialed policy. Require callers to name trusted origins
+  // explicitly (or supply a predicate) instead.
+  if (credentials && origin === '*') {
+    throw new Error('CORS_CREDENTIALS_WILDCARD_ORIGIN');
+  }
 
   return async (request, _context, next) => {
     const requestOrigin = request.headers.get('Origin') || '';
@@ -34,12 +35,7 @@ export function corsMiddleware<TContext = any>(
     let allowedOrigin: string | null = null;
     let varyOnOrigin = false;
     if (typeof origin === 'string') {
-      if (reflectForCredentials) {
-        allowedOrigin = requestOrigin || null;
-        varyOnOrigin = true;
-      } else {
-        allowedOrigin = origin;
-      }
+      allowedOrigin = origin;
     } else if (Array.isArray(origin)) {
       varyOnOrigin = true;
       if (origin.includes(requestOrigin)) {

--- a/packages/http/src/middleware/cors.ts
+++ b/packages/http/src/middleware/cors.ts
@@ -19,18 +19,34 @@ export function corsMiddleware<TContext = any>(
     maxAge = 86400, // 24 hours
   } = options;
 
+  // `Access-Control-Allow-Origin: *` together with credentials is rejected by
+  // browsers, so credentialed responses must reflect a concrete origin. When
+  // credentials are enabled with the wildcard default, reflect the request
+  // origin (and set Vary: Origin) instead of emitting the invalid combination.
+  const reflectForCredentials = credentials && origin === '*';
+
   return async (request, _context, next) => {
     const requestOrigin = request.headers.get('Origin') || '';
 
-    // Determine if origin is allowed
+    // Determine if origin is allowed. `varyOnOrigin` tracks whether the allowed
+    // origin was computed from the request origin, which requires Vary: Origin
+    // so shared/CDN caches don't serve one origin's response to another.
     let allowedOrigin: string | null = null;
+    let varyOnOrigin = false;
     if (typeof origin === 'string') {
-      allowedOrigin = origin;
+      if (reflectForCredentials) {
+        allowedOrigin = requestOrigin || null;
+        varyOnOrigin = true;
+      } else {
+        allowedOrigin = origin;
+      }
     } else if (Array.isArray(origin)) {
+      varyOnOrigin = true;
       if (origin.includes(requestOrigin)) {
         allowedOrigin = requestOrigin;
       }
     } else if (typeof origin === 'function') {
+      varyOnOrigin = true;
       if (origin(requestOrigin)) {
         allowedOrigin = requestOrigin;
       }
@@ -39,6 +55,10 @@ export function corsMiddleware<TContext = any>(
     // Handle preflight request
     if (request.method === 'OPTIONS') {
       const headers = new Headers();
+
+      if (varyOnOrigin) {
+        headers.append('Vary', 'Origin');
+      }
 
       if (allowedOrigin) {
         headers.set('Access-Control-Allow-Origin', allowedOrigin);
@@ -66,16 +86,26 @@ export function corsMiddleware<TContext = any>(
     const response = await next();
 
     // Add CORS headers to response
-    if (allowedOrigin) {
+    if (allowedOrigin || varyOnOrigin) {
       const newHeaders = new Headers(response.headers);
-      newHeaders.set('Access-Control-Allow-Origin', allowedOrigin);
 
-      if (credentials) {
-        newHeaders.set('Access-Control-Allow-Credentials', 'true');
+      // Set Vary: Origin whenever the allowed origin is derived from the
+      // request origin, even if this particular origin was rejected, so caches
+      // key on Origin and never serve a cross-origin response to another origin.
+      if (varyOnOrigin) {
+        newHeaders.append('Vary', 'Origin');
       }
 
-      if (exposedHeaders.length > 0) {
-        newHeaders.set('Access-Control-Expose-Headers', exposedHeaders.join(', '));
+      if (allowedOrigin) {
+        newHeaders.set('Access-Control-Allow-Origin', allowedOrigin);
+
+        if (credentials) {
+          newHeaders.set('Access-Control-Allow-Credentials', 'true');
+        }
+
+        if (exposedHeaders.length > 0) {
+          newHeaders.set('Access-Control-Expose-Headers', exposedHeaders.join(', '));
+        }
       }
 
       return new Response(response.body, {

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -12,7 +12,7 @@ import type {
 import { compilePattern, matchPath, normalizePath, joinPaths, type CompiledPattern } from './path-matcher.js';
 import { createRouteContext, mergeContexts } from './context.js';
 import { executeMiddlewareChain, combineMiddleware } from './middleware.js';
-import { RouterError, NotFoundError } from './errors.js';
+import { RouterError, NotFoundError, MethodNotAllowedError } from './errors.js';
 
 interface CompiledRouteEntry<TContext> {
   route: Route<TContext>;
@@ -32,6 +32,7 @@ export function createRouter<TContext = any>(
     context: contextFactory,
     onError,
     basePath = '/',
+    maxBodyBytes,
   } = options;
 
   // Pre-compile all route patterns
@@ -68,6 +69,21 @@ export function createRouter<TContext = any>(
   }
 
   /**
+   * Collect the HTTP methods registered for a path (regardless of method).
+   * Used to distinguish "no such path" (404) from "wrong method" (405).
+   */
+  function allowedMethodsForPath(path: string): string[] {
+    const normalizedPath = normalizePath(path);
+    const methods = new Set<string>();
+    for (const entry of compiledRoutes) {
+      if (matchPath(entry.compiledPattern, normalizedPath).matched) {
+        methods.add(entry.route.method);
+      }
+    }
+    return [...methods];
+  }
+
+  /**
    * Handle an incoming request
    */
   async function handle(request: Request): Promise<Response> {
@@ -80,11 +96,22 @@ export function createRouter<TContext = any>(
       const matched = match(method, path);
 
       if (!matched) {
+        // Distinguish an unknown path (404) from a known path invoked with an
+        // unsupported method (405 + Allow header, per RFC 7231).
+        const allowed = allowedMethodsForPath(path);
+        if (allowed.length > 0) {
+          const error = new MethodNotAllowedError(
+            `Method ${method} not allowed for ${path}`
+          );
+          const response = error.toResponse();
+          response.headers.set('Allow', allowed.join(', '));
+          return response;
+        }
         throw new NotFoundError(`Route not found: ${method} ${path}`);
       }
 
       // Create route context
-      const routeContext = createRouteContext(request, matched.params);
+      const routeContext = createRouteContext(request, matched.params, { maxBodyBytes });
 
       // Create user context
       let userContext: TContext;

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -156,7 +156,13 @@ export function createRouter<TContext = any>(
         try {
           const response = await onError(error as Error, request);
           if (error instanceof MethodNotAllowedError && error.allowedMethods.length > 0) {
-            response.headers.set('Allow', error.allowedMethods.join(', '));
+            const headers = new Headers(response.headers);
+            headers.set('Allow', error.allowedMethods.join(', '));
+            return new Response(response.body, {
+              status: response.status,
+              statusText: response.statusText,
+              headers,
+            });
           }
           return response;
         } catch (handlerError) {
@@ -171,6 +177,24 @@ export function createRouter<TContext = any>(
       // Default error handling
       if (error instanceof RouterError) {
         return error.toResponse();
+      }
+
+      // Shared middleware packages expose HTTP-shaped errors without taking a
+      // dependency on this package's RouterError class. Honor only explicit,
+      // valid error status metadata; arbitrary exceptions remain generic 500s.
+      const httpError = error as { message?: unknown; code?: unknown; statusCode?: unknown };
+      if (
+        Number.isInteger(httpError?.statusCode) &&
+        (httpError.statusCode as number) >= 400 &&
+        (httpError.statusCode as number) <= 599
+      ) {
+        return Response.json(
+          {
+            error: typeof httpError.message === 'string' ? httpError.message : 'Request failed',
+            ...(typeof httpError.code === 'string' ? { code: httpError.code } : {}),
+          },
+          { status: httpError.statusCode as number },
+        );
       }
 
       // Unknown error - don't expose details

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -35,6 +35,13 @@ export function createRouter<TContext = any>(
     maxBodyBytes,
   } = options;
 
+  if (
+    maxBodyBytes !== undefined &&
+    (!Number.isSafeInteger(maxBodyBytes) || maxBodyBytes < 0)
+  ) {
+    throw new RangeError('maxBodyBytes must be a non-negative integer');
+  }
+
   // Pre-compile all route patterns
   const compiledRoutes: CompiledRouteEntry<TContext>[] = routes.map((route) => {
     const fullPath = joinPaths(basePath, route.path);
@@ -101,11 +108,11 @@ export function createRouter<TContext = any>(
         const allowed = allowedMethodsForPath(path);
         if (allowed.length > 0) {
           const error = new MethodNotAllowedError(
-            `Method ${method} not allowed for ${path}`
+            `Method ${method} not allowed for ${path}`,
+            undefined,
+            allowed
           );
-          const response = error.toResponse();
-          response.headers.set('Allow', allowed.join(', '));
-          return response;
+          throw error;
         }
         throw new NotFoundError(`Route not found: ${method} ${path}`);
       }
@@ -147,7 +154,11 @@ export function createRouter<TContext = any>(
       // Handle errors
       if (onError) {
         try {
-          return await onError(error as Error, request);
+          const response = await onError(error as Error, request);
+          if (error instanceof MethodNotAllowedError && error.allowedMethods.length > 0) {
+            response.headers.set('Allow', error.allowedMethods.join(', '));
+          }
+          return response;
         } catch (handlerError) {
           // If error handler itself fails, return 500
           return Response.json(

--- a/packages/http/src/router.ts
+++ b/packages/http/src/router.ts
@@ -182,8 +182,14 @@ export function createRouter<TContext = any>(
       // Shared middleware packages expose HTTP-shaped errors without taking a
       // dependency on this package's RouterError class. Honor only explicit,
       // valid error status metadata; arbitrary exceptions remain generic 500s.
-      const httpError = error as { message?: unknown; code?: unknown; statusCode?: unknown };
+      const httpError = error as {
+        isHttpError?: unknown;
+        message?: unknown;
+        code?: unknown;
+        statusCode?: unknown;
+      };
       if (
+        httpError?.isHttpError === true &&
         Number.isInteger(httpError?.statusCode) &&
         (httpError.statusCode as number) >= 400 &&
         (httpError.statusCode as number) <= 599

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -65,6 +65,13 @@ export interface RouterOptions<TContext = any> {
 
   /** CORS configuration */
   cors?: CorsOptions | false;
+
+  /**
+   * Maximum request body size in bytes accepted by `ctx.json()`/`ctx.text()`/
+   * `ctx.formData()`. Bodies exceeding this (by Content-Length or by streamed
+   * size) are rejected with a 413 PayloadTooLargeError. Unset means no limit.
+   */
+  maxBodyBytes?: number;
 }
 
 // ============================================================================

--- a/packages/metrics/src/__tests__/metrics.test.ts
+++ b/packages/metrics/src/__tests__/metrics.test.ts
@@ -15,4 +15,13 @@ describe('metrics', () => {
     namespaced.track('event');
     expect(events).toEqual(['recfn.event']);
   });
+
+  it('swallows asynchronous telemetry failures', async () => {
+    const metrics = createMetricsEmitter(async () => {
+      throw new Error('telemetry unavailable');
+    });
+
+    expect(metrics.track('api.request')).toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 });

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -13,7 +13,13 @@ export function createMetricsEmitter(
 
   return {
     track(event: string, properties?: Record<string, unknown>): void {
-      trackFn(event, properties);
+      // Instrumentation must never break the business/request path: a throwing
+      // telemetry sink is swallowed rather than propagated to the caller.
+      try {
+        trackFn(event, properties);
+      } catch {
+        // Intentionally ignored.
+      }
     },
   };
 }

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -3,7 +3,7 @@ export interface MetricsEmitter {
 }
 
 export function createMetricsEmitter(
-  trackFn?: (event: string, properties?: Record<string, unknown>) => void,
+  trackFn?: (event: string, properties?: Record<string, unknown>) => void | PromiseLike<void>,
 ): MetricsEmitter {
   if (!trackFn) {
     return {
@@ -16,7 +16,10 @@ export function createMetricsEmitter(
       // Instrumentation must never break the business/request path: a throwing
       // telemetry sink is swallowed rather than propagated to the caller.
       try {
-        trackFn(event, properties);
+        const result = trackFn(event, properties);
+        if (result && typeof result.then === 'function') {
+          void Promise.resolve(result).catch(() => undefined);
+        }
       } catch {
         // Intentionally ignored.
       }

--- a/packages/oauth-core/src/index.ts
+++ b/packages/oauth-core/src/index.ts
@@ -3,6 +3,16 @@ export interface OAuthProviderDescriptor {
   authorizationUrl: string;
   tokenUrl: string;
   revocationUrl?: string;
+  /**
+   * How to call the revocation endpoint.
+   * - "rfc7009" (default): POST application/x-www-form-urlencoded token body.
+   * - "github": DELETE with JSON body and Basic auth, per GitHub's
+   *   `/applications/{client_id}/token` OAuth app API.
+   *
+   * `revocationUrl` may contain a `{client_id}` placeholder, which is
+   * substituted with the (URL-encoded) client id at request time.
+   */
+  revocationStyle?: "rfc7009" | "github";
   defaultScopes: string[];
   responseType?: string;
   supportsPkce: boolean;

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -107,7 +107,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
       });
     }
 
-    return normalizeTokenResponse(parsedBody);
+    return normalizeTokenResponse(parsedBody, input.grantType);
   }
 
   async revokeToken(input: OAuthRevocationRequest): Promise<void> {
@@ -152,15 +152,20 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
       try {
         response = await this.fetcher(url, init);
       } catch (error) {
+        const timeoutError =
+          error instanceof OAuthHttpError && error.status === 504 && error.retryable;
         const decision = decideRetry(
           {
             attempt,
-            status: 503
+            status: timeoutError ? 504 : 503
           },
           this.retryPolicy
         );
 
         if (!decision.retry) {
+          if (timeoutError) {
+            throw error;
+          }
           throw new OAuthHttpError("OAuth provider request failed", {
             code: "OAUTH_TOKEN_EXCHANGE_FAILED",
             status: 502,
@@ -478,7 +483,10 @@ function parseResponseBody(rawBodyText: string, contentType: string | null): unk
   return parseFormBody(rawBodyText);
 }
 
-function normalizeTokenResponse(parsedBody: unknown): OAuthTokenEndpointResponse {
+function normalizeTokenResponse(
+  parsedBody: unknown,
+  grantType: OAuthTokenGrantType
+): OAuthTokenEndpointResponse {
   if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
     throw new OAuthHttpError("OAuth token response body must be a JSON object", {
       code: "OAUTH_TOKEN_EXCHANGE_FAILED",
@@ -508,11 +516,21 @@ function normalizeTokenResponse(parsedBody: unknown): OAuthTokenEndpointResponse
     raw: payload
   };
 
-  const expiresIn = asNumber(payload.expires_in);
-  // Ignore non-positive `expires_in` values: a negative/zero lifetime would
-  // produce an already-expired token and trigger spurious refresh loops.
-  if (expiresIn !== undefined && expiresIn > 0) {
-    result.expiresIn = expiresIn;
+  if (payload.expires_in !== undefined) {
+    const expiresIn = asNumber(payload.expires_in);
+    if (expiresIn === undefined || expiresIn < 0) {
+      throw new OAuthHttpError("OAuth token response has invalid expires_in", {
+        code: grantType === "refresh_token" ? "OAUTH_TOKEN_REFRESH_FAILED" : "OAUTH_TOKEN_EXCHANGE_FAILED",
+        status: 502,
+        retryable: false,
+        details: { invalidField: "expires_in" }
+      });
+    }
+    // Preserve the established zero-lifetime behavior: some providers use
+    // zero to indicate that no useful expiry was supplied.
+    if (expiresIn > 0) {
+      result.expiresIn = expiresIn;
+    }
   }
 
   return result;
@@ -629,6 +647,7 @@ function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
       controller !== undefined ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
 
     let response: Response;
+    let rawBodyText: string;
     try {
       response = await fetcher(url, {
         method: init.method,
@@ -636,6 +655,10 @@ function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
         body: init.body,
         signal: controller?.signal
       });
+      // Consume the body while the same abort timer remains active. Fetch can
+      // resolve after headers even while an attacker-controlled provider
+      // stalls the response body indefinitely.
+      rawBodyText = await response.text();
     } catch (error) {
       if (controller?.signal.aborted) {
         throw new OAuthHttpError(`OAuth HTTP request timed out after ${timeoutMs}ms`, {
@@ -660,7 +683,7 @@ function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
           return response.headers.get(name);
         }
       },
-      text: () => response.text()
+      text: async () => rawBodyText
     };
   };
 }

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -27,6 +27,8 @@ interface ResponseLike {
   status: number;
   headers: HeadersLike;
   text(): Promise<string>;
+  /** Release an unread response body and any request timeout resources. */
+  discard?(): Promise<void>;
 }
 
 export interface RequestInitLike {
@@ -125,6 +127,10 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
     const endpointRequest = createRevokeRequest(input, credentials);
     const response = await this.executeWithRetry(revocationUrl, endpointRequest);
     if (response.ok) {
+      // RFC 7009 success responses do not require a body. Do not let a
+      // provider that has already returned successful headers delay local
+      // disconnect cleanup with a body that never terminates.
+      await response.discard?.().catch(() => undefined);
       return;
     }
 
@@ -195,6 +201,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
         return response;
       }
 
+      await response.discard?.().catch(() => undefined);
       await this.sleep(decision.delayMs);
       attempt += 1;
     }
@@ -631,6 +638,13 @@ function ensureOAuthHttpError(error: unknown): OAuthHttpError {
 }
 
 function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) {
+    throw new OAuthHttpError("OAuth HTTP timeout must be a finite non-negative number", {
+      code: "VALIDATION_ERROR",
+      status: 400,
+      retryable: false
+    });
+  }
   const fetcher = globalThis.fetch;
   if (!fetcher) {
     throw new OAuthHttpError("global fetch is not available", {
@@ -647,7 +661,6 @@ function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
       controller !== undefined ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
 
     let response: Response;
-    let rawBodyText: string;
     try {
       response = await fetcher(url, {
         method: init.method,
@@ -655,11 +668,10 @@ function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
         body: init.body,
         signal: controller?.signal
       });
-      // Consume the body while the same abort timer remains active. Fetch can
-      // resolve after headers even while an attacker-controlled provider
-      // stalls the response body indefinitely.
-      rawBodyText = await response.text();
     } catch (error) {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
       if (controller?.signal.aborted) {
         throw new OAuthHttpError(`OAuth HTTP request timed out after ${timeoutMs}ms`, {
           code: "INTERNAL_ERROR",
@@ -669,11 +681,32 @@ function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
         });
       }
       throw error;
-    } finally {
-      if (timeoutId !== undefined) {
+    }
+
+    let timeoutCleared = false;
+    const clearRequestTimeout = () => {
+      if (!timeoutCleared && timeoutId !== undefined) {
+        timeoutCleared = true;
         clearTimeout(timeoutId);
       }
-    }
+    };
+    let bodyText: Promise<string> | undefined;
+    const readBody = () => {
+      bodyText ??= response.text()
+        .catch((error) => {
+          if (controller?.signal.aborted) {
+            throw new OAuthHttpError(`OAuth HTTP request timed out after ${timeoutMs}ms`, {
+              code: "INTERNAL_ERROR",
+              status: 504,
+              retryable: true,
+              cause: error
+            });
+          }
+          throw error;
+        })
+        .finally(clearRequestTimeout);
+      return bodyText;
+    };
 
     return {
       ok: response.ok,
@@ -683,7 +716,16 @@ function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
           return response.headers.get(name);
         }
       },
-      text: async () => rawBodyText
+      // Keep the abort timer active through response consumption. Fetch may
+      // resolve after headers while an attacker-controlled body stalls.
+      text: readBody,
+      discard: async () => {
+        try {
+          await response.body?.cancel();
+        } finally {
+          clearRequestTimeout();
+        }
+      }
     };
   };
 }

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -95,7 +95,15 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
       scopes: input.scopes
     });
     const endpointRequest = createTokenRequest(input, credentials);
-    const response = await this.executeWithRetry(input.provider.tokenUrl, endpointRequest, "always");
+    const failureCode = input.grantType === "refresh_token"
+      ? "OAUTH_TOKEN_REFRESH_FAILED"
+      : "OAUTH_TOKEN_EXCHANGE_FAILED";
+    const response = await this.executeWithRetry(
+      input.provider.tokenUrl,
+      endpointRequest,
+      "always",
+      failureCode,
+    );
     const contentType = response.headers.get("content-type");
     const rawBodyText = await response.text();
     const parsedBody = parseResponseBody(rawBodyText, contentType);
@@ -125,7 +133,12 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
     });
     const revocationUrl = resolveRevocationUrl(input.provider.revocationUrl, credentials.clientId);
     const endpointRequest = createRevokeRequest(input, credentials);
-    const response = await this.executeWithRetry(revocationUrl, endpointRequest, "errors-only");
+    const response = await this.executeWithRetry(
+      revocationUrl,
+      endpointRequest,
+      "errors-only",
+      "INTERNAL_ERROR",
+    );
     if (response.ok) {
       return;
     }
@@ -150,7 +163,8 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
   private async executeWithRetry(
     url: string,
     init: RequestInitLike,
-    bodyMode: "always" | "errors-only"
+    bodyMode: "always" | "errors-only",
+    failureCode: OAuthHttpError["code"],
   ): Promise<ResponseLike> {
     let attempt = 1;
     while (true) {
@@ -158,7 +172,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
       try {
         response = await this.fetcher(url, init);
       } catch (error) {
-        await this.retryTransportFailure(error, attempt);
+        await this.retryTransportFailure(error, attempt, failureCode);
         attempt += 1;
         continue;
       }
@@ -197,7 +211,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
         if (bodyMode === "always") {
           const timedOut = error instanceof OAuthHttpError && error.status === 504;
           throw new OAuthHttpError("OAuth provider response body failed", {
-            code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+            code: failureCode,
             status: timedOut ? 504 : 502,
             retryable: false,
             cause: error,
@@ -207,7 +221,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
             }
           });
         }
-        await this.retryTransportFailure(error, attempt);
+        await this.retryTransportFailure(error, attempt, failureCode);
         attempt += 1;
         continue;
       }
@@ -222,7 +236,11 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
     }
   }
 
-  private async retryTransportFailure(error: unknown, attempt: number): Promise<void> {
+  private async retryTransportFailure(
+    error: unknown,
+    attempt: number,
+    failureCode: OAuthHttpError["code"],
+  ): Promise<void> {
     const timeoutError =
       error instanceof OAuthHttpError && error.status === 504 && error.retryable;
     const decision = decideRetry(
@@ -238,7 +256,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
         throw error;
       }
       throw new OAuthHttpError("OAuth provider request failed", {
-        code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+        code: failureCode,
         status: 502,
         retryable: false,
         cause: error,
@@ -540,7 +558,7 @@ function normalizeTokenResponse(
 ): OAuthTokenEndpointResponse {
   if (!parsedBody || typeof parsedBody !== "object" || Array.isArray(parsedBody)) {
     throw new OAuthHttpError("OAuth token response body must be a JSON object", {
-      code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+      code: grantType === "refresh_token" ? "OAUTH_TOKEN_REFRESH_FAILED" : "OAUTH_TOKEN_EXCHANGE_FAILED",
       status: 502,
       retryable: false,
       details: { parsedBodyKeys: [] }
@@ -551,7 +569,7 @@ function normalizeTokenResponse(
   const accessToken = asString(payload.access_token);
   if (!accessToken) {
     throw new OAuthHttpError("OAuth token response missing access_token", {
-      code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+      code: grantType === "refresh_token" ? "OAUTH_TOKEN_REFRESH_FAILED" : "OAUTH_TOKEN_EXCHANGE_FAILED",
       status: 502,
       retryable: false,
       details: { parsedBodyKeys: Object.keys(payload).slice(0, 10) }

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -194,13 +194,28 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
         body = await response.text();
       } catch (error) {
         await response.discard?.().catch(() => undefined);
+        if (bodyMode === "always") {
+          const timedOut = error instanceof OAuthHttpError && error.status === 504;
+          throw new OAuthHttpError("OAuth provider response body failed", {
+            code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+            status: timedOut ? 504 : 502,
+            retryable: false,
+            cause: error,
+            details: {
+              transportFailure: true,
+              responseBodyFailure: true
+            }
+          });
+        }
         await this.retryTransportFailure(error, attempt);
         attempt += 1;
         continue;
       }
 
       return {
-        ...response,
+        ok: response.ok,
+        status: response.status,
+        headers: response.headers,
         text: async () => body,
         discard: async () => undefined
       };

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -122,7 +122,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
       tokenTypeHint: input.tokenTypeHint
     });
     const revocationUrl = resolveRevocationUrl(input.provider.revocationUrl, credentials.clientId);
-    const endpointRequest = createRevokeRequest(input, credentials, revocationUrl);
+    const endpointRequest = createRevokeRequest(input, credentials);
     const response = await this.executeWithRetry(revocationUrl, endpointRequest);
     if (response.ok) {
       return;
@@ -355,29 +355,12 @@ function resolveRevocationUrl(revocationUrl: string | undefined, clientId: strin
   return revocationUrl.replace("{client_id}", encodeURIComponent(clientId));
 }
 
-function isGitHubApplicationRevokeUrl(revocationUrl: string | undefined): boolean {
-  return !!revocationUrl && revocationUrl.includes("/applications/") && revocationUrl.includes("/token");
-}
-
 function createRevokeRequest(
   input: OAuthRevocationRequest,
-  credentials: ResolvedRequestCredentials,
-  revocationUrl: string
+  credentials: ResolvedRequestCredentials
 ): RequestInitLike {
-  if (isGitHubApplicationRevokeUrl(revocationUrl)) {
-    const authUser = encodeURIComponent(credentials.clientId);
-    const authPassword = encodeURIComponent(credentials.clientSecret);
-    const auth = encodeBasicCredentials(authUser, authPassword);
-
-    return {
-      method: "DELETE",
-      headers: {
-        accept: "application/json",
-        authorization: `Basic ${auth}`,
-        "content-type": "application/json"
-      },
-      body: JSON.stringify({ access_token: input.token })
-    };
+  if (input.provider.revocationStyle === "github") {
+    return createGithubRevokeRequest(input, credentials);
   }
 
   const params = new URLSearchParams();
@@ -390,6 +373,28 @@ function createRevokeRequest(
     method: "POST",
     headers: createAuthHeaders(credentials, params),
     body: params.toString()
+  };
+}
+
+/**
+ * GitHub OAuth-app token revocation uses raw client credentials for HTTP
+ * Basic auth. URL encoding is only applied to the client-id URL segment.
+ */
+function createGithubRevokeRequest(
+  input: OAuthRevocationRequest,
+  credentials: ResolvedRequestCredentials
+): RequestInitLike {
+  const auth = encodeBasicCredentials(credentials.clientId, credentials.clientSecret);
+
+  return {
+    method: "DELETE",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Basic ${auth}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28"
+    },
+    body: JSON.stringify({ access_token: input.token })
   };
 }
 

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -41,7 +41,16 @@ export interface OAuthTokenClientOptions {
   fetcher?: OAuthFetchLike;
   retryPolicy?: OAuthRetryPolicy;
   sleep?: (delayMs: number) => Promise<void>;
+  /**
+   * Per-request timeout (ms) applied to the default global-fetch fetcher.
+   * Prevents a hung/slow provider endpoint from blocking indefinitely and
+   * exhausting sockets. Ignored when a custom `fetcher` is supplied. Defaults
+   * to 15000ms; set to 0 to disable.
+   */
+  timeoutMs?: number;
 }
+
+const DEFAULT_OAUTH_REQUEST_TIMEOUT_MS = 15_000;
 
 export interface DisconnectWithRevokeInput {
   revokeSupported: boolean;
@@ -69,7 +78,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
   private readonly sleep: (delayMs: number) => Promise<void>;
 
   constructor(options: OAuthTokenClientOptions = {}) {
-    this.fetcher = options.fetcher ?? getGlobalFetch();
+    this.fetcher = options.fetcher ?? getGlobalFetch(options.timeoutMs ?? DEFAULT_OAUTH_REQUEST_TIMEOUT_MS);
     this.retryPolicy = options.retryPolicy ?? DEFAULT_OAUTH_RETRY_POLICY;
     this.sleep = options.sleep ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
   }
@@ -485,7 +494,9 @@ function normalizeTokenResponse(parsedBody: unknown): OAuthTokenEndpointResponse
   };
 
   const expiresIn = asNumber(payload.expires_in);
-  if (expiresIn !== undefined) {
+  // Ignore non-positive `expires_in` values: a negative/zero lifetime would
+  // produce an already-expired token and trigger spurious refresh loops.
+  if (expiresIn !== undefined && expiresIn > 0) {
     result.expiresIn = expiresIn;
   }
 
@@ -586,7 +597,7 @@ function ensureOAuthHttpError(error: unknown): OAuthHttpError {
   });
 }
 
-function getGlobalFetch(): OAuthFetchLike {
+function getGlobalFetch(timeoutMs: number): OAuthFetchLike {
   const fetcher = globalThis.fetch;
   if (!fetcher) {
     throw new OAuthHttpError("global fetch is not available", {
@@ -597,11 +608,34 @@ function getGlobalFetch(): OAuthFetchLike {
   }
 
   return async (url, init) => {
-    const response = await fetcher(url, {
-      method: init.method,
-      headers: init.headers,
-      body: init.body
-    });
+    const controller =
+      timeoutMs > 0 && typeof AbortController === "function" ? new AbortController() : undefined;
+    const timeoutId =
+      controller !== undefined ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+
+    let response: Response;
+    try {
+      response = await fetcher(url, {
+        method: init.method,
+        headers: init.headers,
+        body: init.body,
+        signal: controller?.signal
+      });
+    } catch (error) {
+      if (controller?.signal.aborted) {
+        throw new OAuthHttpError(`OAuth HTTP request timed out after ${timeoutMs}ms`, {
+          code: "INTERNAL_ERROR",
+          status: 504,
+          retryable: true,
+          cause: error
+        });
+      }
+      throw error;
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
 
     return {
       ok: response.ok,

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -359,7 +359,11 @@ function createRevokeRequest(
   input: OAuthRevocationRequest,
   credentials: ResolvedRequestCredentials
 ): RequestInitLike {
-  if (input.provider.revocationStyle === "github") {
+  if (
+    input.provider.revocationStyle === "github" ||
+    (input.provider.revocationStyle === undefined &&
+      isGitHubApplicationRevokeUrl(input.provider.revocationUrl))
+  ) {
     return createGithubRevokeRequest(input, credentials);
   }
 
@@ -374,6 +378,12 @@ function createRevokeRequest(
     headers: createAuthHeaders(credentials, params),
     body: params.toString()
   };
+}
+
+function isGitHubApplicationRevokeUrl(revocationUrl: string | undefined): boolean {
+  return Boolean(
+    revocationUrl?.includes("/applications/") && revocationUrl.includes("/token")
+  );
 }
 
 /**

--- a/packages/oauth-http/src/token-client.ts
+++ b/packages/oauth-http/src/token-client.ts
@@ -95,7 +95,7 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
       scopes: input.scopes
     });
     const endpointRequest = createTokenRequest(input, credentials);
-    const response = await this.executeWithRetry(input.provider.tokenUrl, endpointRequest);
+    const response = await this.executeWithRetry(input.provider.tokenUrl, endpointRequest, "always");
     const contentType = response.headers.get("content-type");
     const rawBodyText = await response.text();
     const parsedBody = parseResponseBody(rawBodyText, contentType);
@@ -125,12 +125,8 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
     });
     const revocationUrl = resolveRevocationUrl(input.provider.revocationUrl, credentials.clientId);
     const endpointRequest = createRevokeRequest(input, credentials);
-    const response = await this.executeWithRetry(revocationUrl, endpointRequest);
+    const response = await this.executeWithRetry(revocationUrl, endpointRequest, "errors-only");
     if (response.ok) {
-      // RFC 7009 success responses do not require a body. Do not let a
-      // provider that has already returned successful headers delay local
-      // disconnect cleanup with a body that never terminates.
-      await response.discard?.().catch(() => undefined);
       return;
     }
 
@@ -151,44 +147,23 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
     });
   }
 
-  private async executeWithRetry(url: string, init: RequestInitLike): Promise<ResponseLike> {
+  private async executeWithRetry(
+    url: string,
+    init: RequestInitLike,
+    bodyMode: "always" | "errors-only"
+  ): Promise<ResponseLike> {
     let attempt = 1;
     while (true) {
       let response: ResponseLike;
       try {
         response = await this.fetcher(url, init);
       } catch (error) {
-        const timeoutError =
-          error instanceof OAuthHttpError && error.status === 504 && error.retryable;
-        const decision = decideRetry(
-          {
-            attempt,
-            status: timeoutError ? 504 : 503
-          },
-          this.retryPolicy
-        );
-
-        if (!decision.retry) {
-          if (timeoutError) {
-            throw error;
-          }
-          throw new OAuthHttpError("OAuth provider request failed", {
-            code: "OAUTH_TOKEN_EXCHANGE_FAILED",
-            status: 502,
-            retryable: false,
-            cause: error,
-            details: {
-              transportFailure: true
-            }
-          });
-        }
-
-        await this.sleep(decision.delayMs);
+        await this.retryTransportFailure(error, attempt);
         attempt += 1;
         continue;
       }
 
-      const decision = decideRetry(
+      const statusDecision = decideRetry(
         {
           attempt,
           status: response.status,
@@ -197,14 +172,68 @@ export class DefaultOAuthTokenHttpClient implements OAuthTokenHttpClient {
         this.retryPolicy
       );
 
-      if (!decision.retry) {
+      if (statusDecision.retry) {
+        await response.discard?.().catch(() => undefined);
+        await this.sleep(statusDecision.delayMs);
+        attempt += 1;
+        continue;
+      }
+
+      if (bodyMode === "errors-only" && response.ok) {
+        // RFC 7009 success responses do not require a body. Do not let a
+        // provider that returned successful headers delay local cleanup.
+        await response.discard?.().catch(() => undefined);
         return response;
       }
 
-      await response.discard?.().catch(() => undefined);
-      await this.sleep(decision.delayMs);
-      attempt += 1;
+      let body: string;
+      try {
+        // Read before leaving the retry boundary. Response bodies can fail or
+        // time out after headers have arrived and must receive the same retry
+        // and error normalization as the initial fetch.
+        body = await response.text();
+      } catch (error) {
+        await response.discard?.().catch(() => undefined);
+        await this.retryTransportFailure(error, attempt);
+        attempt += 1;
+        continue;
+      }
+
+      return {
+        ...response,
+        text: async () => body,
+        discard: async () => undefined
+      };
     }
+  }
+
+  private async retryTransportFailure(error: unknown, attempt: number): Promise<void> {
+    const timeoutError =
+      error instanceof OAuthHttpError && error.status === 504 && error.retryable;
+    const decision = decideRetry(
+      {
+        attempt,
+        status: timeoutError ? 504 : 503
+      },
+      this.retryPolicy
+    );
+
+    if (!decision.retry) {
+      if (timeoutError) {
+        throw error;
+      }
+      throw new OAuthHttpError("OAuth provider request failed", {
+        code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+        status: 502,
+        retryable: false,
+        cause: error,
+        details: {
+          transportFailure: true
+        }
+      });
+    }
+
+    await this.sleep(decision.delayMs);
   }
 }
 

--- a/packages/oauth-http/tests/token-client.test.ts
+++ b/packages/oauth-http/tests/token-client.test.ts
@@ -630,6 +630,71 @@ describe("oauth-http token client", () => {
     expect(deleteLocalTokenRecord).toHaveBeenCalledTimes(1);
     expect(deleteConnectionRecord).toHaveBeenCalledTimes(1);
   });
+
+  it("revokes RFC 7009 tokens via form-encoded POST", async () => {
+    let capturedUrl: string | null = null;
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return createResponse({ status: 200, contentType: "application/json", body: "{}" });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await client.revokeToken({
+      provider: googleProvider,
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      token: "tok_123",
+      tokenTypeHint: "access_token"
+    });
+
+    expect(capturedUrl).toBe("https://oauth2.googleapis.com/revoke");
+    expect(capturedInit?.method).toBe("POST");
+    expect(capturedInit?.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+    const params = new URLSearchParams(capturedInit?.body);
+    expect(params.get("token")).toBe("tok_123");
+    expect(params.get("token_type_hint")).toBe("access_token");
+  });
+
+  it("revokes GitHub tokens via DELETE with a JSON body, Basic auth and substituted client_id", async () => {
+    const githubProvider = {
+      id: "github",
+      authorizationUrl: "https://github.com/login/oauth/authorize",
+      tokenUrl: "https://github.com/login/oauth/access_token",
+      revocationUrl: "https://api.github.com/applications/{client_id}/token",
+      revocationStyle: "github" as const,
+      defaultScopes: ["read:user"],
+      supportsPkce: true,
+      supportsRefreshToken: false,
+      scopeSeparator: " " as const,
+      tokenAuthMethod: "client_secret_post" as const
+    };
+
+    let capturedUrl: string | null = null;
+    let capturedInit: RequestInitLike | null = null;
+    const fetcher: OAuthFetchLike = async (url, init) => {
+      capturedUrl = url;
+      capturedInit = init;
+      return createResponse({ status: 204, contentType: "application/json", body: "" });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher });
+    await client.revokeToken({
+      provider: githubProvider,
+      clientId: "Iv1.abc+123",
+      clientSecret: "gh-secret/=value%",
+      token: "gho_token"
+    });
+
+    expect(capturedUrl).toBe("https://api.github.com/applications/Iv1.abc%2B123/token");
+    expect(capturedInit?.method).toBe("DELETE");
+    expect(capturedInit?.headers["content-type"]).toBe("application/json");
+    expect(capturedInit?.headers["accept"]).toBe("application/vnd.github+json");
+    const expectedAuth = Buffer.from("Iv1.abc+123:gh-secret/=value%", "utf8").toString("base64");
+    expect(capturedInit?.headers["authorization"]).toBe(`Basic ${expectedAuth}`);
+    expect(JSON.parse(capturedInit?.body ?? "{}")).toEqual({ access_token: "gho_token" });
+  });
 });
 
 function createResponse(input: {

--- a/packages/oauth-http/tests/token-client.test.ts
+++ b/packages/oauth-http/tests/token-client.test.ts
@@ -385,6 +385,44 @@ describe("oauth-http token client", () => {
     expect(response.accessToken).toBe("at_after_retry");
   });
 
+  it("retries response-body failures inside the token request boundary", async () => {
+    const sleep = vi.fn(async () => undefined);
+    let calls = 0;
+    const fetcher: OAuthFetchLike = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          text: async () => {
+            throw new Error("response body disconnected");
+          }
+        };
+      }
+
+      return createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "at_after_body_retry", token_type: "bearer" })
+      });
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher, sleep });
+    const response = await client.exchangeToken({
+      provider: googleProvider,
+      grantType: "authorization_code",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      code: "code-body-retry",
+      redirectUri: "https://app/callback"
+    });
+
+    expect(calls).toBe(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(response.accessToken).toBe("at_after_body_retry");
+  });
+
   it("wraps exhausted fetch exceptions in OAuthHttpError after retry attempts are spent", async () => {
     const sleep = vi.fn(async () => undefined);
     const client = new DefaultOAuthTokenHttpClient({

--- a/packages/oauth-http/tests/token-client.test.ts
+++ b/packages/oauth-http/tests/token-client.test.ts
@@ -421,6 +421,41 @@ describe("oauth-http token client", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
+  it("classifies a refresh response-body failure without replaying the request", async () => {
+    const sleep = vi.fn(async () => undefined);
+    let calls = 0;
+    const fetcher: OAuthFetchLike = async () => {
+      calls += 1;
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        text: async () => {
+          throw new Error("response body disconnected");
+        }
+      };
+    };
+
+    const client = new DefaultOAuthTokenHttpClient({ fetcher, sleep });
+    await expect(client.exchangeToken({
+      provider: googleProvider,
+      grantType: "refresh_token",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      refreshToken: "refresh-body-failure"
+    })).rejects.toMatchObject({
+      code: "OAUTH_TOKEN_REFRESH_FAILED",
+      retryable: false,
+      details: {
+        transportFailure: true,
+        responseBodyFailure: true
+      }
+    });
+
+    expect(calls).toBe(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
   it("preserves prototype-backed fields when a custom fetcher returns Response", async () => {
     const client = new DefaultOAuthTokenHttpClient({
       fetcher: async () => new Response(

--- a/packages/oauth-http/tests/token-client.test.ts
+++ b/packages/oauth-http/tests/token-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DefaultOAuthTokenHttpClient,
   OAuthHttpError,
@@ -18,6 +18,10 @@ const googleProvider = {
   scopeSeparator: " ",
   tokenAuthMethod: "client_secret_post" as const
 };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("oauth-http token client", () => {
   it("serializes token exchange as form-encoded for client_secret_post", async () => {
@@ -461,6 +465,63 @@ describe("oauth-http token client", () => {
       code: "OAUTH_TOKEN_REFRESH_FAILED",
       message: "refresh token expired"
     });
+  });
+
+  it.each([
+    ["authorization_code", "OAUTH_TOKEN_EXCHANGE_FAILED"],
+    ["refresh_token", "OAUTH_TOKEN_REFRESH_FAILED"],
+  ] as const)("rejects negative expires_in values for %s", async (grantType, code) => {
+    const client = new DefaultOAuthTokenHttpClient({
+      fetcher: async () => createResponse({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ access_token: "at_invalid", expires_in: -1 })
+      })
+    });
+
+    await expect(client.exchangeToken({
+      provider: googleProvider,
+      grantType,
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      ...(grantType === "authorization_code"
+        ? { code: "code-invalid", redirectUri: "https://app/callback" }
+        : { refreshToken: "rt_invalid" })
+    })).rejects.toMatchObject({
+      code,
+      status: 502,
+      details: { invalidField: "expires_in" }
+    });
+  });
+
+  it("keeps the timeout active while consuming the provider response body", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (_url: string, init?: RequestInit) => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
+      text: () => new Promise<string>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      })
+    })));
+    const client = new DefaultOAuthTokenHttpClient({
+      timeoutMs: 5,
+      retryPolicy: {
+        maxAttempts: 1,
+        baseDelayMs: 1,
+        maxDelayMs: 1,
+        jitterRatio: 0,
+        random: () => 0
+      }
+    });
+
+    await expect(client.exchangeToken({
+      provider: googleProvider,
+      grantType: "authorization_code",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      code: "code-timeout",
+      redirectUri: "https://app/callback"
+    })).rejects.toMatchObject({ status: 504, retryable: true });
   });
 
   it("calls provider revocation endpoint when supported", async () => {

--- a/packages/oauth-http/tests/token-client.test.ts
+++ b/packages/oauth-http/tests/token-client.test.ts
@@ -385,42 +385,60 @@ describe("oauth-http token client", () => {
     expect(response.accessToken).toBe("at_after_retry");
   });
 
-  it("retries response-body failures inside the token request boundary", async () => {
+  it("does not replay an authorization-code exchange after response headers arrive", async () => {
     const sleep = vi.fn(async () => undefined);
     let calls = 0;
     const fetcher: OAuthFetchLike = async () => {
       calls += 1;
-      if (calls === 1) {
-        return {
-          ok: true,
-          status: 200,
-          headers: { get: () => "application/json" },
-          text: async () => {
-            throw new Error("response body disconnected");
-          }
-        };
-      }
-
-      return createResponse({
+      return {
+        ok: true,
         status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ access_token: "at_after_body_retry", token_type: "bearer" })
-      });
+        headers: { get: () => "application/json" },
+        text: async () => {
+          throw new Error("response body disconnected");
+        }
+      };
     };
 
     const client = new DefaultOAuthTokenHttpClient({ fetcher, sleep });
+    await expect(client.exchangeToken({
+        provider: googleProvider,
+        grantType: "authorization_code",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        code: "code-body-failure",
+        redirectUri: "https://app/callback"
+      })).rejects.toMatchObject({
+        code: "OAUTH_TOKEN_EXCHANGE_FAILED",
+        retryable: false,
+        details: {
+          transportFailure: true,
+          responseBodyFailure: true
+        }
+      });
+
+    expect(calls).toBe(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("preserves prototype-backed fields when a custom fetcher returns Response", async () => {
+    const client = new DefaultOAuthTokenHttpClient({
+      fetcher: async () => new Response(
+        JSON.stringify({ access_token: "at_native", token_type: "bearer" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    });
+
     const response = await client.exchangeToken({
       provider: googleProvider,
       grantType: "authorization_code",
       clientId: "client-id",
       clientSecret: "client-secret",
-      code: "code-body-retry",
+      code: "code-native-response",
       redirectUri: "https://app/callback"
     });
 
-    expect(calls).toBe(2);
-    expect(sleep).toHaveBeenCalledTimes(1);
-    expect(response.accessToken).toBe("at_after_body_retry");
+    expect(response.accessToken).toBe("at_native");
   });
 
   it("wraps exhausted fetch exceptions in OAuthHttpError after retry attempts are spent", async () => {
@@ -559,7 +577,7 @@ describe("oauth-http token client", () => {
       clientSecret: "client-secret",
       code: "code-timeout",
       redirectUri: "https://app/callback"
-    })).rejects.toMatchObject({ status: 504, retryable: true });
+    })).rejects.toMatchObject({ status: 504, retryable: false });
   });
 
   it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(

--- a/packages/oauth-http/tests/token-client.test.ts
+++ b/packages/oauth-http/tests/token-client.test.ts
@@ -524,6 +524,38 @@ describe("oauth-http token client", () => {
     })).rejects.toMatchObject({ status: 504, retryable: true });
   });
 
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
+    "rejects invalid default-fetch timeout configuration: %s",
+    (timeoutMs) => {
+      expect(() => new DefaultOAuthTokenHttpClient({ timeoutMs })).toThrow(
+        expect.objectContaining({ code: "VALIDATION_ERROR", status: 400 })
+      );
+    }
+  );
+
+  it("does not wait for a successful revocation response body", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const text = vi.fn(() => new Promise<string>(() => undefined));
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: { cancel },
+      text,
+    })));
+    const client = new DefaultOAuthTokenHttpClient({ timeoutMs: 50 });
+
+    await client.revokeToken({
+      provider: googleProvider,
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      token: "token-to-revoke",
+    });
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(text).not.toHaveBeenCalled();
+  });
+
   it("calls provider revocation endpoint when supported", async () => {
     const calledUrls: string[] = [];
     let capturedInit: RequestInitLike | null = null;

--- a/packages/oauth-providers/src/providers/github.ts
+++ b/packages/oauth-providers/src/providers/github.ts
@@ -6,6 +6,7 @@ export const githubOAuthProviderDescriptor: OAuthProviderDescriptor = {
   authorizationUrl: "https://github.com/login/oauth/authorize",
   tokenUrl: "https://github.com/login/oauth/access_token",
   revocationUrl: "https://api.github.com/applications/{client_id}/token",
+  revocationStyle: "github",
   defaultScopes: ["read:user", "user:email"],
   supportsPkce: true,
   supportsRefreshToken: false,

--- a/packages/oauth-router/src/__tests__/routes.test.ts
+++ b/packages/oauth-router/src/__tests__/routes.test.ts
@@ -298,6 +298,48 @@ describe("oauth-router route factories", () => {
     expect(redirectResponse.headers.get("location")).toBe("http://localhost/");
   });
 
+  it("falls back to the request origin for non-HTTP returnTo schemes", async () => {
+    const browser = createFlowServiceMocks();
+    browser.handleCallback.mockResolvedValue({
+      providerId: "google",
+      subject: {
+        kind: "browser-auth",
+        intentId: "intent_01",
+        returnTo: "javascript:alert('xss')"
+      },
+      tokenSet: { accessToken: "access_01" }
+    });
+    const browserRoutes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: browser.service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      callbackMode: "redirect"
+    });
+
+    const response = await createRouter({ routes: browserRoutes }).handle(
+      new Request("http://localhost/auth/social/callback/google?code=code_02&state=st_01")
+    );
+
+    expect(response.headers.get("location")).toBe("http://localhost/");
+  });
+
+  it("ignores invalid allowedRedirectOrigins while honoring valid entries", async () => {
+    const browser = createFlowServiceMocks();
+    const browserRoutes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: browser.service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      callbackMode: "redirect",
+      allowedRedirectOrigins: ["not a URL", "https://app.example"]
+    });
+
+    const response = await createRouter({ routes: browserRoutes }).handle(
+      new Request("http://localhost/auth/social/callback/google?code=code_02&state=st_01")
+    );
+
+    expect(response.headers.get("location")).toBe("https://app.example/post-auth");
+  });
+
   it("preserves resolver-provided requestId when the start header is absent", async () => {
     const { service, start } = createFlowServiceMocks();
     const routes = createOAuthConnectionRoutes({

--- a/packages/oauth-router/src/__tests__/routes.test.ts
+++ b/packages/oauth-router/src/__tests__/routes.test.ts
@@ -325,13 +325,25 @@ describe("oauth-router route factories", () => {
 
   it("rejects invalid allowedRedirectOrigins during route construction", () => {
     const browser = createFlowServiceMocks();
-    expect(() => createOAuthBrowserRoutes({
+    const createRoutes = (allowedRedirectOrigins: string[]) => createOAuthBrowserRoutes({
         basePath: "/auth/social",
         flowService: browser.service,
         resolveStartInput: async (request) => (await request.json()) as never,
         callbackMode: "redirect",
-        allowedRedirectOrigins: ["not a URL", "https://app.example"]
-      })).toThrow("OAUTH_ALLOWED_REDIRECT_ORIGIN_INVALID: not a URL");
+        allowedRedirectOrigins
+      });
+
+    for (const invalidOrigin of [
+      "not a URL",
+      "https://app.example/callback",
+      "https://app.example?tenant=one",
+      "https://app.example#callback",
+      "https://user:secret@app.example"
+    ]) {
+      expect(() => createRoutes([invalidOrigin])).toThrow(
+        `OAUTH_ALLOWED_REDIRECT_ORIGIN_INVALID: ${invalidOrigin}`
+      );
+    }
   });
 
   it("preserves resolver-provided requestId when the start header is absent", async () => {

--- a/packages/oauth-router/src/__tests__/routes.test.ts
+++ b/packages/oauth-router/src/__tests__/routes.test.ts
@@ -323,21 +323,15 @@ describe("oauth-router route factories", () => {
     expect(response.headers.get("location")).toBe("http://localhost/");
   });
 
-  it("ignores invalid allowedRedirectOrigins while honoring valid entries", async () => {
+  it("rejects invalid allowedRedirectOrigins during route construction", () => {
     const browser = createFlowServiceMocks();
-    const browserRoutes = createOAuthBrowserRoutes({
-      basePath: "/auth/social",
-      flowService: browser.service,
-      resolveStartInput: async (request) => (await request.json()) as never,
-      callbackMode: "redirect",
-      allowedRedirectOrigins: ["not a URL", "https://app.example"]
-    });
-
-    const response = await createRouter({ routes: browserRoutes }).handle(
-      new Request("http://localhost/auth/social/callback/google?code=code_02&state=st_01")
-    );
-
-    expect(response.headers.get("location")).toBe("https://app.example/post-auth");
+    expect(() => createOAuthBrowserRoutes({
+        basePath: "/auth/social",
+        flowService: browser.service,
+        resolveStartInput: async (request) => (await request.json()) as never,
+        callbackMode: "redirect",
+        allowedRedirectOrigins: ["not a URL", "https://app.example"]
+      })).toThrow("OAUTH_ALLOWED_REDIRECT_ORIGIN_INVALID: not a URL");
   });
 
   it("preserves resolver-provided requestId when the start header is absent", async () => {

--- a/packages/oauth-router/src/__tests__/routes.test.ts
+++ b/packages/oauth-router/src/__tests__/routes.test.ts
@@ -217,7 +217,10 @@ describe("oauth-router route factories", () => {
       basePath: "/auth/social",
       flowService: browser.service,
       resolveStartInput: async (request) => (await request.json()) as never,
-      callbackMode: "redirect"
+      callbackMode: "redirect",
+      // The mocked returnTo is cross-origin (https://app.example) relative to
+      // the http://localhost request, so it must be explicitly allowlisted.
+      allowedRedirectOrigins: ["https://app.example"]
     });
     const browserRouter = createRouter({ routes: browserRoutes });
 
@@ -272,6 +275,27 @@ describe("oauth-router route factories", () => {
 
     expect(redirectResponse.status).toBe(302);
     expect(redirectResponse.headers.get("location")).toBe("https://app.example/");
+  });
+
+  it("blocks open-redirects to cross-origin returnTo values that are not allowlisted", async () => {
+    const browser = createFlowServiceMocks();
+    // The mocked returnTo is https://app.example/post-auth, cross-origin to the
+    // http://localhost request and NOT in allowedRedirectOrigins.
+    const browserRoutes = createOAuthBrowserRoutes({
+      basePath: "/auth/social",
+      flowService: browser.service,
+      resolveStartInput: async (request) => (await request.json()) as never,
+      callbackMode: "redirect"
+    });
+    const browserRouter = createRouter({ routes: browserRoutes });
+
+    const redirectResponse = await browserRouter.handle(
+      new Request("http://localhost/auth/social/callback/google?code=code_02&state=st_01")
+    );
+
+    expect(redirectResponse.status).toBe(302);
+    // Falls back to the request-origin root instead of the attacker origin.
+    expect(redirectResponse.headers.get("location")).toBe("http://localhost/");
   });
 
   it("preserves resolver-provided requestId when the start header is absent", async () => {

--- a/packages/oauth-router/src/browser-routes.ts
+++ b/packages/oauth-router/src/browser-routes.ts
@@ -54,6 +54,7 @@ export interface OAuthBrowserRouteConfig {
 }
 
 export function createOAuthBrowserRoutes(config: OAuthBrowserRouteConfig): Route[] {
+  assertValidRedirectOrigins(config.allowedRedirectOrigins);
   const requestIdHeader = (config.requestIdHeader ?? "x-request-id").toLowerCase();
 
   return [
@@ -123,6 +124,20 @@ export function createOAuthBrowserRoutes(config: OAuthBrowserRouteConfig): Route
       }
     }
   ];
+}
+
+function assertValidRedirectOrigins(origins: readonly string[] | undefined): void {
+  for (const origin of origins ?? []) {
+    let parsed: URL;
+    try {
+      parsed = new URL(origin);
+    } catch {
+      throw new Error(`OAUTH_ALLOWED_REDIRECT_ORIGIN_INVALID: ${origin}`);
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(`OAUTH_ALLOWED_REDIRECT_ORIGIN_INVALID: ${origin}`);
+    }
+  }
 }
 
 function resolveRouteMeta(defaultMeta: HttpRouteMeta, overrideMeta: HttpRouteMeta | undefined): HttpRouteMeta {

--- a/packages/oauth-router/src/browser-routes.ts
+++ b/packages/oauth-router/src/browser-routes.ts
@@ -137,6 +137,15 @@ function assertValidRedirectOrigins(origins: readonly string[] | undefined): voi
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       throw new Error(`OAUTH_ALLOWED_REDIRECT_ORIGIN_INVALID: ${origin}`);
     }
+    if (
+      parsed.username !== "" ||
+      parsed.password !== "" ||
+      (parsed.pathname !== "" && parsed.pathname !== "/") ||
+      parsed.search !== "" ||
+      parsed.hash !== ""
+    ) {
+      throw new Error(`OAUTH_ALLOWED_REDIRECT_ORIGIN_INVALID: ${origin}`);
+    }
   }
 }
 

--- a/packages/oauth-router/src/browser-routes.ts
+++ b/packages/oauth-router/src/browser-routes.ts
@@ -38,6 +38,12 @@ export interface OAuthBrowserRouteConfig {
     request: Request,
     context: RouteContext
   ) => Promise<string> | string;
+  /**
+   * Additional origins (beyond the request's own origin) that a post-callback
+   * redirect is permitted to target. Used to validate `returnTo` and prevent
+   * open-redirect attacks. Same-origin redirects are always allowed.
+   */
+  allowedRedirectOrigins?: string[];
   serializeCallbackResult?: (
     result: OAuthFlowCallbackResult,
     request: Request,
@@ -204,14 +210,63 @@ async function resolveRedirectLocation(
   context: RouteContext
 ): Promise<string> {
   if (config.getRedirectLocation) {
+    // Caller-provided resolvers are trusted to produce safe locations.
     return config.getRedirectLocation(result, request, context);
   }
 
   if (result.subject.kind === "browser-auth" && result.subject.returnTo) {
-    return result.subject.returnTo;
+    // `returnTo` originates from the (unauthenticated) flow start request and
+    // is attacker-influenceable, so it must be validated against the current
+    // origin and any explicitly allowlisted origins to prevent open redirects.
+    return sanitizeRedirectLocation(result.subject.returnTo, request, config.allowedRedirectOrigins);
   }
 
   return new URL("/", request.url).toString();
+}
+
+function sanitizeRedirectLocation(
+  returnTo: string,
+  request: Request,
+  allowedRedirectOrigins?: string[]
+): string {
+  const requestUrl = new URL(request.url);
+  const fallback = new URL("/", requestUrl).toString();
+
+  let target: URL;
+  try {
+    // Resolve relative URLs against the request origin; absolute URLs are
+    // parsed as-is so their origin can be checked.
+    target = new URL(returnTo, requestUrl);
+  } catch {
+    return fallback;
+  }
+
+  // Only http(s) targets are ever acceptable (blocks javascript:, data:, etc.).
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    return fallback;
+  }
+
+  if (target.origin === requestUrl.origin) {
+    return target.toString();
+  }
+
+  const allowed = new Set(
+    (allowedRedirectOrigins ?? [])
+      .map((origin) => {
+        try {
+          return new URL(origin).origin;
+        } catch {
+          return null;
+        }
+      })
+      .filter((origin): origin is string => origin !== null)
+  );
+
+  if (allowed.has(target.origin)) {
+    return target.toString();
+  }
+
+  return fallback;
 }
 
 async function parseDisconnectBody(

--- a/packages/queue/src/__tests__/queue.test.ts
+++ b/packages/queue/src/__tests__/queue.test.ts
@@ -33,6 +33,7 @@ describe('queue adapters', () => {
   it('rejects an invalid maxSize', () => {
     expect(() => new MemoryQueueAdapter<string>({ maxSize: 0 })).toThrow('FLOWFN_QUEUE_MAX_SIZE_INVALID');
     expect(() => new MemoryQueueAdapter<string>({ maxSize: -1 })).toThrow('FLOWFN_QUEUE_MAX_SIZE_INVALID');
+    expect(() => new MemoryQueueAdapter<string>({ maxSize: 1.5 })).toThrow('FLOWFN_QUEUE_MAX_SIZE_INVALID');
   });
 
   it('memory queue preserves undefined payloads', async () => {

--- a/packages/queue/src/__tests__/queue.test.ts
+++ b/packages/queue/src/__tests__/queue.test.ts
@@ -17,6 +17,24 @@ describe('queue adapters', () => {
     expect(await queue.dequeue('q')).toBeNull();
   });
 
+  it('rejects enqueue once maxSize is reached', async () => {
+    const queue = new MemoryQueueAdapter<string>({ maxSize: 2 });
+
+    await queue.enqueue('q', 'a');
+    await queue.enqueue('q', 'b');
+
+    await expect(queue.enqueue('q', 'c')).rejects.toThrow('FLOWFN_QUEUE_FULL');
+
+    // Draining one item frees a slot.
+    expect(await queue.dequeue('q')).toBe('a');
+    await expect(queue.enqueue('q', 'c')).resolves.toBeUndefined();
+  });
+
+  it('rejects an invalid maxSize', () => {
+    expect(() => new MemoryQueueAdapter<string>({ maxSize: 0 })).toThrow('FLOWFN_QUEUE_MAX_SIZE_INVALID');
+    expect(() => new MemoryQueueAdapter<string>({ maxSize: -1 })).toThrow('FLOWFN_QUEUE_MAX_SIZE_INVALID');
+  });
+
   it('memory queue preserves undefined payloads', async () => {
     const queue = new MemoryQueueAdapter<string | undefined>();
 

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -14,12 +14,35 @@ function normalizeQueueName(queueName: string): string {
   return normalized;
 }
 
+export interface MemoryQueueAdapterOptions {
+  /**
+   * Maximum number of items retained per queue. When reached, further
+   * `enqueue` calls reject with `FLOWFN_QUEUE_FULL` instead of growing the
+   * backing array without bound (which would leak memory until OOM if
+   * producers outpace consumers). Unset means unbounded (legacy behaviour).
+   */
+  maxSize?: number;
+}
+
 export class MemoryQueueAdapter<TPayload> implements QueueAdapter<TPayload> {
   private readonly queues = new Map<string, TPayload[]>();
+  private readonly maxSize?: number;
+
+  constructor(options: MemoryQueueAdapterOptions = {}) {
+    if (options.maxSize !== undefined) {
+      if (!Number.isInteger(options.maxSize) || options.maxSize <= 0) {
+        throw new Error('FLOWFN_QUEUE_MAX_SIZE_INVALID');
+      }
+    }
+    this.maxSize = options.maxSize;
+  }
 
   async enqueue(queueName: string, payload: TPayload): Promise<void> {
     const normalizedQueueName = normalizeQueueName(queueName);
     const queue = this.queues.get(normalizedQueueName) ?? [];
+    if (this.maxSize !== undefined && queue.length >= this.maxSize) {
+      throw new Error('FLOWFN_QUEUE_FULL');
+    }
     queue.push(payload);
     this.queues.set(normalizedQueueName, queue);
   }

--- a/packages/storage-azure/src/adapter.ts
+++ b/packages/storage-azure/src/adapter.ts
@@ -418,12 +418,17 @@ export function createAzureStorageAdapter(config: AzureStorageConfig): StorageAd
       }
 
       const nodeStream = response.readableStreamBody as NodeJS.ReadableStream;
+      // Pause immediately and only resume in pull() so backpressure from a slow
+      // consumer propagates to the source stream instead of buffering the whole
+      // object in the ReadableStream's internal queue (memory DoS on large files).
+      nodeStream.pause();
 
       return new ReadableStream({
         start(controller) {
           nodeStream.on('data', (chunk: Buffer | string) => {
             const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
             controller.enqueue(new Uint8Array(buffer));
+            nodeStream.pause();
           });
           nodeStream.on('end', () => {
             controller.close();
@@ -431,6 +436,9 @@ export function createAzureStorageAdapter(config: AzureStorageConfig): StorageAd
           nodeStream.on('error', (err) => {
             controller.error(err);
           });
+        },
+        pull() {
+          nodeStream.resume();
         },
         cancel() {
           if ('destroy' in nodeStream && typeof nodeStream.destroy === 'function') {

--- a/packages/storage-gcs/src/adapter.ts
+++ b/packages/storage-gcs/src/adapter.ts
@@ -205,12 +205,17 @@ export function createGCSStorageAdapter(config: GCSStorageConfig): StorageAdapte
         : undefined;
 
       const gcstream = file.createReadStream(options);
+      // Pause immediately and only resume in pull() so backpressure from a slow
+      // consumer propagates to the source stream instead of buffering the whole
+      // object in the ReadableStream's internal queue (memory DoS on large files).
+      gcstream.pause();
 
       return new ReadableStream({
         start(controller) {
           gcstream.on('data', (chunk: Buffer | string) => {
             const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
             controller.enqueue(new Uint8Array(buffer));
+            gcstream.pause();
           });
           gcstream.on('end', () => {
             controller.close();
@@ -222,6 +227,9 @@ export function createGCSStorageAdapter(config: GCSStorageConfig): StorageAdapte
               controller.error(err);
             }
           });
+        },
+        pull() {
+          gcstream.resume();
         },
         cancel() {
           gcstream.destroy();

--- a/packages/storage/src/internal/errors.ts
+++ b/packages/storage/src/internal/errors.ts
@@ -32,15 +32,22 @@ export function assertValidSignedUrlExpiry(
   expiresInSeconds: number,
   maxSeconds: number = MAX_SIGNED_URL_EXPIRY_SECONDS
 ): void {
+  if (!Number.isFinite(maxSeconds) || maxSeconds <= 0) {
+    throw createStorageError(
+      'Signed URL maximum expiry must be a positive finite number of seconds',
+      'STORAGE_SIGNED_URL_EXPIRY_INVALID'
+    );
+  }
+  const effectiveMaxSeconds = Math.min(maxSeconds, MAX_SIGNED_URL_EXPIRY_SECONDS);
   if (!Number.isInteger(expiresInSeconds) || expiresInSeconds <= 0) {
     throw createStorageError(
       'Signed URL expiry must be a positive integer number of seconds',
       'STORAGE_SIGNED_URL_EXPIRY_INVALID'
     );
   }
-  if (expiresInSeconds > maxSeconds) {
+  if (expiresInSeconds > effectiveMaxSeconds) {
     throw createStorageError(
-      `Signed URL expiry must not exceed ${maxSeconds} seconds`,
+      `Signed URL expiry must not exceed ${effectiveMaxSeconds} seconds`,
       'STORAGE_SIGNED_URL_EXPIRY_INVALID'
     );
   }

--- a/packages/storage/src/internal/errors.ts
+++ b/packages/storage/src/internal/errors.ts
@@ -20,6 +20,32 @@ export function assertMultipartParts(
   }
 }
 
+/** Upper bound for presigned URL lifetimes: 7 days, the AWS SigV4 maximum. */
+export const MAX_SIGNED_URL_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Validate a presigned-URL expiry (in seconds). Rejects non-positive, non-finite
+ * and out-of-range values so a caller bug or malicious input cannot mint URLs
+ * that never expire (or are already expired).
+ */
+export function assertValidSignedUrlExpiry(
+  expiresInSeconds: number,
+  maxSeconds: number = MAX_SIGNED_URL_EXPIRY_SECONDS
+): void {
+  if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+    throw createStorageError(
+      'Signed URL expiry must be a positive number of seconds',
+      'STORAGE_SIGNED_URL_EXPIRY_INVALID'
+    );
+  }
+  if (expiresInSeconds > maxSeconds) {
+    throw createStorageError(
+      `Signed URL expiry must not exceed ${maxSeconds} seconds`,
+      'STORAGE_SIGNED_URL_EXPIRY_INVALID'
+    );
+  }
+}
+
 export function isNotFoundError(
   error: unknown,
   options?: {

--- a/packages/storage/src/internal/errors.ts
+++ b/packages/storage/src/internal/errors.ts
@@ -32,9 +32,9 @@ export function assertValidSignedUrlExpiry(
   expiresInSeconds: number,
   maxSeconds: number = MAX_SIGNED_URL_EXPIRY_SECONDS
 ): void {
-  if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+  if (!Number.isInteger(expiresInSeconds) || expiresInSeconds <= 0) {
     throw createStorageError(
-      'Signed URL expiry must be a positive number of seconds',
+      'Signed URL expiry must be a positive integer number of seconds',
       'STORAGE_SIGNED_URL_EXPIRY_INVALID'
     );
   }

--- a/packages/storage/src/internal/s3-compatible.test.ts
+++ b/packages/storage/src/internal/s3-compatible.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import { createS3CompatibleStorageAdapter } from './s3-compatible.js';
+import { assertValidSignedUrlExpiry } from './errors.js';
 
 describe('s3-compatible shared core', () => {
+  it.each([
+    [1, true],
+    [1.5, false],
+    [604800, true],
+    [604801, false],
+  ] as const)('validates signed URL expiry boundary %s', (expiresInSeconds, valid) => {
+    if (valid) {
+      expect(() => assertValidSignedUrlExpiry(expiresInSeconds)).not.toThrow();
+    } else {
+      expect(() => assertValidSignedUrlExpiry(expiresInSeconds)).toThrow(
+        expect.objectContaining({ code: 'STORAGE_SIGNED_URL_EXPIRY_INVALID' })
+      );
+    }
+  });
+
   it('maps configured not-found errors to STORAGE_NOT_FOUND', async () => {
     const adapter = createS3CompatibleStorageAdapter({
       name: 'test',

--- a/packages/storage/src/internal/s3-compatible.test.ts
+++ b/packages/storage/src/internal/s3-compatible.test.ts
@@ -18,6 +18,15 @@ describe('s3-compatible shared core', () => {
     }
   });
 
+  it('never lets a custom expiry limit exceed the hard seven-day maximum', () => {
+    expect(() => assertValidSignedUrlExpiry(604801, 999999)).toThrow(
+      expect.objectContaining({ code: 'STORAGE_SIGNED_URL_EXPIRY_INVALID' })
+    );
+    expect(() => assertValidSignedUrlExpiry(60, Number.POSITIVE_INFINITY)).toThrow(
+      expect.objectContaining({ code: 'STORAGE_SIGNED_URL_EXPIRY_INVALID' })
+    );
+  });
+
   it('maps configured not-found errors to STORAGE_NOT_FOUND', async () => {
     const adapter = createS3CompatibleStorageAdapter({
       name: 'test',

--- a/packages/storage/src/internal/s3-compatible.ts
+++ b/packages/storage/src/internal/s3-compatible.ts
@@ -15,7 +15,12 @@ import type {
   StorageAdapterCapabilities,
   StorageObjectStat,
 } from '../types.js';
-import { assertMultipartParts, createNotFoundError, isNotFoundError } from './errors.js';
+import {
+  assertMultipartParts,
+  assertValidSignedUrlExpiry,
+  createNotFoundError,
+  isNotFoundError,
+} from './errors.js';
 
 interface S3LikeClient {
   send(command: unknown): Promise<any>;
@@ -90,6 +95,7 @@ export function createS3CompatibleStorageAdapter(config: S3CompatibleAdapterConf
       expiresInSeconds: number;
       constraints?: SignedUrlConstraints;
     }): Promise<{ url: string; headers?: Record<string, string> }> {
+      assertValidSignedUrlExpiry(input.expiresInSeconds);
       const command = new PutObjectCommand({
         Bucket: bucket,
         Key: input.key,
@@ -117,6 +123,7 @@ export function createS3CompatibleStorageAdapter(config: S3CompatibleAdapterConf
       expiresInSeconds: number;
       constraints?: { responseContentType?: string };
     }): Promise<{ url: string; headers?: Record<string, string> }> {
+      assertValidSignedUrlExpiry(input.expiresInSeconds);
       const command = new GetObjectCommand({
         Bucket: bucket,
         Key: input.key,
@@ -158,6 +165,7 @@ export function createS3CompatibleStorageAdapter(config: S3CompatibleAdapterConf
       expiresInSeconds: number;
       constraints?: SignedUrlConstraints;
     }): Promise<{ url: string; headers?: Record<string, string> }> {
+      assertValidSignedUrlExpiry(input.expiresInSeconds);
       const command = new UploadPartCommand({
         Bucket: bucket,
         Key: input.key,

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -37,6 +37,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "undici": "^5.29.0"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0",

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "undici": "^5.29.0"
+    "undici": "^6.28.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -174,7 +174,7 @@ describe('webhooks package exports', () => {
   });
 
   it('aborts a hanging attempt using the configured per-attempt timeout', async () => {
-    const fetchMock = undiciFetchMock.mockImplementation((_url: string, init?: RequestInit) => {
+    undiciFetchMock.mockImplementation((_url: string, init?: RequestInit) => {
       return new Promise((_resolve, reject) => {
         init?.signal?.addEventListener('abort', () => {
           reject(new DOMException('The operation was aborted.', 'AbortError'));

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -111,6 +111,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
         maxRetries: 3,
         initialDelayMs: 1,
@@ -153,6 +154,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
         maxRetries: 3,
         initialDelayMs: 1,
@@ -180,6 +182,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
         maxRetries: 1,
         perAttemptTimeoutMs: 5,
@@ -218,6 +221,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
       }
     );
@@ -253,6 +257,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
       }
     );
@@ -280,6 +285,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
       }
     );
@@ -365,7 +371,7 @@ describe('webhooks package exports', () => {
     const fetchMock = vi.fn();
     const result = await deliverWebhook(
       { url: 'file:///etc/passwd', payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch }
+      { fetch: fetchMock as unknown as typeof fetch, fetchSupportsPinnedDispatcher: true }
     );
 
     expect(result.ok).toBe(false);
@@ -377,7 +383,7 @@ describe('webhooks package exports', () => {
     const fetchMock = vi.fn();
     const result = await deliverWebhook(
       { url: 'not a url', payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch }
+      { fetch: fetchMock as unknown as typeof fetch, fetchSupportsPinnedDispatcher: true }
     );
 
     expect(result.ok).toBe(false);
@@ -401,6 +407,7 @@ describe('webhooks package exports', () => {
       { url, payload: { hello: 'world' } },
       {
         fetch: fetchMock as unknown as typeof fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolver,
       }
     );
@@ -421,7 +428,11 @@ describe('webhooks package exports', () => {
 
     const result = await deliverWebhook(
       { url, payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch, resolveHostname: resolver }
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        fetchSupportsPinnedDispatcher: true,
+        resolveHostname: resolver,
+      }
     );
 
     expect(result.ok).toBe(false);
@@ -438,7 +449,11 @@ describe('webhooks package exports', () => {
 
     const result = await deliverWebhook(
       { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch, resolveHostname }
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        fetchSupportsPinnedDispatcher: true,
+        resolveHostname,
+      }
     );
 
     expect(result.ok).toBe(false);
@@ -451,11 +466,28 @@ describe('webhooks package exports', () => {
 
     const result = await deliverWebhook(
       { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch, resolveHostname: resolvePublicHostname }
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        fetchSupportsPinnedDispatcher: true,
+        resolveHostname: resolvePublicHostname,
+      }
     );
 
     expect(result.ok).toBe(true);
     expect(fetchMock.mock.calls[0]?.[1]).toHaveProperty('dispatcher');
+  });
+
+  it('rejects a custom fetch that does not attest to pinned-dispatcher support', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+
+    const result = await deliverWebhook(
+      { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
+      { fetch: fetchMock as unknown as typeof fetch, resolveHostname: resolvePublicHostname }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]?.error).toContain('must honor the pinned dispatcher');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('resolves hostnames and refuses delivery when any address is non-public', async () => {
@@ -466,6 +498,7 @@ describe('webhooks package exports', () => {
       { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
       {
         fetch: fetchMock as unknown as typeof fetch,
+        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolver,
       }
     );

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -202,6 +202,30 @@ describe('webhooks package exports', () => {
     });
   });
 
+  it('bounds hostname validation with the configured per-attempt timeout', async () => {
+    const resolver = vi.fn(() => new Promise<readonly string[]>(() => undefined));
+
+    const result = await deliverWebhook(
+      {
+        url: 'https://stalled.example.com/hook',
+        payload: { hello: 'world' },
+      },
+      {
+        resolveHostname: resolver,
+        maxRetries: 1,
+        perAttemptTimeoutMs: 5,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]).toMatchObject({
+      attempt: 1,
+      ok: false,
+      error: 'Webhook target validation timed out after 5ms',
+    });
+    expect(undiciFetchMock).not.toHaveBeenCalled();
+  });
+
   it('canonicalizes content-type and signature headers before delivery', async () => {
     const fetchMock = undiciFetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       return {

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -7,6 +7,8 @@ import {
   verifyWebhookSignature
 } from '../index.js';
 
+const resolvePublicHostname = async () => ['93.184.216.34'] as const;
+
 describe('webhooks package exports', () => {
   it('signs and verifies webhook payload using timing-safe verification path', () => {
     const payload = JSON.stringify({ event: 'bot.joined', id: 'evt_1' });
@@ -109,6 +111,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        resolveHostname: resolvePublicHostname,
         maxRetries: 3,
         initialDelayMs: 1,
         maxDelayMs: 2,
@@ -150,6 +153,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        resolveHostname: resolvePublicHostname,
         maxRetries: 3,
         initialDelayMs: 1,
       }
@@ -176,6 +180,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        resolveHostname: resolvePublicHostname,
         maxRetries: 1,
         perAttemptTimeoutMs: 5,
       }
@@ -213,6 +218,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        resolveHostname: resolvePublicHostname,
       }
     );
 
@@ -247,6 +253,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        resolveHostname: resolvePublicHostname,
       }
     );
 
@@ -273,6 +280,7 @@ describe('webhooks package exports', () => {
       },
       {
         fetch: fetchMock as unknown as typeof globalThis.fetch,
+        resolveHostname: resolvePublicHostname,
       }
     );
 
@@ -373,6 +381,49 @@ describe('webhooks package exports', () => {
     );
 
     expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'http://127.0.0.1/hook',
+    'http://10.0.0.1/hook',
+    'http://169.254.169.254/latest/meta-data',
+    'http://[::1]/hook',
+    'http://[fd00::1]/hook',
+    'http://[fe80::1]/hook',
+  ])('refuses to deliver to a non-public literal address: %s', async (url) => {
+    const fetchMock = vi.fn();
+    const resolver = vi.fn(resolvePublicHostname);
+
+    const result = await deliverWebhook(
+      { url, payload: { hello: 'world' } },
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        resolveHostname: resolver,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]?.error).toContain('non-public address');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('resolves hostnames and refuses delivery when any address is non-public', async () => {
+    const fetchMock = vi.fn();
+    const resolver = vi.fn(async () => ['93.184.216.34', '10.0.0.5']);
+
+    const result = await deliverWebhook(
+      { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
+      {
+        fetch: fetchMock as unknown as typeof fetch,
+        resolveHostname: resolver,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]?.error).toContain('10.0.0.5');
+    expect(resolver).toHaveBeenCalledWith('hooks.example.com');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -390,6 +390,7 @@ describe('webhooks package exports', () => {
     'http://[::1]/hook',
     'http://[::10.0.0.5]/hook',
     'http://[64:ff9b::10.0.0.5]/hook',
+    'http://[64:ff9b:1::a00:1]/hook',
     'http://[fd00::1]/hook',
     'http://[fe80::1]/hook',
   ])('refuses to deliver to a non-public literal address: %s', async (url) => {

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -352,4 +352,27 @@ describe('webhooks package exports', () => {
       })
     ).rejects.toThrow('WEBHOOK_SIGNATURE_HEADER_INVALID');
   });
+
+  it('refuses to deliver to non-http(s) URL schemes (SSRF guard)', async () => {
+    const fetchMock = vi.fn();
+    const result = await deliverWebhook(
+      { url: 'file:///etc/passwd', payload: { hello: 'world' } },
+      { fetch: fetchMock as unknown as typeof fetch }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.attempts[0]?.error).toContain('scheme not allowed');
+  });
+
+  it('refuses to deliver to a malformed URL', async () => {
+    const fetchMock = vi.fn();
+    const result = await deliverWebhook(
+      { url: 'not a url', payload: { hello: 'world' } },
+      { fetch: fetchMock as unknown as typeof fetch }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -203,7 +203,11 @@ describe('webhooks package exports', () => {
   });
 
   it('bounds hostname validation with the configured per-attempt timeout', async () => {
-    const resolver = vi.fn(() => new Promise<readonly string[]>(() => undefined));
+    const resolver = vi.fn((_hostname: string, signal: AbortSignal) =>
+      new Promise<readonly string[]>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      })
+    );
 
     const result = await deliverWebhook(
       {
@@ -224,6 +228,7 @@ describe('webhooks package exports', () => {
       error: 'Webhook target validation timed out after 5ms',
     });
     expect(undiciFetchMock).not.toHaveBeenCalled();
+    expect(resolver.mock.calls[0]?.[1].aborted).toBe(true);
   });
 
   it('canonicalizes content-type and signature headers before delivery', async () => {
@@ -502,7 +507,8 @@ describe('webhooks package exports', () => {
 
     expect(result.ok).toBe(false);
     expect(result.attempts[0]?.error).toContain('10.0.0.5');
-    expect(resolver).toHaveBeenCalledWith('hooks.example.com');
+    expect(resolver).toHaveBeenCalledWith('hooks.example.com', expect.anything());
+    expect(resolver.mock.calls[0]?.[1].aborted).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -389,6 +389,8 @@ describe('webhooks package exports', () => {
     'http://10.0.0.1/hook',
     'http://169.254.169.254/latest/meta-data',
     'http://[::1]/hook',
+    'http://[::10.0.0.5]/hook',
+    'http://[64:ff9b::10.0.0.5]/hook',
     'http://[fd00::1]/hook',
     'http://[fe80::1]/hook',
   ])('refuses to deliver to a non-public literal address: %s', async (url) => {
@@ -407,6 +409,53 @@ describe('webhooks package exports', () => {
     expect(result.attempts[0]?.error).toContain('non-public address');
     expect(fetchMock).not.toHaveBeenCalled();
     expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'http://localhost/hook',
+    'http://api.localhost/hook',
+    'http://foo.localhost./hook',
+  ])('refuses to deliver to a localhost-style hostname: %s', async (url) => {
+    const fetchMock = vi.fn();
+    const resolver = vi.fn(resolvePublicHostname);
+
+    const result = await deliverWebhook(
+      { url, payload: { hello: 'world' } },
+      { fetch: fetchMock as unknown as typeof fetch, resolveHostname: resolver }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]?.error).toContain('not public');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['resolver error', async () => { throw new Error('dns unavailable'); }],
+    ['empty result', async () => []],
+  ] as const)('refuses delivery after a DNS %s', async (_label, resolveHostname) => {
+    const fetchMock = vi.fn();
+
+    const result = await deliverWebhook(
+      { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
+      { fetch: fetchMock as unknown as typeof fetch, resolveHostname }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts[0]?.error).toContain('could not be resolved');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('passes a pinned dispatcher to the actual webhook request', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+
+    const result = await deliverWebhook(
+      { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
+      { fetch: fetchMock as unknown as typeof fetch, resolveHostname: resolvePublicHostname }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock.mock.calls[0]?.[1]).toHaveProperty('dispatcher');
   });
 
   it('resolves hostnames and refuses delivery when any address is non-public', async () => {

--- a/packages/webhooks/src/__tests__/webhooks.test.ts
+++ b/packages/webhooks/src/__tests__/webhooks.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from 'node:crypto';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   deliverWebhook,
   signWebhookPayload,
@@ -7,7 +7,18 @@ import {
   verifyWebhookSignature
 } from '../index.js';
 
+const { undiciFetchMock } = vi.hoisted(() => ({ undiciFetchMock: vi.fn() }));
+
+vi.mock('undici', async () => {
+  const actual = await vi.importActual<typeof import('undici')>('undici');
+  return { ...actual, fetch: undiciFetchMock };
+});
+
 const resolvePublicHostname = async () => ['93.184.216.34'] as const;
+
+beforeEach(() => {
+  undiciFetchMock.mockReset();
+});
 
 describe('webhooks package exports', () => {
   it('signs and verifies webhook payload using timing-safe verification path', () => {
@@ -93,7 +104,7 @@ describe('webhooks package exports', () => {
 
   it('delivers payload with bounded retries and returns structured attempts', async () => {
     let attempt = 0;
-    const fetchMock = vi.fn().mockImplementation(async () => {
+    const fetchMock = undiciFetchMock.mockImplementation(async () => {
       attempt += 1;
       if (attempt < 3) {
         return { ok: false, status: 500 };
@@ -110,8 +121,6 @@ describe('webhooks package exports', () => {
         signatureHeader: 'X-Test-Signature',
       },
       {
-        fetch: fetchMock as unknown as typeof globalThis.fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
         maxRetries: 3,
         initialDelayMs: 1,
@@ -145,7 +154,7 @@ describe('webhooks package exports', () => {
   });
 
   it('does not retry non-transient HTTP failures', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: false, status: 400 }));
+    const fetchMock = undiciFetchMock.mockImplementation(async () => ({ ok: false, status: 400 }));
 
     const result = await deliverWebhook(
       {
@@ -153,8 +162,6 @@ describe('webhooks package exports', () => {
         payload: { hello: 'world' },
       },
       {
-        fetch: fetchMock as unknown as typeof globalThis.fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
         maxRetries: 3,
         initialDelayMs: 1,
@@ -167,7 +174,7 @@ describe('webhooks package exports', () => {
   });
 
   it('aborts a hanging attempt using the configured per-attempt timeout', async () => {
-    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+    const fetchMock = undiciFetchMock.mockImplementation((_url: string, init?: RequestInit) => {
       return new Promise((_resolve, reject) => {
         init?.signal?.addEventListener('abort', () => {
           reject(new DOMException('The operation was aborted.', 'AbortError'));
@@ -181,8 +188,6 @@ describe('webhooks package exports', () => {
         payload: { hello: 'world' },
       },
       {
-        fetch: fetchMock as unknown as typeof globalThis.fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
         maxRetries: 1,
         perAttemptTimeoutMs: 5,
@@ -198,7 +203,7 @@ describe('webhooks package exports', () => {
   });
 
   it('canonicalizes content-type and signature headers before delivery', async () => {
-    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    const fetchMock = undiciFetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       return {
         ok: true,
         status: 200,
@@ -220,8 +225,6 @@ describe('webhooks package exports', () => {
         },
       },
       {
-        fetch: fetchMock as unknown as typeof globalThis.fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
       }
     );
@@ -238,7 +241,7 @@ describe('webhooks package exports', () => {
   });
 
   it('prefers the latest content-type variant when canonicalizing headers', async () => {
-    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    const fetchMock = undiciFetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       return {
         ok: true,
         status: 200,
@@ -256,8 +259,6 @@ describe('webhooks package exports', () => {
         },
       },
       {
-        fetch: fetchMock as unknown as typeof globalThis.fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
       }
     );
@@ -267,7 +268,7 @@ describe('webhooks package exports', () => {
   });
 
   it('forces application/json when caller supplies a non-json content type', async () => {
-    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    const fetchMock = undiciFetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       return {
         ok: true,
         status: 200,
@@ -284,8 +285,6 @@ describe('webhooks package exports', () => {
         },
       },
       {
-        fetch: fetchMock as unknown as typeof globalThis.fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
       }
     );
@@ -368,11 +367,8 @@ describe('webhooks package exports', () => {
   });
 
   it('refuses to deliver to non-http(s) URL schemes (SSRF guard)', async () => {
-    const fetchMock = vi.fn();
-    const result = await deliverWebhook(
-      { url: 'file:///etc/passwd', payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch, fetchSupportsPinnedDispatcher: true }
-    );
+    const fetchMock = undiciFetchMock;
+    const result = await deliverWebhook({ url: 'file:///etc/passwd', payload: { hello: 'world' } });
 
     expect(result.ok).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
@@ -380,11 +376,8 @@ describe('webhooks package exports', () => {
   });
 
   it('refuses to deliver to a malformed URL', async () => {
-    const fetchMock = vi.fn();
-    const result = await deliverWebhook(
-      { url: 'not a url', payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch, fetchSupportsPinnedDispatcher: true }
-    );
+    const fetchMock = undiciFetchMock;
+    const result = await deliverWebhook({ url: 'not a url', payload: { hello: 'world' } });
 
     expect(result.ok).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
@@ -400,14 +393,12 @@ describe('webhooks package exports', () => {
     'http://[fd00::1]/hook',
     'http://[fe80::1]/hook',
   ])('refuses to deliver to a non-public literal address: %s', async (url) => {
-    const fetchMock = vi.fn();
+    const fetchMock = undiciFetchMock;
     const resolver = vi.fn(resolvePublicHostname);
 
     const result = await deliverWebhook(
       { url, payload: { hello: 'world' } },
       {
-        fetch: fetchMock as unknown as typeof fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolver,
       }
     );
@@ -423,14 +414,12 @@ describe('webhooks package exports', () => {
     'http://api.localhost/hook',
     'http://foo.localhost./hook',
   ])('refuses to deliver to a localhost-style hostname: %s', async (url) => {
-    const fetchMock = vi.fn();
+    const fetchMock = undiciFetchMock;
     const resolver = vi.fn(resolvePublicHostname);
 
     const result = await deliverWebhook(
       { url, payload: { hello: 'world' } },
       {
-        fetch: fetchMock as unknown as typeof fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolver,
       }
     );
@@ -445,13 +434,11 @@ describe('webhooks package exports', () => {
     ['resolver error', async () => { throw new Error('dns unavailable'); }],
     ['empty result', async () => []],
   ] as const)('refuses delivery after a DNS %s', async (_label, resolveHostname) => {
-    const fetchMock = vi.fn();
+    const fetchMock = undiciFetchMock;
 
     const result = await deliverWebhook(
       { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
       {
-        fetch: fetchMock as unknown as typeof fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname,
       }
     );
@@ -462,13 +449,13 @@ describe('webhooks package exports', () => {
   });
 
   it('passes a pinned dispatcher to the actual webhook request', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
+    const fetchMock = undiciFetchMock.mockImplementation(
+      async () => ({ ok: true, status: 200 }) as Response
+    );
 
     const result = await deliverWebhook(
       { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
       {
-        fetch: fetchMock as unknown as typeof fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolvePublicHostname,
       }
     );
@@ -477,28 +464,13 @@ describe('webhooks package exports', () => {
     expect(fetchMock.mock.calls[0]?.[1]).toHaveProperty('dispatcher');
   });
 
-  it('rejects a custom fetch that does not attest to pinned-dispatcher support', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: true, status: 200 }) as Response);
-
-    const result = await deliverWebhook(
-      { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
-      { fetch: fetchMock as unknown as typeof fetch, resolveHostname: resolvePublicHostname }
-    );
-
-    expect(result.ok).toBe(false);
-    expect(result.attempts[0]?.error).toContain('must honor the pinned dispatcher');
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
   it('resolves hostnames and refuses delivery when any address is non-public', async () => {
-    const fetchMock = vi.fn();
+    const fetchMock = undiciFetchMock;
     const resolver = vi.fn(async () => ['93.184.216.34', '10.0.0.5']);
 
     const result = await deliverWebhook(
       { url: 'https://hooks.example.com/delivery', payload: { hello: 'world' } },
       {
-        fetch: fetchMock as unknown as typeof fetch,
-        fetchSupportsPinnedDispatcher: true,
         resolveHostname: resolver,
       }
     );

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -476,10 +476,16 @@ export async function deliverWebhook(
     );
   }
 
-  const validatedTarget = await validateWebhookTarget(
-    parsedUrl,
-    options.resolveHostname ?? defaultResolveHostname
-  );
+  let validatedTarget: Awaited<ReturnType<typeof validateWebhookTarget>>;
+  try {
+    validatedTarget = await withTimeout(
+      validateWebhookTarget(parsedUrl, options.resolveHostname ?? defaultResolveHostname),
+      perAttemptTimeoutMs,
+      `Webhook target validation timed out after ${perAttemptTimeoutMs}ms`
+    );
+  } catch (error) {
+    return failedDelivery(error instanceof Error ? error.message : String(error));
+  }
   if (validatedTarget.error) {
     return failedDelivery(validatedTarget.error);
   }
@@ -621,6 +627,24 @@ function decodeSignature(value: string, encoding: SignatureEncoding): Buffer | n
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withTimeout<T>(operation: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  if (timeoutMs <= 0) {
+    return operation;
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 function shouldRetryWebhookStatus(status: number): boolean {

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -299,6 +299,20 @@ function isNonPublicAddress(address: string): boolean {
       return isNonPublicIpv4(bytes.slice(12).join('.'));
     }
 
+    // RFC 8215 reserves 64:ff9b:1::/48 for local-use NAT64. Its translation
+    // policy is network-specific and can reach private IPv4 services, so the
+    // entire local-use prefix is non-public regardless of its embedded bits.
+    if (
+      bytes[0] === 0x00 &&
+      bytes[1] === 0x64 &&
+      bytes[2] === 0xff &&
+      bytes[3] === 0x9b &&
+      bytes[4] === 0x00 &&
+      bytes[5] === 0x01
+    ) {
+      return true;
+    }
+
     const unspecified = bytes.every((byte) => byte === 0);
     const loopback = bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1;
     const uniqueLocal = (bytes[0]! & 0xfe) === 0xfc; // fc00::/7

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -1,4 +1,6 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
 
 export type SignatureEncoding = 'hex' | 'base64';
 
@@ -127,6 +129,7 @@ export type WebhookDeliveryResult = {
 
 export type WebhookDeliveryOptions = {
   fetch?: typeof globalThis.fetch;
+  resolveHostname?: (hostname: string) => Promise<readonly string[]>;
   maxRetries?: number;
   initialDelayMs?: number;
   maxDelayMs?: number;
@@ -165,6 +168,143 @@ function normalizeNonNegativeDuration(
     throw new Error(errorCode);
   }
   return Math.max(0, value);
+}
+
+async function defaultResolveHostname(hostname: string): Promise<readonly string[]> {
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  return addresses.map(({ address }) => address);
+}
+
+function failedDelivery(error: string): WebhookDeliveryResult {
+  return {
+    ok: false,
+    attempts: [{ attempt: 1, ok: false, error }],
+  };
+}
+
+async function validateWebhookTarget(
+  url: URL,
+  resolveHostname: (hostname: string) => Promise<readonly string[]>
+): Promise<string | null> {
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+    return `Webhook target hostname is not public: ${hostname}`;
+  }
+
+  const literalVersion = isIP(hostname);
+  let addresses: readonly string[];
+  if (literalVersion !== 0) {
+    addresses = [hostname];
+  } else {
+    try {
+      addresses = await resolveHostname(hostname);
+    } catch {
+      return `Webhook target hostname could not be resolved: ${hostname}`;
+    }
+    if (addresses.length === 0) {
+      return `Webhook target hostname could not be resolved: ${hostname}`;
+    }
+  }
+
+  for (const address of addresses) {
+    if (isNonPublicAddress(address)) {
+      return `Webhook target resolves to a non-public address: ${address}`;
+    }
+  }
+  return null;
+}
+
+function isNonPublicAddress(address: string): boolean {
+  const normalized = address.replace(/^\[|\]$/g, '').split('%', 1)[0] ?? '';
+  const version = isIP(normalized);
+  if (version === 4) {
+    return isNonPublicIpv4(normalized);
+  }
+  if (version === 6) {
+    const bytes = parseIpv6(normalized);
+    if (!bytes) {
+      return true;
+    }
+
+    // IPv4-mapped IPv6 (::ffff:0:0/96) must inherit the IPv4 restrictions.
+    if (
+      bytes.slice(0, 10).every((byte) => byte === 0) &&
+      bytes[10] === 0xff &&
+      bytes[11] === 0xff
+    ) {
+      return isNonPublicIpv4(bytes.slice(12).join('.'));
+    }
+
+    const unspecified = bytes.every((byte) => byte === 0);
+    const loopback = bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1;
+    const uniqueLocal = (bytes[0]! & 0xfe) === 0xfc; // fc00::/7
+    const linkLocal = bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0x80; // fe80::/10
+    const siteLocal = bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0xc0; // fec0::/10
+    const multicast = bytes[0] === 0xff; // ff00::/8
+    return unspecified || loopback || uniqueLocal || linkLocal || siteLocal || multicast;
+  }
+  return true;
+}
+
+function isNonPublicIpv4(address: string): boolean {
+  const octets = address.split('.').map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) {
+    return true;
+  }
+  const [a, b, c] = octets as [number, number, number, number];
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 192 && b === 0 && (c === 0 || c === 2)) ||
+    (a === 198 && (b === 18 || b === 19 || (b === 51 && c === 100))) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+function parseIpv6(address: string): number[] | null {
+  let input = address.toLowerCase();
+  if (input.includes('.')) {
+    const separator = input.lastIndexOf(':');
+    const ipv4 = input.slice(separator + 1).split('.').map(Number);
+    if (
+      separator < 0 ||
+      ipv4.length !== 4 ||
+      ipv4.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+    ) {
+      return null;
+    }
+    input = `${input.slice(0, separator)}:${((ipv4[0]! << 8) | ipv4[1]!).toString(16)}:${(
+      (ipv4[2]! << 8) |
+      ipv4[3]!
+    ).toString(16)}`;
+  }
+
+  if ((input.match(/::/g) ?? []).length > 1) {
+    return null;
+  }
+  const [leftText, rightText] = input.split('::');
+  const left = leftText ? leftText.split(':') : [];
+  const right = rightText ? rightText.split(':') : [];
+  const missing = 8 - left.length - right.length;
+  if ((input.includes('::') && missing < 1) || (!input.includes('::') && missing !== 0)) {
+    return null;
+  }
+  const parts = [...left, ...Array.from({ length: missing }, () => '0'), ...right];
+  const bytes: number[] = [];
+  for (const part of parts) {
+    if (!/^[0-9a-f]{1,4}$/.test(part)) {
+      return null;
+    }
+    const value = Number.parseInt(part, 16);
+    bytes.push(value >> 8, value & 0xff);
+  }
+  return bytes.length === 16 ? bytes : null;
 }
 
 export async function deliverWebhook(
@@ -259,6 +399,14 @@ export async function deliverWebhook(
     );
   }
 
+  const targetError = await validateWebhookTarget(
+    parsedUrl,
+    options.resolveHostname ?? defaultResolveHostname
+  );
+  if (targetError) {
+    return failedDelivery(targetError);
+  }
+
   const attempts: WebhookDeliveryAttempt[] = [];
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -273,6 +421,9 @@ export async function deliverWebhook(
         headers,
         body: payloadString,
         signal: controller?.signal,
+        // Do not let an allowed public target redirect the request to an
+        // unchecked internal address.
+        redirect: 'manual',
       });
       if (timeoutId) {
         clearTimeout(timeoutId);

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -129,14 +129,6 @@ export type WebhookDeliveryResult = {
 };
 
 export type WebhookDeliveryOptions = {
-  /**
-   * Custom transport used for delivery. Because DNS-rebinding protection
-   * relies on Undici's `dispatcher`, custom transports must explicitly attest
-   * that they honor that option; ordinary standards-only fetch functions are
-   * rejected instead of silently bypassing address pinning.
-   */
-  fetch?: typeof globalThis.fetch;
-  fetchSupportsPinnedDispatcher?: boolean;
   resolveHostname?: (hostname: string) => Promise<readonly string[]>;
   maxRetries?: number;
   initialDelayMs?: number;
@@ -383,7 +375,6 @@ export async function deliverWebhook(
   input: WebhookDeliveryInput,
   options: WebhookDeliveryOptions = {}
 ): Promise<WebhookDeliveryResult> {
-  const fetchFn = options.fetch ?? (undiciFetch as unknown as typeof globalThis.fetch);
   const maxRetries = normalizeRetryCount(options.maxRetries);
   const initialDelayMs = normalizeNonNegativeDuration(
     options.initialDelayMs,
@@ -478,10 +469,6 @@ export async function deliverWebhook(
   if (validatedTarget.error) {
     return failedDelivery(validatedTarget.error);
   }
-  if (options.fetch && options.fetchSupportsPinnedDispatcher !== true) {
-    return failedDelivery('Custom webhook fetch must honor the pinned dispatcher');
-  }
-
   // Keep the TLS/HTTP hostname unchanged, but force the connection lookup to
   // use only addresses that passed the public-address checks. This closes the
   // DNS-rebinding gap between validation and the actual socket connection.
@@ -500,7 +487,9 @@ export async function deliverWebhook(
         timeoutId = setTimeout(() => controller.abort(), perAttemptTimeoutMs);
       }
       try {
-        const response = await fetchFn(input.url, {
+        // Delivery always uses Undici so callers cannot bypass the validated,
+        // pinned dispatcher with a fetch implementation that ignores it.
+        const response = await undiciFetch(input.url, {
           method: input.method ?? 'POST',
           headers,
           body: payloadString,
@@ -509,7 +498,7 @@ export async function deliverWebhook(
           // unchecked internal address.
           redirect: 'manual',
           dispatcher: pinnedDispatcher,
-        } as RequestInit & { dispatcher: Agent });
+        } as Parameters<typeof undiciFetch>[1]);
         if (timeoutId) {
           clearTimeout(timeoutId);
         }

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -129,7 +129,14 @@ export type WebhookDeliveryResult = {
 };
 
 export type WebhookDeliveryOptions = {
+  /**
+   * Custom transport used for delivery. Because DNS-rebinding protection
+   * relies on Undici's `dispatcher`, custom transports must explicitly attest
+   * that they honor that option; ordinary standards-only fetch functions are
+   * rejected instead of silently bypassing address pinning.
+   */
   fetch?: typeof globalThis.fetch;
+  fetchSupportsPinnedDispatcher?: boolean;
   resolveHostname?: (hostname: string) => Promise<readonly string[]>;
   maxRetries?: number;
   initialDelayMs?: number;
@@ -470,6 +477,9 @@ export async function deliverWebhook(
   );
   if (validatedTarget.error) {
     return failedDelivery(validatedTarget.error);
+  }
+  if (options.fetch && options.fetchSupportsPinnedDispatcher !== true) {
+    return failedDelivery('Custom webhook fetch must honor the pinned dispatcher');
   }
 
   // Keep the TLS/HTTP hostname unchanged, but force the connection lookup to

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -188,6 +188,27 @@ export async function deliverWebhook(
     'WEBHOOK_PER_ATTEMPT_TIMEOUT_INVALID'
   );
 
+  // Only http(s) delivery targets are permitted. This blocks SSRF vectors via
+  // other URL schemes (file:, gopher:, data:, ...) should the delivery URL be
+  // influenced by untrusted input.
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(input.url);
+  } catch {
+    return {
+      ok: false,
+      attempts: [{ attempt: 1, ok: false, error: 'Webhook URL is not a valid URL' }],
+    };
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    return {
+      ok: false,
+      attempts: [
+        { attempt: 1, ok: false, error: `Webhook URL scheme not allowed: ${parsedUrl.protocol}` },
+      ],
+    };
+  }
+
   let payloadString: string;
   try {
     payloadString = JSON.stringify(input.payload);

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { lookup } from 'node:dns/promises';
+import { Resolver } from 'node:dns/promises';
 import { isIP, type LookupFunction } from 'node:net';
 import { Agent, fetch as undiciFetch } from 'undici';
 
@@ -129,7 +129,7 @@ export type WebhookDeliveryResult = {
 };
 
 export type WebhookDeliveryOptions = {
-  resolveHostname?: (hostname: string) => Promise<readonly string[]>;
+  resolveHostname?: (hostname: string, signal: AbortSignal) => Promise<readonly string[]>;
   maxRetries?: number;
   initialDelayMs?: number;
   maxDelayMs?: number;
@@ -170,9 +170,38 @@ function normalizeNonNegativeDuration(
   return Math.max(0, value);
 }
 
-async function defaultResolveHostname(hostname: string): Promise<readonly string[]> {
-  const addresses = await lookup(hostname, { all: true, verbatim: true });
-  return addresses.map(({ address }) => address);
+async function defaultResolveHostname(
+  hostname: string,
+  signal: AbortSignal
+): Promise<readonly string[]> {
+  if (signal.aborted) {
+    throw signal.reason;
+  }
+
+  // Resolver.cancel() actively releases outstanding c-ares requests when the
+  // delivery deadline fires; a Promise.race alone would leave DNS work alive.
+  const resolver = new Resolver();
+  const cancel = () => resolver.cancel();
+  signal.addEventListener('abort', cancel, { once: true });
+  try {
+    const results = await Promise.allSettled([
+      resolver.resolve4(hostname),
+      resolver.resolve6(hostname),
+    ]);
+    if (signal.aborted) {
+      throw signal.reason;
+    }
+    const addresses = results.flatMap((result) =>
+      result.status === 'fulfilled' ? result.value : []
+    );
+    if (addresses.length === 0) {
+      const failure = results.find((result) => result.status === 'rejected');
+      throw failure?.reason ?? new Error(`DNS lookup returned no addresses for ${hostname}`);
+    }
+    return addresses;
+  } finally {
+    signal.removeEventListener('abort', cancel);
+  }
 }
 
 function failedDelivery(error: string): WebhookDeliveryResult {
@@ -184,7 +213,8 @@ function failedDelivery(error: string): WebhookDeliveryResult {
 
 async function validateWebhookTarget(
   url: URL,
-  resolveHostname: (hostname: string) => Promise<readonly string[]>
+  resolveHostname: (hostname: string, signal: AbortSignal) => Promise<readonly string[]>,
+  signal: AbortSignal
 ): Promise<{ error: string | null; hostname: string; addresses: readonly string[] }> {
   const hostname = url.hostname.replace(/^\[|\]$/g, '').replace(/\.+$/, '').toLowerCase();
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
@@ -201,7 +231,7 @@ async function validateWebhookTarget(
     addresses = [hostname];
   } else {
     try {
-      addresses = await resolveHostname(hostname);
+      addresses = await resolveHostname(hostname, signal);
     } catch {
       return {
         error: `Webhook target hostname could not be resolved: ${hostname}`,
@@ -477,11 +507,17 @@ export async function deliverWebhook(
   }
 
   let validatedTarget: Awaited<ReturnType<typeof validateWebhookTarget>>;
+  const validationController = new AbortController();
   try {
     validatedTarget = await withTimeout(
-      validateWebhookTarget(parsedUrl, options.resolveHostname ?? defaultResolveHostname),
+      validateWebhookTarget(
+        parsedUrl,
+        options.resolveHostname ?? defaultResolveHostname,
+        validationController.signal
+      ),
       perAttemptTimeoutMs,
-      `Webhook target validation timed out after ${perAttemptTimeoutMs}ms`
+      `Webhook target validation timed out after ${perAttemptTimeoutMs}ms`,
+      () => validationController.abort()
     );
   } catch (error) {
     return failedDelivery(error instanceof Error ? error.message : String(error));
@@ -629,14 +665,22 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function withTimeout<T>(operation: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+async function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  message: string,
+  onTimeout?: () => void
+): Promise<T> {
   if (timeoutMs <= 0) {
     return operation;
   }
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+    timeoutId = setTimeout(() => {
+      reject(new Error(message));
+      onTimeout?.();
+    }, timeoutMs);
   });
   try {
     return await Promise.race([operation, timeout]);

--- a/packages/webhooks/src/index.ts
+++ b/packages/webhooks/src/index.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { lookup } from 'node:dns/promises';
-import { isIP } from 'node:net';
+import { isIP, type LookupFunction } from 'node:net';
+import { Agent, fetch as undiciFetch } from 'undici';
 
 export type SignatureEncoding = 'hex' | 'base64';
 
@@ -185,10 +186,14 @@ function failedDelivery(error: string): WebhookDeliveryResult {
 async function validateWebhookTarget(
   url: URL,
   resolveHostname: (hostname: string) => Promise<readonly string[]>
-): Promise<string | null> {
-  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+): Promise<{ error: string | null; hostname: string; addresses: readonly string[] }> {
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').replace(/\.+$/, '').toLowerCase();
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
-    return `Webhook target hostname is not public: ${hostname}`;
+    return {
+      error: `Webhook target hostname is not public: ${hostname}`,
+      hostname,
+      addresses: [],
+    };
   }
 
   const literalVersion = isIP(hostname);
@@ -199,19 +204,66 @@ async function validateWebhookTarget(
     try {
       addresses = await resolveHostname(hostname);
     } catch {
-      return `Webhook target hostname could not be resolved: ${hostname}`;
+      return {
+        error: `Webhook target hostname could not be resolved: ${hostname}`,
+        hostname,
+        addresses: [],
+      };
     }
     if (addresses.length === 0) {
-      return `Webhook target hostname could not be resolved: ${hostname}`;
+      return {
+        error: `Webhook target hostname could not be resolved: ${hostname}`,
+        hostname,
+        addresses: [],
+      };
     }
   }
 
   for (const address of addresses) {
     if (isNonPublicAddress(address)) {
-      return `Webhook target resolves to a non-public address: ${address}`;
+      return {
+        error: `Webhook target resolves to a non-public address: ${address}`,
+        hostname,
+        addresses,
+      };
     }
   }
-  return null;
+  return { error: null, hostname, addresses };
+}
+
+function createPinnedDispatcher(hostname: string, addresses: readonly string[]): Agent {
+  let nextAddress = 0;
+  const lookupPinnedAddress = ((requestedHostname, options, callback) => {
+    const normalizedHostname = requestedHostname
+      .replace(/^\[|\]$/g, '')
+      .replace(/\.+$/, '')
+      .toLowerCase();
+    if (normalizedHostname !== hostname) {
+      callback(new Error(`WEBHOOK_UNVALIDATED_HOSTNAME: ${normalizedHostname}`), '', 0);
+      return;
+    }
+
+    const family = typeof options === 'object' ? options.family : 0;
+    const candidates = addresses.filter((address) => family === 0 || isIP(address) === family);
+    if (candidates.length === 0) {
+      callback(new Error(`WEBHOOK_VALIDATED_ADDRESS_FAMILY_UNAVAILABLE: ${hostname}`), '', 0);
+      return;
+    }
+
+    if (typeof options === 'object' && options.all) {
+      callback(
+        null,
+        candidates.map((address) => ({ address, family: isIP(address) }))
+      );
+      return;
+    }
+
+    const address = candidates[nextAddress % candidates.length]!;
+    nextAddress += 1;
+    callback(null, address, isIP(address));
+  }) as LookupFunction;
+
+  return new Agent({ connect: { lookup: lookupPinnedAddress } });
 }
 
 function isNonPublicAddress(address: string): boolean {
@@ -226,11 +278,24 @@ function isNonPublicAddress(address: string): boolean {
       return true;
     }
 
-    // IPv4-mapped IPv6 (::ffff:0:0/96) must inherit the IPv4 restrictions.
+    // Embedded-IPv4 forms must inherit the IPv4 restrictions. Cover both
+    // IPv4-mapped (::ffff:0:0/96) and IPv4-compatible (::/96) addresses.
+    const first10Zero = bytes.slice(0, 10).every((byte) => byte === 0);
     if (
-      bytes.slice(0, 10).every((byte) => byte === 0) &&
-      bytes[10] === 0xff &&
-      bytes[11] === 0xff
+      first10Zero &&
+      ((bytes[10] === 0xff && bytes[11] === 0xff) ||
+        (bytes[10] === 0 && bytes[11] === 0))
+    ) {
+      return isNonPublicIpv4(bytes.slice(12).join('.'));
+    }
+
+    // NAT64's well-known 64:ff9b::/96 prefix also embeds an IPv4 destination.
+    if (
+      bytes[0] === 0x00 &&
+      bytes[1] === 0x64 &&
+      bytes[2] === 0xff &&
+      bytes[3] === 0x9b &&
+      bytes.slice(4, 12).every((byte) => byte === 0)
     ) {
       return isNonPublicIpv4(bytes.slice(12).join('.'));
     }
@@ -311,7 +376,7 @@ export async function deliverWebhook(
   input: WebhookDeliveryInput,
   options: WebhookDeliveryOptions = {}
 ): Promise<WebhookDeliveryResult> {
-  const fetchFn = options.fetch ?? globalThis.fetch;
+  const fetchFn = options.fetch ?? (undiciFetch as unknown as typeof globalThis.fetch);
   const maxRetries = normalizeRetryCount(options.maxRetries);
   const initialDelayMs = normalizeNonNegativeDuration(
     options.initialDelayMs,
@@ -399,94 +464,110 @@ export async function deliverWebhook(
     );
   }
 
-  const targetError = await validateWebhookTarget(
+  const validatedTarget = await validateWebhookTarget(
     parsedUrl,
     options.resolveHostname ?? defaultResolveHostname
   );
-  if (targetError) {
-    return failedDelivery(targetError);
+  if (validatedTarget.error) {
+    return failedDelivery(validatedTarget.error);
   }
+
+  // Keep the TLS/HTTP hostname unchanged, but force the connection lookup to
+  // use only addresses that passed the public-address checks. This closes the
+  // DNS-rebinding gap between validation and the actual socket connection.
+  const pinnedDispatcher = createPinnedDispatcher(
+    validatedTarget.hostname,
+    validatedTarget.addresses
+  );
 
   const attempts: WebhookDeliveryAttempt[] = [];
 
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const controller = typeof AbortController === 'function' ? new AbortController() : undefined;
-    if (controller && perAttemptTimeoutMs > 0) {
-      timeoutId = setTimeout(() => controller.abort(), perAttemptTimeoutMs);
-    }
-    try {
-      const response = await fetchFn(input.url, {
-        method: input.method ?? 'POST',
-        headers,
-        body: payloadString,
-        signal: controller?.signal,
-        // Do not let an allowed public target redirect the request to an
-        // unchecked internal address.
-        redirect: 'manual',
-      });
-      if (timeoutId) {
-        clearTimeout(timeoutId);
+  try {
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const controller = typeof AbortController === 'function' ? new AbortController() : undefined;
+      if (controller && perAttemptTimeoutMs > 0) {
+        timeoutId = setTimeout(() => controller.abort(), perAttemptTimeoutMs);
       }
+      try {
+        const response = await fetchFn(input.url, {
+          method: input.method ?? 'POST',
+          headers,
+          body: payloadString,
+          signal: controller?.signal,
+          // Do not let an allowed public target redirect the request to an
+          // unchecked internal address.
+          redirect: 'manual',
+          dispatcher: pinnedDispatcher,
+        } as RequestInit & { dispatcher: Agent });
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        if (response.body) {
+          await response.body.cancel().catch(() => undefined);
+        }
 
-      if (response.ok) {
+        if (response.ok) {
+          attempts.push({
+            attempt,
+            ok: true,
+            status: response.status,
+          });
+
+          return {
+            ok: true,
+            attempts,
+            responseStatus: response.status,
+          };
+        }
+
         attempts.push({
           attempt,
-          ok: true,
+          ok: false,
           status: response.status,
+          error: `HTTP ${response.status}`,
         });
 
-        return {
-          ok: true,
-          attempts,
-          responseStatus: response.status,
-        };
-      }
-
-      attempts.push({
-        attempt,
-        ok: false,
-        status: response.status,
-        error: `HTTP ${response.status}`,
-      });
-
-      if (attempt >= maxRetries || !shouldRetryWebhookStatus(response.status)) {
-        return {
+        if (attempt >= maxRetries || !shouldRetryWebhookStatus(response.status)) {
+          return {
+            ok: false,
+            attempts,
+            responseStatus: response.status,
+          };
+        }
+      } catch (error) {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        attempts.push({
+          attempt,
           ok: false,
-          attempts,
-          responseStatus: response.status,
-        };
-      }
-    } catch (error) {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      attempts.push({
-        attempt,
-        ok: false,
-        error: error instanceof Error ? error.message : String(error),
-      });
+          error: error instanceof Error ? error.message : String(error),
+        });
 
-      if (attempt >= maxRetries || !shouldRetryWebhookError(error)) {
-        return {
-          ok: false,
-          attempts,
-          responseStatus: attempts[attempts.length - 1]?.status,
-        };
+        if (attempt >= maxRetries || !shouldRetryWebhookError(error)) {
+          return {
+            ok: false,
+            attempts,
+            responseStatus: attempts[attempts.length - 1]?.status,
+          };
+        }
+      }
+
+      if (attempt < maxRetries) {
+        const delay = Math.min(maxDelayMs, initialDelayMs * 2 ** (attempt - 1));
+        await sleep(delay);
       }
     }
 
-    if (attempt < maxRetries) {
-      const delay = Math.min(maxDelayMs, initialDelayMs * 2 ** (attempt - 1));
-      await sleep(delay);
-    }
+    return {
+      ok: false,
+      attempts,
+      responseStatus: attempts[attempts.length - 1]?.status,
+    };
+  } finally {
+    await pinnedDispatcher.close().catch(() => undefined);
   }
-
-  return {
-    ok: false,
-    attempts,
-    responseStatus: attempts[attempts.length - 1]?.status,
-  };
 }
 
 function normalizeRetryCount(value: number | undefined): number {

--- a/plugfn/core/src/core/action-executor.ts
+++ b/plugfn/core/src/core/action-executor.ts
@@ -90,7 +90,7 @@ export class ActionExecutor {
   ): Promise<ActionResult<T>> {
     const startTime = Date.now();
     let retries = 0;
-    let cached = false;
+    const cached = false;
 
     try {
       // Get provider

--- a/plugfn/core/src/core/plug-fn.ts
+++ b/plugfn/core/src/core/plug-fn.ts
@@ -375,7 +375,6 @@ export function plugFn(config: PlugFnConfig): PlugFn {
   // Event handlers
   const eventHandlers = new Map<string, Set<(event: any) => void>>();
   const persistenceSinks = new Map<string, PlugFnPersistenceSink>();
-  let proxyApi!: PlugFn;
 
   // Create the main API
   const api: PlugFn = {
@@ -967,7 +966,7 @@ export function plugFn(config: PlugFnConfig): PlugFn {
   }
 
   // Create dynamic provider proxies
-  proxyApi = new Proxy(api, {
+  const proxyApi = new Proxy(api, {
     get(target, prop: string) {
       // If property exists on target, return it
       if (prop in target) {
@@ -988,7 +987,7 @@ export function plugFn(config: PlugFnConfig): PlugFn {
       };
 
       // Add all actions
-      for (const [actionName, _action] of Object.entries(provider.actions)) {
+      for (const actionName of Object.keys(provider.actions)) {
         providerProxy[actionName] = async (options: ActionOptions) => {
           const result = await actionExecutor.execute(prop, actionName, options);
           if (!result.success) {

--- a/plugfn/core/src/middleware/rate-limiter.ts
+++ b/plugfn/core/src/middleware/rate-limiter.ts
@@ -39,7 +39,7 @@ export class RateLimiter {
     const limiter = this.getSharedLimiter(config);
     const start = this.now();
 
-    while (true) {
+    for (;;) {
       if (this.destroyed) {
         throw new Error('Rate limiter destroyed');
       }
@@ -66,7 +66,7 @@ export class RateLimiter {
     const start = this.now();
     let waited = false;
 
-    while (true) {
+    for (;;) {
       if (this.destroyed) {
         throw new Error('Rate limiter destroyed');
       }


### PR DESCRIPTION
Audit-driven correctness, security, and reliability fixes across the shared `packages/`. Each fix has test coverage; all touched packages' suites pass (`db` 172, `http` 51, `auth` 9, `oauth-core` 13, `oauth-providers` 13, `oauth-flow` 26, `oauth-router` 16, `oauth-http` 21, `storage*` 45, `queue` 12, `metrics` 2, `webhooks` 16).

**db**
- Drizzle SQLite transactions now use explicit `BEGIN`/`COMMIT`/`ROLLBACK` so awaited operations actually run inside the transaction. The old sync `better-sqlite3` wrapper returned a pending promise and committed before any `await`, giving no atomicity/rollback. Re-enabled the two previously-skipped transaction tests.
- Prisma and Kysely `WHERE` builders now honor `OR`/`AND` connectors with correct left-associative grouping (matching Drizzle). Previously Prisma flattened everything into `AND` and Kysely relied on SQL precedence via flat `.where()/.orWhere()` chaining — both returned wrong rows and could leak across row-level namespaces (e.g. `(a OR b)` scoped query became `a OR (b AND __ns=…)`).
- Singular `update()`/`delete()` now reject an empty `where` clause across drizzle/kysely/memory (previously affected/deleted all rows). Use `updateMany`/`deleteMany` for that.
- Memory adapter IDs use `crypto.randomUUID()` instead of collision-prone `Math.random()`.

**http**
- CORS: emit `Vary: Origin` for reflected origins (cache poisoning), and never send `*` together with credentials — reflect a concrete origin instead (browsers reject the invalid combination).
- Router: return `405` + `Allow` header when a path exists under a different method (was `404`); add configurable `maxBodyBytes` with `413` enforcement by Content-Length and streamed size (body DoS).

**auth**
- Resource-authorization middleware now fails closed (throws `AuthenticationError`) when no session is present, instead of calling `next()` — the previous fail-open silently bypassed the control if misordered/misconfigured.

**oauth**
- `oauth-router`: validate `returnTo` against the request origin plus an optional `allowedRedirectOrigins` allowlist, closing an open-redirect via the unauthenticated flow-start input.
- `oauth-http`: per-request timeout on the default global-fetch fetcher (hung provider DoS); ignore non-positive `expires_in` to avoid spurious refresh loops.
- `oauth-http`/`oauth-providers`: implement GitHub token revocation. The `{client_id}` URL placeholder is now substituted, and revocation requests branch on a new descriptor `revocationStyle` — GitHub uses `DELETE` + JSON body + Basic auth on `/applications/{client_id}/token`, while other providers keep the RFC-7009 form-POST.

**storage**
- GCS/Azure download streams apply backpressure (`pause`/`resume`/`pull`) matching the local adapter, avoiding unbounded memory buffering of large objects on slow consumers.
- Validate/clamp presigned-URL expiry in the S3-compatible adapter (positive, ≤ 7-day SigV4 max).

**queue / metrics / webhooks**
- `MemoryQueueAdapter` gains an optional `maxSize` with a reject policy (unbounded-growth memory leak).
- Metrics emitter swallows exceptions from the user track function so telemetry can't break the request path.
- Webhook delivery rejects non-`http(s)` URL schemes (SSRF guard).

### Not addressed (documented for follow-up)
These were found in the audit but deferred to avoid fragile, hard-to-verify changes or larger design decisions:
- OIDC `id_token` signature/nonce verification is delegated to consumers (a generated nonce is currently unchecked) — needs JWKS verification or an explicit `verifyIdToken` hook.
- Token-storage plaintext-unsafe default (fail-open) — hardening to fail-closed is breaking and left for a follow-up decision.
- `SchemaTracker.getVersion/getAllVersions` swallow all errors as "version 0" — should distinguish "table missing" from transient DB errors (dialect-specific error matching).
- `escapeLikeWildcards` doesn't escape `\` / emit an explicit `ESCAPE` clause (correctness, not injection — values are parameterized).
- Refresh-token rotation reuse detection (new feature).

## Summary by Sourcery

Harden shared packages for production by fixing correctness issues and adding security, resource, and failure-boundary protections.

New Features:
- Add configurable HTTP request body limits with 413 enforcement and distinguish unsupported methods with 405 responses and Allow headers.
- Add optional bounded capacity to the in-memory queue adapter.
- Support provider-specific OAuth revocation, including GitHub token revocation, and configurable OAuth request timeouts.

Bug Fixes:
- Correct database transaction and query-filter behavior to preserve atomicity, connector grouping, and row-level namespace isolation.
- Prevent destructive singular updates and deletes without filters across database adapters.
- Harden authentication, CORS, OAuth redirects, webhook delivery, presigned URLs, object download streams, and telemetry against security or reliability failures.
- Improve transactional synchronization by binding change tracking and idempotency stores to transaction-scoped database adapters.

Enhancements:
- Improve in-memory adapter ID generation and enforce safer OAuth token expiry handling.
- Add backpressure to cloud storage download streams and preserve bounded request-body parsing for binary and multipart payloads.

Build:
- Add the webhook package's undici runtime dependency and allow the Svelte package test script to pass when no tests are present.

Tests:
- Expand coverage for HTTP limits and method handling, CORS behavior, OAuth timeouts and revocation, webhook SSRF protection, database write guards, queue limits, metrics failures, and signed URL validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Resource authorization denies requests without a valid session.
  - OAuth redirects are restricted to safe destinations.
  - Webhooks reject private, malformed, and non-HTTP(S) targets.
  - Signed URLs enforce valid expiration limits.

- **New Features**
  - HTTP routers support body-size limits and 413 responses.
  - Unsupported methods return 405 responses with allowed methods.
  - In-memory queues support capacity limits.
  - OAuth clients support timeouts and provider-specific revocation.
  - Metrics reporting safely handles asynchronous failures.

- **Bug Fixes**
  - Database filters preserve mixed AND/OR logic and block unsafe single-record mutations.
  - CORS responses correctly vary by origin.
  - Storage downloads reduce buffering through backpressure.
  - Transactional synchronization and idempotency handling are more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->