### PR TITLE
Add per-package READMEs and rewrite the ApiFn toolkit README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 *.tsbuildinfo
 **/*.js
 **/*.d.ts
+!apifn/docsfn/src/svelte/ApifnApiReference.svelte.d.ts
 **/*.d.ts.map
 **/*.js.map
 

--- a/apifn/README.md
+++ b/apifn/README.md
@@ -4,18 +4,22 @@ ApiFn is a code-first, self-hosted API development toolkit. Generate OpenAPI spe
 
 Your router is the source of truth: introspect it into OpenAPI 3.1, then drive validation, diffing, testing, mocking, snippets, and documentation from the same spec.
 
-## Packages
+## npm packages
 
 | Package | Description |
 |---------|-------------|
-| [`@apifn/core`](./core) | Route introspection, schema conversion (Zod/TypeBox → JSON Schema), OpenAPI 3.1 generation, diff, and ecosystem integrations. Every package depends on it. |
+| [`@apifn/core`](./core) | Route introspection, schema conversion (Zod/TypeBox → JSON Schema), OpenAPI 3.1 generation, diff, and ecosystem integrations. The other ApiFn npm packages build on it. |
 | [`@apifn/cli`](./cli) | The `apifn` command — generate, export, import, validate, diff, test, mock, serve, snippet. |
 | [`@apifn/collections`](./collections) | OpenCollection YAML read/write/run: portable request collections with assertions, scripting, and reporters. |
-| [`@apifn/mock`](./mock) | Zero-dependency mock server from any OpenAPI spec, with schema/example/random responses and request validation. |
+| [`@apifn/mock`](./mock) | Framework-free mock server from any OpenAPI spec, with schema/example/random responses and request validation. |
 | [`@apifn/snippets`](./snippets) | Generate request code snippets for 11 languages/clients (curl, fetch, axios, Python, Go, Java, …). |
 | [`@apifn/react`](./react) | React components — interactive API explorer, Try-It console, schema viewer, diff, performance overlays. |
 | [`@apifn/svelte`](./svelte) | The same UI surface for Svelte, shipped as `.svelte` source. |
 | [`@apifn/docsfn`](./docsfn) | docsfn plugin — render an OpenAPI spec as an interactive API reference. |
+
+## Python SDK
+
+[`apifn`](./python) provides Python helpers for OpenAPI generation, diffing, collections, FastAPI, and Flask. It requires Python 3.10 or newer and is versioned separately from the npm packages.
 
 ## Quick Start
 

--- a/apifn/README.md
+++ b/apifn/README.md
@@ -1,6 +1,78 @@
 # ApiFn
 
-ApiFn is a code-first, self-hosted API development toolkit for OpenAPI generation, diffing, and collection testing.
+ApiFn is a code-first, self-hosted API development toolkit. Generate OpenAPI specs from your router, diff them for breaking changes, run collection-based test suites, mock endpoints, embed interactive API docs, and gate it all in CI — without leaving your codebase.
+
+Your router is the source of truth: introspect it into OpenAPI 3.1, then drive validation, diffing, testing, mocking, snippets, and documentation from the same spec.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@apifn/core`](./core) | Route introspection, schema conversion (Zod/TypeBox → JSON Schema), OpenAPI 3.1 generation, diff, and ecosystem integrations. Every package depends on it. |
+| [`@apifn/cli`](./cli) | The `apifn` command — generate, export, import, validate, diff, test, mock, serve, snippet. |
+| [`@apifn/collections`](./collections) | OpenCollection YAML read/write/run: portable request collections with assertions, scripting, and reporters. |
+| [`@apifn/mock`](./mock) | Zero-dependency mock server from any OpenAPI spec, with schema/example/random responses and request validation. |
+| [`@apifn/snippets`](./snippets) | Generate request code snippets for 11 languages/clients (curl, fetch, axios, Python, Go, Java, …). |
+| [`@apifn/react`](./react) | React components — interactive API explorer, Try-It console, schema viewer, diff, performance overlays. |
+| [`@apifn/svelte`](./svelte) | The same UI surface for Svelte, shipped as `.svelte` source. |
+| [`@apifn/docsfn`](./docsfn) | docsfn plugin — render an OpenAPI spec as an interactive API reference. |
+
+## Quick Start
+
+Install the CLI and scaffold a collection:
+
+```bash
+npm install --save-dev @apifn/cli
+npx apifn init .apifn/collection
+```
+
+Generate an OpenAPI document from your `@superfunctions/http` router:
+
+```typescript
+// apifn.config.ts
+import { defineConfig } from "@apifn/cli";
+
+export default defineConfig({
+  router: "./src/router.ts",
+  output: ".apifn",
+  openapi: {
+    info: { title: "My API", version: "1.0.0" },
+    servers: [{ url: "https://api.example.com" }],
+  },
+});
+```
+
+```bash
+apifn generate                          # → .apifn/openapi.yml
+apifn validate .apifn/openapi.yml       # validate the document
+apifn mock .apifn/openapi.yml           # mock server on :4010
+apifn serve .apifn/openapi.yml          # interactive explorer on :4100
+apifn test .apifn/collection            # run collection tests
+```
+
+Or use the library directly:
+
+```typescript
+import { fromRouter, diffOpenAPI, formatDiffAsText } from "@apifn/core";
+
+const doc = fromRouter(router, {
+  info: { title: "My API", version: "1.0.0" },
+  servers: [{ url: "https://api.example.com" }],
+});
+
+const result = diffOpenAPI(baselineDoc, doc);
+console.log(formatDiffAsText(result));
+```
+
+## Ecosystem Integrations
+
+`@apifn/core` ships first-class hooks into the wider Superfunctions stack:
+
+- **watchfn** — per-endpoint performance metrics and request telemetry
+- **authfn** — mint short-lived test tokens and inject auth into collection runs
+- **secfn** — read rate-limit state for endpoints
+- **logfn** — structured run reporting and a CLI logger
+- **testfn** — an adapter that discovers and runs collections as test cases
 
 ## CI/CD
 
@@ -37,3 +109,7 @@ apifn validate .apifn/openapi.yml --format json
 apifn diff .apifn/base-openapi.yml .apifn/openapi.yml --format json
 apifn test .apifn/collection --env development --reporter json
 ```
+
+## License
+
+MIT

--- a/apifn/cli/README.md
+++ b/apifn/cli/README.md
@@ -1,0 +1,211 @@
+# @apifn/cli
+
+CLI tools for ApiFn. Generate OpenAPI specs from your router, diff them for breaking changes, validate documents, run collection test suites, mock APIs, serve an interactive explorer, and generate code snippets — all from one `apifn` command.
+
+## Installation
+
+```bash
+npm install --save-dev @apifn/cli
+# or run ad-hoc
+npx @apifn/cli --help
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `init [dir]` | Scaffold a new OpenCollection directory |
+| `generate [router]` | Generate an OpenAPI document from a router |
+| `export [format] [output]` | Export a generated spec as YAML or JSON |
+| `import <kind> <source>` | Import an OpenAPI document as an OpenCollection |
+| `test [collectionDir]` | Run a collection's tests |
+| `diff <before> <after>` | Compare two specs for breaking changes |
+| `validate <specPath>` | Validate an OpenAPI document |
+| `serve [specPath]` | Serve an interactive API explorer |
+| `mock <specPath>` | Start a mock server from a spec |
+| `snippet <specPath> [apiPath]` | Generate a code snippet for an endpoint |
+
+### Global options
+
+`--config <path>` (default `apifn.config.ts`) · `--verbose` · `--quiet` · `--no-color`
+
+---
+
+## init
+
+Scaffold an OpenCollection directory with a `development` environment and a sample request.
+
+```bash
+apifn init .apifn/collection --yes
+```
+
+- `--yes` — skip interactive prompts (name, base URL)
+- `--force` — allow initializing into a non-empty directory
+
+## generate
+
+Generate an OpenAPI document from a `@superfunctions/http` router. The router comes from the argument or `config.router`.
+
+```bash
+apifn generate ./src/router.ts --output .apifn/openapi.yml
+```
+
+- `--output <path>` — output path (default `<config.output>/openapi.yml`, i.e. `.apifn/openapi.yml`)
+
+`info` defaults to `{ title: "API", version: "1.0.0" }`, merged with `config.openapi.info` and `config.openapi.servers`.
+
+## export
+
+Re-serialize a generated spec.
+
+```bash
+apifn export json openapi.json --input .apifn/openapi.yml
+```
+
+- `format` — `yaml` (default) or `json`
+- `--input <path>` — input spec (default `<config.output>/openapi.yml`)
+
+## import
+
+Import an OpenAPI document (file path or `http(s)` URL) as an OpenCollection.
+
+```bash
+apifn import openapi ./openapi.yml --output .apifn/collection --group-by tag
+```
+
+- `--output <dir>` — output directory (default `.`)
+- `--base-url <url>` — base URL for the generated environment
+- `--env <name>` — environment name (default `development`)
+- `--group-by <mode>` — `tag` (default) or `path`
+- `--force` — allow writing into a non-empty directory
+
+## test
+
+Run a collection's requests and assertions.
+
+```bash
+apifn test .apifn/collection --env development --reporter json --output test-report.json
+```
+
+| Option | Description |
+|--------|-------------|
+| `--env <name>` | Environment (defaults to the first defined) |
+| `--bail` | Stop on first failure |
+| `--parallel` | Run requests concurrently |
+| `--concurrency <n>` | Max concurrent requests |
+| `--timeout <ms>` | Per-request timeout |
+| `--include <pattern>` / `--exclude <pattern>` | Filter requests (repeatable) |
+| `--retries <n>` | Retry failed requests |
+| `--delay <ms>` | Delay between sequential requests |
+| `--env-var <KEY=value>` | Override an environment variable (repeatable) |
+| `--dotenv <path>` | Load a dotenv file as overrides |
+| `--redact-header <name>` | Additional header to redact (repeatable) |
+| `--output <path>` | Write a machine-readable report |
+| `--reporter <type>` | `console` (default), `json`, `junit`, `silent` |
+
+Exit codes: `0` all passed · `1` failures/errors · `2` load/run error.
+
+## diff
+
+Compare two specs (file paths or URLs) for breaking changes.
+
+```bash
+apifn diff base-openapi.yml openapi.yml --format json
+```
+
+- `--format <type>` — `text` (default) or `json`
+- `--fail-on-breaking` — exit `1` on breaking changes (default `true`)
+
+Exit codes: `0` no breaking changes · `1` breaking detected · `2` load/parse error.
+
+## validate
+
+```bash
+apifn validate .apifn/openapi.yml --format json
+```
+
+- `--format <type>` — `text` (default) or `json`
+
+Exit codes: `0` valid · `1` validation errors · `2` load/parse error.
+
+## serve
+
+Serve a built-in interactive explorer with live reload (SSE on spec file changes).
+
+```bash
+apifn serve .apifn/openapi.yml --port 4100 --open
+```
+
+- `--port <port>` — default `4100`
+- `--open` — open the browser automatically
+
+## mock
+
+Start a mock server (via [`@apifn/mock`](../mock)).
+
+```bash
+apifn mock .apifn/openapi.yml --mode examples --port 4010 --validate-requests --delay 100
+```
+
+- `--mode <mode>` — `schema` (default), `examples`, `random`
+- `--port <port>` — default `4010`
+- `--validate-requests` — validate incoming request bodies
+- `--delay <ms>` — add response latency
+
+## snippet
+
+Generate a code snippet for one endpoint or the whole spec (via [`@apifn/snippets`](../snippets)).
+
+```bash
+apifn snippet .apifn/openapi.yml /users --method get --target curl
+apifn snippet .apifn/openapi.yml --all --target python-requests
+```
+
+- `--target <target>` — `curl` (default), `fetch`, `axios`, `python-requests`, … (see `@apifn/snippets`)
+- `--method <method>` — HTTP method (default `get`)
+- `--base-url <url>` — base URL override
+- `--all` — generate snippets for every endpoint
+
+---
+
+## Configuration
+
+Create an `apifn.config.ts` and type it with `defineConfig`:
+
+```typescript
+import { defineConfig } from "@apifn/cli";
+
+export default defineConfig({
+  router: "./src/router.ts",
+  collection: ".apifn/collection",
+  output: ".apifn",
+  defaultEnvironment: "development",
+  openapi: {
+    info: { title: "My API", version: "1.0.0" },
+    servers: [{ url: "https://api.example.com" }],
+  },
+  diff: { failOnBreaking: true },
+  snippets: ["curl", "python-requests"],
+});
+```
+
+Config files (`.ts`/`.js`/`.mjs`) are loaded at runtime via `jiti`. Unknown fields are rejected.
+
+## Programmatic API
+
+```typescript
+import { runCli, loadConfig, defineConfig } from "@apifn/cli";
+
+const exitCode = await runCli(["validate", ".apifn/openapi.yml", "--format", "json"], {
+  cwd: process.cwd(),
+  stdout: (t) => process.stdout.write(t),
+});
+```
+
+- `runCli(argv?, { cwd?, stdout?, stderr? })` — run the CLI, returns an exit code
+- `loadConfig({ cwd?, configPath? })` — load and validate config
+- `defineConfig(config)` — typed config helper
+
+## License
+
+MIT

--- a/apifn/cli/README.md
+++ b/apifn/cli/README.md
@@ -189,7 +189,7 @@ export default defineConfig({
 });
 ```
 
-Config files (`.ts`/`.js`/`.mjs`) are loaded at runtime via `jiti`. Unknown fields are rejected.
+Config files (`.ts`/`.js`/`.mjs`) are loaded at runtime via `jiti`. Unknown top-level fields are rejected.
 
 ## Programmatic API
 

--- a/apifn/collections/README.md
+++ b/apifn/collections/README.md
@@ -13,7 +13,7 @@ npm install @apifn/collections
 - **Read / Write** — Load and persist an OpenCollection directory (`opencollection.yml` + per-request YAML + environments)
 - **Generate** — Produce a collection from an OpenAPI document or a `@superfunctions/http` router
 - **Run** — Execute a collection with sequential or parallel scheduling, retries, timeouts, and bail-on-failure
-- **Assertions** — Chai-like `expect`/`test` runtime with JSON-schema and JSONPath support
+- **Assertions** — Chai-like `expect`/`test` runtime with JSON Schema and JSONPath support
 - **Scripting** — Sandboxed pre-request and test scripts (Node `vm`, no `process`/`require`/`fetch`)
 - **Reporters** — Console, JSON, JUnit XML, and silent reporters
 - **Safety** — Secret redaction in captured request/response data, path-traversal-safe writes
@@ -122,7 +122,7 @@ console.log(report.summary);
 | `concurrency` | `number` | Max concurrent requests in parallel mode (default: 4) |
 | `timeout` | `number` | Per-request timeout in ms (default: 30000) |
 | `bail` | `boolean` | Stop on first failure |
-| `retries` | `number` | Retry failed requests / HTTP 5xx (default: 0) |
+| `retries` | `number` | Retry network errors and HTTP 5xx responses (default: 0) |
 | `delay` | `number` | Delay between sequential requests in ms |
 | `httpClient` | `HttpClient` | Custom client (default: built-in fetch-based) |
 | `cookieJar` | `CookieJar` | Shared cookie jar |

--- a/apifn/collections/README.md
+++ b/apifn/collections/README.md
@@ -1,0 +1,237 @@
+# @apifn/collections
+
+OpenCollection YAML read/write/run for ApiFn. Read and write portable API request collections, generate them from OpenAPI specs or routers, and run them as a test suite with assertions, scripting, and pluggable reporters.
+
+## Installation
+
+```bash
+npm install @apifn/collections
+```
+
+## Features
+
+- **Read / Write** — Load and persist an OpenCollection directory (`opencollection.yml` + per-request YAML + environments)
+- **Generate** — Produce a collection from an OpenAPI document or a `@superfunctions/http` router
+- **Run** — Execute a collection with sequential or parallel scheduling, retries, timeouts, and bail-on-failure
+- **Assertions** — Chai-like `expect`/`test` runtime with JSON-schema and JSONPath support
+- **Scripting** — Sandboxed pre-request and test scripts (Node `vm`, no `process`/`require`/`fetch`)
+- **Reporters** — Console, JSON, JUnit XML, and silent reporters
+- **Safety** — Secret redaction in captured request/response data, path-traversal-safe writes
+
+---
+
+## Reading & Writing
+
+### readCollection
+
+Reads an OpenCollection directory. Expects `opencollection.yml` at the root; files under `environments/` become environments; any YAML with both `info` and `http` keys is a request. Items are assembled into a nested folder tree.
+
+```typescript
+import { readCollection } from "@apifn/collections";
+
+const collection = await readCollection("./.apifn/collection");
+// { info, environments, items, rootDir }
+```
+
+### writeCollection
+
+Persists a `Collection` back to its `rootDir` (writes `opencollection.yml`, `environments/*.yml`, and each request/folder). Paths are validated against traversal.
+
+```typescript
+import { writeCollection } from "@apifn/collections";
+
+await writeCollection(collection);
+```
+
+### validateCollection
+
+Returns `ValidationError[]` describing structural problems (missing `info.name`, malformed environments, requests missing `http.method`, etc.).
+
+```typescript
+import { validateCollection } from "@apifn/collections";
+
+const errors = validateCollection(collection);
+```
+
+---
+
+## Generating Collections
+
+### openAPIToCollection
+
+Build a collection from an OpenAPI document. Operations are grouped by tag (default) or first path segment.
+
+```typescript
+import { openAPIToCollection } from "@apifn/collections";
+
+const collection = openAPIToCollection(openApiDoc, {
+  baseUrl: "https://api.example.com",
+  environmentName: "development",
+  groupBy: "tag", // or "path"
+  includeExamples: true,
+});
+```
+
+### routerToCollection
+
+Introspect a `@superfunctions/http` router and produce a collection in one step.
+
+```typescript
+import { routerToCollection } from "@apifn/collections";
+
+const collection = routerToCollection(router, {
+  baseUrl: "https://api.example.com",
+  info: { title: "My API", version: "1.0.0" },
+});
+```
+
+Path params `{id}` become `{{id}}` template variables and URLs are prefixed with `{{baseUrl}}`.
+
+---
+
+## Running Collections
+
+### runCollection
+
+Execute a collection against an environment. Returns a `RunReport`.
+
+```typescript
+import { readCollection, runCollection, createConsoleReporter } from "@apifn/collections";
+
+const collection = await readCollection("./.apifn/collection");
+const report = await runCollection(collection, {
+  environment: "development",
+  reporter: createConsoleReporter(),
+  parallel: false,
+  bail: false,
+  retries: 1,
+  timeout: 30_000,
+});
+
+console.log(report.summary);
+// { total, passed, failed, skipped, errors, duration }
+```
+
+#### RunOptions
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `environment` | `string \| Environment` | Environment name or object (required) |
+| `include` / `exclude` | `string[]` | Glob-ish patterns matched against path/name/`"METHOD url"` |
+| `parallel` | `boolean` | Run requests concurrently (default: sequential) |
+| `concurrency` | `number` | Max concurrent requests in parallel mode (default: 4) |
+| `timeout` | `number` | Per-request timeout in ms (default: 30000) |
+| `bail` | `boolean` | Stop on first failure |
+| `retries` | `number` | Retry failed requests / HTTP 5xx (default: 0) |
+| `delay` | `number` | Delay between sequential requests in ms |
+| `httpClient` | `HttpClient` | Custom client (default: built-in fetch-based) |
+| `cookieJar` | `CookieJar` | Shared cookie jar |
+| `reporter` | `RunReporter` | Progress/result reporter |
+| `overrides` | `Record<string, string>` | Variable overrides (highest precedence) |
+| `redactHeaders` | `string[]` | Extra headers to redact in captured data |
+
+A request passes when its status matches the expected status (default `< 400`, or `settings.expectedStatus`) and no assertion fails.
+
+**Redaction:** `authorization`, `cookie`, `set-cookie`, `x-api-key`, and `x-auth-token` headers are redacted by default (plus any `redactHeaders`), and common secret-bearing body keys (`token`, `password`, `apiKey`, `otp`, …) are recursively masked.
+
+---
+
+## Reporters
+
+| Reporter | Factory | Output |
+|----------|---------|--------|
+| Console | `createConsoleReporter({ color?, write? })` | Colored per-request badges + summary |
+| JSON | `createJsonReporter({ write?, indent? })` | Full `RunReport` as JSON |
+| JUnit | `createJUnitReporter({ write? })` | JUnit XML (`reportToJUnitXml(report)` for a string) |
+| Silent | `createSilentReporter()` | No output |
+
+```typescript
+import { runCollection, createJsonReporter } from "@apifn/collections";
+
+await runCollection(collection, {
+  environment: "development",
+  reporter: createJsonReporter({ indent: 2 }),
+});
+```
+
+---
+
+## Assertions
+
+`createAssertionRuntime()` returns a Chai-like `expect`/`test` API used inside test scripts.
+
+```typescript
+import { createAssertionRuntime } from "@apifn/collections";
+
+const { expect, test, getResults } = createAssertionRuntime();
+
+test("returns the user", () => {
+  expect(res.statusCode).to.equal(200);
+  expect(res.json()).to.have.property("id");
+  expect(res.json().roles).to.include("admin");
+  expect(res.json()).to.have.jsonPath("$.profile.email");
+  expect(res.durationMs).to.be.below(500);
+});
+
+const results = getResults(); // AssertionResult[]
+```
+
+Supported matchers: `.equal`, `.include`, `.matchSchema`, `.have.property`, `.have.length` / `.have.length.above`, `.have.jsonPath`, `.be.below`.
+
+---
+
+## Scripting
+
+Pre-request and test scripts run in a locked-down Node `vm` sandbox (`SCRIPT_TIMEOUT_MS` = 10s). Available globals: `console`, `URL`, `URLSearchParams`, `crypto.randomUUID`, `btoa`, `atob`. Disabled: `process`, `require`, `module`, `fetch`, `eval`, `Function`, timers.
+
+```typescript
+import { executePreRequestScript, executeTestScript } from "@apifn/collections";
+```
+
+- `executePreRequestScript({ code, env, req, cookies?, timeoutMs? })` — mutate `req`, set `env` variables before sending
+- `executeTestScript({ code, env, req, res, cookies?, assertionResults, timeoutMs? })` — assert against `res` with `expect`/`test`
+
+---
+
+## Environments & Variables
+
+```typescript
+import {
+  readEnvironments,
+  selectEnvironment,
+  interpolateVariables,
+  resolveVariableContext,
+  loadDotEnvFile,
+} from "@apifn/collections";
+
+const envs = await readEnvironments("./.apifn/collection/environments");
+const env = selectEnvironment(envs, "development");
+
+const context = resolveVariableContext({
+  collection: {},
+  environment: env.variables, // collection < environment < overrides
+  overrides: loadDotEnvFile(".env"),
+  processEnv: process.env,
+});
+
+const { value, warnings } = interpolateVariables("{{baseUrl}}/users", context);
+```
+
+`{{var}}` tokens are replaced from the context; `{{process.env.X}}` reads from `processEnv`; unknown tokens are left intact and reported in `warnings`.
+
+---
+
+## HTTP Client & Cookies
+
+```typescript
+import { createFetchHttpClient, createCookieJar } from "@apifn/collections";
+
+const jar = createCookieJar();
+const client = createFetchHttpClient({ cookieJar: jar, followRedirects: true, maxRedirects: 10 });
+```
+
+The built-in fetch client handles redirects manually, strips sensitive headers on cross-origin redirects, downgrades 303 to GET, and injects/stores cookies via the jar.
+
+## License
+
+MIT

--- a/apifn/collections/README.md
+++ b/apifn/collections/README.md
@@ -164,13 +164,18 @@ await runCollection(collection, {
 import { createAssertionRuntime } from "@apifn/collections";
 
 const { expect, test, getResults } = createAssertionRuntime();
+const response = {
+  status: 200,
+  body: { id: "usr_123", roles: ["admin"], profile: { email: "dev@example.com" } },
+  responseTime: 120,
+};
 
 test("returns the user", () => {
-  expect(res.statusCode).to.equal(200);
-  expect(res.json()).to.have.property("id");
-  expect(res.json().roles).to.include("admin");
-  expect(res.json()).to.have.jsonPath("$.profile.email");
-  expect(res.durationMs).to.be.below(500);
+  expect(response.status).to.equal(200);
+  expect(response.body).to.have.property("id");
+  expect(response.body.roles).to.include("admin");
+  expect(response.body).to.have.jsonPath("$.profile.email");
+  expect(response.responseTime).to.be.below(500);
 });
 
 const results = getResults(); // AssertionResult[]
@@ -182,7 +187,7 @@ Supported matchers: `.equal`, `.include`, `.matchSchema`, `.have.property`, `.ha
 
 ## Scripting
 
-Pre-request and test scripts run in a locked-down Node `vm` sandbox (`SCRIPT_TIMEOUT_MS` = 10s). Available globals: `console`, `URL`, `URLSearchParams`, `crypto.randomUUID`, `btoa`, `atob`. Disabled: `process`, `require`, `module`, `fetch`, `eval`, `Function`, timers.
+Pre-request and test scripts run in a locked-down Node `vm` sandbox (`SCRIPT_TIMEOUT_MS` = `10000` ms). Available globals: `console`, `URL`, `URLSearchParams`, `crypto.randomUUID`, `btoa`, `atob`. Disabled: `process`, `require`, `module`, `fetch`, `eval`, `Function`, timers.
 
 ```typescript
 import { executePreRequestScript, executeTestScript } from "@apifn/collections";
@@ -211,13 +216,16 @@ const context = resolveVariableContext({
   collection: {},
   environment: env.variables, // collection < environment < overrides
   overrides: loadDotEnvFile(".env"),
-  processEnv: process.env,
 });
 
-const { value, warnings } = interpolateVariables("{{baseUrl}}/users", context);
+const { value, warnings } = interpolateVariables(
+  "{{baseUrl}}/users?token={{process.env.API_TOKEN}}",
+  context,
+  { processEnv: process.env },
+);
 ```
 
-`{{var}}` tokens are replaced from the context; `{{process.env.X}}` reads from `processEnv`; unknown tokens are left intact and reported in `warnings`.
+`{{var}}` tokens are replaced from the context; unknown context tokens are left intact and reported in `warnings`. `{{process.env.X}}` reads from the `processEnv` interpolation option (or the current process by default) and throws if the requested environment variable is not set.
 
 ---
 

--- a/apifn/core/README.md
+++ b/apifn/core/README.md
@@ -1,0 +1,255 @@
+# @apifn/core
+
+Core library for ApiFn — route introspection, schema conversion, OpenAPI generation, and diff. Every other ApiFn package depends on `@apifn/core`.
+
+## Installation
+
+```bash
+npm install @apifn/core
+```
+
+## Features
+
+- **Route Introspection** — Walk a `@superfunctions/http` router and describe every route (parameters, request bodies, responses, security)
+- **Schema Conversion** — Convert Zod and TypeBox schemas to JSON Schema, with auto-detection and deduplication
+- **OpenAPI Generation** — Produce an OpenAPI 3.1 document directly from a router
+- **OpenAPI Parsing & Validation** — Parse YAML/JSON specs and validate them against the OpenAPI schema
+- **Diff** — Compare two OpenAPI documents and classify changes as breaking / non-breaking
+- **Integrations** — First-class hooks for authfn, secfn, watchfn, logfn, and testfn
+
+---
+
+## OpenAPI Generation
+
+### fromRouter
+
+Generate an OpenAPI document from a `@superfunctions/http` router in one step. `FromRouterOptions` combines `OpenAPIGenerateOptions` (info, servers, security schemes) and `IntrospectOptions` (include/exclude/basePath).
+
+```typescript
+import { fromRouter } from "@apifn/core";
+
+const doc = fromRouter(router, {
+  info: {
+    title: "My API",
+    version: "1.0.0",
+    description: "Public API surface",
+  },
+  servers: [{ url: "https://api.example.com" }],
+  // IntrospectOptions
+  include: ["/v1"],
+  exclude: ["/internal"],
+  basePath: "/api",
+});
+```
+
+### introspectRouter
+
+Describe a router's routes without generating a full document. Returns `IntrospectedRoute[]`.
+
+```typescript
+import { introspectRouter } from "@apifn/core";
+
+const routes = introspectRouter(router, { include: ["/v1"] });
+// [{ method, path, parameters, requestBody, responses, security }, ...]
+```
+
+### generateOpenAPI
+
+Build the document from already-introspected routes. `fromRouter` is `introspectRouter` + `generateOpenAPI`.
+
+```typescript
+import { introspectRouter, generateOpenAPI } from "@apifn/core";
+
+const doc = generateOpenAPI(introspectRouter(router), {
+  info: { title: "My API", version: "1.0.0" },
+});
+```
+
+---
+
+## Parsing & Validation
+
+### parseOpenAPI
+
+Parse a YAML or JSON OpenAPI string into an `OpenAPIDocument`.
+
+```typescript
+import { parseOpenAPI } from "@apifn/core";
+import { readFile } from "node:fs/promises";
+
+const doc = parseOpenAPI(await readFile("./openapi.yml", "utf8"));
+```
+
+### validateOpenAPI
+
+Validate a document. Returns validation errors (`ValidationError[]`) for a report or gate.
+
+```typescript
+import { validateOpenAPI } from "@apifn/core";
+
+const errors = await validateOpenAPI(doc);
+if (errors.length > 0) {
+  // handle invalid spec
+}
+```
+
+### upconvertFrom3_0
+
+Up-convert an OpenAPI 3.0 document to 3.1.
+
+```typescript
+import { upconvertFrom3_0 } from "@apifn/core";
+
+const doc31 = upconvertFrom3_0(doc30);
+```
+
+---
+
+## Schema Conversion
+
+ApiFn converts framework-native schemas to JSON Schema for OpenAPI output.
+
+| Function | Description |
+|----------|-------------|
+| `detectSchemaType(schema)` | Detect whether a value is a Zod, TypeBox, or plain JSON schema (`SchemaType`) |
+| `convertSchema(schema)` | Convert any supported schema to JSON Schema, auto-detecting the type |
+| `convertZodSchema(schema)` | Convert a Zod schema to JSON Schema |
+| `convertTypeBoxSchema(schema)` | Convert a TypeBox schema to JSON Schema |
+| `deduplicateSchemas(input)` | Extract shared/duplicated schemas into reusable `components` (`DeduplicateSchemasResult`) |
+
+```typescript
+import { convertSchema, detectSchemaType } from "@apifn/core";
+import { z } from "zod";
+
+detectSchemaType(z.object({ id: z.string() })); // "zod"
+const jsonSchema = convertSchema(z.object({ id: z.string() }));
+```
+
+### apiSchema
+
+Attach a schema descriptor to a route so introspection can pick up request/response shapes.
+
+```typescript
+import { apiSchema } from "@apifn/core";
+```
+
+---
+
+## Diff
+
+### diffOpenAPI
+
+Compare two OpenAPI documents. Returns a `DiffResult` with a list of `DiffEntry` changes, each classified by severity.
+
+```typescript
+import { diffOpenAPI, formatDiffAsText, formatDiffAsJson } from "@apifn/core";
+
+const result = diffOpenAPI(beforeDoc, afterDoc);
+
+console.log(formatDiffAsText(result)); // human-readable
+const report = formatDiffAsJson(result); // DiffReportJson (machine-readable)
+```
+
+- `formatDiffAsText(result)` — colored/plain text summary
+- `formatDiffAsJson(result)` — structured `DiffReportJson` for CI artifacts
+
+---
+
+## Integrations
+
+### watchfn
+
+Fetch endpoint performance metrics and stream request telemetry to a watchfn instance.
+
+```typescript
+import {
+  fetchEndpointMetrics,
+  createWatchFnClient,
+  apifnWatchMiddleware,
+} from "@apifn/core";
+
+// Fetch p50/p95/p99 + error-rate metrics; degrades gracefully to [] on failure
+const metrics = await fetchEndpointMetrics({
+  baseUrl: "https://watch.example.com",
+  timeRange: "PT1H", // ISO 8601 duration
+});
+
+const client = createWatchFnClient({ baseUrl: "https://watch.example.com" });
+
+// Middleware records per-endpoint timing to watchfn
+router.use(apifnWatchMiddleware({ baseUrl: "https://watch.example.com" }));
+```
+
+### authfn
+
+Mint short-lived test tokens (TTL ≤ 3600s) and inject bearer auth into collection runs.
+
+```typescript
+import { mintTestToken, createAuthfnCollectionMiddleware } from "@apifn/core";
+
+const { token, expiresAt } = await mintTestToken(
+  { baseUrl: "https://auth.example.com", adminKey: process.env.AUTHFN_ADMIN_KEY },
+  { ttl: 900, scopes: ["read"] },
+);
+
+const client = createAuthfnCollectionMiddleware(baseHttpClient, token);
+```
+
+### secfn
+
+Fetch (non-consuming) rate-limit information for endpoints.
+
+```typescript
+import { fetchRateLimits } from "@apifn/core";
+
+const limits = await fetchRateLimits(rateLimiter, ["GET /users"]); // RateLimitInfo[]
+```
+
+### logfn
+
+Structured reporter and CLI logger.
+
+```typescript
+import { logfnReporter, createCliLogger } from "@apifn/core";
+
+const logger = createCliLogger({ /* CliLoggerOptions */ });
+```
+
+### testfn
+
+Adapter that plugs ApiFn collection runs into testfn.
+
+```typescript
+import { ApifnTestAdapter } from "@apifn/core";
+```
+
+---
+
+## Exports
+
+```typescript
+// OpenAPI
+export { fromRouter, introspectRouter, generateOpenAPI, parseOpenAPI, validateOpenAPI, upconvertFrom3_0 }
+
+// Schema
+export { detectSchemaType, convertSchema, convertZodSchema, convertTypeBoxSchema, deduplicateSchemas, apiSchema }
+
+// Diff
+export { diffOpenAPI, formatDiffAsText, formatDiffAsJson }
+
+// Integrations
+export { fetchEndpointMetrics, createWatchFnClient, apifnWatchMiddleware }
+export { mintTestToken, createAuthfnCollectionMiddleware }
+export { fetchRateLimits }
+export { logfnReporter, createCliLogger }
+export { ApifnTestAdapter }
+
+// Types — HTTP, OpenAPI document objects, introspection descriptors,
+// diff, validation, snippets, mock, and integration types
+```
+
+The `@apifn/core/types` subpath re-exports the full type surface for consumers who only need types.
+
+## License
+
+MIT

--- a/apifn/core/README.md
+++ b/apifn/core/README.md
@@ -248,7 +248,7 @@ export { ApifnTestAdapter }
 // diff, validation, snippets, mock, and integration types
 ```
 
-The `@apifn/core/types` subpath re-exports the full type surface for consumers who only need types.
+The `@apifn/core/types` subpath exports the shared model types declared by the core package, including HTTP/OpenAPI, schema, diff, validation, snippet, mock, and integration data shapes. Types declared alongside runtime modules, such as `FromRouterOptions`, `SchemaType`, and `DiffReportJson`, are exported from the package root.
 
 ## License
 

--- a/apifn/core/README.md
+++ b/apifn/core/README.md
@@ -1,6 +1,6 @@
 # @apifn/core
 
-Core library for ApiFn — route introspection, schema conversion, OpenAPI generation, and diff. Every other ApiFn package depends on `@apifn/core`.
+Core JavaScript/TypeScript library for ApiFn — route introspection, schema conversion, OpenAPI generation, and diff. The other ApiFn npm packages build on `@apifn/core`.
 
 ## Installation
 

--- a/apifn/core/tsup.config.ts
+++ b/apifn/core/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/types.ts"],
   format: ["cjs", "esm"],
   external: ["@apifn/collections"],
   dts: true,

--- a/apifn/docsfn/README.md
+++ b/apifn/docsfn/README.md
@@ -1,0 +1,105 @@
+# @apifn/docsfn
+
+docsfn plugin for ApiFn API reference. Turn an OpenAPI document into docsfn content entries and render them as an interactive API reference (React or Svelte) with embedded Try-It consoles and performance metrics.
+
+## Installation
+
+```bash
+npm install @apifn/docsfn
+```
+
+`docsfn` is an **optional** peer dependency — this package defines the minimal `DocsContentProvider` / `RawContentEntry` interfaces itself, so you get correct types even without docsfn installed.
+
+## Features
+
+- **Content provider** — Convert an OpenAPI spec into docsfn `RawContentEntry[]`
+- **Tag splitting** — One page per tag (default) or a single full-spec page
+- **Sidebar generation** — Auto-built navigation with per-endpoint anchors
+- **Reference renderers** — `ApifnApiReference` for React and Svelte, wrapping the `@apifn/react` / `@apifn/svelte` components
+
+---
+
+## createApifnProvider
+
+Create a `DocsContentProvider` — a callable that returns `RawContentEntry[]` (memoized) and carries an `.entries` array.
+
+```typescript
+import { createApifnProvider } from "@apifn/docsfn";
+
+const provider = createApifnProvider({
+  specPath: "./openapi.yml", // or: spec: openApiDocument
+  basePath: "/api",
+  splitByTag: true,
+});
+
+const entries = await provider(); // RawContentEntry[]
+```
+
+### CreateApifnProviderOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `spec` | `OpenAPIDocument` | — | The document (provide this or `specPath`) |
+| `specPath` | `string` | — | Path to a JSON or YAML spec |
+| `basePath` | `string` | `"/api"` | Slug prefix for generated pages |
+| `splitByTag` | `boolean` | `true` | One entry per tag, or a single full-spec entry |
+| `baseUrl` | `string` | — | Base URL embedded in entries (for Try-It) |
+
+With `splitByTag: true`, each tag becomes a `RawContentEntry` with slug `${basePath}/${tag}` and a sidebar group whose links point to per-endpoint anchors (`${slug}#${method}-${path}`). With `splitByTag: false`, a single entry contains every endpoint. Path-level parameters are merged into each operation.
+
+---
+
+## Rendering the reference
+
+The package root (`@apifn/docsfn`) exports the provider and types. `ApifnApiReference` renderer components are provided for both React (`src/react/ApifnApiReference.tsx`) and Svelte (`src/svelte/ApifnApiReference.svelte`) and are imported from their component source; docsfn wires them up to render each `RawContentEntry`.
+
+```tsx
+import { ApifnApiReference } from "@apifn/docsfn/src/react/ApifnApiReference";
+
+<ApifnApiReference
+  entry={entry}
+  tryIt
+  baseUrl="https://api.example.com"
+  theme="light"
+  performanceMetrics={{
+    "GET /users": { p50Ms: 12, p95Ms: 40, p99Ms: 90, errorRatePct: 0.5, requestsPerMinute: 320 },
+  }}
+/>
+```
+
+The Svelte renderer takes the same props (`entry`, `tryIt`, `baseUrl`, `theme`, `performanceMetrics`).
+
+### ApifnApiReferenceProps
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `entry` | `RawContentEntry` | — | A single entry from `createApifnProvider` (required) |
+| `tryIt` | `boolean` | `false` | Show an embedded Try-It console per endpoint |
+| `baseUrl` | `string` | `entry.spec.servers[0].url` | Base URL for Try-It requests |
+| `theme` | `"light" \| "dark" \| "auto"` | `"auto"` | Theme for embedded components |
+| `performanceMetrics` | `Record<string, …>` | — | Per-endpoint metrics keyed `"METHOD /path"` (you supply `p50Ms`/`p95Ms`/`p99Ms`/`errorRatePct`/`requestsPerMinute`) |
+
+Each endpoint renders as a collapsible card with Docs / Try It / Performance tabs, delegating to the `EndpointViewer`, `TryIt`, and `PerformanceOverlay` components from `@apifn/react` / `@apifn/svelte`.
+
+---
+
+## How it plugs into docsfn
+
+`createApifnProvider(...)` yields a `DocsContentProvider` that docsfn's content pipeline consumes. Each `RawContentEntry` carries `kind: "api"` (signalling an API reference page), a `sidebar` group for navigation, and the full `spec`. docsfn renders each entry with the matching `ApifnApiReference` component.
+
+## Exports
+
+```typescript
+export { createApifnProvider }
+export type {
+  DocsContentProvider, RawContentEntry, ApiEndpoint,
+  SidebarItem, SidebarLink, SidebarGroup,
+  CreateApifnProviderOptions, ApifnApiReferenceProps,
+  OpenAPIDocument, OperationObject,
+}
+// ApifnApiReference components live in src/react and src/svelte (imported from source)
+```
+
+## License
+
+MIT

--- a/apifn/docsfn/README.md
+++ b/apifn/docsfn/README.md
@@ -51,10 +51,15 @@ With `splitByTag: true`, each tag becomes a `RawContentEntry` with slug `${baseP
 
 ## Rendering the reference
 
-The package root (`@apifn/docsfn`) exports the provider and types. `ApifnApiReference` renderer components are provided for both React (`src/react/ApifnApiReference.tsx`) and Svelte (`src/svelte/ApifnApiReference.svelte`) and are imported from their component source; docsfn wires them up to render each `RawContentEntry`.
+The package root (`@apifn/docsfn`) exports the provider and types. Renderer components are available from framework-specific public subpaths:
+
+- React: `@apifn/docsfn/react`
+- Svelte: `@apifn/docsfn/svelte`
+
+Pass each `RawContentEntry` returned by the provider to the renderer used by your docsfn integration.
 
 ```tsx
-import { ApifnApiReference } from "@apifn/docsfn/src/react/ApifnApiReference";
+import { ApifnApiReference } from "@apifn/docsfn/react";
 
 <ApifnApiReference
   entry={entry}
@@ -67,7 +72,15 @@ import { ApifnApiReference } from "@apifn/docsfn/src/react/ApifnApiReference";
 />
 ```
 
-The Svelte renderer takes the same props (`entry`, `tryIt`, `baseUrl`, `theme`, `performanceMetrics`).
+The Svelte renderer takes the same props (`entry`, `tryIt`, `baseUrl`, `theme`, `performanceMetrics`):
+
+```svelte
+<script lang="ts">
+  import ApifnApiReference from "@apifn/docsfn/svelte";
+</script>
+
+<ApifnApiReference {entry} tryIt theme="auto" />
+```
 
 ### ApifnApiReferenceProps
 
@@ -75,17 +88,19 @@ The Svelte renderer takes the same props (`entry`, `tryIt`, `baseUrl`, `theme`, 
 |------|------|---------|-------------|
 | `entry` | `RawContentEntry` | — | A single entry from `createApifnProvider` (required) |
 | `tryIt` | `boolean` | `false` | Show an embedded Try-It console per endpoint |
-| `baseUrl` | `string` | `entry.spec.servers[0].url` | Base URL for Try-It requests |
+| `baseUrl` | `string` | See below | Base URL for Try-It requests |
 | `theme` | `"light" \| "dark" \| "auto"` | `"auto"` | Theme for embedded components |
 | `performanceMetrics` | `Record<string, …>` | — | Per-endpoint metrics keyed `"METHOD /path"` (you supply `p50Ms`/`p95Ms`/`p99Ms`/`errorRatePct`/`requestsPerMinute`) |
 
 Each endpoint renders as a collapsible card with Docs / Try It / Performance tabs, delegating to the `EndpointViewer`, `TryIt`, and `PerformanceOverlay` components from `@apifn/react` / `@apifn/svelte`.
 
+The Try-It base URL is selected in this order: the renderer's `baseUrl` prop, the provider's `baseUrl` embedded in the entry, the first URL in `entry.spec.servers`, then `https://api.example.com` as a placeholder fallback.
+
 ---
 
 ## How it plugs into docsfn
 
-`createApifnProvider(...)` yields a `DocsContentProvider` that docsfn's content pipeline consumes. Each `RawContentEntry` carries `kind: "api"` (signalling an API reference page), a `sidebar` group for navigation, and the full `spec`. docsfn renders each entry with the matching `ApifnApiReference` component.
+`createApifnProvider(...)` yields a `DocsContentProvider` suitable for a docsfn content pipeline. Each `RawContentEntry` carries `kind: "api"`, a `sidebar` group for navigation, and the full `spec`. Register the provider and the appropriate `ApifnApiReference` renderer in your docsfn application according to its integration API.
 
 ## Exports
 
@@ -97,7 +112,8 @@ export type {
   CreateApifnProviderOptions, ApifnApiReferenceProps,
   OpenAPIDocument, OperationObject,
 }
-// ApifnApiReference components live in src/react and src/svelte (imported from source)
+// React: import { ApifnApiReference } from "@apifn/docsfn/react"
+// Svelte: import ApifnApiReference from "@apifn/docsfn/svelte"
 ```
 
 ## License

--- a/apifn/docsfn/README.md
+++ b/apifn/docsfn/README.md
@@ -45,7 +45,7 @@ const entries = await provider(); // RawContentEntry[]
 | `splitByTag` | `boolean` | `true` | One entry per tag, or a single full-spec entry |
 | `baseUrl` | `string` | — | Base URL embedded in entries (for Try-It) |
 
-With `splitByTag: true`, each tag becomes a `RawContentEntry` with slug `${basePath}/${tag}` and a sidebar group whose links point to per-endpoint anchors (`${slug}#${method}-${path}`). With `splitByTag: false`, a single entry contains every endpoint. Path-level parameters are merged into each operation.
+With `splitByTag: true`, each tag becomes a `RawContentEntry`. The tag is lowercased and each run of non-alphanumeric characters becomes `-`, so `My Tag Group` produces `${basePath}/my-tag-group`. Sidebar links use the lowercased method followed by the path with each non-alphanumeric character replaced by `-`; for example, `GET /users/{id}` links to `${slug}#get--users--id-`. With `splitByTag: false`, a single entry contains every endpoint. Path-level parameters are merged into each operation.
 
 ---
 

--- a/apifn/docsfn/__tests__/provider.test.ts
+++ b/apifn/docsfn/__tests__/provider.test.ts
@@ -180,6 +180,15 @@ describe("TV-DOCS-001: createApifnProvider — split by tag", () => {
         await provider();
         expect(provider.entries.length).toBeGreaterThan(0);
     });
+
+    it("embeds an explicit Try-It base URL in every entry", async () => {
+        const provider = createApifnProvider({
+            spec: TAGGED_SPEC,
+            baseUrl: "https://staging.example.com",
+        });
+        const entries = await provider();
+        expect(entries.every((entry) => entry.baseUrl === "https://staging.example.com")).toBe(true);
+    });
 });
 
 // ─── TV-DOCS-001: splitByTag=false ───────────────────────────────────────────
@@ -207,6 +216,16 @@ describe("TV-DOCS-001: createApifnProvider — full spec (splitByTag: false)", (
         const provider = createApifnProvider({ spec: TAGGED_SPEC, splitByTag: false });
         const entries = await provider();
         expect(entries[0].title).toBe("Test API");
+    });
+
+    it("embeds an explicit Try-It base URL in the single entry", async () => {
+        const provider = createApifnProvider({
+            spec: TAGGED_SPEC,
+            splitByTag: false,
+            baseUrl: "https://staging.example.com",
+        });
+        const entries = await provider();
+        expect(entries[0].baseUrl).toBe("https://staging.example.com");
     });
 });
 

--- a/apifn/docsfn/package.json
+++ b/apifn/docsfn/package.json
@@ -18,6 +18,7 @@
       "require": "./dist/react.cjs"
     },
     "./svelte": {
+      "types": "./src/svelte/ApifnApiReference.svelte.d.ts",
       "svelte": "./src/svelte/ApifnApiReference.svelte",
       "default": "./src/svelte/ApifnApiReference.svelte"
     }
@@ -35,6 +36,7 @@
   "peerDependencies": {
     "docsfn": "*",
     "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "svelte": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
@@ -42,6 +44,9 @@
       "optional": true
     },
     "react": {
+      "optional": true
+    },
+    "react-dom": {
       "optional": true
     },
     "svelte": {

--- a/apifn/docsfn/package.json
+++ b/apifn/docsfn/package.json
@@ -11,6 +11,15 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs"
+    },
+    "./svelte": {
+      "svelte": "./src/svelte/ApifnApiReference.svelte",
+      "default": "./src/svelte/ApifnApiReference.svelte"
     }
   },
   "scripts": {
@@ -24,10 +33,18 @@
     "@apifn/svelte": "0.0.2"
   },
   "peerDependencies": {
-    "docsfn": "*"
+    "docsfn": "*",
+    "react": "^18.0.0 || ^19.0.0",
+    "svelte": "^4.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "docsfn": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "svelte": {
       "optional": true
     }
   },
@@ -51,6 +68,7 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "src/svelte"
   ]
 }

--- a/apifn/docsfn/src/provider.ts
+++ b/apifn/docsfn/src/provider.ts
@@ -106,6 +106,7 @@ function buildEntries(
     const {
         basePath = "/api",
         splitByTag = true,
+        baseUrl,
     } = options;
 
     const info = spec.info as { title?: string; version?: string } | undefined;
@@ -123,6 +124,7 @@ function buildEntries(
             endpoints: allEndpoints,
             sidebar,
             spec,
+            ...(baseUrl !== undefined ? { baseUrl } : {}),
         }];
     }
 
@@ -145,6 +147,7 @@ function buildEntries(
             endpoints,
             sidebar,
             spec,
+            ...(baseUrl !== undefined ? { baseUrl } : {}),
         };
     });
 }

--- a/apifn/docsfn/src/react/ApifnApiReference.tsx
+++ b/apifn/docsfn/src/react/ApifnApiReference.tsx
@@ -37,7 +37,7 @@ function getThemeStyle(theme: "light" | "dark" | "auto"): string {
   `;
     if (theme === "dark") return `.apifn-root{${dark}}`;
     if (theme === "light") return `.apifn-root{${light}}`;
-    return `@media(prefers-color-scheme:dark){.apifn-root{${dark}}}.apifn-root{${light}}`;
+    return `.apifn-root{${light}}@media(prefers-color-scheme:dark){.apifn-root{${dark}}}`;
 }
 
 const s = {
@@ -133,11 +133,14 @@ function EndpointCard({
 }
 
 export function ApifnApiReference({
-    entry, tryIt = false, baseUrl = "https://api.example.com", theme = "auto", performanceMetrics,
+    entry, tryIt = false, baseUrl, theme = "auto", performanceMetrics,
 }: ApifnApiReferenceProps): React.ReactElement {
     const themeStyle = getThemeStyle(theme);
     const effectiveBaseUrl =
-        (entry.spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url ?? baseUrl;
+        baseUrl
+        ?? entry.baseUrl
+        ?? (entry.spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url
+        ?? "https://api.example.com";
 
     return (
         <div className="apifn-root">

--- a/apifn/docsfn/src/react/ApifnApiReference.tsx
+++ b/apifn/docsfn/src/react/ApifnApiReference.tsx
@@ -84,14 +84,14 @@ const s = {
 
 function EndpointCard({
     path, method, operation, tryIt, baseUrl, performanceMetrics,
-}: {
+}: Readonly<{
     path: string;
     method: string;
     operation: OperationObject;
     tryIt: boolean;
     baseUrl: string;
     performanceMetrics?: ApifnApiReferenceProps["performanceMetrics"];
-}) {
+}>) {
     const [open, setOpen] = useState(false);
     const [tab, setTab] = useState<"docs" | "tryit" | "perf">("docs");
 
@@ -134,7 +134,7 @@ function EndpointCard({
 
 export function ApifnApiReference({
     entry, tryIt = false, baseUrl, theme = "auto", performanceMetrics,
-}: ApifnApiReferenceProps): React.ReactElement {
+}: Readonly<ApifnApiReferenceProps>): React.ReactElement {
     const themeStyle = getThemeStyle(theme);
     const effectiveBaseUrl =
         baseUrl

--- a/apifn/docsfn/src/svelte/ApifnApiReference.svelte
+++ b/apifn/docsfn/src/svelte/ApifnApiReference.svelte
@@ -3,11 +3,11 @@
   import EndpointViewer from "@apifn/svelte/EndpointViewer.svelte";
   import TryIt from "@apifn/svelte/TryIt.svelte";
   import PerformanceOverlay from "@apifn/svelte/PerformanceOverlay.svelte";
-  import type { ApifnApiReferenceProps, RawContentEntry, ApiEndpoint } from "../types.js";
+  import type { ApifnApiReferenceProps, RawContentEntry, ApiEndpoint } from "@apifn/docsfn";
 
   export let entry: RawContentEntry;
   export let tryIt: boolean = false;
-  export let baseUrl: string = "https://api.example.com";
+  export let baseUrl: string | undefined = undefined;
   export let theme: "light" | "dark" | "auto" = "auto";
   export let performanceMetrics: ApifnApiReferenceProps["performanceMetrics"] = undefined;
 
@@ -21,7 +21,10 @@
     return METHOD_COLORS[method.toLowerCase()] ?? { bg: "#2d3748", text: "#9ca3af" };
   }
 
-  $: effectiveBaseUrl = (entry.spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url ?? baseUrl;
+  $: effectiveBaseUrl = baseUrl
+    ?? entry.baseUrl
+    ?? (entry.spec as { servers?: Array<{ url: string }> }).servers?.[0]?.url
+    ?? "https://api.example.com";
 
   // Per-endpoint card open/tab state
   let openStates: Record<string, boolean> = {};
@@ -36,11 +39,13 @@
   function getThemeVars(t: "light" | "dark" | "auto"): string {
     const dark = `--apifn-bg:#0f1117;--apifn-bg-surface:#1a1d2e;--apifn-bg-surface-hover:#252840;--apifn-border:#2d3748;--apifn-text:#e2e8f0;--apifn-text-muted:#64748b;--apifn-accent:#7c3aed;--apifn-accent-text:#c4b5fd;--apifn-green:#6ee7b7;--apifn-blue:#93c5fd;--apifn-yellow:#fcd34d;--apifn-red:#fca5a5;--apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif`;
     const light = `--apifn-bg:#ffffff;--apifn-bg-surface:#f8fafc;--apifn-bg-surface-hover:#f1f5f9;--apifn-border:#e2e8f0;--apifn-text:#0f172a;--apifn-text-muted:#64748b;--apifn-accent:#7c3aed;--apifn-accent-text:#6d28d9;--apifn-green:#059669;--apifn-blue:#2563eb;--apifn-yellow:#d97706;--apifn-red:#dc2626;--apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif`;
-    return t === "dark" ? dark : light;
+    if (t === "dark") return dark;
+    if (t === "light") return light;
+    return "";
   }
 </script>
 
-<div class="apifn-root" style={getThemeVars(theme)}>
+<div class="apifn-root" class:auto-theme={theme === "auto"} style={getThemeVars(theme)}>
   <div class="page">
     <h1 class="page-title">{entry.title}</h1>
     {#if entry.tag}
@@ -101,7 +106,23 @@
 </div>
 
 <style>
-  .apifn-root { font-family: var(--apifn-font-sans, sans-serif); color: var(--apifn-text); background: var(--apifn-bg); }
+  .apifn-root {
+    --apifn-bg:#ffffff;--apifn-bg-surface:#f8fafc;--apifn-bg-surface-hover:#f1f5f9;
+    --apifn-border:#e2e8f0;--apifn-text:#0f172a;--apifn-text-muted:#64748b;
+    --apifn-accent:#7c3aed;--apifn-accent-text:#6d28d9;--apifn-green:#059669;
+    --apifn-blue:#2563eb;--apifn-yellow:#d97706;--apifn-red:#dc2626;
+    --apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;
+    --apifn-font-sans:-apple-system,sans-serif;
+    font-family: var(--apifn-font-sans, sans-serif); color: var(--apifn-text); background: var(--apifn-bg);
+  }
+  @media (prefers-color-scheme: dark) {
+    .apifn-root.auto-theme {
+      --apifn-bg:#0f1117;--apifn-bg-surface:#1a1d2e;--apifn-bg-surface-hover:#252840;
+      --apifn-border:#2d3748;--apifn-text:#e2e8f0;--apifn-text-muted:#64748b;
+      --apifn-accent:#7c3aed;--apifn-accent-text:#c4b5fd;--apifn-green:#6ee7b7;
+      --apifn-blue:#93c5fd;--apifn-yellow:#fcd34d;--apifn-red:#fca5a5;
+    }
+  }
   .page { max-width: 960px; margin: 0 auto; padding: 0 24px 48px; }
   .page-title { font-size: 28px; font-weight: 800; margin-bottom: 8px; }
   .page-subtitle { font-size: 14px; color: var(--apifn-text-muted); margin-bottom: 40px; }

--- a/apifn/docsfn/src/svelte/ApifnApiReference.svelte.d.ts
+++ b/apifn/docsfn/src/svelte/ApifnApiReference.svelte.d.ts
@@ -1,0 +1,4 @@
+import { SvelteComponent } from "svelte";
+import type { ApifnApiReferenceProps } from "@apifn/docsfn";
+
+export default class ApifnApiReference extends SvelteComponent<ApifnApiReferenceProps> {}

--- a/apifn/docsfn/src/types.ts
+++ b/apifn/docsfn/src/types.ts
@@ -53,6 +53,8 @@ export interface RawContentEntry {
     sidebar: SidebarGroup;
     /** Full OpenAPI spec (so renderers can look up $refs etc.) */
     spec: OpenAPIDocument;
+    /** Optional Try-It base URL supplied by the provider */
+    baseUrl?: string;
 }
 
 /** A DocsContentProvider is a callable that returns RawContentEntry[]. */

--- a/apifn/docsfn/tsconfig.json
+++ b/apifn/docsfn/tsconfig.json
@@ -21,6 +21,7 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "src/svelte/ApifnApiReference.svelte.d.ts"
   ]
 }

--- a/apifn/docsfn/tsup.config.ts
+++ b/apifn/docsfn/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: {
+    index: "src/index.ts",
+    react: "src/react/ApifnApiReference.tsx",
+  },
   format: ["cjs", "esm"],
   dts: true,
   clean: true,

--- a/apifn/mock/README.md
+++ b/apifn/mock/README.md
@@ -1,6 +1,6 @@
 # @apifn/mock
 
-Mock server for ApiFn. Spin up a zero-dependency HTTP server from any OpenAPI document that returns realistic responses, optionally validating incoming requests against the spec.
+Mock server for ApiFn. Spin up a framework-free HTTP server from any OpenAPI document that returns realistic responses, optionally validating incoming requests against the spec.
 
 ## Installation
 
@@ -53,7 +53,7 @@ await mock.stop();
 | `responseMode` | `"schema" \| "examples" \| "random"` | `"schema"` | How response bodies are generated |
 | `validateRequests` | `boolean` | `false` | Validate incoming params and JSON bodies |
 | `delay` | `number` | `0` | Response delay in ms (simulate latency) |
-| `maxRequestBodyBytes` | `number` | `10 MiB` | Max accepted request body size |
+| `maxRequestBodyBytes` | `number` | `10485760` | Max accepted request body size (10 MiB) |
 | `cors` | `boolean \| CorsOptions` | — | Enable/configure CORS |
 
 ### MockServer
@@ -98,7 +98,7 @@ generateFromSchema({ type: "object", properties: { id: { type: "string", format:
 
 ### generateRandom
 
-Like `generateFromSchema` but produces randomized values valid against the schema.
+Like `generateFromSchema`, but produces randomized primitive values. It respects `type`, string `enum`, and a small set of formats; it does not currently enforce constraints such as `minimum`, `maximum`, `minLength`, `maxLength`, `pattern`, or array bounds.
 
 ```typescript
 import { generateRandom } from "@apifn/mock";

--- a/apifn/mock/README.md
+++ b/apifn/mock/README.md
@@ -1,0 +1,151 @@
+# @apifn/mock
+
+Mock server for ApiFn. Spin up a zero-dependency HTTP server from any OpenAPI document that returns realistic responses, optionally validating incoming requests against the spec.
+
+## Installation
+
+```bash
+npm install @apifn/mock
+```
+
+## Features
+
+- **Instant mock server** — Serve every operation in an OpenAPI spec with no framework
+- **Three response modes** — Deterministic from schema, from examples, or randomized
+- **Request validation** — Optionally validate query/path params and JSON bodies against schemas
+- **Latency simulation** — Add a fixed response delay
+- **CORS** — Built-in CORS handling with sensible defaults or custom options
+- **Safety** — Configurable max request body size (default 10 MiB)
+
+---
+
+## createMockServer
+
+```typescript
+import { createMockServer } from "@apifn/mock";
+import { parseOpenAPI } from "@apifn/core";
+import { readFile } from "node:fs/promises";
+
+const spec = parseOpenAPI(await readFile("./openapi.yml", "utf8"));
+
+const mock = createMockServer({
+  spec,
+  port: 4010,
+  responseMode: "schema", // "schema" | "examples" | "random"
+  validateRequests: true,
+  delay: 0,
+  cors: true,
+});
+
+await mock.start();
+console.log(`Mock server listening on http://localhost:${mock.port}`);
+
+// later
+await mock.stop();
+```
+
+### MockServerOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `spec` | `OpenAPIDocument` | — | The OpenAPI document to mock (required) |
+| `port` | `number` | `4010` | Port to bind (use `0` for a random free port) |
+| `responseMode` | `"schema" \| "examples" \| "random"` | `"schema"` | How response bodies are generated |
+| `validateRequests` | `boolean` | `false` | Validate incoming params and JSON bodies |
+| `delay` | `number` | `0` | Response delay in ms (simulate latency) |
+| `maxRequestBodyBytes` | `number` | `10 MiB` | Max accepted request body size |
+| `cors` | `boolean \| CorsOptions` | — | Enable/configure CORS |
+
+### MockServer
+
+```typescript
+interface MockServer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  server: http.Server; // underlying Node server
+  port: number;        // the actually-bound port
+}
+```
+
+Unmatched routes return `404 { error: "Not Found", path }`. `OPTIONS` preflight requests return `204`.
+
+---
+
+## Response Generation
+
+Use the generators directly when you need a mock payload without a server.
+
+### generateResponse
+
+Pick the first 2xx response for an operation and produce a body for the given mode.
+
+```typescript
+import { generateResponse } from "@apifn/mock";
+
+const { statusCode, body } = generateResponse(operation, "schema");
+```
+
+### generateFromSchema
+
+Deterministic values from a JSON schema — strings become `"string"` (format-aware for `date-time`, `email`, `uri`, `uuid`, …), numbers `0`, booleans `true`, arrays a single generated item, objects recurse over their properties.
+
+```typescript
+import { generateFromSchema } from "@apifn/mock";
+
+generateFromSchema({ type: "object", properties: { id: { type: "string", format: "uuid" } } });
+// { id: "00000000-0000-0000-0000-000000000000" }
+```
+
+### generateRandom
+
+Like `generateFromSchema` but produces randomized values valid against the schema.
+
+```typescript
+import { generateRandom } from "@apifn/mock";
+
+const value = generateRandom(schema);
+```
+
+---
+
+## Request Validation
+
+Self-contained JSON-schema validation (no external dependencies).
+
+### validateRequestBody
+
+```typescript
+import { validateRequestBody } from "@apifn/mock";
+
+const result = validateRequestBody(body, operation);
+// { valid: boolean, errors: ValidationError[] }  where ValidationError = { path, message }
+```
+
+Reads `operation.requestBody.content["application/json"].schema`; if the body is required but missing, returns an error.
+
+### validateParameters
+
+```typescript
+import { validateParameters } from "@apifn/mock";
+
+const result = validateParameters(queryParams, pathParams, operation);
+```
+
+Checks `operation.parameters` for missing required query/path params and basic numeric coercion.
+
+---
+
+## Exports
+
+```typescript
+export { createMockServer }
+export type { MockServer }
+export { generateFromSchema, generateRandom, generateResponse }
+export type { ResponseMode }
+export { validateRequestBody, validateParameters }
+export type { ValidationError, ValidationResult }
+```
+
+## License
+
+MIT

--- a/apifn/react/README.md
+++ b/apifn/react/README.md
@@ -1,0 +1,130 @@
+# @apifn/react
+
+React UI components for ApiFn. Render an interactive API explorer — endpoint docs, a live Try-It console, schema viewer, request history, response diffing, and performance overlays — from any OpenAPI document.
+
+## Installation
+
+```bash
+npm install @apifn/react
+```
+
+`react` and `react-dom` (`^18` or `^19`) are peer dependencies.
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `ApiExplorer` | Full explorer shell (sidebar + tabs) — the all-in-one entry point |
+| `EndpointViewer` | Documentation for a single operation (params, body, responses) |
+| `SchemaViewer` | Collapsible JSON-schema tree |
+| `TryIt` | Live request console with auth, params, and body |
+| `RequestHistory` | List of past requests with expandable detail |
+| `ResponseDiff` | Side-by-side diff of two responses |
+| `PerformanceOverlay` | Latency/throughput KPIs and bar charts |
+
+---
+
+## Quick Start
+
+```tsx
+import { ApiExplorer } from "@apifn/react";
+
+export function Docs({ spec }) {
+  return <ApiExplorer spec={spec} baseUrl="https://api.example.com" theme="dark" showHistory />;
+}
+```
+
+### ApiExplorer props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `spec` | `OpenAPIDocument` | — | The document to render (required) |
+| `baseUrl` | `string` | `spec.servers[0].url` | Base URL for Try-It requests |
+| `theme` | `"light" \| "dark" \| "auto"` | `"auto"` | Color theme |
+| `showHistory` | `boolean` | `true` | Show the request history tab |
+| `watchfn` | `WatchFnClient` | — | Enables the Performance tab (polled metrics) |
+| `watchfnInterval` | `number` | `10000` | Metrics polling interval in ms |
+| `rateLimits` | `Record<string, RateLimitInfo>` | — | Rate-limit badges, keyed `"METHOD /path"` |
+| `className` | `string` | — | Custom class name |
+
+The explorer renders a searchable, tag-grouped sidebar and tabs for Documentation, Try It, Performance (when `watchfn` is supplied), and History (when `showHistory`). It collapses to a hamburger menu at ≤768px.
+
+---
+
+## Individual Components
+
+```tsx
+import {
+  EndpointViewer,
+  SchemaViewer,
+  TryIt,
+  RequestHistory,
+  ResponseDiff,
+  PerformanceOverlay,
+} from "@apifn/react";
+
+// Docs for one operation
+<EndpointViewer path="/users/{id}" method="get" operation={op} />
+
+// Schema tree
+<SchemaViewer schema={userSchema} name="User" required expandDepth={3} />
+
+// Live request console
+<TryIt
+  path="/users"
+  method="post"
+  operation={op}
+  baseUrl="https://api.example.com"
+  defaultAuth={{ type: "bearer", token: "abc" }}
+  onResponse={(r) => console.log(r.statusCode)}
+/>
+
+// History (typically driven by TryIt via onResponse)
+<RequestHistory entries={entries} onClear={() => setEntries([])} onSelect={setSelected} maxEntries={500} />
+
+// Compare two responses
+<ResponseDiff left={respA} right={respB} leftLabel="v1" rightLabel="v2" />
+
+// Performance KPIs
+<PerformanceOverlay
+  metrics={{
+    endpoint: "/users", method: "get",
+    p50Ms: 12, p95Ms: 40, p99Ms: 90,
+    errorRatePct: 0.5, requestsPerMinute: 320,
+    lastUpdated: new Date().toISOString(),
+  }}
+  compact
+/>
+```
+
+### Component props at a glance
+
+- **EndpointViewer** — `path`, `method`, `operation` (all required)
+- **SchemaViewer** — `schema` (required), `name?`, `required?` (default `false`), `expandDepth?` (default `2`)
+- **TryIt** — `path`, `method`, `operation` (required), `baseUrl?`, `defaultAuth?: AuthConfig`, `onResponse?: (r: TryItResponse) => void`
+- **RequestHistory** — `entries: HistoryEntry[]` (required), `onClear?`, `onSelect?`, `maxEntries?` (default `500`)
+- **ResponseDiff** — `left`, `right` (required), `leftLabel?` (`"Before"`), `rightLabel?` (`"After"`)
+- **PerformanceOverlay** — `metrics: PerformanceMetrics` (required), `compact?` (default `false`)
+
+---
+
+## Theming
+
+All components are styled with `--apifn-*` CSS variables and ship a `.apifn-root` scope. `ApiExplorer` (and docsfn's `ApifnApiReference`) inject the theme automatically; when using leaf components standalone, render them inside a themed `ApiExplorer` or provide the CSS variables yourself. `theme="auto"` follows `prefers-color-scheme`.
+
+---
+
+## Exports
+
+```typescript
+export { ApiExplorer, EndpointViewer, SchemaViewer, TryIt, RequestHistory, ResponseDiff, PerformanceOverlay }
+export type {
+  ApiExplorerProps, EndpointViewerProps, SchemaViewerProps, TryItProps,
+  RequestHistoryProps, ResponseDiffProps, PerformanceOverlayProps,
+}
+export type { Theme, HistoryEntry, PerformanceMetrics, AuthConfig, TryItResponse }
+```
+
+## License
+
+MIT

--- a/apifn/react/src/styles/tokens.ts
+++ b/apifn/react/src/styles/tokens.ts
@@ -67,9 +67,8 @@ export function getThemeStyle(theme: "light" | "dark" | "auto"): string {
     if (theme === "light") return `.apifn-root { ${LIGHT_THEME} }`;
     if (theme === "dark") return `.apifn-root { ${DARK_THEME} }`;
     return `
-    @media (prefers-color-scheme: dark) { .apifn-root { ${DARK_THEME} } }
-    @media (prefers-color-scheme: light) { .apifn-root { ${LIGHT_THEME} } }
     .apifn-root { ${LIGHT_THEME} }
+    @media (prefers-color-scheme: dark) { .apifn-root { ${DARK_THEME} } }
   `;
 }
 

--- a/apifn/snippets/README.md
+++ b/apifn/snippets/README.md
@@ -1,0 +1,93 @@
+# @apifn/snippets
+
+Code snippet generation for ApiFn. Turn any OpenAPI operation into a ready-to-run request snippet across 11 languages and HTTP clients.
+
+## Installation
+
+```bash
+npm install @apifn/snippets
+```
+
+## Supported Targets
+
+| Target | Language / Client |
+|--------|-------------------|
+| `curl` | cURL |
+| `fetch` | Browser Fetch |
+| `axios` | Axios (Node/browser) |
+| `node-fetch` | node-fetch |
+| `python-requests` | Python `requests` |
+| `python-httpx` | Python `httpx` |
+| `go-http` | Go `net/http` |
+| `ruby-net-http` | Ruby `Net::HTTP` |
+| `php-curl` | PHP cURL |
+| `csharp-httpclient` | C# `HttpClient` |
+| `java-okhttp` | Java OkHttp |
+
+`SUPPORTED_TARGETS` exports this list at runtime.
+
+---
+
+## generateSnippet
+
+Generate a snippet for a single operation.
+
+```typescript
+import { generateSnippet } from "@apifn/snippets";
+
+const code = generateSnippet(operation, "/users/{id}", "get", {
+  target: "curl",
+  baseUrl: "https://api.example.com",
+  auth: { type: "bearer", token: "abc123" },
+  indent: 2,
+});
+
+console.log(code);
+```
+
+### SnippetOptions
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `target` | `SnippetTarget` | — | Language/client (required) |
+| `baseUrl` | `string` | — | Base URL (required) |
+| `auth` | `{ type: string; token?; key? }` | — | Inject auth headers (`bearer` / `apikey` / `basic`) |
+| `indent` | `number` | `2` | Indentation width in spaces |
+
+Path parameters are resolved from each parameter's `example`/`schema.example`, falling back to the `{name}` placeholder. Request bodies are synthesized from the `application/json` `example`, `schema.example`, or the schema's properties. An unknown `target` throws.
+
+---
+
+## generateAllSnippets
+
+Generate one snippet per operation across an entire spec.
+
+```typescript
+import { generateAllSnippets } from "@apifn/snippets";
+
+const { snippets } = generateAllSnippets(openApiDoc, {
+  target: "python-requests",
+  baseUrl: "https://api.example.com",
+});
+
+for (const s of snippets) {
+  console.log(`# ${s.method.toUpperCase()} ${s.path}`);
+  console.log(s.code);
+}
+```
+
+Each `OperationSnippet` is `{ path, method, operationId?, target, code }`.
+
+---
+
+## Exports
+
+```typescript
+export { generateSnippet, generateAllSnippets, SUPPORTED_TARGETS }
+export type { SnippetContext, OperationSnippet, AllSnippetsResult, SnippetTargetGenerator }
+// SnippetTarget and SnippetOptions are re-exported from @apifn/core
+```
+
+## License
+
+MIT

--- a/apifn/svelte/README.md
+++ b/apifn/svelte/README.md
@@ -1,0 +1,108 @@
+# @apifn/svelte
+
+Svelte UI components for ApiFn. The Svelte counterpart to [`@apifn/react`](../react) — an interactive API explorer, live Try-It console, schema viewer, request history, response diffing, and performance overlays, rendered from any OpenAPI document.
+
+## Installation
+
+```bash
+npm install @apifn/svelte
+```
+
+`svelte` (`^4` or `^5`) is a peer dependency.
+
+> Components are shipped as **`.svelte` source** and compiled by your app's Svelte toolchain. Import each component from its own subpath (e.g. `@apifn/svelte/ApiExplorer.svelte`). The package root (`@apifn/svelte`) exports TypeScript prop types only.
+
+## Components
+
+| Component | Subpath | Purpose |
+|-----------|---------|---------|
+| `ApiExplorer` | `@apifn/svelte/ApiExplorer.svelte` | Full explorer shell — the all-in-one entry point |
+| `EndpointViewer` | `@apifn/svelte/EndpointViewer.svelte` | Documentation for a single operation |
+| `SchemaViewer` | `@apifn/svelte/SchemaViewer.svelte` | Collapsible JSON-schema tree |
+| `TryIt` | `@apifn/svelte/TryIt.svelte` | Live request console |
+| `RequestHistory` | `@apifn/svelte/RequestHistory.svelte` | Past requests with expandable detail |
+| `ResponseDiff` | `@apifn/svelte/ResponseDiff.svelte` | Side-by-side response diff |
+| `PerformanceOverlay` | `@apifn/svelte/PerformanceOverlay.svelte` | Latency/throughput KPIs |
+
+---
+
+## Quick Start
+
+```svelte
+<script>
+  import ApiExplorer from "@apifn/svelte/ApiExplorer.svelte";
+  export let spec;
+</script>
+
+<ApiExplorer {spec} baseUrl="https://api.example.com" theme="auto" showHistory={true} />
+```
+
+### ApiExplorer props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `spec` | `OpenAPIDocument` | — | The document to render (required) |
+| `baseUrl` | `string` | `spec.servers[0].url` | Base URL for Try-It requests |
+| `theme` | `"light" \| "dark" \| "auto"` | `"auto"` | Color theme |
+| `showHistory` | `boolean` | `true` | Show the request history tab |
+| `watchfn` | `WatchFnClient` | — | Enables the Performance tab (polled metrics) |
+| `watchfnInterval` | `number` | `10000` | Metrics polling interval in ms |
+| `rateLimits` | `Record<string, RateLimitInfo>` | — | Rate-limit badges, keyed `"METHOD /path"` |
+
+The explorer renders a searchable, tag-grouped sidebar and Documentation / Try It / Performance / History tabs, collapsing to a hamburger overlay at ≤768px.
+
+---
+
+## Individual Components
+
+```svelte
+<script>
+  import EndpointViewer from "@apifn/svelte/EndpointViewer.svelte";
+  import TryIt from "@apifn/svelte/TryIt.svelte";
+  import SchemaViewer from "@apifn/svelte/SchemaViewer.svelte";
+  export let operation;
+  export let schema;
+</script>
+
+<EndpointViewer path="/users/{id}" method="get" {operation} />
+
+<SchemaViewer {schema} name="User" required expandDepth={3} />
+
+<TryIt
+  path="/users"
+  method="post"
+  {operation}
+  baseUrl="https://api.example.com"
+  on:response={(e) => console.log(e.detail.statusCode)}
+/>
+```
+
+### Events
+
+Unlike the React package's callback props, Svelte components dispatch events:
+
+- **TryIt** — `on:response` with a `TryItResponse` detail
+- **RequestHistory** — `on:select` (a `HistoryEntry`) and `on:clear`
+
+### Component props at a glance
+
+- **EndpointViewer** — `path`, `method`, `operation` (required)
+- **SchemaViewer** — `schema` (required), `name?`, `required?` (default `false`), `expandDepth?` (default `2`)
+- **TryIt** — `path`, `method`, `operation` (required), `baseUrl?`
+- **RequestHistory** — `entries: HistoryEntry[]`, `maxEntries?` (default `500`)
+- **ResponseDiff** — `left`, `right` (required), `leftLabel?` (`"Before"`), `rightLabel?` (`"After"`)
+- **PerformanceOverlay** — `metrics: PerformanceMetrics` (required), `compact?` (default `false`)
+
+---
+
+## Theming
+
+Components use `--apifn-*` CSS variables scoped to `.apifn-root`. `ApiExplorer` injects the theme automatically; the leaf components expect those variables to be provided by a parent (an `ApiExplorer` or docsfn's `ApifnApiReference`). `theme="auto"` follows `prefers-color-scheme`.
+
+## Types
+
+The package root exports prop interfaces for TypeScript consumers: `ApiExplorerProps`, `EndpointViewerProps`, `SchemaViewerProps`, `TryItProps`, `RequestHistoryProps`, `ResponseDiffProps`, `PerformanceOverlayProps`, plus `HistoryEntry`, `TryItResponse`, and `PerformanceMetrics`. `OpenAPIDocument`, `OperationObject`, and `SchemaObject` are re-exported from `@apifn/core`.
+
+## License
+
+MIT

--- a/apifn/svelte/src/ApiExplorer.svelte
+++ b/apifn/svelte/src/ApiExplorer.svelte
@@ -283,6 +283,7 @@
       --apifn-border: #2d3748; --apifn-text: #e2e8f0; --apifn-text-muted: #64748b;
       --apifn-accent: #7c3aed; --apifn-accent-text: #c4b5fd; --apifn-green: #6ee7b7;
       --apifn-blue: #93c5fd; --apifn-yellow: #fcd34d; --apifn-red: #fca5a5;
+      --apifn-purple: #c4b5fd; --apifn-orange: #fdba74;
     }
   }
   .topbar { display: flex; align-items: center; gap: 12px; padding: 0 20px; height: 52px; border-bottom: 1px solid var(--apifn-border); background: var(--apifn-bg-surface); flex-shrink: 0; }

--- a/apifn/svelte/src/ApiExplorer.svelte
+++ b/apifn/svelte/src/ApiExplorer.svelte
@@ -6,7 +6,7 @@
   import TryIt from "./TryIt.svelte";
   import RequestHistory from "./RequestHistory.svelte";
   import PerformanceOverlay from "./PerformanceOverlay.svelte";
-  import type { WatchFnClient, EndpointMetrics } from "@apifn/core";
+  import type { WatchFnClient, EndpointMetrics, RateLimitInfo } from "@apifn/core";
 
   export let spec: OpenAPIDocument;
   export let baseUrl: string | undefined = undefined;
@@ -48,7 +48,7 @@
     const light = `--apifn-bg:#ffffff;--apifn-bg-surface:#f8fafc;--apifn-bg-surface-hover:#f1f5f9;--apifn-border:#e2e8f0;--apifn-text:#0f172a;--apifn-text-muted:#64748b;--apifn-accent:#7c3aed;--apifn-accent-text:#6d28d9;--apifn-green:#059669;--apifn-blue:#2563eb;--apifn-yellow:#d97706;--apifn-red:#dc2626;--apifn-purple:#7c3aed;--apifn-orange:#ea580c;--apifn-radius:6px;--apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif`;
     if (t === "dark") return dark;
     if (t === "light") return light;
-    return light; // auto defaults to light; media query in style handles dark
+    return "";
   }
 
   $: endpoints = collectEndpoints(spec);
@@ -148,7 +148,7 @@
   $: themeVars = getThemeCSS(theme);
 </script>
 
-<div class="apifn-root" style={themeVars}>
+<div class="apifn-root" class:auto-theme={theme === "auto"} style={themeVars}>
   <!-- Top Bar -->
   <header class="topbar">
     <button
@@ -263,6 +263,12 @@
 
 <style>
   .apifn-root {
+    --apifn-bg:#ffffff;--apifn-bg-surface:#f8fafc;--apifn-bg-surface-hover:#f1f5f9;
+    --apifn-border:#e2e8f0;--apifn-text:#0f172a;--apifn-text-muted:#64748b;
+    --apifn-accent:#7c3aed;--apifn-accent-text:#6d28d9;--apifn-green:#059669;
+    --apifn-blue:#2563eb;--apifn-yellow:#d97706;--apifn-red:#dc2626;
+    --apifn-purple:#7c3aed;--apifn-orange:#ea580c;--apifn-radius:6px;
+    --apifn-font-mono:'JetBrains Mono',monospace;--apifn-font-sans:-apple-system,sans-serif;
     font-family: var(--apifn-font-sans, sans-serif);
     background: var(--apifn-bg, #0f1117);
     color: var(--apifn-text, #e2e8f0);
@@ -272,7 +278,7 @@
     overflow: hidden;
   }
   @media (prefers-color-scheme: dark) {
-    .apifn-root {
+    .apifn-root.auto-theme {
       --apifn-bg: #0f1117; --apifn-bg-surface: #1a1d2e; --apifn-bg-surface-hover: #252840;
       --apifn-border: #2d3748; --apifn-text: #e2e8f0; --apifn-text-muted: #64748b;
       --apifn-accent: #7c3aed; --apifn-accent-text: #c4b5fd; --apifn-green: #6ee7b7;

--- a/apifn/svelte/src/index.ts
+++ b/apifn/svelte/src/index.ts
@@ -15,6 +15,9 @@ export interface ApiExplorerProps {
     baseUrl?: string;
     theme?: "light" | "dark" | "auto";
     showHistory?: boolean;
+    watchfn?: import("@apifn/core").WatchFnClient;
+    watchfnInterval?: number;
+    rateLimits?: Record<string, import("@apifn/core").RateLimitInfo>;
 }
 
 export interface EndpointViewerProps {

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,10 +253,18 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "docsfn": "*"
+        "docsfn": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "svelte": "^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "docsfn": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,6 +255,7 @@
       "peerDependencies": {
         "docsfn": "*",
         "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "svelte": "^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -262,6 +263,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         },
         "svelte": {


### PR DESCRIPTION
Brings the ApiFn toolkit documentation to npm-publish readiness, following the datafn/authfn README conventions.

- Adds a `README.md` for each of the eight `@apifn/*` packages (`core`, `cli`, `collections`, `mock`, `snippets`, `react`, `svelte`, and `docsfn`).
- Rewrites `apifn/README.md` with the npm package inventory, Python SDK, quick start, ecosystem integrations, and existing CI/CD guidance.
- Corrects source mismatches in assertion and variable examples, numeric defaults, configuration scope, and mock-generation claims.
- Publishes the documented `@apifn/core/types`, `@apifn/docsfn/react`, and `@apifn/docsfn/svelte` subpaths.
- Propagates the docsfn provider `baseUrl` into entries and applies deterministic renderer fallback precedence.
- Aligns Svelte public prop types with the component and fixes `theme="auto"` behavior in the React/Svelte explorers and docsfn renderers.

Validation:

- 201 unit tests pass across core, collections, mock, and docsfn.
- Affected packages build successfully; core and docsfn TypeScript checks pass.
- Both modified Svelte components compile through the repository's Vite/Svelte preprocessor.
- Packed-package dry runs include every advertised public export, and import-resolution smoke tests pass.

## Summary by Sourcery

Document ApiFn packages for npm readiness and align UI explorers/docs renderers with clarified theming, base URL, and type exports.

New Features:
- Add comprehensive READMEs for @apifn core, cli, collections, mock, snippets, react, svelte, and docsfn packages, plus expand the main ApiFn README with package inventory, Python SDK, quick start, and integrations.
- Expose @apifn/core/types and @apifn/docsfn/react and @apifn/docsfn/svelte subpaths for consumers, and add React/Svelte renderer entries to docsfn builds.

Enhancements:
- Propagate docsfn provider baseUrl to content entries and use deterministic base URL precedence in React/Svelte API reference renderers.
- Align Svelte ApiExplorer public prop typings with underlying implementation, including watchfn and rate limit support.
- Adjust React/Svelte theming behavior so theme="auto" uses CSS defaults with prefers-color-scheme media queries rather than forcing light mode.

Build:
- Update core and docsfn tsup configurations and docsfn package.json exports/files to produce separate type bundles and framework-specific entrypoints.

Tests:
- Extend docsfn provider tests to cover baseUrl propagation into generated entries.